### PR TITLE
ci: 加 GitHub Actions 快速门禁（typecheck + 单测 + 构建）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+# 快速门禁（零 token）：typecheck + 单测 + 构建。
+# 对应 README「Testing」的本地命令，搬到 PR/push 自动跑。
+# 真实会话 / 烧 token 的黑盒回归不在此 —— 那由独立测试床流水线负责。
+
+on:
+  push:
+    branches: [development, main]
+  pull_request:
+    branches: [development, main]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      # 注：当前 lockfile 与 package.json 不同步（见 issue：CLI 改名后未重生成），
+      # `npm ci` 会失败。修复并提交 package-lock.json 后此步转绿。
+      - name: Install
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Unit tests (non-web, deterministic mock)
+        env:
+          BP_MOCK: "1"
+        run: npm test
+
+      - name: Web tests + build
+        working-directory: packages/web
+        run: |
+          npm test
+          npm run build
+
+      - name: Build all packages
+        run: npm run build


### PR DESCRIPTION
## 目的

为 `development`/`main` 的 PR/push 加一道**零 token 快速门禁**——把 README「Testing」里的本地命令搬到 CI 自动跑，每次改动自动验证不破坏类型/单测/构建。

## 包含的步骤
- `npm run typecheck`（tsc -b 5 包）
- `npm test`（vitest，`BP_MOCK=1` 确定性 mock，**不消耗 API 配额**）
- web 包 `npm test` + `npm run build`
- `npm run build` 整体构建

均已在干净 Node 22 环境预演通过：**typecheck OK、217 + 25 测试全过、web build OK**。

## ⚠️ 合入前提：lockfile
install 步骤用 `npm ci`（CI 标准做法）。当前 `package-lock.json` 与 `package.json` 不同步（CLI 改名 `@brainpilot/cli`→`@brainpilot/app` 后未重新生成），`npm ci` 会失败 —— 见 #1。

建议：合本 PR 前先修 #1（`npm install` 重生成并提交 lockfile），CI 即转绿；或与本 PR 一并处理。CI 立起来后会持续盯着这个不变量。

## 范围边界
此 CI 只是快速门禁。**真实多智能体会话 / 烧 token 的黑盒回归**（oracle 判错、错误案例库回归、质量评测）不在此，由独立的测试床流水线负责。

🤖 Generated with [Claude Code](https://claude.com/claude-code)