### PR TITLE
docs(readme): lead with npm, demote Docker to third deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,58 @@
 
 BrainPilot is an open-source, single-user multi-agent collaboration platform built with TypeScript + the Pi SDK (a Principal agent coordinating specialist agents over a file-based mailbox), served as a Hono backend + React SPA.
 
-## 🚀 Quick Start (Docker)
+## 🚀 Quick Start (npm)
+
+BrainPilot runs as a local process via `@brainpilot/app` — no Docker required.
+This is the recommended way to get started.
+
+### Prerequisites
+- Node.js ≥ 22
+- An Anthropic API key (or `BP_MOCK=1` for a no-key test run)
+
+### 1. Install
+```bash
+npm install -g @brainpilot/app
+```
+This installs the `brainpilot` CLI (`bnpt` is a built-in short alias for the same command).
+
+### 2. Initialize
+```bash
+brainpilot init --api-key <your-anthropic-key>   # scaffold config under ./brainpilot
+```
+The key is persisted to `brainpilot/bp_template/settings.json`. You can also omit
+`--api-key` and supply the key via the `ANTHROPIC_API_KEY` environment variable
+instead — without a key (and without `BP_MOCK=1`), `brainpilot up` exits with
+"No provider API key found."
+
+### 3. Launch
+```bash
+brainpilot up        # foreground by default; Ctrl-C to stop
+```
+No API key needed for a smoke run: `BP_MOCK=1 brainpilot up`.
+
+Use detached mode when you want a background process managed by the CLI:
+```bash
+brainpilot up --detach
+brainpilot status    # health + child pid (detached mode)
+brainpilot logs      # tail backend log; add --runtime for runtime log
+brainpilot down      # stop the detached backend
+```
+
+## 💻 Run from source (contributors)
+
+From a local BrainPilot checkout:
+```bash
+npm install
+npm run build
+npm run bp -- up     # equivalent to `brainpilot up` from the built CLI
+```
+
+## 🐳 Docker deployment
+
+The npm path above is the recommended single-user, local-process setup. Docker is
+the third option — reach for it when you want a containerized, reproducible
+deployment or the static `main` + `sandbox` topology.
 
 ### Prerequisites
 - Docker 20.10+ and Docker Compose v2
@@ -30,6 +81,32 @@ docker compose -f docker-compose.yml -f docker-compose.host.yml up -d --build
 docker compose down
 ```
 
+### 🧩 Customizing sandbox dependencies
+
+The `brainpilot-sandbox` image ships a **lightweight baseline** (Node + runtime
+only — no Python, no GPU, no terminal). To add dependencies, edit
+**`docker/sandbox/extra-deps.sh`** — a build-time hook with worked examples for:
+- installing Python3 + pip packages,
+- installing system packages (apt),
+- installing global npm tools.
+
+After editing, rebuild: `docker compose build sandbox`.
+
+Build-time acceleration (optional, default = official sources): pass
+`NPM_REGISTRY` / `APT_MIRROR` / `HTTP_PROXY` via `.env` (consumed as build args).
+
+### 🔀 Deployment modes
+
+Deployment mode is a **Docker-only** concern. The npm path (above) is always a
+single-user, local-process setup and needs none of these variables.
+
+| Mode | Sandbox topology | Selected by | This repo |
+|------|------|------|-----------|
+| `static` | 1 shared `main` + 1 fixed `sandbox` (compose-managed), single user | `BP_RUNTIME_URL` set (points main at the sandbox) | ✅ shipped |
+| `dynamic` | shared `main` + **per-user** sandbox started on demand via docker.sock | `BP_ORCHESTRATOR=docker` (and leave `BP_RUNTIME_URL` unset) | 🚧 skeleton only (`docker-compose.dynamic.yml`); implemented in a downstream multi-user repo, reusing these images unchanged |
+
+A Docker-free local path also exists (`@brainpilot/app`, `brainpilot up`) — see the npm Quick Start above. It runs a single user on the local orchestrator; deployment-mode variables do not apply.
+
 ## 🤖 Using a third-party / custom model
 
 By default BrainPilot talks to Pi's built-in Anthropic endpoint. Pi does **not**
@@ -52,7 +129,7 @@ BrainPilot auto-generates a one-provider `models.json` pointed at the gateway
 `compat` flags, or OpenAI-compatible endpoints like Ollama/vLLM). Copy the
 template and edit it:
 ```bash
-cp models.example.json brainpilot/models.json   # brainpilot/ = your BP_DATA_DIR
+cp models.example.json brainpilot/models.json   # brainpilot/ = your data dir (BP_DATA_DIR under Docker, ./brainpilot from `brainpilot init` locally)
 ```
 Then in `.env`:
 ```bash
@@ -68,61 +145,8 @@ Full `models.json` schema — `api` types, `compat` flags, `$ENV` key
 interpolation, per-model cost/limits — is documented at
 <https://pi.dev/docs/latest/models>.
 
-## 🧩 Customizing sandbox dependencies
+## 📦 Publishing (maintainers)
 
-The `brainpilot-sandbox` image ships a **lightweight baseline** (Node + runtime
-only — no Python, no GPU, no terminal). To add dependencies, edit
-**`docker/sandbox/extra-deps.sh`** — a build-time hook with worked examples for:
-- installing Python3 + pip packages,
-- installing system packages (apt),
-- installing global npm tools.
-
-After editing, rebuild: `docker compose build sandbox`.
-
-Build-time acceleration (optional, default = official sources): pass
-`NPM_REGISTRY` / `APT_MIRROR` / `HTTP_PROXY` via `.env` (consumed as build args).
-
-## 🔀 Deployment modes
-
-Deployment mode is a **Docker-only** concern. The npm path (below) is always a
-single-user, local-process setup and needs none of these variables.
-
-| Mode | Sandbox topology | Selected by | This repo |
-|------|------|------|-----------|
-| `static` | 1 shared `main` + 1 fixed `sandbox` (compose-managed), single user | `BP_RUNTIME_URL` set (points main at the sandbox) | ✅ shipped |
-| `dynamic` | shared `main` + **per-user** sandbox started on demand via docker.sock | `BP_ORCHESTRATOR=docker` (and leave `BP_RUNTIME_URL` unset) | 🚧 skeleton only (`docker-compose.dynamic.yml`); implemented in a downstream multi-user repo, reusing these images unchanged |
-
-A Docker-free local path also exists (`@brainpilot/app`, `brainpilot up`) — see the app package. It runs a single user on the local orchestrator; deployment-mode variables do not apply.
-
-## 💻 Install without Docker
-
-BrainPilot runs without Docker via `@brainpilot/app` — a local launcher that
-spawns the backend + runtime as child processes.
-
-### Path A — npm (end users)
-```bash
-npm install -g @brainpilot/app
-brainpilot init      # scaffold config under ./brainpilot
-brainpilot up        # foreground by default; Ctrl-C to stop
-```
-Use detached mode when you want a background process managed by the CLI:
-```bash
-brainpilot up --detach
-brainpilot status    # health + child pid (detached mode)
-brainpilot logs      # tail backend log; add --runtime for runtime log
-brainpilot down      # stop the detached backend
-```
-No API key needed for a smoke run: `BP_MOCK=1 brainpilot up`.
-
-### Path B — from source (contributors)
-From a local BrainPilot checkout:
-```bash
-npm install
-npm run build
-npm run bp -- up     # equivalent to `brainpilot up` from the built CLI
-```
-
-### Publishing (maintainers)
 ```bash
 npm login                 # account with @brainpilot scope access
 npm run version:check     # verify all workspace package versions are aligned


### PR DESCRIPTION
## What

Reorders the README's deployment guidance to reflect the intended priority: **npm → run from source → Docker**. README stays in English.

## Changes

- **🚀 Quick Start (npm)** — promoted to the lead section. Added Prerequisites (Node ≥22 + API key), real API-key instructions (`brainpilot init --api-key <key>` or `ANTHROPIC_API_KEY`, with the "No provider API key found" caveat), and a note that `bnpt` is a short alias.
- **💻 Run from source (contributors)** — split into its own section.
- **🐳 Docker deployment** — retitled (was "Quick Start (Docker)") and demoted to the third option; *Customizing sandbox dependencies* and *Deployment modes* nested under it. Fixed the now-stale "npm path (below)" → "above".
- **🤖 Using a third-party / custom model** — moved after the three deploy options; the `BP_DATA_DIR` example now reads correctly for the local/npm path too.
- **📦 Publishing (maintainers)** — promoted to its own section.

Section-body text is preserved verbatim where unchanged; this is a reorder + targeted accuracy fixes, not a rewrite.

## Verification

- Heading order confirmed: intro → npm → source → Docker (+sandbox deps + modes) → custom model → Publishing → Testing → Monorepo → License.
- No stale references remain (`Install without Docker`, `Quick Start (Docker)`, `Path A/B`, `path (below)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)