### PR TITLE
fix(cli): skip provider key check under BP_MOCK=1 (BPCASE-0002)

### DIFF
--- a/packages/cli/src/commands/up.test.ts
+++ b/packages/cli/src/commands/up.test.ts
@@ -90,6 +90,26 @@ describe("up — provider key resolution", () => {
     );
     expect(cfg.port).toBeGreaterThan(0);
   });
+
+  it("skips the key check under BP_MOCK=1 (no key needed)", async () => {
+    const root = join(dir, "brainpilot");
+    let started = false;
+    const result = await up(
+      { dir: root, port: 9800, foreground: true, open: false },
+      {
+        env: { BP_MOCK: "1" }, // no ANTHROPIC_API_KEY
+        startServer: async () => {
+          started = true;
+          return { stop: async () => {} } as unknown as RunningServer;
+        },
+        isPortFree: freePorts(),
+        webDist: () => null,
+        log: () => {},
+      },
+    );
+    expect(started).toBe(true);
+    expect(result.url).toBe("http://127.0.0.1:9800");
+  });
 });
 
 describe("up — foreground start", () => {

--- a/packages/cli/src/commands/up.ts
+++ b/packages/cli/src/commands/up.ts
@@ -16,6 +16,7 @@
  */
 import { resolveProvider } from "@brainpilot/backend-core";
 import type { StartServerOptions, RunningServer } from "@brainpilot/backend-core";
+import { isMockMode } from "@brainpilot/runtime";
 import pc from "picocolors";
 import { resolveDataDir, dataPaths } from "../paths.js";
 import { scaffold, isScaffolded, DEFAULT_PORT } from "../scaffold.js";
@@ -153,9 +154,10 @@ export async function up(
     await scaffold(dataDir, { port });
   }
 
-  // 3. Resolve provider key.
+  // 3. Resolve provider key. Skipped under BP_MOCK=1 — the mock agent replaces
+  //    the whole Pi layer and never makes a real LLM call, so no key is needed.
   const provider = await resolveProvider({ dataDir, env });
-  if (!provider.apiKey) {
+  if (!isMockMode(env) && !provider.apiKey) {
     throw new ProviderKeyError(dataDir);
   }
 

--- a/packages/runtime/src/agent-factory.ts
+++ b/packages/runtime/src/agent-factory.ts
@@ -18,8 +18,8 @@ import type { AgentSessionFactory, IAgentSession, PiAgentEvent, SystemTool } fro
 import { MockAgentSession } from "./mock-agent.js";
 import { resolveGatewayModel, type PiProviderSdk } from "./pi-provider.js";
 
-export function isMockMode(): boolean {
-  return process.env.BP_MOCK === "1" || process.env.BP_MOCK === "true";
+export function isMockMode(env: Record<string, string | undefined> = process.env): boolean {
+  return env.BP_MOCK === "1" || env.BP_MOCK === "true";
 }
 
 export const mockAgentFactory: AgentSessionFactory = async ({ sessionId, agentName, systemTools }) => {


### PR DESCRIPTION
## What

`brainpilot up` threw `ProviderKeyError` even with `BP_MOCK=1`, contradicting the purpose of mock mode (zero-key, zero-quota deterministic runs). The mock agent replaces the entire Pi layer and never makes a real LLM call, so no provider key is needed.

Fixes #4.

## Root cause

`packages/cli/src/commands/up.ts` threw unconditionally after `resolveProvider()`:

```js
const provider = await resolveProvider({ dataDir, env });
if (!provider.apiKey) throw new ProviderKeyError(dataDir);
```

## Fix

Gate the key check on mock mode — evaluated against the **injected `env`**, not global `process.env`. This matters: the existing "no key → throws" test injects `env: {}`, and the standard test command is `BP_MOCK=1 vitest run`. A `process.env`-based check would make that test wrongly skip the throw under CI.

- **runtime** (`agent-factory.ts`): `isMockMode(env = process.env)` gains an optional `env` arg. The BP_MOCK predicate stays the single source of truth; existing no-arg callers (`selectFactory`, etc.) are unaffected.
- **cli** (`up.ts`): `if (!isMockMode(env) && !provider.apiKey) throw ...`
- **test** (`up.test.ts`): new case — `BP_MOCK=1` with no key starts the backend instead of throwing.

## Verification

- `npm run typecheck` ✅
- `BP_MOCK=1 npx vitest run packages/cli` → 70 passed (incl. new test) ✅
- `BP_MOCK=1 npx vitest run packages/runtime packages/backend-core` → 99 passed ✅
- End-to-end repro from the issue now prints `BrainPilot backend running` with no `ANTHROPIC_API_KEY` set:
  ```bash
  env -u ANTHROPIC_API_KEY BP_MOCK=1 brainpilot up --port 19010 --no-open
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)