### PR TITLE
feat: GitHub Issue/PR 状态推送到飞书群

### DIFF
--- a/.github/scripts/lark-notify/README.md
+++ b/.github/scripts/lark-notify/README.md
@@ -1,0 +1,51 @@
+# Lark Notify — GitHub Issue/PR → 飞书群
+
+事件驱动：issue/PR 变动时，GitHub Actions 构造飞书交互卡片，POST 到开发者小群的自定义机器人 webhook。
+
+## 一次性配置
+
+1. 飞书目标群 → 设置 → 群机器人 → 添加「自定义机器人」→ 复制 **Webhook 地址**。
+   - 可选：开启「签名校验」，复制其 **密钥**。
+2. GitHub 仓库 → Settings → Secrets and variables → Actions → New repository secret：
+   - `LARK_WEBHOOK_URL`（必填）= 上面的 Webhook 地址
+   - `LARK_WEBHOOK_SECRET`（仅当开启签名校验时填）= 上面的密钥
+
+> workflow 文件只引用 `${{ secrets.* }}`，真实地址/密钥只存 GitHub Secret，不进 git。
+> 通知 workflow（`lark-notify.yml`）必须在仓库**默认分支 main** 上才会接收 issue/PR 事件。
+
+## 覆盖的事件（12 类）
+
+Issue：opened / closed / 评论；
+PR：opened / merged / closed(未合并) / 转 ready / 请求评审 / 评论；
+评审提交：通过 / 请求修改 / 评论。
+
+评论/正文在卡片中显示约 200 字摘要（超出截断）。
+
+## 本地测试脚本
+
+```bash
+brew install bats-core jq      # macOS
+bats .github/scripts/lark-notify/test/
+```
+
+CI 会在 PR / push 改动脚本或 workflow 时自动跑这些测试（见 `lark-notify-test.yml`）。
+
+## 手动冒烟（合并到 main 后）
+
+新建测试 issue → 看群里出「🟢 新 Issue」；评论 / 关闭依次验证；
+提 draft PR → 转 ready → 请求评审 → approve → 合并，逐一核对卡片。
+验证完删除测试 issue/PR。Actions 页面可看每次运行日志，失败 step 标红。
+
+## 安全与开源
+
+PR 事件用 `pull_request_target`（在 base 仓上下文运行、可拿 secret），使仓库**开源后外部 fork PR 也能推群**。这是安全的，因为本 workflow：
+- 绝不 checkout / 执行 PR 的代码，只读 `github.event.pull_request.*` 元数据；
+- PR 标题/正文只作为数据经环境变量 + `jq --arg` 进卡片，绝不拼进 shell；
+- `permissions` 只有 `contents: read`。
+
+### 转 public 前 checklist
+
+- [ ] `git log -p | grep -iE 'open.feishu|larksuite|/bot/v2/hook/'` 确认历史无真实 webhook 残留
+- [ ] 确认 secret 已配置、workflow 仅含 `${{ secrets.* }}` 占位引用
+- [ ] 确认 PR 事件用 `pull_request_target`、**无 checkout PR head 代码的步骤**、`permissions` 最小
+- [ ] （可选）飞书侧已开签名校验

--- a/.github/scripts/lark-notify/build-card.sh
+++ b/.github/scripts/lark-notify/build-card.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# 读环境变量，输出飞书 interactive 卡片 JSON 到 stdout。纯函数，无网络。
+set -euo pipefail
+
+NOTIFY_KIND="${NOTIFY_KIND:?NOTIFY_KIND required}"
+TITLE="${TITLE:-}"
+REPO="${REPO:-}"
+ACTOR="${ACTOR:-}"
+URL="${URL:-}"
+BODY="${BODY:-}"
+
+# 事件类型 → 颜色 + 中文标题
+case "$NOTIFY_KIND" in
+  issue_opened)       TEMPLATE="green";  HEAD="🟢 新 Issue" ;;
+  issue_closed)       TEMPLATE="red";    HEAD="🔴 Issue 已关闭" ;;
+  issue_comment)      TEMPLATE="blue";   HEAD="🔵 Issue 新评论" ;;
+  pr_comment)         TEMPLATE="blue";   HEAD="🔵 PR 新评论" ;;
+  pr_opened)          TEMPLATE="green";  HEAD="🟢 新 PR" ;;
+  pr_merged)          TEMPLATE="green";  HEAD="🟢 PR 已合并" ;;
+  pr_closed)          TEMPLATE="red";    HEAD="🔴 PR 已关闭(未合并)" ;;
+  pr_ready)           TEMPLATE="blue";   HEAD="🔵 PR 转为可评审" ;;
+  review_requested)   TEMPLATE="blue";   HEAD="🔵 请求评审" ;;
+  review_approved)    TEMPLATE="green";  HEAD="🟢 评审已通过" ;;
+  review_changes)     TEMPLATE="red";    HEAD="🔴 评审请求修改" ;;
+  review_commented)   TEMPLATE="yellow"; HEAD="🟡 评审评论" ;;
+  *) echo "unknown NOTIFY_KIND: $NOTIFY_KIND" >&2; exit 1 ;;
+esac
+
+# 正文摘要：超过 200 字符时截断为 199 字 + …；否则原样。先去掉 \r
+SUMMARY=""
+if [ -n "$BODY" ]; then
+  SUMMARY="$(BODY="$BODY" jq -rn '
+    (env.BODY | gsub("\r";"")) as $b
+    | if ($b | length) > 200 then ($b[0:199] + "…") else $b end')"
+fi
+
+jq -n \
+  --arg template "$TEMPLATE" \
+  --arg head "$HEAD" \
+  --arg title "$TITLE" \
+  --arg repo "$REPO" \
+  --arg actor "$ACTOR" \
+  --arg url "$URL" \
+  --arg summary "$SUMMARY" \
+  '
+  # 转义标题中的 * 以免破坏 lark_md 粗体
+  ($title | gsub("\\*"; "\\*")) as $safetitle
+  | ( "**" + $safetitle + "**\n仓库：" + $repo + "\n作者：" + $actor ) as $base
+  | ( if $summary == "" then $base
+      else $base + "\n┄┄┄┄┄┄┄┄┄┄\n" + $summary end ) as $body
+  | {
+    msg_type: "interactive",
+    card: {
+      config: { wide_screen_mode: true },
+      header: {
+        template: $template,
+        title: { tag: "plain_text", content: $head }
+      },
+      elements: [
+        { tag: "div", text: { tag: "lark_md", content: $body } },
+        { tag: "action", actions: [
+          { tag: "button", text: { tag: "plain_text", content: "在 GitHub 查看" },
+            url: $url, type: "primary" } ] }
+      ]
+    }
+  }'

--- a/.github/scripts/lark-notify/dispatch.sh
+++ b/.github/scripts/lark-notify/dispatch.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# 按 NOTIFY_KIND 从对应的 GitHub 事件环境变量里选出 TITLE/ACTOR/URL/BODY，
+# 调 build-card.sh 生成卡片，再交给 send.sh 发送。
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SEND_BIN="${LARK_NOTIFY_SEND_BIN:-$HERE/send.sh}"
+
+NOTIFY_KIND="${NOTIFY_KIND:?}"
+REPO="${REPO:-}"
+
+case "$NOTIFY_KIND" in
+  issue_opened|issue_closed)
+    NUM="${ISSUE_NUM:-}"; T="${ISSUE_TITLE:-}"; U="${ISSUE_URL:-}"; A="${ISSUE_USER:-}"; B=""
+    ;;
+  issue_comment|pr_comment)
+    NUM="${ISSUE_NUM:-${PR_NUM:-}}"
+    T="${ISSUE_TITLE:-${PR_TITLE:-}}"
+    U="${COMMENT_URL:-}"; A="${COMMENT_USER:-}"; B="${COMMENT_BODY:-}"
+    ;;
+  pr_opened|pr_merged|pr_closed|pr_ready|review_requested)
+    NUM="${PR_NUM:-}"; T="${PR_TITLE:-}"; U="${PR_URL:-}"; A="${PR_USER:-}"; B="${PR_BODY:-}"
+    ;;
+  review_approved|review_changes|review_commented)
+    NUM="${PR_NUM:-}"; T="${PR_TITLE:-}"; U="${REVIEW_URL:-}"; A="${REVIEW_USER:-}"; B="${REVIEW_BODY:-}"
+    ;;
+  *) echo "dispatch: unknown NOTIFY_KIND $NOTIFY_KIND" >&2; exit 1 ;;
+esac
+
+TITLE="#${NUM} ${T}"
+
+NOTIFY_KIND="$NOTIFY_KIND" TITLE="$TITLE" REPO="$REPO" ACTOR="$A" URL="$U" BODY="$B" \
+  bash "$HERE/build-card.sh" | bash "$SEND_BIN"

--- a/.github/scripts/lark-notify/send.sh
+++ b/.github/scripts/lark-notify/send.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# 从 stdin 读卡片 JSON，按需签名，POST 到飞书自定义机器人。失败退出非 0。
+set -euo pipefail
+
+URL="${LARK_WEBHOOK_URL:?LARK_WEBHOOK_URL required}"
+SECRET="${LARK_WEBHOOK_SECRET:-}"
+
+CARD_JSON="$(cat)"
+
+if [ -n "$SECRET" ]; then
+  TS="$(date +%s)"
+  # 飞书签名：HMAC-SHA256，key = "<timestamp>\n<secret>"，data 为空，结果 base64
+  STRING_TO_SIGN="${TS}"$'\n'"${SECRET}"
+  SIGN="$(printf '%s' "" | openssl dgst -sha256 -hmac "$STRING_TO_SIGN" -binary | base64)"
+  PAYLOAD="$(jq -n --arg ts "$TS" --arg sign "$SIGN" --argjson card "$CARD_JSON" \
+    '$card + { timestamp: $ts, sign: $sign }')"
+else
+  PAYLOAD="$CARD_JSON"
+fi
+
+REQ_BODY_FILE="$(mktemp)"
+trap 'rm -f "$REQ_BODY_FILE"' EXIT
+printf '%s' "$PAYLOAD" > "$REQ_BODY_FILE"
+
+RESP="$(curl -sS -m 15 -X POST "$URL" \
+  -H 'Content-Type: application/json' \
+  --data-binary "@$REQ_BODY_FILE")"
+
+printf '飞书响应: %s\n' "${RESP}" >&2
+if ! CODE="$(printf '%s' "$RESP" | jq -r '.code // .StatusCode // "missing"' 2>/dev/null)"; then
+  echo "推送失败：响应非合法 JSON: ${RESP}" >&2
+  exit 1
+fi
+if [ "$CODE" != "0" ]; then
+  echo "推送失败，code=${CODE}，响应: ${RESP}" >&2
+  exit 1
+fi

--- a/.github/scripts/lark-notify/test/build-card.bats
+++ b/.github/scripts/lark-notify/test/build-card.bats
@@ -1,0 +1,136 @@
+#!/usr/bin/env bats
+
+SCRIPT="${BATS_TEST_DIRNAME}/../build-card.sh"
+
+@test "issue opened: green header" {
+  export NOTIFY_KIND="issue_opened"
+  export TITLE="#12 修复登录崩溃"
+  export REPO="NeuroAIHub/BrainPilot"
+  export ACTOR="HaoxuanLiTHUAI"
+  export URL="https://github.com/NeuroAIHub/BrainPilot/issues/12"
+  export BODY=""
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e . >/dev/null
+  [ "$(echo "$output" | jq -r '.msg_type')" = "interactive" ]
+  [ "$(echo "$output" | jq -r '.card.header.template')" = "green" ]
+  [ "$(echo "$output" | jq -r '.card.header.title.content')" = "🟢 新 Issue" ]
+}
+
+@test "issue closed: red header" {
+  export NOTIFY_KIND="issue_closed" TITLE="#1 x" REPO="r" ACTOR="a" URL="u" BODY=""
+  run bash "$SCRIPT"
+  [ "$(echo "$output" | jq -r '.card.header.template')" = "red" ]
+  [ "$(echo "$output" | jq -r '.card.header.title.content')" = "🔴 Issue 已关闭" ]
+}
+
+@test "issue comment: blue header" {
+  export NOTIFY_KIND="issue_comment" TITLE="#1 x" REPO="r" ACTOR="a" URL="u" BODY="hi"
+  run bash "$SCRIPT"
+  [ "$(echo "$output" | jq -r '.card.header.template')" = "blue" ]
+  [ "$(echo "$output" | jq -r '.card.header.title.content')" = "🔵 Issue 新评论" ]
+}
+
+@test "pr comment: blue header" {
+  export NOTIFY_KIND="pr_comment" TITLE="#2 y" REPO="r" ACTOR="a" URL="u" BODY="hi"
+  run bash "$SCRIPT"
+  [ "$(echo "$output" | jq -r '.card.header.template')" = "blue" ]
+  [ "$(echo "$output" | jq -r '.card.header.title.content')" = "🔵 PR 新评论" ]
+}
+
+@test "pr opened: green" {
+  export NOTIFY_KIND="pr_opened" TITLE="#2 y" REPO="r" ACTOR="a" URL="u" BODY=""
+  run bash "$SCRIPT"
+  [ "$(echo "$output" | jq -r '.card.header.template')" = "green" ]
+  [ "$(echo "$output" | jq -r '.card.header.title.content')" = "🟢 新 PR" ]
+}
+
+@test "pr merged: green" {
+  export NOTIFY_KIND="pr_merged" TITLE="#2 y" REPO="r" ACTOR="a" URL="u" BODY=""
+  run bash "$SCRIPT"
+  [ "$(echo "$output" | jq -r '.card.header.template')" = "green" ]
+  [ "$(echo "$output" | jq -r '.card.header.title.content')" = "🟢 PR 已合并" ]
+}
+
+@test "pr closed unmerged: red" {
+  export NOTIFY_KIND="pr_closed" TITLE="#2 y" REPO="r" ACTOR="a" URL="u" BODY=""
+  run bash "$SCRIPT"
+  [ "$(echo "$output" | jq -r '.card.header.template')" = "red" ]
+  [ "$(echo "$output" | jq -r '.card.header.title.content')" = "🔴 PR 已关闭(未合并)" ]
+}
+
+@test "pr ready for review: blue" {
+  export NOTIFY_KIND="pr_ready" TITLE="#2 y" REPO="r" ACTOR="a" URL="u" BODY=""
+  run bash "$SCRIPT"
+  [ "$(echo "$output" | jq -r '.card.header.template')" = "blue" ]
+  [ "$(echo "$output" | jq -r '.card.header.title.content')" = "🔵 PR 转为可评审" ]
+}
+
+@test "review requested: blue" {
+  export NOTIFY_KIND="review_requested" TITLE="#2 y" REPO="r" ACTOR="a" URL="u" BODY=""
+  run bash "$SCRIPT"
+  [ "$(echo "$output" | jq -r '.card.header.template')" = "blue" ]
+  [ "$(echo "$output" | jq -r '.card.header.title.content')" = "🔵 请求评审" ]
+}
+
+@test "review approved: green" {
+  export NOTIFY_KIND="review_approved" TITLE="#2 y" REPO="r" ACTOR="a" URL="u" BODY=""
+  run bash "$SCRIPT"
+  [ "$(echo "$output" | jq -r '.card.header.template')" = "green" ]
+  [ "$(echo "$output" | jq -r '.card.header.title.content')" = "🟢 评审已通过" ]
+}
+
+@test "review changes_requested: red" {
+  export NOTIFY_KIND="review_changes" TITLE="#2 y" REPO="r" ACTOR="a" URL="u" BODY=""
+  run bash "$SCRIPT"
+  [ "$(echo "$output" | jq -r '.card.header.template')" = "red" ]
+  [ "$(echo "$output" | jq -r '.card.header.title.content')" = "🔴 评审请求修改" ]
+}
+
+@test "review commented: yellow" {
+  export NOTIFY_KIND="review_commented" TITLE="#2 y" REPO="r" ACTOR="a" URL="u" BODY=""
+  run bash "$SCRIPT"
+  [ "$(echo "$output" | jq -r '.card.header.template')" = "yellow" ]
+  [ "$(echo "$output" | jq -r '.card.header.title.content')" = "🟡 评审评论" ]
+}
+
+@test "body present: appended into content" {
+  export NOTIFY_KIND="issue_comment" TITLE="#1 x" REPO="r" ACTOR="a" URL="u" BODY="这是一条评论"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  content="$(echo "$output" | jq -r '.card.elements[0].text.content')"
+  echo "$content" | grep -q "这是一条评论"
+}
+
+@test "body empty: no separator line" {
+  export NOTIFY_KIND="pr_opened" TITLE="#2 y" REPO="r" ACTOR="a" URL="u" BODY=""
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  content="$(echo "$output" | jq -r '.card.elements[0].text.content')"
+  ! echo "$content" | grep -q "┄"
+}
+
+@test "body over 200 chars: summary is exactly 200 chars ending in ellipsis" {
+  long="$(printf '中%.0s' {1..300})"
+  export NOTIFY_KIND="issue_comment" TITLE="#1 x" REPO="r" ACTOR="a" URL="u" BODY="$long"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  content="$(echo "$output" | jq -r '.card.elements[0].text.content')"
+  # 取分隔线之后的摘要部分（非贪婪匹配完整 10 字符分隔符 + 换行）
+  summary="${content#*┄┄┄┄┄┄┄┄┄┄$'\n'}"
+  # 摘要必须以省略号结尾
+  [ "${summary: -1}" = "…" ]
+  # 摘要 unicode 字符数必须恰好 200（199 正文 + …）
+  len="$(printf '%s' "$summary" | jq -Rs 'length')"
+  [ "$len" -eq 200 ]
+}
+
+@test "title with asterisks: escaped so bold not broken" {
+  export NOTIFY_KIND="issue_opened" TITLE="#5 fix **bold** and *italic*" REPO="r" ACTOR="a" URL="u" BODY=""
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e . >/dev/null
+  content="$(echo "$output" | jq -r '.card.elements[0].text.content')"
+  # raw asterisks from the title must be backslash-escaped in the output
+  echo "$content" | grep -q 'fix \\\*\\\*bold\\\*\\\*'
+}

--- a/.github/scripts/lark-notify/test/dispatch.bats
+++ b/.github/scripts/lark-notify/test/dispatch.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+
+DIR="${BATS_TEST_DIRNAME}/.."
+SCRIPT="$DIR/dispatch.sh"
+
+setup() {
+  TMP="$(mktemp -d)"
+  cat > "$TMP/send.sh" <<EOF
+#!/usr/bin/env bash
+cat > "$TMP/sent.json"
+EOF
+  chmod +x "$TMP/send.sh"
+  export LARK_NOTIFY_SEND_BIN="$TMP/send.sh"
+}
+teardown() { rm -rf "$TMP"; }
+
+@test "issue_opened maps issue fields into card title with number" {
+  export NOTIFY_KIND="issue_opened" REPO="NeuroAIHub/BrainPilot"
+  export ISSUE_NUM="12" ISSUE_TITLE="登录崩溃" ISSUE_URL="https://x/issues/12" ISSUE_USER="alice"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  title="$(jq -r '.card.elements[0].text.content' "$TMP/sent.json")"
+  echo "$title" | grep -q "#12 登录崩溃"
+  echo "$title" | grep -q "alice"
+  [ "$(jq -r '.card.elements[1].actions[0].url' "$TMP/sent.json")" = "https://x/issues/12" ]
+}
+
+@test "pr_comment uses comment fields and pr number" {
+  export NOTIFY_KIND="pr_comment" REPO="r"
+  export PR_NUM="7" ISSUE_TITLE="" PR_TITLE=""
+  export ISSUE_NUM="7"
+  export COMMENT_BODY="LGTM" COMMENT_URL="https://x/pull/7#c1" COMMENT_USER="bob"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  content="$(jq -r '.card.elements[0].text.content' "$TMP/sent.json")"
+  echo "$content" | grep -q "LGTM"
+  echo "$content" | grep -q "bob"
+}
+
+@test "review_approved uses review fields" {
+  export NOTIFY_KIND="review_approved" REPO="r"
+  export PR_NUM="7" PR_TITLE="加功能" PR_URL="https://x/pull/7"
+  export REVIEW_BODY="nice" REVIEW_URL="https://x/pull/7#r1" REVIEW_USER="carol"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  content="$(jq -r '.card.elements[0].text.content' "$TMP/sent.json")"
+  echo "$content" | grep -q "carol"
+  [ "$(jq -r '.card.elements[1].actions[0].url' "$TMP/sent.json")" = "https://x/pull/7#r1" ]
+}

--- a/.github/scripts/lark-notify/test/send.bats
+++ b/.github/scripts/lark-notify/test/send.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+
+SCRIPT="${BATS_TEST_DIRNAME}/../send.sh"
+
+setup() {
+  TMP="$(mktemp -d)"
+  cat > "$TMP/curl" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "$ARGS_FILE"
+prev=""
+for a in "$@"; do
+  case "$prev" in
+    --data|--data-binary|-d)
+      f="${a#@}"; [ -f "$f" ] && cat "$f" > "$BODY_FILE" ;;
+  esac
+  prev="$a"
+done
+echo '{"code":0,"msg":"success"}'
+EOF
+  chmod +x "$TMP/curl"
+  export PATH="$TMP:$PATH"
+  export ARGS_FILE="$TMP/args" BODY_FILE="$TMP/body"
+  : > "$ARGS_FILE"; : > "$BODY_FILE"
+}
+
+teardown() { rm -rf "$TMP"; }
+
+@test "no secret: body has no timestamp or sign, has card" {
+  export LARK_WEBHOOK_URL="https://example.invalid/hook"
+  unset LARK_WEBHOOK_SECRET || true
+  run bash -c 'echo '\''{"msg_type":"interactive","card":{"x":1}}'\'' | bash "'"$SCRIPT"'"'
+  [ "$status" -eq 0 ]
+  run cat "$BODY_FILE"
+  [ "$(echo "$output" | jq -r '.timestamp // "none"')" = "none" ]
+  [ "$(echo "$output" | jq -r '.sign // "none"')" = "none" ]
+  [ "$(echo "$output" | jq -r '.msg_type')" = "interactive" ]
+}
+
+@test "with secret: body has timestamp and base64 sign" {
+  export LARK_WEBHOOK_URL="https://example.invalid/hook"
+  export LARK_WEBHOOK_SECRET="mysecret"
+  run bash -c 'echo '\''{"msg_type":"interactive","card":{"x":1}}'\'' | bash "'"$SCRIPT"'"'
+  [ "$status" -eq 0 ]
+  run cat "$BODY_FILE"
+  ts="$(echo "$output" | jq -r '.timestamp')"
+  sign="$(echo "$output" | jq -r '.sign')"
+  [ -n "$ts" ] && [ "$ts" != "null" ]
+  [ -n "$sign" ] && [ "$sign" != "null" ]
+  echo "$sign" | base64 -d >/dev/null 2>&1
+}
+
+@test "posts to configured URL with json content-type" {
+  export LARK_WEBHOOK_URL="https://example.invalid/hook"
+  unset LARK_WEBHOOK_SECRET || true
+  run bash -c 'echo '\''{"msg_type":"interactive","card":{}}'\'' | bash "'"$SCRIPT"'"'
+  [ "$status" -eq 0 ]
+  grep -q "https://example.invalid/hook" "$ARGS_FILE"
+  grep -q "Content-Type: application/json" "$ARGS_FILE"
+}
+
+@test "non-zero business code: exits 1" {
+  # override the mock curl to return a failure code
+  cat > "$TMP/curl" <<'EOF'
+#!/usr/bin/env bash
+echo '{"code":19021,"msg":"sign match fail"}'
+EOF
+  chmod +x "$TMP/curl"
+  export LARK_WEBHOOK_URL="https://example.invalid/hook"
+  unset LARK_WEBHOOK_SECRET || true
+  run bash -c 'echo '\''{"msg_type":"interactive","card":{}}'\'' | bash "'"$SCRIPT"'"'
+  [ "$status" -eq 1 ]
+}

--- a/.github/workflows/lark-notify-test.yml
+++ b/.github/workflows/lark-notify-test.yml
@@ -1,0 +1,29 @@
+name: Lark Notify Tests
+
+on:
+  pull_request:
+    paths:
+      - '.github/scripts/lark-notify/**'
+      - '.github/workflows/lark-notify*.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.github/scripts/lark-notify/**'
+      - '.github/workflows/lark-notify*.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  bats:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install bats
+        run: sudo apt-get update && sudo apt-get install -y bats jq
+      - name: Run script tests
+        run: bats .github/scripts/lark-notify/test/
+      - name: Validate workflow YAML
+        run: |
+          python3 -c "import yaml; yaml.safe_load(open('.github/workflows/lark-notify.yml')); print('lark-notify.yml OK')"
+          python3 -c "import yaml; yaml.safe_load(open('.github/workflows/lark-notify-test.yml')); print('lark-notify-test.yml OK')"

--- a/.github/workflows/lark-notify.yml
+++ b/.github/workflows/lark-notify.yml
@@ -1,0 +1,97 @@
+name: Lark Notify
+
+# 安全：PR 事件用 pull_request_target（在 base 仓上下文运行、可拿 secret，
+# 使公开后外部 fork PR 也能推群）。严守边界：本 workflow 绝不 checkout/执行 PR
+# 代码，只读 github.event.pull_request.* 元数据；PR 文本只经环境变量+jq 当数据；
+# permissions 收最小。详见 spec §10.2。
+on:
+  issues:
+    types: [opened, closed]
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, ready_for_review, review_requested]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (base branch scripts only)
+        # pull_request_target 下默认 checkout 的是 base 分支（可信 main）上的脚本，
+        # 不是 PR head。绝不加 ref: PR head —— 那会引入 pwn request 漏洞。
+        uses: actions/checkout@v4
+
+      - name: Decide notification kind
+        id: kind
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          ACTION: ${{ github.event.action }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
+          REVIEW_STATE: ${{ github.event.review.state }}
+          IS_PR_COMMENT: ${{ github.event.issue.pull_request != null }}
+        run: |
+          KIND=""
+          case "$EVENT_NAME" in
+            issues)
+              [ "$ACTION" = "opened" ] && KIND="issue_opened"
+              [ "$ACTION" = "closed" ] && KIND="issue_closed"
+              ;;
+            issue_comment)
+              if [ "$ACTION" = "created" ]; then
+                if [ "$IS_PR_COMMENT" = "true" ]; then KIND="pr_comment"; else KIND="issue_comment"; fi
+              fi
+              ;;
+            pull_request_target)
+              case "$ACTION" in
+                opened) KIND="pr_opened" ;;
+                ready_for_review) KIND="pr_ready" ;;
+                review_requested) KIND="review_requested" ;;
+                closed) [ "$PR_MERGED" = "true" ] && KIND="pr_merged" || KIND="pr_closed" ;;
+              esac
+              ;;
+            pull_request_review)
+              if [ "$ACTION" = "submitted" ]; then
+                case "$REVIEW_STATE" in
+                  approved) KIND="review_approved" ;;
+                  changes_requested) KIND="review_changes" ;;
+                  commented) KIND="review_commented" ;;
+                esac
+              fi
+              ;;
+          esac
+          echo "kind=$KIND" >> "$GITHUB_OUTPUT"
+          if [ -z "$KIND" ]; then echo "无匹配通知类型，跳过"; fi
+
+      - name: Build & send card
+        if: steps.kind.outputs.kind != ''
+        env:
+          NOTIFY_KIND: ${{ steps.kind.outputs.kind }}
+          REPO: ${{ github.repository }}
+          LARK_WEBHOOK_URL: ${{ secrets.LARK_WEBHOOK_URL }}
+          LARK_WEBHOOK_SECRET: ${{ secrets.LARK_WEBHOOK_SECRET }}
+          # issue
+          ISSUE_NUM: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_USER: ${{ github.event.issue.user.login }}
+          # comment
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_URL: ${{ github.event.comment.html_url }}
+          COMMENT_USER: ${{ github.event.comment.user.login }}
+          # pr
+          PR_NUM: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_USER: ${{ github.event.pull_request.user.login }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          # review
+          REVIEW_BODY: ${{ github.event.review.body }}
+          REVIEW_URL: ${{ github.event.review.html_url }}
+          REVIEW_USER: ${{ github.event.review.user.login }}
+        run: |
+          bash .github/scripts/lark-notify/dispatch.sh


### PR DESCRIPTION
## 这是什么

事件驱动的团队通知:**issue/PR 变动时,GitHub Actions 构造飞书交互卡片,POST 到开发者群的自定义机器人 webhook**。零自建服务器,逻辑全在 GitHub 托管 runner。

## 覆盖的事件(12 类)

- **Issue**:opened / closed / 评论
- **PR**:opened / merged / closed(未合并) / 转 ready / 请求评审 / 评论
- **评审提交**:通过 / 请求修改 / 评论

彩色交互卡片(中文标签,绿/红/蓝/黄按事件类型),评论显示 ≤200 字摘要,卡片带「在 GitHub 查看」按钮。

## 合并后需要做的配置(否则不发消息)

1. 飞书目标群 → 添加「自定义机器人」→ 复制 Webhook 地址(可选开签名校验拿密钥)
2. 仓库 Settings → Secrets and variables → Actions 添加:
   - `LARK_WEBHOOK_URL`(必填)
   - `LARK_WEBHOOK_SECRET`(仅开启签名校验时)

> ⚠️ workflow 只在**默认分支 main** 上才会接收 issue/PR 事件,所以需合并本 PR 后生效。

## 安全

- PR 事件用 `pull_request_target`,使**开源后外部 fork PR 也能推群**;安全前提:绝不 checkout/执行 PR 代码、PR 文本只当数据经 env+`jq --arg`、`permissions: contents: read`、secret 只存 GitHub Secret(workflow 仅含 `\${{ secrets.* }}` 占位)。
- 详见 `.github/scripts/lark-notify/README.md` 的「转 public 前 checklist」。

## 测试

- 23 个 bats 单测(build-card / send / dispatch),覆盖 12 类映射、签名(HMAC-SHA256 三方法交叉验证)、200 字截断、标题转义、非零返回码退出、PR评论vs Issue评论区分等
- 新增 CI workflow `lark-notify-test.yml`:PR/push 改动脚本或 workflow 时自动跑 bats + 校验 YAML
- 全套在本地(bash 3.2.57)与目标仓克隆中均 23/23 通过

## 文件(全在 .github/ 下,自洽)

```
.github/scripts/lark-notify/{build-card,send,dispatch}.sh
.github/scripts/lark-notify/test/{build-card,send,dispatch}.bats
.github/scripts/lark-notify/README.md
.github/workflows/{lark-notify,lark-notify-test}.yml
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)