### PR TITLE
feat(runtime): app-controlled session skills, drop host-global discovery

### DIFF
--- a/packages/cli/src/paths.ts
+++ b/packages/cli/src/paths.ts
@@ -38,6 +38,7 @@ export interface DataPaths {
   bpTemplateAgents: string;
   bpTemplateSettings: string;
   bpTemplateMcpServers: string;
+  bpTemplateSkills: string;
   bp: string;
   workspaces: string;
   brainpilotConfig: string;
@@ -61,6 +62,7 @@ export function dataPaths(dataDir: string): DataPaths {
     bpTemplateAgents: join(bpTemplate, "agents"),
     bpTemplateSettings: join(bpTemplate, "settings.json"),
     bpTemplateMcpServers: join(bpTemplate, "mcp_servers.json"),
+    bpTemplateSkills: join(bpTemplate, "skills"),
     bp: join(dataDir, ".bp"),
     workspaces: join(dataDir, "workspaces"),
     brainpilotConfig: join(dataDir, "brainpilot.config.json"),

--- a/packages/cli/src/scaffold.test.ts
+++ b/packages/cli/src/scaffold.test.ts
@@ -33,6 +33,9 @@ describe("scaffold", () => {
     expect(await exists(join(paths.bpTemplateAgents, "principal", "manifest.json"))).toBe(true);
     expect(await exists(paths.bpTemplateSettings)).toBe(true);
     expect(await exists(paths.bpTemplateMcpServers)).toBe(true);
+    expect(await exists(paths.bpTemplateSkills)).toBe(true);
+    expect(await exists(join(paths.bpTemplateSkills, "README.md"))).toBe(true);
+    expect(await exists(join(paths.bpTemplateSkills, "example.md"))).toBe(true);
     expect(await exists(paths.brainpilotConfig)).toBe(true);
     expect(await exists(paths.bp)).toBe(true);
     expect(await exists(paths.workspaces)).toBe(true);

--- a/packages/cli/src/scaffold.ts
+++ b/packages/cli/src/scaffold.ts
@@ -84,6 +84,60 @@ const TEMPLATE_MCP_EXAMPLE = JSON.stringify(
   2,
 );
 
+/**
+ * README for `bp_template/skills/` — explains the app-controlled skill dir.
+ * BrainPilot loads skills ONLY from this template dir (shared by every session)
+ * and each session's own `.bp/<id>/skills/`; the host-global `~/.pi/agent/skills`
+ * is intentionally NOT loaded (`noSkills: true`), so agent behaviour stays
+ * reproducible across machines.
+ */
+const SKILLS_README = `# BrainPilot skills
+
+Drop Agent Skills here to extend what the agents can do. Everything in this
+folder is shared by **every session** in this data dir.
+
+Two ways to add a skill:
+
+1. A single Markdown file — \`my-skill.md\` (loaded as one skill).
+2. A folder containing \`SKILL.md\` — \`my-skill/SKILL.md\` (the folder is the
+   skill root; supporting files can live alongside it).
+
+Each skill starts with YAML frontmatter:
+
+\`\`\`markdown
+---
+name: my-skill
+description: One line telling the model when to use this skill.
+# disable-model-invocation: true   # hide from the prompt; only /skill:my-skill
+---
+
+Instructions the agent follows when this skill is invoked.
+\`\`\`
+
+Notes:
+- Skills without \`disable-model-invocation\` are injected into the system prompt,
+  so the model can invoke them autonomously.
+- Per-session overrides go in \`.bp/<session-id>/skills/\` (same rules).
+- The host's global \`~/.pi/agent/skills\` is **not** loaded — only this dir.
+`;
+
+/** A disabled-by-default example skill so the template dir is self-documenting. */
+const EXAMPLE_SKILL = `---
+name: example
+description: Example skill template. Replace with your own; remove disable-model-invocation to let the model use it.
+disable-model-invocation: true
+---
+
+# Example skill
+
+This is a placeholder skill shipped with BrainPilot's scaffold. It is hidden
+from the model (\`disable-model-invocation: true\`) so it never affects real runs.
+
+To create your own skill, copy this file, rename it, write a clear
+\`description:\` (the model reads it to decide when to use the skill), drop the
+\`disable-model-invocation\` line, and put the instructions below the frontmatter.
+`;
+
 export interface ScaffoldOptions {
   /** Default backend port baked into brainpilot.config.json. */
   port?: number;
@@ -113,6 +167,7 @@ export async function scaffold(
   const principalDir = join(p.bpTemplateAgents, "principal");
   await mkdir(p.dataDir, { recursive: true });
   await mkdir(principalDir, { recursive: true });
+  await mkdir(p.bpTemplateSkills, { recursive: true });
   await mkdir(p.bp, { recursive: true });
   await mkdir(p.workspaces, { recursive: true });
   await mkdir(p.logsDir, { recursive: true });
@@ -127,6 +182,9 @@ export async function scaffold(
     [join(p.bpTemplate, "settings.example.json"), TEMPLATE_SETTINGS_EXAMPLE],
     [p.bpTemplateMcpServers, TEMPLATE_MCP_EXAMPLE],
     [join(p.bpTemplate, "mcp_servers.example.json"), TEMPLATE_MCP_EXAMPLE],
+    // ③a app-controlled skills (loaded instead of host-global ~/.pi/agent/skills).
+    [join(p.bpTemplateSkills, "README.md"), SKILLS_README],
+    [join(p.bpTemplateSkills, "example.md"), EXAMPLE_SKILL],
     // ④ CLI global config.
     [
       p.brainpilotConfig,

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -51,6 +51,23 @@ describe("SessionManager (mock mode)", () => {
     const agents = m.listAgents(s.id);
     expect(agents.map((a) => a.name)).toContain("principal");
   });
+
+  it("passes app-controlled skill dirs (template + session) to the factory", async () => {
+    const seen: string[][] = [];
+    const spyFactory: typeof mockAgentFactory = async (params) => {
+      seen.push(params.skillPaths);
+      return mockAgentFactory(params);
+    };
+    const sm = new SessionManager({ persist: false, agentFactory: spyFactory });
+    const s = await sm.createSession();
+    await sm.sendMessage(s.id, "hi");
+    await waitFor(() => seen.length > 0);
+
+    expect(seen[0]).toHaveLength(2);
+    // shared template dir + this session's own dir.
+    expect(seen[0][0]).toMatch(/bp_template[/\\]skills$/);
+    expect(seen[0][1]).toMatch(new RegExp(`\\.bp[/\\\\]${s.id}[/\\\\]skills$`));
+  });
 });
 
 async function waitFor(pred: () => boolean, timeoutMs = 2000): Promise<void> {

--- a/packages/runtime/src/agent-factory.ts
+++ b/packages/runtime/src/agent-factory.ts
@@ -48,11 +48,21 @@ export const realAgentFactory: AgentSessionFactory = async (params) => {
   // `createAgentSession` has NO `systemPrompt`/`instructions` option — the
   // per-role persona is injected through a DefaultResourceLoader. We use
   // `appendSystemPrompt` (NOT `systemPrompt`) so Pi's built-in tool-calling
-  // guidance is preserved and our role persona is appended after it. Custom
-  // loaders are NOT auto-reloaded by the SDK, so we must reload() before use.
+  // guidance is preserved and our role persona is appended after it.
+  //
+  // Skills: Pi's DefaultResourceLoader otherwise auto-discovers skills from the
+  // HOST machine's global dirs (~/.pi/agent/skills, ~/.agents/skills), which
+  // makes agent behaviour depend on whoever runs the runtime — not reproducible.
+  // We set `noSkills: true` to drop that implicit discovery and load skills ONLY
+  // from BrainPilot's own app-controlled dirs (`bp_template/skills/` shared +
+  // `.bp/<sid>/skills/` per-session, passed as `skillPaths`). `additionalSkillPaths`
+  // bypasses Pi's project-trust gate, so this works in our non-interactive runtime.
+  // Custom loaders are NOT auto-reloaded by the SDK, so we must reload() before use.
   const resourceLoader = new DefaultResourceLoader({
     cwd: params.cwd,
     agentDir,
+    noSkills: true,
+    additionalSkillPaths: params.skillPaths,
     appendSystemPrompt: params.systemPrompt ? [params.systemPrompt] : [],
   });
   await resourceLoader.reload();
@@ -148,6 +158,10 @@ interface PiSdk {
     agentDir: string;
     appendSystemPrompt?: string[];
     systemPrompt?: string;
+    /** Drop host-global skill auto-discovery (~/.pi/agent/skills, etc.). */
+    noSkills?: boolean;
+    /** Explicit skill dirs/files; loaded even when noSkills is true, and not trust-gated. */
+    additionalSkillPaths?: string[];
   }) => { reload(): Promise<void> };
   getAgentDir(): string;
   AuthStorage: { create(path: string): unknown };

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -106,6 +106,14 @@ export class SessionManager {
   private historyPath(sid: string, agent: string): string {
     return join(this.bpDir(sid), "history", `${agent}.jsonl`);
   }
+  /** Skills shared by every session (user-editable `bp_template/skills/`). */
+  private templateSkillsDir(): string {
+    return join(this.dataRoot, "bp_template", "skills");
+  }
+  /** This session's own skill dir (`.bp/<sid>/skills/`), overrides/augments the template. */
+  private sessionSkillsDir(sid: string): string {
+    return join(this.bpDir(sid), "skills");
+  }
 
   /* ---------------------------- session CRUD ---------------------------- */
 
@@ -138,6 +146,7 @@ export class SessionManager {
 
     if (this.persist) {
       await mkdir(join(this.bpDir(id), "history"), { recursive: true });
+      await mkdir(this.sessionSkillsDir(id), { recursive: true });
       await mkdir(this.workspaceDir(id), { recursive: true });
       await this.writeMeta(entry);
       await mailbox.recover();
@@ -261,6 +270,7 @@ export class SessionManager {
       systemTools: agentTools,
       allowedToolNames,
       systemPrompt: `You are the ${name} agent (${role}).`,
+      skillPaths: [this.templateSkillsDir(), this.sessionSkillsDir(sessionId)],
     });
 
     const agent = new MasAgent({

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -107,6 +107,12 @@ export type AgentSessionFactory = (params: {
   allowedToolNames: string[];
   /** System prompt for the agent. */
   systemPrompt: string;
+  /**
+   * App-controlled skill directories loaded for this agent (template dir shared
+   * by all sessions + this session's own dir). Replaces the host-global skill
+   * discovery — see agent-factory `noSkills: true`.
+   */
+  skillPaths: string[];
 }) => Promise<IAgentSession>;
 
 /**


### PR DESCRIPTION
## Problem

Pi's `DefaultResourceLoader` auto-discovers Agent Skills from the **host machine's** global dirs (`~/.pi/agent/skills`, `~/.agents/skills`) by default. Our runtime used a bare loader, so:

- Agent behaviour silently depended on whoever ran the runtime → **not reproducible** across machines / CI.
- It contradicted BrainPilot's design where personas are injected **explicitly** via `appendSystemPrompt`; skills were leaking in implicitly.

(Confirmed against Pi SDK 0.79.1 source: `noSkills` defaults to `false`, and `DefaultResourceLoader.reload()` scans the host-global dirs automatically.)

## Change

Load skills **only** from BrainPilot's own, app-controlled dirs:

| Dir | Scope |
|-----|-------|
| `bp_template/skills/` | user-editable, **shared by every session** |
| `.bp/<session-id>/skills/` | per-session override |

- **agent-factory**: `noSkills: true` (drop host-global discovery) + `additionalSkillPaths: params.skillPaths`. `additionalSkillPaths` bypasses Pi's project-trust gate, so it works in our non-interactive runtime.
- **session-manager**: computes the two skill dirs and passes them as `skillPaths`; the per-session dir is created at scaffold time.
- **scaffold**: materializes `bp_template/skills/` with a `README.md` and a disabled-by-default `example.md` so the dir is self-documenting.
- **types**: `AgentSessionFactory` params gain `skillPaths: string[]`.

Skills dropped in these dirs (without `disable-model-invocation`) are injected into the system prompt for autonomous model invocation, exactly as before — only the **source** changed from host-global to app-controlled. Drop-in usage: put a `my-skill.md` (or `my-skill/SKILL.md`) into `bp_template/skills/`.

## Verification

- `npm run typecheck` ✅
- Full suite **220 passing** ✅ (new: scaffold creates the skills dir + files; session-manager passes both skill dirs to the factory)
- E2E: `brainpilot init` scaffolds `bp_template/skills/` with README + example ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)