### PR TITLE
feat(runtime): real per-agent personas + load prompt.md from disk

### DIFF
--- a/packages/cli/src/scaffold.test.ts
+++ b/packages/cli/src/scaffold.test.ts
@@ -45,6 +45,32 @@ describe("scaffold", () => {
     expect(await isScaffolded(root)).toBe(true);
   });
 
+  it("scaffolds prompt.md + manifest.json for every built-in agent", async () => {
+    const root = join(dir, "brainpilot");
+    const { paths } = await scaffold(root);
+    for (const name of ["principal", "librarian", "experimentalist", "engineer", "writer", "trace"]) {
+      const agentDir = join(paths.bpTemplateAgents, name);
+      expect(await exists(join(agentDir, "prompt.md")), `${name}/prompt.md`).toBe(true);
+      expect(await exists(join(agentDir, "manifest.json")), `${name}/manifest.json`).toBe(true);
+      const prompt = await readFile(join(agentDir, "prompt.md"), "utf8");
+      expect(prompt, name).not.toContain("mcp__builtin__");
+    }
+  });
+
+  it("engineer manifest grants write + bash; librarian does not", async () => {
+    const { paths } = await scaffold(join(dir, "bp"));
+    const eng = JSON.parse(
+      await readFile(join(paths.bpTemplateAgents, "engineer", "manifest.json"), "utf8"),
+    );
+    expect(eng.role).toBe("expert");
+    expect(eng.allowedTools).toEqual(expect.arrayContaining(["write", "bash", "send_message"]));
+    const lib = JSON.parse(
+      await readFile(join(paths.bpTemplateAgents, "librarian", "manifest.json"), "utf8"),
+    );
+    expect(lib.allowedTools).not.toContain("write");
+    expect(lib.allowedTools).not.toContain("bash");
+  });
+
   it("bakes the port into brainpilot.config.json", async () => {
     const { paths } = await scaffold(join(dir, "bp"), { port: 9100 });
     const cfg = JSON.parse(await readFile(paths.brainpilotConfig, "utf8"));

--- a/packages/cli/src/scaffold.ts
+++ b/packages/cli/src/scaffold.ts
@@ -10,6 +10,13 @@
 import { mkdir, writeFile, access } from "node:fs/promises";
 import { constants as FS } from "node:fs";
 import { join } from "node:path";
+import {
+  PERSONAS,
+  BUILTIN_PERSONA_NAMES,
+  AGENT_TOOL_CONFIG,
+  BUILTIN_TOOL_CONFIG,
+  BUILTIN_TOOL_CONFIG_BY_NAME,
+} from "@brainpilot/runtime";
 import { dataPaths, type DataPaths } from "./paths.js";
 
 /** Default backend port (§11A.5 决策 D). Runtime uses port+1 (stride-2 §16). */
@@ -31,16 +38,47 @@ async function writeIfAbsent(path: string, content: string): Promise<boolean> {
   return true;
 }
 
-/** Default principal agent prompt — minimal, user-editable. */
-const PRINCIPAL_PROMPT = `# Principal Agent (PI)
+/**
+ * Per-agent persona text, sourced from the runtime's single-source-of-truth
+ * `PERSONAS` registry so the scaffolded, user-editable copies never drift from
+ * the built-in defaults the runtime falls back to.
+ */
+const AGENT_PROMPTS: Record<string, string> = PERSONAS;
 
-You are the Principal Investigator — the user-facing orchestrator of the
-BrainPilot multi-agent system. You decompose the user's request, delegate to
-expert agents via \`send_message\`, and synthesize their results into a final
-answer.
+/** Roles by agent name (mirrors `roleFor` in the runtime). */
+function roleForName(name: string): string {
+  if (name === "principal") return "principal";
+  if (name === "trace") return "trace";
+  return "expert";
+}
 
-Keep the user informed of progress. Be concise and rigorous.
-`;
+/** Full tool allowlist (system + builtin) an agent is granted, for the manifest. */
+function allowedToolsForName(name: string): string[] {
+  const role = roleForName(name);
+  const sys =
+    role === "principal"
+      ? AGENT_TOOL_CONFIG.principal!
+      : role === "trace"
+        ? AGENT_TOOL_CONFIG.trace!
+        : (AGENT_TOOL_CONFIG[name] ?? AGENT_TOOL_CONFIG.expert!);
+  const builtin =
+    role === "expert"
+      ? (BUILTIN_TOOL_CONFIG_BY_NAME[name] ?? BUILTIN_TOOL_CONFIG.expert!)
+      : (BUILTIN_TOOL_CONFIG[role] ?? BUILTIN_TOOL_CONFIG._default!);
+  return [...sys, ...builtin];
+}
+
+function agentManifest(name: string): string {
+  return JSON.stringify(
+    {
+      role: roleForName(name),
+      parent: name === "principal" ? null : "principal",
+      allowedTools: allowedToolsForName(name),
+    },
+    null,
+    2,
+  );
+}
 
 const PRINCIPAL_SETTINGS = JSON.stringify(
   {
@@ -48,16 +86,6 @@ const PRINCIPAL_SETTINGS = JSON.stringify(
     model: "claude-sonnet-4-6",
     timeoutMs: 120000,
     maxRetries: 2,
-  },
-  null,
-  2,
-);
-
-const PRINCIPAL_MANIFEST = JSON.stringify(
-  {
-    role: "principal",
-    parent: null,
-    allowedTools: ["send_message", "create_agent", "destroy_agent", "record_trace"],
   },
   null,
   2,
@@ -164,19 +192,30 @@ export async function scaffold(
   const created: string[] = [];
 
   // ① Directory skeleton.
-  const principalDir = join(p.bpTemplateAgents, "principal");
   await mkdir(p.dataDir, { recursive: true });
-  await mkdir(principalDir, { recursive: true });
+  await mkdir(p.bpTemplateAgents, { recursive: true });
   await mkdir(p.bpTemplateSkills, { recursive: true });
   await mkdir(p.bp, { recursive: true });
   await mkdir(p.workspaces, { recursive: true });
   await mkdir(p.logsDir, { recursive: true });
 
-  // ② Default bp_template/agents/principal/* (user-editable).
-  const writes: Array<[string, string]> = [
-    [join(principalDir, "prompt.md"), PRINCIPAL_PROMPT],
-    [join(principalDir, "settings.json"), PRINCIPAL_SETTINGS],
-    [join(principalDir, "manifest.json"), PRINCIPAL_MANIFEST],
+  // ② Default bp_template/agents/<name>/* for every built-in agent
+  //    (user-editable; the runtime loads prompt.md when present, else falls
+  //    back to the same built-in persona this is sourced from).
+  const writes: Array<[string, string]> = [];
+  for (const name of BUILTIN_PERSONA_NAMES) {
+    const dir = join(p.bpTemplateAgents, name);
+    await mkdir(dir, { recursive: true });
+    writes.push([join(dir, "prompt.md"), AGENT_PROMPTS[name]!]);
+    writes.push([join(dir, "manifest.json"), agentManifest(name)]);
+    // Only the principal carries provider/model defaults; experts inherit the
+    // session-level template settings.
+    if (name === "principal") {
+      writes.push([join(dir, "settings.json"), PRINCIPAL_SETTINGS]);
+    }
+  }
+
+  writes.push(
     // ③ session-level template defaults.
     [p.bpTemplateSettings, TEMPLATE_SETTINGS_EXAMPLE],
     [join(p.bpTemplate, "settings.example.json"), TEMPLATE_SETTINGS_EXAMPLE],
@@ -199,7 +238,7 @@ export async function scaffold(
         2,
       ),
     ],
-  ];
+  );
 
   for (const [path, content] of writes) {
     if (await writeIfAbsent(path, content)) created.push(path);

--- a/packages/runtime/src/__tests__/personas.test.ts
+++ b/packages/runtime/src/__tests__/personas.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { PERSONAS, BUILTIN_PERSONA_NAMES, personaFor } from "../personas.js";
+
+describe("personas", () => {
+  const EXPECTED = ["principal", "librarian", "experimentalist", "engineer", "writer", "trace"];
+
+  it("ships a curated persona for every built-in agent", () => {
+    for (const name of EXPECTED) {
+      expect(BUILTIN_PERSONA_NAMES).toContain(name);
+      const p = PERSONAS[name];
+      expect(p, name).toBeTruthy();
+      // Not the old one-line placeholder.
+      expect(p.length, name).toBeGreaterThan(200);
+    }
+  });
+
+  it("uses BARE tool names — never the legacy mcp__builtin__ prefix", () => {
+    for (const [name, p] of Object.entries(PERSONAS)) {
+      expect(p, name).not.toContain("mcp__builtin__");
+    }
+  });
+
+  it("does not reference legacy Docker mount paths", () => {
+    for (const [name, p] of Object.entries(PERSONAS)) {
+      expect(p, name).not.toContain("/workspace");
+      expect(p, name).not.toContain("/root/.claude");
+      expect(p, name).not.toContain("/shared");
+    }
+  });
+
+  it("principal persona is delegation-oriented and names the experts", () => {
+    const p = PERSONAS.principal!;
+    expect(p).toContain("send_message");
+    expect(p).toContain("librarian");
+    expect(p).toContain("engineer");
+    expect(p).toContain("writer");
+    expect(p).toContain("experimentalist");
+  });
+
+  it("expert personas carry the send_message-back contract", () => {
+    for (const name of ["librarian", "engineer", "experimentalist", "writer"]) {
+      expect(PERSONAS[name], name).toContain('send_message(to="principal"');
+    }
+  });
+
+  it("authoring experts mention their write/run capability", () => {
+    expect(PERSONAS.engineer!).toContain("bash");
+    expect(PERSONAS.writer!).toContain("write");
+  });
+
+  it("personaFor falls back to a generic expert persona for unknown agents", () => {
+    const p = personaFor("statistician", "expert");
+    expect(p).toContain("statistician");
+    expect(p).toContain('send_message(to="principal"');
+    expect(p).not.toContain("mcp__builtin__");
+  });
+
+  it("personaFor returns the curated persona when one exists", () => {
+    expect(personaFor("engineer", "expert")).toBe(PERSONAS.engineer);
+  });
+});

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { parseEvent, type AgUiEvent } from "@brainpilot/protocol";
 import { SessionManager } from "../session-manager.js";
 import { mockAgentFactory } from "../agent-factory.js";
@@ -67,6 +70,42 @@ describe("SessionManager (mock mode)", () => {
     // shared template dir + this session's own dir.
     expect(seen[0][0]).toMatch(/bp_template[/\\]skills$/);
     expect(seen[0][1]).toMatch(new RegExp(`\\.bp[/\\\\]${s.id}[/\\\\]skills$`));
+  });
+
+  it("injects the built-in persona (not the old placeholder) for the principal", async () => {
+    const seen: string[] = [];
+    const spyFactory: typeof mockAgentFactory = async (params) => {
+      if (params.agentName === "principal") seen.push(params.systemPrompt);
+      return mockAgentFactory(params);
+    };
+    const sm = new SessionManager({ persist: false, agentFactory: spyFactory });
+    const s = await sm.createSession();
+    await sm.sendMessage(s.id, "hi");
+    await waitFor(() => seen.length > 0);
+
+    expect(seen[0]).toContain("Principal Investigator");
+    expect(seen[0]).not.toMatch(/^You are the principal agent/);
+    expect(seen[0]).not.toContain("mcp__builtin__");
+  });
+
+  it("prefers an on-disk bp_template/agents/<name>/prompt.md override", async () => {
+    const root = await mkdtemp(join(tmpdir(), "bp-persona-"));
+    const promptDir = join(root, "bp_template", "agents", "principal");
+    await mkdir(promptDir, { recursive: true });
+    await writeFile(join(promptDir, "prompt.md"), "# Custom PI\nDo it my way.", "utf8");
+
+    const seen: string[] = [];
+    const spyFactory: typeof mockAgentFactory = async (params) => {
+      if (params.agentName === "principal") seen.push(params.systemPrompt);
+      return mockAgentFactory(params);
+    };
+    const sm = new SessionManager({ dataRoot: root, persist: false, agentFactory: spyFactory });
+    const s = await sm.createSession();
+    await sm.sendMessage(s.id, "hi");
+    await waitFor(() => seen.length > 0);
+
+    expect(seen[0]).toBe("# Custom PI\nDo it my way.");
+    await rm(root, { recursive: true, force: true });
   });
 });
 

--- a/packages/runtime/src/__tests__/tool-access.test.ts
+++ b/packages/runtime/src/__tests__/tool-access.test.ts
@@ -55,4 +55,30 @@ describe("tool access control (§9)", () => {
     expect(builtinToolNamesForRole("expert")).toContain("read");
     expect(builtinToolNamesForRole("trace")).toEqual(["read"]);
   });
+
+  it("authoring experts get write + bash builtins by name", () => {
+    const eng = builtinToolNamesForRole("expert", "engineer");
+    expect(eng).toEqual(expect.arrayContaining(["read", "write", "edit", "bash"]));
+    const exp = builtinToolNamesForRole("expert", "experimentalist");
+    expect(exp).toEqual(expect.arrayContaining(["write", "bash"]));
+  });
+
+  it("writer can write but not run a shell", () => {
+    const w = builtinToolNamesForRole("expert", "writer");
+    expect(w).toContain("write");
+    expect(w).not.toContain("bash");
+  });
+
+  it("librarian stays read-only (no write/bash)", () => {
+    const lib = builtinToolNamesForRole("expert", "librarian");
+    expect(lib).toContain("read");
+    expect(lib).not.toContain("write");
+    expect(lib).not.toContain("bash");
+  });
+
+  it("unknown experts fall back to the lean role default", () => {
+    expect(builtinToolNamesForRole("expert", "statistician").sort()).toEqual(
+      ["find", "grep", "read"].sort(),
+    );
+  });
 });

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -34,8 +34,15 @@ export {
   builtinToolNamesForRole,
   AGENT_TOOL_CONFIG,
   BUILTIN_TOOL_CONFIG,
+  BUILTIN_TOOL_CONFIG_BY_NAME,
 } from "./tools/system-tools.js";
 export type { ToolDeps } from "./tools/system-tools.js";
+
+export {
+  PERSONAS,
+  BUILTIN_PERSONA_NAMES,
+  personaFor,
+} from "./personas.js";
 
 export { createServer, startServer } from "./server.js";
 export type { StartServerOptions } from "./server.js";

--- a/packages/runtime/src/personas.ts
+++ b/packages/runtime/src/personas.ts
@@ -1,0 +1,344 @@
+/**
+ * Per-agent system personas (system prompts), single source of truth.
+ *
+ * These are injected into each agent session via the Pi SDK's
+ * `appendSystemPrompt` (see `agent-factory.ts`) — appended AFTER Pi's built-in
+ * tool-calling guidance, so the model keeps its native tool protocol and gains
+ * our role persona on top.
+ *
+ * Ported and adapted from the legacy `claude/agents/*.md` prompts. THREE
+ * deliberate changes vs. legacy, required by the current architecture:
+ *
+ *  1. Tool names are BARE (`send_message`, `record_trace`, …). Legacy used the
+ *     old Claude-SDK `mcp__builtin__` prefix; Pi registers tools under their
+ *     plain names, so any `mcp__*` reference would break tool calls.
+ *  2. No Docker mount paths (`/workspace`, `/data`, `/shared`, `/root/.claude`).
+ *     Each agent runs with its session workspace as cwd; refer to files by
+ *     relative path.
+ *  3. Capabilities match the REAL tool allowlist (`AGENT_TOOL_CONFIG` /
+ *     `BUILTIN_TOOL_CONFIG` in `tools/system-tools.ts`). Personas only promise
+ *     what the role can actually do.
+ *
+ * Scaffold (`@brainpilot/cli`) writes these out as user-editable
+ * `bp_template/agents/<name>/prompt.md` copies; the runtime loads the on-disk
+ * copy when present and falls back to these constants otherwise.
+ */
+
+/* ----------------------------- shared blocks ----------------------------- */
+
+/** A2A messaging contract — identical mechanics for every non-trace agent. */
+const A2A_EXPERT = `## Communicating back to the Principal
+
+Tasks are delivered to you automatically — you never poll for messages. When
+you finish a task, you MUST report back by calling:
+
+    send_message(to="principal", content="<your complete result>")
+
+This is mandatory. Your plain text output alone does NOT reach the Principal —
+the only channel that delivers a result is the \`send_message\` tool. Do not end
+your turn without it.
+
+If you need input from another agent, \`send_message\` them and then STOP your
+turn. Their reply is delivered to you automatically when they finish; do not try
+to do their work while waiting.
+
+Messages you receive carry a \`<message_envelope>\` header naming the sender
+(\`<source type="user"/>\` or \`<source type="agent" name="principal" .../>\`).
+Read it to know who you are answering.`;
+
+/** Trace self-recording contract — for every expert that produces artifacts. */
+const TRACE_EXPERT = `## Recording your own work
+
+You log your OWN tangible outputs to the Graph of Trace with \`record_trace\`.
+The Principal does not log your work for you — if you don't record it, it won't
+appear in the graph. Call it immediately after you produce a real deliverable
+(a file written, a result computed, a synthesis reached), and right BEFORE the
+\`send_message\` that delivers it, so the trace predates the delivery.
+
+Each call should carry a full-sentence \`description\` (subject + action +
+outcome, not a single word) and a \`context\` explaining why the step mattered.
+Skip process noise — reading one file, a failed attempt you immediately retry,
+or merely acknowledging a task.`;
+
+/* ------------------------------- principal ------------------------------- */
+
+const PRINCIPAL = `# Principal Investigator (PI)
+
+You are the Principal Investigator — the user-facing orchestrator of the
+BrainPilot multi-agent system. You decompose the user's request, delegate to
+expert agents, and synthesize their results into a single rigorous answer.
+
+## Core boundary: coordinate, don't execute
+
+Your value is global coordination, not deep execution. Delegate work that needs
+domain expertise or takes more than a few minutes; handle only lightweight
+framing and synthesis yourself.
+
+**Handle directly:** problem framing with the user, synthesizing findings across
+experts, quality review of their outputs, decisions about next steps, and the
+final response to the user.
+
+**Delegate:**
+- Literature search / background knowledge / hypothesis grounding → \`librarian\`
+- Experiment design, protocol writing, result interpretation → \`experimentalist\`
+- Code implementation, data pipelines, computation, visualization → \`engineer\`
+- Manuscripts, reports, formal documentation → \`writer\`
+
+## Analyze before acting
+
+For any non-trivial request (data analysis, experiment design, implementation,
+or multi-step problem solving), first work out — briefly — the goal, the task
+type, what is known vs. what an expert must supply, and which agent owns each
+piece. Then delegate. Simple Q&A, file inspection, or an explicit "just do X"
+you may answer directly.
+
+## Delegation protocol
+
+Delegate with \`send_message(to="<agent>", content="<task + all context>")\`.
+After delegating you MUST stop your turn and wait — the expert's result is
+delivered back to you automatically as a new message. Do not keep working, do
+not attempt the expert's job, and do not speculate about what they'll return.
+
+- **Sequential** work: delegate one task, wait, process the result, then delegate
+  the next with that result as context.
+- **Parallel** work: send several independent \`send_message\` calls in one turn,
+  then stop; results arrive one at a time as each expert finishes.
+
+${A2A_EXPERT}
+
+## Recording decisions in the Graph of Trace
+
+Call \`record_trace\` for YOUR OWN work — a strategy decision, a delegation, a
+synthesis of multiple expert results, a methodology choice, or approving a
+deliverable. Do NOT record what an expert did; each expert logs its own outputs,
+and the Trace Agent merges your delegation with their completion into one node.
+Recording both yourself just adds noise.
+
+## Keeping the user informed
+
+Show progress and delegation status ("I've asked the librarian to survey X"),
+synthesized findings, decisions, and next steps. State assumptions, rationale,
+and risks for any direction you commit to. Be concise and rigorous.`;
+
+/* ------------------------------- librarian ------------------------------- */
+
+const LIBRARIAN = `# Librarian
+
+You are the knowledge search and synthesis specialist. Your mission is to
+search, read, evaluate, and organize knowledge so the rest of the team can work
+from a clear "what is known / what is unknown" picture.
+
+## Cognitive style
+
+Inductive synthesis across many sources; critical evaluation of quality,
+methodology, and relevance; concept mapping that connects ideas across domains.
+
+## Responsibilities
+
+- **Literature survey:** find relevant work, extract key findings, identify
+  seminal vs. recent advances, and map the landscape of a topic.
+- **Knowledge provision:** explain concepts, translate dense technical material
+  into accessible summaries, bridge gaps between domains.
+- **Hypothesis grounding:** surface knowledge gaps as opportunities and propose
+  hypotheses grounded in the evidence you found.
+
+## Output format
+
+Deliver a structured summary: an overview, bulleted **Key Findings**, explicit
+**Knowledge Gaps** (what's unknown or contradictory), **Suggested Hypotheses**
+grounded in those gaps, and **References**.
+
+## Search tools
+
+When external search/fetch MCP tools are present in your environment, use them —
+they're injected automatically and you don't need their exact server names.
+Read local or cached files with \`read\`/\`grep\`. For live URL fetching beyond
+your tools, ask the \`engineer\` via \`send_message\`. You do not write files or
+run shell commands; if a deliverable must be saved, hand the content to the
+\`engineer\` or return it to the Principal.
+
+${TRACE_EXPERT}
+
+${A2A_EXPERT}`;
+
+/* ---------------------------- experimentalist ---------------------------- */
+
+const EXPERIMENTALIST = `# Experimentalist
+
+You are an experimental scientist specializing in research design and
+validation. You decide WHAT to do scientifically; the \`engineer\` decides HOW to
+implement it in code.
+
+## Cognitive style
+
+Operational thinking (translate theory into concrete procedures), control
+thinking (identify and control confounds), measurement thinking (valid
+operationalization), and iterative refinement based on results.
+
+## Design framework
+
+1. **Operationalization** — turn abstract concepts into measurable variables
+   with explicit operational definitions.
+2. **Control design** — name confounds; design controls, randomization, and
+   balancing.
+3. **Sample planning** — power analysis, sample size justification, inclusion /
+   exclusion criteria.
+4. **Procedure** — a step-by-step protocol with timing and quality checkpoints.
+5. **Analysis plan** — primary outcome measures, secondary analyses, and the
+   statistical tests chosen in advance.
+
+## Output format
+
+Produce a protocol: hypothesis and key variables, subjects and sample-size
+justification, materials, the step-by-step procedure, and the pre-registered
+analysis plan. You may write design documents and run validation scripts; for
+substantial implementation, delegate to the \`engineer\` via \`send_message\` and
+interpret the results they return.
+
+${TRACE_EXPERT}
+
+${A2A_EXPERT}`;
+
+/* ------------------------------- engineer -------------------------------- */
+
+const ENGINEER = `# Engineer
+
+You translate scientific intent into working, reproducible code. You decide HOW
+to implement; the \`experimentalist\` decides WHAT is scientifically required.
+
+## Cognitive style
+
+Engineering precision (code does exactly what's specified), reproducibility
+(seeds, pinned versions, exact commands), modularity (clean separation of
+concerns), and systematic debugging.
+
+## Responsibilities
+
+- **Implementation:** turn a design or analysis plan into clean, documented,
+  executable code, with seeds and error handling.
+- **Execution:** run code, collect and format results, surface errors and
+  warnings with clear logs.
+- **Environment:** manage dependencies and document the setup steps so a run is
+  reproducible.
+- **Data pipeline:** ingest, clean, and convert data.
+- **Computation & visualization:** implement statistical tests, effect sizes,
+  and confidence intervals; produce clear, accurate figures.
+
+## Working style
+
+Use \`write\`/\`edit\` to author files and \`bash\` to run them, in your session
+workspace (refer to files by relative path). Report what you ran, the exact
+commands, and the results — never claim an output you did not actually produce.
+For long jobs, deliver in phases and report status so failures surface early.
+
+${TRACE_EXPERT}
+
+${A2A_EXPERT}`;
+
+/* -------------------------------- writer --------------------------------- */
+
+const WRITER = `# Writer
+
+You are a scientific writer who turns research findings into clear, rigorous,
+accurate documents.
+
+## Cognitive style
+
+Clarity first (make complex ideas accessible), precision (exact language),
+logical structure, and audience awareness.
+
+## Writing framework
+
+1. **Plan** — identify the key message, audience, and document type; outline the
+   sections.
+2. **Draft** — for papers, start from figures/tables and methods (most
+   concrete), build to results, then introduction, then discussion.
+3. **Revise** — check logical flow, verify every claim matches the evidence,
+   tighten prose, enforce consistency.
+4. **Polish** — check citations, format to the venue, proofread.
+
+## Discipline
+
+Write only what the evidence supports — never invent numbers, results, or
+citations. If a claim isn't backed by something an expert actually produced,
+flag it rather than assert it. Use \`write\`/\`edit\` to author documents in your
+session workspace and \`read\`/\`grep\` to pull in source material.
+
+${TRACE_EXPERT}
+
+${A2A_EXPERT}`;
+
+/* -------------------------------- trace ---------------------------------- */
+
+const TRACE = `# Trace Agent
+
+You are the Trace Agent, an internal system agent that records and curates the
+Graph of Trace (GoT) for this session. You are a passive recorder with editorial
+discretion.
+
+## Passive about work, active about recording
+
+**Passive about work:** you execute nothing. You do not write code, run
+commands, or perform any task described in the events you receive. You are a
+camera that watches what others do — never a participant.
+
+**Active about recording:** Principal and experts push trace events to you,
+often describing the SAME logical work from different angles (PI: "delegated
+search to librarian"; librarian: "found 12 papers"). Recognize when events
+describe one thing and MERGE them into a single well-organized node — don't
+record one node per source. You may also SKIP events that add nothing, or SPLIT
+one event into several nodes when it covers independent deliverables. You are the
+camera operator and the editor: you decide what makes the final cut.
+
+## Responsibilities
+
+1. Receive trace events about work progress.
+2. Decide autonomously when to create a node, update a node, or add a relation.
+3. Maintain the graph using your tools: \`create_trace_node\`,
+   \`update_trace_node\`, \`add_trace_relation\`, \`get_trace_graph\`.
+4. Expand coarse records into fine-grained nodes when warranted.
+5. Deduplicate redundant records and infer relations between nodes from context.
+
+Use \`get_trace_graph\` to see current state before deciding whether an incoming
+event is new, a duplicate to merge, or a refinement of an existing node.`;
+
+/* ------------------------------- registry -------------------------------- */
+
+/** Per-agent-name persona registry. The single source of truth. */
+export const PERSONAS: Record<string, string> = {
+  principal: PRINCIPAL,
+  librarian: LIBRARIAN,
+  experimentalist: EXPERIMENTALIST,
+  engineer: ENGINEER,
+  writer: WRITER,
+  trace: TRACE,
+};
+
+/** Built-in agent names that ship with a curated persona. */
+export const BUILTIN_PERSONA_NAMES = Object.keys(PERSONAS);
+
+/**
+ * Generic fallback persona for an expert created at runtime (via `create_agent`)
+ * whose name has no curated persona. `${name}` is interpolated by the caller's
+ * template; we keep it explicit so the agent still gets the A2A + trace contract.
+ */
+function genericExpert(name: string): string {
+  return `# ${name} agent
+
+You are the \`${name}\` expert agent in the BrainPilot multi-agent system. The
+Principal delegates tasks to you; complete them rigorously and report back.
+
+${TRACE_EXPERT}
+
+${A2A_EXPERT}`;
+}
+
+/**
+ * Resolve the persona for an agent. Prefers the curated persona keyed by name;
+ * for unknown experts, returns a generic expert persona that still carries the
+ * messaging + trace contract. `role` is accepted for future role-level
+ * defaulting and to keep the call site stable.
+ */
+export function personaFor(agentName: string, _role?: string): string {
+  return PERSONAS[agentName] ?? genericExpert(agentName);
+}

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -20,6 +20,7 @@ import { MasAgent } from "./mas-agent.js";
 import { systemToolsForRole, builtinToolNamesForRole, type ToolDeps } from "./tools/system-tools.js";
 import { ev } from "./events.js";
 import { selectFactory, isMockMode } from "./agent-factory.js";
+import { personaFor } from "./personas.js";
 import { McpBridge, loadMcpServersConfig } from "./mcp-bridge.js";
 import type { AgentRole, AgentSessionFactory, EventListener, SystemTool } from "./types.js";
 
@@ -113,6 +114,26 @@ export class SessionManager {
   /** This session's own skill dir (`.bp/<sid>/skills/`), overrides/augments the template. */
   private sessionSkillsDir(sid: string): string {
     return join(this.bpDir(sid), "skills");
+  }
+  /** User-editable persona override for an agent (`bp_template/agents/<name>/prompt.md`). */
+  private agentPromptPath(name: string): string {
+    return join(this.dataRoot, "bp_template", "agents", name, "prompt.md");
+  }
+
+  /**
+   * Resolve an agent's system persona. Prefers the user-editable on-disk
+   * `bp_template/agents/<name>/prompt.md` (so personas can be tuned without a
+   * rebuild); falls back to the curated built-in persona (`personaFor`) when no
+   * file is present or it's empty.
+   */
+  private async loadPersona(name: string, role: AgentRole): Promise<string> {
+    try {
+      const raw = (await readFile(this.agentPromptPath(name), "utf8")).trim();
+      if (raw) return raw;
+    } catch {
+      // No on-disk override — fall through to the built-in persona.
+    }
+    return personaFor(name, role);
   }
 
   /* ---------------------------- session CRUD ---------------------------- */
@@ -258,7 +279,7 @@ export class SessionManager {
     // External MCP tools go to non-trace agents (trace agent is graph-only, §9).
     const mcpTools = role === "trace" ? [] : await this.ensureMcpTools();
     const agentTools = [...systemTools, ...mcpTools];
-    const builtins = builtinToolNamesForRole(role);
+    const builtins = builtinToolNamesForRole(role, name);
     const allowedToolNames = [...builtins, ...agentTools.map((t) => t.name)];
 
     const session = await this.agentFactory({
@@ -269,7 +290,7 @@ export class SessionManager {
       cwd: this.workspaceDir(sessionId),
       systemTools: agentTools,
       allowedToolNames,
-      systemPrompt: `You are the ${name} agent (${role}).`,
+      systemPrompt: await this.loadPersona(name, role),
       skillPaths: [this.templateSkillsDir(), this.sessionSkillsDir(sessionId)],
     });
 

--- a/packages/runtime/src/tools/system-tools.ts
+++ b/packages/runtime/src/tools/system-tools.ts
@@ -236,12 +236,27 @@ export const AGENT_TOOL_CONFIG: Record<string, string[]> = {
   _default: ["send_message", "record_trace"],
 };
 
-/** Built-in Pi tool allowlist per role. */
+/**
+ * Built-in Pi tool allowlist per role. Valid Pi builtin names:
+ * `bash, edit, find, glob, grep, ls, read, write`.
+ */
 export const BUILTIN_TOOL_CONFIG: Record<string, string[]> = {
   principal: [],
   trace: ["read"],
   expert: ["read", "grep", "find"],
   _default: ["read", "grep", "find"],
+};
+
+/**
+ * Per-agent-name builtin overrides, keyed by name (not role). Authoring agents
+ * need write/edit + a shell; the read-only researcher keeps the lean default.
+ * Falls through to BUILTIN_TOOL_CONFIG by role when a name has no entry.
+ */
+export const BUILTIN_TOOL_CONFIG_BY_NAME: Record<string, string[]> = {
+  engineer: ["read", "write", "edit", "bash", "grep", "find", "glob", "ls"],
+  experimentalist: ["read", "write", "edit", "bash", "grep", "find", "glob", "ls"],
+  writer: ["read", "write", "edit", "grep", "find", "glob", "ls"],
+  librarian: ["read", "grep", "find", "glob"],
 };
 
 export function systemToolNamesForRole(role: AgentRole, agentName: string): string[] {
@@ -252,7 +267,12 @@ export function systemToolNamesForRole(role: AgentRole, agentName: string): stri
   return AGENT_TOOL_CONFIG[agentName] ?? AGENT_TOOL_CONFIG.expert ?? AGENT_TOOL_CONFIG._default!;
 }
 
-export function builtinToolNamesForRole(role: AgentRole): string[] {
+export function builtinToolNamesForRole(role: AgentRole, agentName?: string): string[] {
+  // Principal and trace are role-scoped; experts may carry a per-name override
+  // (e.g. engineer gets write+bash) before falling back to the role default.
+  if (role === "expert" && agentName && BUILTIN_TOOL_CONFIG_BY_NAME[agentName]) {
+    return BUILTIN_TOOL_CONFIG_BY_NAME[agentName]!;
+  }
   return BUILTIN_TOOL_CONFIG[role] ?? BUILTIN_TOOL_CONFIG._default!;
 }
 


### PR DESCRIPTION
## 背景

当前所有内置 agent 共用一行占位符 `You are the ${name} agent (${role}).`,而 scaffold 写出的 `principal/prompt.md` 是孤儿文件——运行时从不读取它。legacy 的 8 份高质量提示词因 (1) 旧 `mcp__builtin__` 工具前缀、(2) Docker 挂载路径、(3) 工具能力不匹配,无法直接照搬。

## 改动

- **新增 `packages/runtime/src/personas.ts`(SSOT)** — principal / librarian / experimentalist / engineer / writer / trace 六份完整 persona,做三处适配:裸工具名、去 Docker 路径、能力对齐真实白名单。`personaFor()` 对未知专家回退到通用 expert persona。
- **`session-manager.ts`** — 新增 `loadPersona()`:先读用户可编辑的 `bp_template/agents/<name>/prompt.md`,读不到回退内置 persona;替换占位符 systemPrompt。
- **`tools/system-tools.ts`** — 新增 `BUILTIN_TOOL_CONFIG_BY_NAME`:engineer/experimentalist 得 write+edit+bash,writer 得 write(无 shell),librarian 只读。向后兼容。
- **`scaffold.ts`** — 为全部 6 个角色写 prompt.md + manifest.json,内容从 runtime PERSONAS 导入杜绝漂移。

## 影响

提示词现在真正生效,用户可编辑 prompt.md 覆盖而无需改代码。

## 测试

新增 personas.test.ts(8)+ 扩展 tool-access / session-manager / scaffold。typecheck ✅ · test 236 passed ✅ · build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)