### PR TITLE
release: v0.0.4 → main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brainpilot",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "brainpilot",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/protocol",
@@ -8276,11 +8276,11 @@
     },
     "packages/backend-core": {
       "name": "@brainpilot/backend-core",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@brainpilot/protocol": "^0.0.3",
-        "@brainpilot/runtime": "^0.0.3",
+        "@brainpilot/protocol": "^0.0.4",
+        "@brainpilot/runtime": "^0.0.4",
         "@hono/node-server": "^1.13.0",
         "hono": "^4.6.0"
       },
@@ -8290,13 +8290,13 @@
     },
     "packages/cli": {
       "name": "@brainpilot/app",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@brainpilot/backend-core": "^0.0.3",
-        "@brainpilot/protocol": "^0.0.3",
-        "@brainpilot/runtime": "^0.0.3",
-        "@brainpilot/web": "^0.0.3",
+        "@brainpilot/backend-core": "^0.0.4",
+        "@brainpilot/protocol": "^0.0.4",
+        "@brainpilot/runtime": "^0.0.4",
+        "@brainpilot/web": "^0.0.4",
         "commander": "^12.1.0",
         "picocolors": "^1.1.0"
       },
@@ -8307,7 +8307,7 @@
     },
     "packages/client-cli": {
       "name": "@brainpilot/client-cli",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "dependencies": {
         "@brainpilot/protocol": "*",
         "commander": "^12.1.0"
@@ -8318,7 +8318,7 @@
     },
     "packages/protocol": {
       "name": "@brainpilot/protocol",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.24.0"
@@ -8326,10 +8326,10 @@
     },
     "packages/runtime": {
       "name": "@brainpilot/runtime",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@brainpilot/protocol": "^0.0.3",
+        "@brainpilot/protocol": "^0.0.4",
         "@earendil-works/pi-coding-agent": "^0.79.0",
         "@hono/node-server": "^1.19.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
@@ -8339,10 +8339,10 @@
     },
     "packages/web": {
       "name": "@brainpilot/web",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@brainpilot/protocol": "^0.0.3",
+        "@brainpilot/protocol": "^0.0.4",
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource-variable/geist-mono": "^5.2.8",
         "@types/react": "^18.3.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainpilot",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "type": "module",
   "description": "BrainPilot — multi-agent research collaboration platform (TS + Pi SDK)",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/backend-core",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "Apache-2.0",
   "type": "module",
   "description": "BrainPilot Backend — Hono REST+SSE proxy, serve web, Orchestrator abstraction (Docker/Local)",
@@ -34,8 +34,8 @@
     "start": "node ./dist/server.js"
   },
   "dependencies": {
-    "@brainpilot/protocol": "^0.0.3",
-    "@brainpilot/runtime": "^0.0.3",
+    "@brainpilot/protocol": "^0.0.4",
+    "@brainpilot/runtime": "^0.0.4",
     "@hono/node-server": "^1.13.0",
     "hono": "^4.6.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/app",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "Apache-2.0",
   "type": "module",
   "description": "BrainPilot CLI — Docker-free local one-click launch (bin: brainpilot / bnpt)",
@@ -27,10 +27,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@brainpilot/backend-core": "^0.0.3",
-    "@brainpilot/protocol": "^0.0.3",
-    "@brainpilot/runtime": "^0.0.3",
-    "@brainpilot/web": "^0.0.3",
+    "@brainpilot/backend-core": "^0.0.4",
+    "@brainpilot/protocol": "^0.0.4",
+    "@brainpilot/runtime": "^0.0.4",
+    "@brainpilot/web": "^0.0.4",
     "commander": "^12.1.0",
     "picocolors": "^1.1.0"
   }

--- a/packages/client-cli/package.json
+++ b/packages/client-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/client-cli",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "type": "module",
   "description": "BrainPilot headless verification client (dev/CI) — drive a session without the web UI",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/protocol",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "Apache-2.0",
   "type": "module",
   "description": "BrainPilot AG-UI events + REST/SSE schemas + Runtime HTTP contract (SSOT, zod-validated)",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/runtime",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "Apache-2.0",
   "type": "module",
   "description": "BrainPilot Runtime — Pi SDK orchestration, SessionManager, Mailbox, GoT, state authority, HTTP server",
@@ -34,7 +34,7 @@
     "start": "node ./dist/server.js"
   },
   "dependencies": {
-    "@brainpilot/protocol": "^0.0.3",
+    "@brainpilot/protocol": "^0.0.4",
     "@earendil-works/pi-coding-agent": "^0.79.0",
     "@hono/node-server": "^1.19.0",
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/web",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "Apache-2.0",
   "type": "module",
   "files": [
@@ -22,7 +22,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@brainpilot/protocol": "^0.0.3",
+    "@brainpilot/protocol": "^0.0.4",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.8",
     "@types/react": "^18.3.12",


### PR DESCRIPTION
## 概述

发布 **v0.0.4**:5 个公开包已 publish 到 npm registry,本 PR 把版本号 bump 同步回 `main`。

## 已发布到 npm(0.0.4,已验证上线)

- @brainpilot/protocol
- @brainpilot/runtime
- @brainpilot/backend-core
- @brainpilot/web
- @brainpilot/app

`@brainpilot/client-cli` 保持 private,不发布。

## 改动

仅版本号:根 package.json 0.0.3→0.0.4,`version:sync` 对齐所有 workspace 及其 `@brainpilot/*` 依赖范围,`package-lock.json` 重生成。采用 merge(非 squash)保留 main 上的飞书通知。

## 验证(本地)

- `npm run version:check` — all aligned at 0.0.4 ✅
- `npm ci` 从新 lockfile 安装 ✅
- `npm run typecheck` ✅
- `npm test` 非 web **236 passed** + web **25 passed** ✅
- `npm run build` ✅
- publish dry-run 5 包 tarball 校验 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)