### PR TITLE
feat(mcp): streamable-http + sse transports & default remote services

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,82 @@ Full `models.json` schema — `api` types, `compat` flags, `$ENV` key
 interpolation, per-model cost/limits — is documented at
 <https://pi.dev/docs/latest/models>.
 
+## 🔌 Connecting MCP servers
+
+Agents can call tools served over the **Model Context Protocol**. The runtime
+bridges every configured MCP server into the agents' toolset: each remote tool
+shows up namespaced as `mcp__<server>__<tool>`. Three transports are supported —
+**stdio** (spawned local process), **streamable-http**, and **sse** (remote).
+
+### What ships by default
+
+`brainpilot init` (and `brainpilot up`, which scaffolds on first launch) writes
+`mcp_servers.json` into your **data dir** — it is generated at runtime, not stored
+in the repo. The data dir is resolved as `--dir` > `$BP_DATA_DIR` > `./brainpilot`
+under the directory you run the command from, so the file lands at
+`<data-dir>/bp_template/mcp_servers.json`. It comes pre-wired to BrainPilot's three
+built-in remote services (streamable-http, no auth):
+
+| Server | Purpose | URL |
+|--------|---------|-----|
+| `bp_KB` | Knowledge base | `http://8.145.42.208:8005/mcp` |
+| `bp_skills` | Skills | `http://8.145.42.208:8006/mcp` |
+| `bp_papersearch` | Paper search | `http://8.145.42.208:8007/mcp` |
+
+These connect automatically on launch — no extra setup. Remove or edit any entry
+to opt out or point at your own deployment. A server is connected lazily and a
+failing one is logged and skipped, so it never blocks the others or aborts launch.
+
+> Scaffolding is idempotent: an existing `mcp_servers.json` is never overwritten.
+> If you initialized before these defaults existed, edit the file in your data dir
+> by hand (or delete it and re-run `brainpilot init`).
+
+### Adding your own server
+
+Edit `<data-dir>/bp_template/mcp_servers.json` (global, shared by every session)
+or `<data-dir>/.bp/<session-id>/mcp_servers.json` (per session) — where
+`<data-dir>` is your generated data dir (e.g. `./brainpilot`), not a path in the
+repo. The format is the standard MCP/Claude `mcpServers` map; pick a transport
+with `type`:
+
+```jsonc
+{
+  "mcpServers": {
+    // Local process over stdio (type defaults to "stdio" if omitted):
+    "fs": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/path/to/dir"],
+      "env": {}
+    },
+    // Remote over streamable-http, with an auth header:
+    "my-api": {
+      "type": "http",
+      "url": "https://your-host.example.com/mcp",
+      "headers": { "Authorization": "Bearer <token>" }
+    },
+    // Remote over server-sent events:
+    "my-events": {
+      "type": "sse",
+      "url": "https://your-host.example.com/sse",
+      "headers": { "Authorization": "Bearer <token>" }
+    }
+  }
+}
+```
+
+Field reference:
+- `type` — `"stdio"` | `"http"` | `"sse"`. Omitted ⇒ `"stdio"`.
+- `command` / `args` / `env` — stdio only: the executable to spawn and its env.
+- `url` — http/sse only: the server endpoint.
+- `headers` — http/sse only: extra HTTP headers (e.g. `Authorization`) sent on
+  every request.
+
+An http/sse entry whose `url` is left blank (or a stdio entry with no `command`)
+is treated as an unconfigured placeholder and skipped silently at startup, so you
+can keep a slot in the file before wiring up its address. A ready-to-copy example
+covering all three transports is written to `bp_template/mcp_servers.example.json`.
+
 ## 📦 Publishing (maintainers)
 
 ```bash

--- a/packages/cli/src/scaffold.ts
+++ b/packages/cli/src/scaffold.ts
@@ -103,10 +103,59 @@ const TEMPLATE_SETTINGS_EXAMPLE = JSON.stringify(
   2,
 );
 
-/** MCP server config template (§11A.2). */
+/**
+ * Default `mcp_servers.json` written into `bp_template/` (§11A.2).
+ *
+ * Ships BrainPilot's three built-in remote MCP services (knowledge base, skills,
+ * paper search) over streamable-http. Edit or remove these entries to point at
+ * your own deployment; an entry whose `url` is blanked out is treated as an
+ * unconfigured placeholder and skipped at startup.
+ */
+const TEMPLATE_MCP_DEFAULT = JSON.stringify(
+  {
+    mcpServers: {
+      bp_KB: {
+        type: "http",
+        url: "http://8.145.42.208:8005/mcp",
+      },
+      bp_skills: {
+        type: "http",
+        url: "http://8.145.42.208:8006/mcp",
+      },
+      bp_papersearch: {
+        type: "http",
+        url: "http://8.145.42.208:8007/mcp",
+      },
+    },
+  },
+  null,
+  2,
+);
+
+/**
+ * Annotated `mcp_servers.example.json` — shows every supported transport
+ * (stdio / streamable-http / sse) with a filled-in shape to copy from.
+ */
 const TEMPLATE_MCP_EXAMPLE = JSON.stringify(
   {
-    mcpServers: {},
+    mcpServers: {
+      "fs-stdio": {
+        type: "stdio",
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-filesystem", "/path/to/dir"],
+        env: {},
+      },
+      "remote-http": {
+        type: "http",
+        url: "https://your-mcp-host.example.com/mcp",
+        headers: { Authorization: "Bearer <token>" },
+      },
+      "remote-sse": {
+        type: "sse",
+        url: "https://your-mcp-host.example.com/sse",
+        headers: { Authorization: "Bearer <token>" },
+      },
+    },
   },
   null,
   2,
@@ -219,7 +268,7 @@ export async function scaffold(
     // ③ session-level template defaults.
     [p.bpTemplateSettings, TEMPLATE_SETTINGS_EXAMPLE],
     [join(p.bpTemplate, "settings.example.json"), TEMPLATE_SETTINGS_EXAMPLE],
-    [p.bpTemplateMcpServers, TEMPLATE_MCP_EXAMPLE],
+    [p.bpTemplateMcpServers, TEMPLATE_MCP_DEFAULT],
     [join(p.bpTemplate, "mcp_servers.example.json"), TEMPLATE_MCP_EXAMPLE],
     // ③a app-controlled skills (loaded instead of host-global ~/.pi/agent/skills).
     [join(p.bpTemplateSkills, "README.md"), SKILLS_README],

--- a/packages/runtime/src/__tests__/mcp-bridge.test.ts
+++ b/packages/runtime/src/__tests__/mcp-bridge.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   McpBridge,
   loadMcpServersConfig,
+  openTransport,
   type McpClientLike,
 } from "../mcp-bridge.js";
 
@@ -80,5 +81,51 @@ describe("McpBridge", () => {
     await bridge.close();
     expect(close).toHaveBeenCalledTimes(1);
     expect(bridge.tools).toHaveLength(0);
+  });
+
+  it("skips placeholder slots (blank url/command) without connecting", async () => {
+    const connect = vi.fn(async () => fakeClient());
+    const bridge = new McpBridge(connect);
+    const tools = await bridge.connectAll({
+      mcpServers: {
+        unfilledHttp: { type: "http", url: "" },
+        unfilledStdio: { command: "" },
+        real: { command: "y" },
+      },
+    });
+    // Only the real stdio server connects; the two placeholders are skipped.
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(tools).toHaveLength(1);
+    expect(tools[0]!.name).toBe("mcp__real__search");
+  });
+});
+
+describe("openTransport", () => {
+  it("defaults to a stdio transport when type is omitted", async () => {
+    const t = await openTransport("fs", { command: "npx", args: ["-y", "srv"] });
+    expect(t.constructor.name).toBe("StdioClientTransport");
+  });
+
+  it("selects the streamable-http transport for type 'http'", async () => {
+    const t = await openTransport("api", {
+      type: "http",
+      url: "https://host.example.com/mcp",
+      headers: { Authorization: "Bearer t" },
+    });
+    expect(t.constructor.name).toBe("StreamableHTTPClientTransport");
+  });
+
+  it("selects the SSE transport for type 'sse'", async () => {
+    const t = await openTransport("evt", { type: "sse", url: "https://host.example.com/sse" });
+    expect(t.constructor.name).toBe("SSEClientTransport");
+  });
+
+  it("rejects an http/sse spec with no url", async () => {
+    await expect(openTransport("api", { type: "http" })).rejects.toThrow(/requires a 'url'/);
+    await expect(openTransport("evt", { type: "sse" })).rejects.toThrow(/requires a 'url'/);
+  });
+
+  it("rejects a stdio spec with no command", async () => {
+    await expect(openTransport("fs", { type: "stdio" })).rejects.toThrow(/requires a 'command'/);
   });
 });

--- a/packages/runtime/src/mcp-bridge.ts
+++ b/packages/runtime/src/mcp-bridge.ts
@@ -10,17 +10,32 @@
  * Tools are namespaced `mcp__<server>__<tool>` to avoid cross-server collisions.
  * A failing server is logged and skipped — it never aborts the others.
  *
- * Config shape (standard MCP/Claude format), stdio servers only:
- *   { "mcpServers": { "fs": { "command": "npx", "args": ["-y", "..."], "env": {} } } }
+ * Config shape (standard MCP/Claude format). Three transports are supported,
+ * selected by the optional `type` field (defaults to "stdio" for back-compat):
+ *   stdio: { "fs":  { "command": "npx", "args": ["-y", "..."], "env": {} } }
+ *   http:  { "api": { "type": "http", "url": "https://host/mcp", "headers": {} } }
+ *   sse:   { "evt": { "type": "sse",  "url": "https://host/sse", "headers": {} } }
  */
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { SystemTool, SystemToolResult } from "./types.js";
 
+/** Wire transport for an MCP server. Absent ⇒ "stdio" (back-compat). */
+export type McpTransportType = "stdio" | "http" | "sse";
+
 export interface McpServerSpec {
-  command: string;
+  /** Transport. Defaults to "stdio" when omitted. */
+  type?: McpTransportType;
+  /** stdio: executable to spawn. */
+  command?: string;
+  /** stdio: arguments for `command`. */
   args?: string[];
+  /** stdio: extra environment for the spawned process. */
   env?: Record<string, string>;
+  /** http/sse: endpoint URL of the remote MCP server. */
+  url?: string;
+  /** http/sse: extra HTTP headers (e.g. Authorization) sent on every request. */
+  headers?: Record<string, string>;
 }
 
 export interface McpServersConfig {
@@ -67,23 +82,47 @@ export async function loadMcpServersConfig(dataRoot: string): Promise<McpServers
   return null;
 }
 
-/** Real connect: spawn a stdio MCP server and hand back a thin client. */
+/** Real connect: open the transport named by `spec.type` and hand back a thin client. */
 export const defaultMcpConnect: McpConnectFn = async (name, spec) => {
   const { Client } = await import("@modelcontextprotocol/sdk/client/index.js");
-  const { StdioClientTransport } = await import("@modelcontextprotocol/sdk/client/stdio.js");
-  const transport = new StdioClientTransport({
-    command: spec.command,
-    args: spec.args ?? [],
-    ...(spec.env ? { env: spec.env } : {}),
-  });
   const client = new Client({ name: `brainpilot-${name}`, version: "0.1.0" });
-  await client.connect(transport);
+  await client.connect(await openTransport(name, spec));
   return {
     listTools: () => client.listTools() as Promise<{ tools: McpToolDescriptor[] }>,
     callTool: (a) => client.callTool(a) as Promise<McpCallResult>,
     close: () => client.close(),
   };
 };
+
+/** Build the SDK transport for a server spec; defaults to stdio. Exported for tests. */
+export async function openTransport(name: string, spec: McpServerSpec) {
+  const type = spec.type ?? "stdio";
+  if (type === "http" || type === "sse") {
+    if (!spec.url) {
+      throw new Error(`mcp server '${name}': type '${type}' requires a 'url'`);
+    }
+    const url = new URL(spec.url);
+    // Custom headers (e.g. Authorization) ride on `requestInit` for both transports.
+    const opts = spec.headers ? { requestInit: { headers: spec.headers } } : undefined;
+    if (type === "http") {
+      const { StreamableHTTPClientTransport } = await import(
+        "@modelcontextprotocol/sdk/client/streamableHttp.js"
+      );
+      return new StreamableHTTPClientTransport(url, opts);
+    }
+    const { SSEClientTransport } = await import("@modelcontextprotocol/sdk/client/sse.js");
+    return new SSEClientTransport(url, opts);
+  }
+  if (!spec.command) {
+    throw new Error(`mcp server '${name}': type 'stdio' requires a 'command'`);
+  }
+  const { StdioClientTransport } = await import("@modelcontextprotocol/sdk/client/stdio.js");
+  return new StdioClientTransport({
+    command: spec.command,
+    args: spec.args ?? [],
+    ...(spec.env ? { env: spec.env } : {}),
+  });
+}
 
 export class McpBridge {
   private clients: McpClientLike[] = [];
@@ -98,6 +137,13 @@ export class McpBridge {
   /** Connect every server in the config and collect their tools. */
   async connectAll(cfg: McpServersConfig): Promise<SystemTool[]> {
     for (const [name, spec] of Object.entries(cfg.mcpServers)) {
+      if (isPlaceholderSpec(spec)) {
+        // A scaffolded slot whose url/command hasn't been filled in yet — skip
+        // quietly so the default config never delays launch or logs an error.
+        // eslint-disable-next-line no-console
+        console.info(`[mcp] server '${name}' not configured yet — skipping`);
+        continue;
+      }
       try {
         const client = await this.connect(name, spec);
         this.clients.push(client);
@@ -129,6 +175,18 @@ export class McpBridge {
     this.clients = [];
     this._tools = [];
   }
+}
+
+/**
+ * A spec is a "placeholder" when its required address field is blank: an
+ * http/sse entry with no `url`, or a stdio entry with no `command`. The scaffold
+ * ships one such slot (`type:"http", url:""`) so the runtime treats an unfilled
+ * default as opt-in rather than a misconfiguration.
+ */
+function isPlaceholderSpec(spec: McpServerSpec): boolean {
+  const type = spec.type ?? "stdio";
+  if (type === "http" || type === "sse") return !spec.url?.trim();
+  return !spec.command?.trim();
 }
 
 /** Map an MCP tool-call `content` payload into our text-content shape. */


### PR DESCRIPTION
## What

The MCP bridge previously connected **stdio** servers only. This PR adds transport selection so remote MCP servers can be configured, and ships BrainPilot's built-in remote services by default.

## Changes

- **`runtime/mcp-bridge.ts`** — extend `McpServerSpec` with `type` / `url` / `headers` (aligned with protocol's `McpServerEntry`). Split out `openTransport()` to pick `Stdio` / `StreamableHTTP` / `SSE` by `type` (defaults to `stdio`, fully back-compatible). Custom headers (e.g. `Authorization`) ride on `requestInit.headers`. `connectAll` now skips placeholder entries (blank `url`/`command`) silently at startup, so an unconfigured slot never delays launch or logs an error.
- **`cli/scaffold.ts`** — default `mcp_servers.json` now ships BrainPilot's three built-in remote services over streamable-http: `bp_KB`, `bp_skills`, `bp_papersearch`. `mcp_servers.example.json` now demonstrates all three transports.
- **tests** (+6) — transport selection (asserting real SDK class names), missing `url`/`command` errors, and placeholder skipping.
- **README** — new "🔌 Connecting MCP servers" section: default services + how to add your own (stdio/http/sse), and clarifies the config file is generated into the data dir, not stored in the repo.

## Verification

- `npm run typecheck` (tsc -b) ✅
- full vitest suite: **242 passed** ✅ (mcp-bridge: 12, scaffold: 7)
- No new dependencies — `@modelcontextprotocol/sdk` already provides all three client transports.

## Notes

- The three default services are plain http with **no auth header**; add `headers` per entry if a deployment needs auth.
- Scaffolding is idempotent — existing data dirs are not overwritten by the new defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)