### PR TITLE
feat(web): disable login by default for single-user (keep toggle for multi-user)

### DIFF
--- a/.github/scripts/lark-notify/README.md
+++ b/.github/scripts/lark-notify/README.md
@@ -1,0 +1,51 @@
+# Lark Notify — GitHub Issue/PR → 飞书群
+
+事件驱动：issue/PR 变动时，GitHub Actions 构造飞书交互卡片，POST 到开发者小群的自定义机器人 webhook。
+
+## 一次性配置
+
+1. 飞书目标群 → 设置 → 群机器人 → 添加「自定义机器人」→ 复制 **Webhook 地址**。
+   - 可选：开启「签名校验」，复制其 **密钥**。
+2. GitHub 仓库 → Settings → Secrets and variables → Actions → New repository secret：
+   - `LARK_WEBHOOK_URL`（必填）= 上面的 Webhook 地址
+   - `LARK_WEBHOOK_SECRET`（仅当开启签名校验时填）= 上面的密钥
+
+> workflow 文件只引用 `${{ secrets.* }}`，真实地址/密钥只存 GitHub Secret，不进 git。
+> 通知 workflow（`lark-notify.yml`）必须在仓库**默认分支 main** 上才会接收 issue/PR 事件。
+
+## 覆盖的事件（12 类）
+
+Issue：opened / closed / 评论；
+PR：opened / merged / closed(未合并) / 转 ready / 请求评审 / 评论；
+评审提交：通过 / 请求修改 / 评论。
+
+评论/正文在卡片中显示约 200 字摘要（超出截断）。
+
+## 本地测试脚本
+
+```bash
+brew install bats-core jq      # macOS
+bats .github/scripts/lark-notify/test/
+```
+
+CI 会在 PR / push 改动脚本或 workflow 时自动跑这些测试（见 `lark-notify-test.yml`）。
+
+## 手动冒烟（合并到 main 后）
+
+新建测试 issue → 看群里出「🟢 新 Issue」；评论 / 关闭依次验证；
+提 draft PR → 转 ready → 请求评审 → approve → 合并，逐一核对卡片。
+验证完删除测试 issue/PR。Actions 页面可看每次运行日志，失败 step 标红。
+
+## 安全与开源
+
+PR 事件用 `pull_request_target`（在 base 仓上下文运行、可拿 secret），使仓库**开源后外部 fork PR 也能推群**。这是安全的，因为本 workflow：
+- 绝不 checkout / 执行 PR 的代码，只读 `github.event.pull_request.*` 元数据；
+- PR 标题/正文只作为数据经环境变量 + `jq --arg` 进卡片，绝不拼进 shell；
+- `permissions` 只有 `contents: read`。
+
+### 转 public 前 checklist
+
+- [ ] `git log -p | grep -iE 'open.feishu|larksuite|/bot/v2/hook/'` 确认历史无真实 webhook 残留
+- [ ] 确认 secret 已配置、workflow 仅含 `${{ secrets.* }}` 占位引用
+- [ ] 确认 PR 事件用 `pull_request_target`、**无 checkout PR head 代码的步骤**、`permissions` 最小
+- [ ] （可选）飞书侧已开签名校验

--- a/.github/scripts/lark-notify/build-card.sh
+++ b/.github/scripts/lark-notify/build-card.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# 读环境变量，输出飞书 interactive 卡片 JSON 到 stdout。纯函数，无网络。
+set -euo pipefail
+
+NOTIFY_KIND="${NOTIFY_KIND:?NOTIFY_KIND required}"
+TITLE="${TITLE:-}"
+REPO="${REPO:-}"
+ACTOR="${ACTOR:-}"
+URL="${URL:-}"
+BODY="${BODY:-}"
+
+# 事件类型 → 颜色 + 中文标题
+case "$NOTIFY_KIND" in
+  issue_opened)       TEMPLATE="green";  HEAD="🟢 新 Issue" ;;
+  issue_closed)       TEMPLATE="red";    HEAD="🔴 Issue 已关闭" ;;
+  issue_comment)      TEMPLATE="blue";   HEAD="🔵 Issue 新评论" ;;
+  pr_comment)         TEMPLATE="blue";   HEAD="🔵 PR 新评论" ;;
+  pr_opened)          TEMPLATE="green";  HEAD="🟢 新 PR" ;;
+  pr_merged)          TEMPLATE="green";  HEAD="🟢 PR 已合并" ;;
+  pr_closed)          TEMPLATE="red";    HEAD="🔴 PR 已关闭(未合并)" ;;
+  pr_ready)           TEMPLATE="blue";   HEAD="🔵 PR 转为可评审" ;;
+  review_requested)   TEMPLATE="blue";   HEAD="🔵 请求评审" ;;
+  review_approved)    TEMPLATE="green";  HEAD="🟢 评审已通过" ;;
+  review_changes)     TEMPLATE="red";    HEAD="🔴 评审请求修改" ;;
+  review_commented)   TEMPLATE="yellow"; HEAD="🟡 评审评论" ;;
+  *) echo "unknown NOTIFY_KIND: $NOTIFY_KIND" >&2; exit 1 ;;
+esac
+
+# 正文摘要：超过 200 字符时截断为 199 字 + …；否则原样。先去掉 \r
+SUMMARY=""
+if [ -n "$BODY" ]; then
+  SUMMARY="$(BODY="$BODY" jq -rn '
+    (env.BODY | gsub("\r";"")) as $b
+    | if ($b | length) > 200 then ($b[0:199] + "…") else $b end')"
+fi
+
+jq -n \
+  --arg template "$TEMPLATE" \
+  --arg head "$HEAD" \
+  --arg title "$TITLE" \
+  --arg repo "$REPO" \
+  --arg actor "$ACTOR" \
+  --arg url "$URL" \
+  --arg summary "$SUMMARY" \
+  '
+  # 转义标题中的 * 以免破坏 lark_md 粗体
+  ($title | gsub("\\*"; "\\*")) as $safetitle
+  | ( "**" + $safetitle + "**\n仓库：" + $repo + "\n作者：" + $actor ) as $base
+  | ( if $summary == "" then $base
+      else $base + "\n┄┄┄┄┄┄┄┄┄┄\n" + $summary end ) as $body
+  | {
+    msg_type: "interactive",
+    card: {
+      config: { wide_screen_mode: true },
+      header: {
+        template: $template,
+        title: { tag: "plain_text", content: $head }
+      },
+      elements: [
+        { tag: "div", text: { tag: "lark_md", content: $body } },
+        { tag: "action", actions: [
+          { tag: "button", text: { tag: "plain_text", content: "在 GitHub 查看" },
+            url: $url, type: "primary" } ] }
+      ]
+    }
+  }'

--- a/.github/scripts/lark-notify/dispatch.sh
+++ b/.github/scripts/lark-notify/dispatch.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# 按 NOTIFY_KIND 从对应的 GitHub 事件环境变量里选出 TITLE/ACTOR/URL/BODY，
+# 调 build-card.sh 生成卡片，再交给 send.sh 发送。
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SEND_BIN="${LARK_NOTIFY_SEND_BIN:-$HERE/send.sh}"
+
+NOTIFY_KIND="${NOTIFY_KIND:?}"
+REPO="${REPO:-}"
+
+case "$NOTIFY_KIND" in
+  issue_opened|issue_closed)
+    NUM="${ISSUE_NUM:-}"; T="${ISSUE_TITLE:-}"; U="${ISSUE_URL:-}"; A="${ISSUE_USER:-}"; B=""
+    ;;
+  issue_comment|pr_comment)
+    NUM="${ISSUE_NUM:-${PR_NUM:-}}"
+    T="${ISSUE_TITLE:-${PR_TITLE:-}}"
+    U="${COMMENT_URL:-}"; A="${COMMENT_USER:-}"; B="${COMMENT_BODY:-}"
+    ;;
+  pr_opened|pr_merged|pr_closed|pr_ready|review_requested)
+    NUM="${PR_NUM:-}"; T="${PR_TITLE:-}"; U="${PR_URL:-}"; A="${PR_USER:-}"; B="${PR_BODY:-}"
+    ;;
+  review_approved|review_changes|review_commented)
+    NUM="${PR_NUM:-}"; T="${PR_TITLE:-}"; U="${REVIEW_URL:-}"; A="${REVIEW_USER:-}"; B="${REVIEW_BODY:-}"
+    ;;
+  *) echo "dispatch: unknown NOTIFY_KIND $NOTIFY_KIND" >&2; exit 1 ;;
+esac
+
+TITLE="#${NUM} ${T}"
+
+NOTIFY_KIND="$NOTIFY_KIND" TITLE="$TITLE" REPO="$REPO" ACTOR="$A" URL="$U" BODY="$B" \
+  bash "$HERE/build-card.sh" | bash "$SEND_BIN"

--- a/.github/scripts/lark-notify/send.sh
+++ b/.github/scripts/lark-notify/send.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# 从 stdin 读卡片 JSON，按需签名，POST 到飞书自定义机器人。失败退出非 0。
+set -euo pipefail
+
+URL="${LARK_WEBHOOK_URL:?LARK_WEBHOOK_URL required}"
+SECRET="${LARK_WEBHOOK_SECRET:-}"
+
+CARD_JSON="$(cat)"
+
+if [ -n "$SECRET" ]; then
+  TS="$(date +%s)"
+  # 飞书签名：HMAC-SHA256，key = "<timestamp>\n<secret>"，data 为空，结果 base64
+  STRING_TO_SIGN="${TS}"$'\n'"${SECRET}"
+  SIGN="$(printf '%s' "" | openssl dgst -sha256 -hmac "$STRING_TO_SIGN" -binary | base64)"
+  PAYLOAD="$(jq -n --arg ts "$TS" --arg sign "$SIGN" --argjson card "$CARD_JSON" \
+    '$card + { timestamp: $ts, sign: $sign }')"
+else
+  PAYLOAD="$CARD_JSON"
+fi
+
+REQ_BODY_FILE="$(mktemp)"
+trap 'rm -f "$REQ_BODY_FILE"' EXIT
+printf '%s' "$PAYLOAD" > "$REQ_BODY_FILE"
+
+RESP="$(curl -sS -m 15 -X POST "$URL" \
+  -H 'Content-Type: application/json' \
+  --data-binary "@$REQ_BODY_FILE")"
+
+printf '飞书响应: %s\n' "${RESP}" >&2
+if ! CODE="$(printf '%s' "$RESP" | jq -r '.code // .StatusCode // "missing"' 2>/dev/null)"; then
+  echo "推送失败：响应非合法 JSON: ${RESP}" >&2
+  exit 1
+fi
+if [ "$CODE" != "0" ]; then
+  echo "推送失败，code=${CODE}，响应: ${RESP}" >&2
+  exit 1
+fi

--- a/.github/scripts/lark-notify/test/build-card.bats
+++ b/.github/scripts/lark-notify/test/build-card.bats
@@ -1,0 +1,136 @@
+#!/usr/bin/env bats
+
+SCRIPT="${BATS_TEST_DIRNAME}/../build-card.sh"
+
+@test "issue opened: green header" {
+  export NOTIFY_KIND="issue_opened"
+  export TITLE="#12 修复登录崩溃"
+  export REPO="NeuroAIHub/BrainPilot"
+  export ACTOR="HaoxuanLiTHUAI"
+  export URL="https://github.com/NeuroAIHub/BrainPilot/issues/12"
+  export BODY=""
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e . >/dev/null
+  [ "$(echo "$output" | jq -r '.msg_type')" = "interactive" ]
+  [ "$(echo "$output" | jq -r '.card.header.template')" = "green" ]
+  [ "$(echo "$output" | jq -r '.card.header.title.content')" = "🟢 新 Issue" ]
+}
+
+@test "issue closed: red header" {
+  export NOTIFY_KIND="issue_closed" TITLE="#1 x" REPO="r" ACTOR="a" URL="u" BODY=""
+  run bash "$SCRIPT"
+  [ "$(echo "$output" | jq -r '.card.header.template')" = "red" ]
+  [ "$(echo "$output" | jq -r '.card.header.title.content')" = "🔴 Issue 已关闭" ]
+}
+
+@test "issue comment: blue header" {
+  export NOTIFY_KIND="issue_comment" TITLE="#1 x" REPO="r" ACTOR="a" URL="u" BODY="hi"
+  run bash "$SCRIPT"
+  [ "$(echo "$output" | jq -r '.card.header.template')" = "blue" ]
+  [ "$(echo "$output" | jq -r '.card.header.title.content')" = "🔵 Issue 新评论" ]
+}
+
+@test "pr comment: blue header" {
+  export NOTIFY_KIND="pr_comment" TITLE="#2 y" REPO="r" ACTOR="a" URL="u" BODY="hi"
+  run bash "$SCRIPT"
+  [ "$(echo "$output" | jq -r '.card.header.template')" = "blue" ]
+  [ "$(echo "$output" | jq -r '.card.header.title.content')" = "🔵 PR 新评论" ]
+}
+
+@test "pr opened: green" {
+  export NOTIFY_KIND="pr_opened" TITLE="#2 y" REPO="r" ACTOR="a" URL="u" BODY=""
+  run bash "$SCRIPT"
+  [ "$(echo "$output" | jq -r '.card.header.template')" = "green" ]
+  [ "$(echo "$output" | jq -r '.card.header.title.content')" = "🟢 新 PR" ]
+}
+
+@test "pr merged: green" {
+  export NOTIFY_KIND="pr_merged" TITLE="#2 y" REPO="r" ACTOR="a" URL="u" BODY=""
+  run bash "$SCRIPT"
+  [ "$(echo "$output" | jq -r '.card.header.template')" = "green" ]
+  [ "$(echo "$output" | jq -r '.card.header.title.content')" = "🟢 PR 已合并" ]
+}
+
+@test "pr closed unmerged: red" {
+  export NOTIFY_KIND="pr_closed" TITLE="#2 y" REPO="r" ACTOR="a" URL="u" BODY=""
+  run bash "$SCRIPT"
+  [ "$(echo "$output" | jq -r '.card.header.template')" = "red" ]
+  [ "$(echo "$output" | jq -r '.card.header.title.content')" = "🔴 PR 已关闭(未合并)" ]
+}
+
+@test "pr ready for review: blue" {
+  export NOTIFY_KIND="pr_ready" TITLE="#2 y" REPO="r" ACTOR="a" URL="u" BODY=""
+  run bash "$SCRIPT"
+  [ "$(echo "$output" | jq -r '.card.header.template')" = "blue" ]
+  [ "$(echo "$output" | jq -r '.card.header.title.content')" = "🔵 PR 转为可评审" ]
+}
+
+@test "review requested: blue" {
+  export NOTIFY_KIND="review_requested" TITLE="#2 y" REPO="r" ACTOR="a" URL="u" BODY=""
+  run bash "$SCRIPT"
+  [ "$(echo "$output" | jq -r '.card.header.template')" = "blue" ]
+  [ "$(echo "$output" | jq -r '.card.header.title.content')" = "🔵 请求评审" ]
+}
+
+@test "review approved: green" {
+  export NOTIFY_KIND="review_approved" TITLE="#2 y" REPO="r" ACTOR="a" URL="u" BODY=""
+  run bash "$SCRIPT"
+  [ "$(echo "$output" | jq -r '.card.header.template')" = "green" ]
+  [ "$(echo "$output" | jq -r '.card.header.title.content')" = "🟢 评审已通过" ]
+}
+
+@test "review changes_requested: red" {
+  export NOTIFY_KIND="review_changes" TITLE="#2 y" REPO="r" ACTOR="a" URL="u" BODY=""
+  run bash "$SCRIPT"
+  [ "$(echo "$output" | jq -r '.card.header.template')" = "red" ]
+  [ "$(echo "$output" | jq -r '.card.header.title.content')" = "🔴 评审请求修改" ]
+}
+
+@test "review commented: yellow" {
+  export NOTIFY_KIND="review_commented" TITLE="#2 y" REPO="r" ACTOR="a" URL="u" BODY=""
+  run bash "$SCRIPT"
+  [ "$(echo "$output" | jq -r '.card.header.template')" = "yellow" ]
+  [ "$(echo "$output" | jq -r '.card.header.title.content')" = "🟡 评审评论" ]
+}
+
+@test "body present: appended into content" {
+  export NOTIFY_KIND="issue_comment" TITLE="#1 x" REPO="r" ACTOR="a" URL="u" BODY="这是一条评论"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  content="$(echo "$output" | jq -r '.card.elements[0].text.content')"
+  echo "$content" | grep -q "这是一条评论"
+}
+
+@test "body empty: no separator line" {
+  export NOTIFY_KIND="pr_opened" TITLE="#2 y" REPO="r" ACTOR="a" URL="u" BODY=""
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  content="$(echo "$output" | jq -r '.card.elements[0].text.content')"
+  ! echo "$content" | grep -q "┄"
+}
+
+@test "body over 200 chars: summary is exactly 200 chars ending in ellipsis" {
+  long="$(printf '中%.0s' {1..300})"
+  export NOTIFY_KIND="issue_comment" TITLE="#1 x" REPO="r" ACTOR="a" URL="u" BODY="$long"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  content="$(echo "$output" | jq -r '.card.elements[0].text.content')"
+  # 取分隔线之后的摘要部分（非贪婪匹配完整 10 字符分隔符 + 换行）
+  summary="${content#*┄┄┄┄┄┄┄┄┄┄$'\n'}"
+  # 摘要必须以省略号结尾
+  [ "${summary: -1}" = "…" ]
+  # 摘要 unicode 字符数必须恰好 200（199 正文 + …）
+  len="$(printf '%s' "$summary" | jq -Rs 'length')"
+  [ "$len" -eq 200 ]
+}
+
+@test "title with asterisks: escaped so bold not broken" {
+  export NOTIFY_KIND="issue_opened" TITLE="#5 fix **bold** and *italic*" REPO="r" ACTOR="a" URL="u" BODY=""
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e . >/dev/null
+  content="$(echo "$output" | jq -r '.card.elements[0].text.content')"
+  # raw asterisks from the title must be backslash-escaped in the output
+  echo "$content" | grep -q 'fix \\\*\\\*bold\\\*\\\*'
+}

--- a/.github/scripts/lark-notify/test/dispatch.bats
+++ b/.github/scripts/lark-notify/test/dispatch.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+
+DIR="${BATS_TEST_DIRNAME}/.."
+SCRIPT="$DIR/dispatch.sh"
+
+setup() {
+  TMP="$(mktemp -d)"
+  cat > "$TMP/send.sh" <<EOF
+#!/usr/bin/env bash
+cat > "$TMP/sent.json"
+EOF
+  chmod +x "$TMP/send.sh"
+  export LARK_NOTIFY_SEND_BIN="$TMP/send.sh"
+}
+teardown() { rm -rf "$TMP"; }
+
+@test "issue_opened maps issue fields into card title with number" {
+  export NOTIFY_KIND="issue_opened" REPO="NeuroAIHub/BrainPilot"
+  export ISSUE_NUM="12" ISSUE_TITLE="登录崩溃" ISSUE_URL="https://x/issues/12" ISSUE_USER="alice"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  title="$(jq -r '.card.elements[0].text.content' "$TMP/sent.json")"
+  echo "$title" | grep -q "#12 登录崩溃"
+  echo "$title" | grep -q "alice"
+  [ "$(jq -r '.card.elements[1].actions[0].url' "$TMP/sent.json")" = "https://x/issues/12" ]
+}
+
+@test "pr_comment uses comment fields and pr number" {
+  export NOTIFY_KIND="pr_comment" REPO="r"
+  export PR_NUM="7" ISSUE_TITLE="" PR_TITLE=""
+  export ISSUE_NUM="7"
+  export COMMENT_BODY="LGTM" COMMENT_URL="https://x/pull/7#c1" COMMENT_USER="bob"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  content="$(jq -r '.card.elements[0].text.content' "$TMP/sent.json")"
+  echo "$content" | grep -q "LGTM"
+  echo "$content" | grep -q "bob"
+}
+
+@test "review_approved uses review fields" {
+  export NOTIFY_KIND="review_approved" REPO="r"
+  export PR_NUM="7" PR_TITLE="加功能" PR_URL="https://x/pull/7"
+  export REVIEW_BODY="nice" REVIEW_URL="https://x/pull/7#r1" REVIEW_USER="carol"
+  run bash "$SCRIPT"
+  [ "$status" -eq 0 ]
+  content="$(jq -r '.card.elements[0].text.content' "$TMP/sent.json")"
+  echo "$content" | grep -q "carol"
+  [ "$(jq -r '.card.elements[1].actions[0].url' "$TMP/sent.json")" = "https://x/pull/7#r1" ]
+}

--- a/.github/scripts/lark-notify/test/send.bats
+++ b/.github/scripts/lark-notify/test/send.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+
+SCRIPT="${BATS_TEST_DIRNAME}/../send.sh"
+
+setup() {
+  TMP="$(mktemp -d)"
+  cat > "$TMP/curl" <<'EOF'
+#!/usr/bin/env bash
+echo "$@" >> "$ARGS_FILE"
+prev=""
+for a in "$@"; do
+  case "$prev" in
+    --data|--data-binary|-d)
+      f="${a#@}"; [ -f "$f" ] && cat "$f" > "$BODY_FILE" ;;
+  esac
+  prev="$a"
+done
+echo '{"code":0,"msg":"success"}'
+EOF
+  chmod +x "$TMP/curl"
+  export PATH="$TMP:$PATH"
+  export ARGS_FILE="$TMP/args" BODY_FILE="$TMP/body"
+  : > "$ARGS_FILE"; : > "$BODY_FILE"
+}
+
+teardown() { rm -rf "$TMP"; }
+
+@test "no secret: body has no timestamp or sign, has card" {
+  export LARK_WEBHOOK_URL="https://example.invalid/hook"
+  unset LARK_WEBHOOK_SECRET || true
+  run bash -c 'echo '\''{"msg_type":"interactive","card":{"x":1}}'\'' | bash "'"$SCRIPT"'"'
+  [ "$status" -eq 0 ]
+  run cat "$BODY_FILE"
+  [ "$(echo "$output" | jq -r '.timestamp // "none"')" = "none" ]
+  [ "$(echo "$output" | jq -r '.sign // "none"')" = "none" ]
+  [ "$(echo "$output" | jq -r '.msg_type')" = "interactive" ]
+}
+
+@test "with secret: body has timestamp and base64 sign" {
+  export LARK_WEBHOOK_URL="https://example.invalid/hook"
+  export LARK_WEBHOOK_SECRET="mysecret"
+  run bash -c 'echo '\''{"msg_type":"interactive","card":{"x":1}}'\'' | bash "'"$SCRIPT"'"'
+  [ "$status" -eq 0 ]
+  run cat "$BODY_FILE"
+  ts="$(echo "$output" | jq -r '.timestamp')"
+  sign="$(echo "$output" | jq -r '.sign')"
+  [ -n "$ts" ] && [ "$ts" != "null" ]
+  [ -n "$sign" ] && [ "$sign" != "null" ]
+  echo "$sign" | base64 -d >/dev/null 2>&1
+}
+
+@test "posts to configured URL with json content-type" {
+  export LARK_WEBHOOK_URL="https://example.invalid/hook"
+  unset LARK_WEBHOOK_SECRET || true
+  run bash -c 'echo '\''{"msg_type":"interactive","card":{}}'\'' | bash "'"$SCRIPT"'"'
+  [ "$status" -eq 0 ]
+  grep -q "https://example.invalid/hook" "$ARGS_FILE"
+  grep -q "Content-Type: application/json" "$ARGS_FILE"
+}
+
+@test "non-zero business code: exits 1" {
+  # override the mock curl to return a failure code
+  cat > "$TMP/curl" <<'EOF'
+#!/usr/bin/env bash
+echo '{"code":19021,"msg":"sign match fail"}'
+EOF
+  chmod +x "$TMP/curl"
+  export LARK_WEBHOOK_URL="https://example.invalid/hook"
+  unset LARK_WEBHOOK_SECRET || true
+  run bash -c 'echo '\''{"msg_type":"interactive","card":{}}'\'' | bash "'"$SCRIPT"'"'
+  [ "$status" -eq 1 ]
+}

--- a/.github/workflows/lark-notify-test.yml
+++ b/.github/workflows/lark-notify-test.yml
@@ -1,0 +1,29 @@
+name: Lark Notify Tests
+
+on:
+  pull_request:
+    paths:
+      - '.github/scripts/lark-notify/**'
+      - '.github/workflows/lark-notify*.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.github/scripts/lark-notify/**'
+      - '.github/workflows/lark-notify*.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  bats:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install bats
+        run: sudo apt-get update && sudo apt-get install -y bats jq
+      - name: Run script tests
+        run: bats .github/scripts/lark-notify/test/
+      - name: Validate workflow YAML
+        run: |
+          python3 -c "import yaml; yaml.safe_load(open('.github/workflows/lark-notify.yml')); print('lark-notify.yml OK')"
+          python3 -c "import yaml; yaml.safe_load(open('.github/workflows/lark-notify-test.yml')); print('lark-notify-test.yml OK')"

--- a/.github/workflows/lark-notify.yml
+++ b/.github/workflows/lark-notify.yml
@@ -1,0 +1,97 @@
+name: Lark Notify
+
+# 安全：PR 事件用 pull_request_target（在 base 仓上下文运行、可拿 secret，
+# 使公开后外部 fork PR 也能推群）。严守边界：本 workflow 绝不 checkout/执行 PR
+# 代码，只读 github.event.pull_request.* 元数据；PR 文本只经环境变量+jq 当数据；
+# permissions 收最小。详见 spec §10.2。
+on:
+  issues:
+    types: [opened, closed]
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, ready_for_review, review_requested]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (base branch scripts only)
+        # pull_request_target 下默认 checkout 的是 base 分支（可信 main）上的脚本，
+        # 不是 PR head。绝不加 ref: PR head —— 那会引入 pwn request 漏洞。
+        uses: actions/checkout@v4
+
+      - name: Decide notification kind
+        id: kind
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          ACTION: ${{ github.event.action }}
+          PR_MERGED: ${{ github.event.pull_request.merged }}
+          REVIEW_STATE: ${{ github.event.review.state }}
+          IS_PR_COMMENT: ${{ github.event.issue.pull_request != null }}
+        run: |
+          KIND=""
+          case "$EVENT_NAME" in
+            issues)
+              [ "$ACTION" = "opened" ] && KIND="issue_opened"
+              [ "$ACTION" = "closed" ] && KIND="issue_closed"
+              ;;
+            issue_comment)
+              if [ "$ACTION" = "created" ]; then
+                if [ "$IS_PR_COMMENT" = "true" ]; then KIND="pr_comment"; else KIND="issue_comment"; fi
+              fi
+              ;;
+            pull_request_target)
+              case "$ACTION" in
+                opened) KIND="pr_opened" ;;
+                ready_for_review) KIND="pr_ready" ;;
+                review_requested) KIND="review_requested" ;;
+                closed) [ "$PR_MERGED" = "true" ] && KIND="pr_merged" || KIND="pr_closed" ;;
+              esac
+              ;;
+            pull_request_review)
+              if [ "$ACTION" = "submitted" ]; then
+                case "$REVIEW_STATE" in
+                  approved) KIND="review_approved" ;;
+                  changes_requested) KIND="review_changes" ;;
+                  commented) KIND="review_commented" ;;
+                esac
+              fi
+              ;;
+          esac
+          echo "kind=$KIND" >> "$GITHUB_OUTPUT"
+          if [ -z "$KIND" ]; then echo "无匹配通知类型，跳过"; fi
+
+      - name: Build & send card
+        if: steps.kind.outputs.kind != ''
+        env:
+          NOTIFY_KIND: ${{ steps.kind.outputs.kind }}
+          REPO: ${{ github.repository }}
+          LARK_WEBHOOK_URL: ${{ secrets.LARK_WEBHOOK_URL }}
+          LARK_WEBHOOK_SECRET: ${{ secrets.LARK_WEBHOOK_SECRET }}
+          # issue
+          ISSUE_NUM: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_USER: ${{ github.event.issue.user.login }}
+          # comment
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_URL: ${{ github.event.comment.html_url }}
+          COMMENT_USER: ${{ github.event.comment.user.login }}
+          # pr
+          PR_NUM: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_USER: ${{ github.event.pull_request.user.login }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          # review
+          REVIEW_BODY: ${{ github.event.review.body }}
+          REVIEW_URL: ${{ github.event.review.html_url }}
+          REVIEW_USER: ${{ github.event.review.user.login }}
+        run: |
+          bash .github/scripts/lark-notify/dispatch.sh

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,10 @@ build/
 .env.local
 .env.*.local
 
+# Release push private config (registry addresses + mirror sources)
+scripts/release-targets.local.sh
+scripts/release-mirrors.local.sh
+
 # Benchmark data (mounted externally, never committed)
 benchmark_tasks/
 benchmark_results/

--- a/README.md
+++ b/README.md
@@ -155,6 +155,30 @@ npm run release           # version-sync, build, then publish protocol→runtime
 ```
 `@brainpilot/client-cli` stays private and is never published.
 
+### Docker 镜像发布
+
+镜像版本号与 npm 版本一致（根 `package.json` 的 `version`）。三个镜像：`brainpilot-main`、
+`brainpilot-sandbox`（cpu）、`brainpilot-sandbox-gpu`（CUDA torch）。
+
+```bash
+# 一次性：复制示范配置，填入国内镜像源 / 私有 registry 地址（两个 .local 文件均不提交）
+cp scripts/release-mirrors.example.sh scripts/release-mirrors.local.sh   # pip/apt 镜像源
+cp scripts/release-targets.example.sh scripts/release-targets.local.sh   # ACR/内网 registry
+
+# 构建（默认全部；可传子串只建子集）
+bash scripts/release-build.sh                # 全部三个镜像
+bash scripts/release-build.sh main           # 只建 main
+bash scripts/release-build.sh sandbox-gpu    # 只建 GPU 变体（体积大、慢）
+
+# 推送（需先 docker login 各 registry）
+bash scripts/release-push.sh --dry-run                       # 先看计划
+bash scripts/release-push.sh                                 # 全部 → 全部 registry
+bash scripts/release-push.sh --image sandbox-gpu --registry acr,intranet  # GPU 跳过公网 ghcr
+```
+
+推送目标 registry 在 `scripts/release-images.sh`（ghcr，公开）+ `release-targets.local.sh`
+（ACR / 内网，私有）声明。GPU 镜像约 6GB，推公网 ghcr 可能超时，建议 `--registry acr,intranet`。
+
 ## 🧪 Testing
 
 ```bash

--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -27,6 +27,11 @@ FROM node:22-slim AS runtime
 
 ARG APT_MIRROR=""
 ARG NPM_REGISTRY=""
+# sandbox 变体选择 + pip 镜像源（build-arg → ENV，供 extra-deps 脚本读取；空则官方源默认）
+ARG SANDBOX_EXTRA_DEPS=extra-deps.sh
+ARG PIP_INDEX_URL=""
+ARG PIP_EXTRA_INDEX_URL=""
+ENV APT_MIRROR=${APT_MIRROR} PIP_INDEX_URL=${PIP_INDEX_URL} PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL}
 
 # curl is needed for the HEALTHCHECK probe.
 RUN if [ -n "$APT_MIRROR" ]; then \
@@ -42,8 +47,11 @@ COPY --from=builder /app/packages ./packages
 COPY --from=builder /app/package.json ./package.json
 
 # User-editable dependency injection point (runs at build time).
-COPY docker/sandbox/extra-deps.sh /tmp/extra-deps.sh
-RUN chmod +x /tmp/extra-deps.sh && bash /tmp/extra-deps.sh
+# 同时 COPY 共享片段 + 选中的变体脚本（cpu: extra-deps.sh / gpu: extra-deps.gpu.sh）。
+# 两个脚本都 source ./_python-base.sh，故 _python-base.sh 必须同目录存在。
+COPY docker/sandbox/_python-base.sh /tmp/_python-base.sh
+COPY docker/sandbox/${SANDBOX_EXTRA_DEPS} /tmp/extra-deps.sh
+RUN chmod +x /tmp/extra-deps.sh /tmp/_python-base.sh && bash /tmp/extra-deps.sh
 
 ENV PORT=8081 AGENT_RUNTIME_PORT=8081 BP_DATA_DIR=/root/.bp-root
 EXPOSE 8081

--- a/docker/sandbox/_python-base.sh
+++ b/docker/sandbox/_python-base.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# _python-base.sh — cpu/gpu sandbox 共享的 python3 + pip + 镜像源安装段。
+# 由 extra-deps.sh / extra-deps.gpu.sh source。镜像源来自 ENV（Dockerfile 经 build-arg 透传），
+# 为空则用镜像自带官方源（pypi.org / deb.debian.org）。
+set -euo pipefail
+
+# apt 源：APT_MIRROR 注入则替换官方源
+[ -n "${APT_MIRROR:-}" ] && sed -i "s|http://deb.debian.org|$APT_MIRROR|g" \
+  /etc/apt/sources.list.d/*.sources /etc/apt/sources.list 2>/dev/null || true
+apt-get update && apt-get install -y --no-install-recommends python3 python3-pip python3-venv
+rm -rf /var/lib/apt/lists/*
+
+# pip 源：PIP_INDEX_URL 注入则固化 /etc/pip.conf，否则用 pip 官方默认
+if [ -n "${PIP_INDEX_URL:-}" ]; then
+  { echo '[global]'
+    echo "index-url = ${PIP_INDEX_URL}"
+    [ -n "${PIP_EXTRA_INDEX_URL:-}" ] && echo "extra-index-url = ${PIP_EXTRA_INDEX_URL}"
+    echo 'timeout = 60'
+  } > /etc/pip.conf
+fi

--- a/docker/sandbox/extra-deps.gpu.sh
+++ b/docker/sandbox/extra-deps.gpu.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # extra-deps.gpu.sh — sandbox-gpu 变体依赖（构建期执行）。
 # = cpu 的 python3 基础 + 预装科学/PDF 栈 + CUDA 12.4 PyTorch。
-# torch 版本/源沿用 legacy 实测配置（legacy/docker/agent_runtime/Dockerfile.base，2026-05-29）。
-# 镜像源经 ENV 注入（见 _python-base.sh）；torch 用专属 whl 源不受其影响。
+# torch cu124 走上海交大 pytorch-wheels 镜像（国内高速、绕开官方源经代理崩溃，见 §4 注释）。
+# 镜像源经 ENV 注入（见 _python-base.sh）。
 set -euo pipefail
 
 # 1) python3 + pip + 镜像源（与 cpu 共享）
@@ -20,11 +20,27 @@ pip3 install --break-system-packages \
   nvidia-cusolver-cu12==11.6.1.9 nvidia-cusparse-cu12==12.3.1.170 \
   nvidia-nccl-cu12==2.21.5 nvidia-nvtx-cu12==12.4.127 nvidia-nvjitlink-cu12==12.4.127
 
-# 4) PyTorch cu124（官方 whl 源——清华 pytorch-wheels 不同步 cu124 会 404；
-#    此 index-url 是 torch 专属、不受镜像源外置影响。构建时 --network=host 借宿主代理）
-pip3 install --break-system-packages \
-  torch==2.5.1+cu124 torchvision==0.20.1+cu124 torchaudio==2.5.1+cu124 \
-  --index-url https://download.pytorch.org/whl/cu124 \
-  --extra-index-url "${PIP_INDEX_URL:-https://pypi.org/simple/}"
+# 4) PyTorch cu124 —— curl 直下上海交大 wheel 文件，再 pip 装本地文件。
+#    为什么不用 pip --index-url 交大：交大 simple 索引页（/cu124/torch/）里登记的 wheel 链接
+#    指向官方 download.pytorch.org → 302 Cloudflare R2，pip 跟着去 R2，该流经 Clash 代理会
+#    限速崩溃+哈希不匹配（2026-06-15 两次实测）。而直接拼文件 URL（/cu124/<wheel>）会 302 到
+#    交大自有 S3（s3.jcloud.sjtu.edu.cn，国内 ~13MB/s），绕开 R2 与代理。故 curl 直下。
+#    torch 的纯 Python 依赖（sympy/networkx/jinja2/fsspec…）仍由 pip 从 PIP_INDEX_URL 装。
+#    源根可被 TORCH_WHEEL_BASE 覆盖（默认交大）。
+TORCH_WHEEL_BASE="${TORCH_WHEEL_BASE:-https://mirror.sjtu.edu.cn/pytorch-wheels/cu124}"
+_tw=/tmp/torch-wheels
+mkdir -p "$_tw"
+for whl in \
+  "torch-2.5.1%2Bcu124-cp311-cp311-linux_x86_64.whl" \
+  "torchvision-0.20.1%2Bcu124-cp311-cp311-linux_x86_64.whl" \
+  "torchaudio-2.5.1%2Bcu124-cp311-cp311-linux_x86_64.whl"; do
+  # %2B 是 + 的 URL 编码；落地文件名解码回 +
+  out="$_tw/$(printf '%s' "$whl" | sed 's/%2B/+/g')"
+  echo "[extra-deps.gpu] downloading $out"
+  curl -fSL --retry 5 --retry-delay 3 --connect-timeout 30 -o "$out" "$TORCH_WHEEL_BASE/$whl"
+done
+# pip 装本地 wheel；torch 依赖从 PIP_INDEX_URL（阿里云/官方）补齐
+pip3 install --break-system-packages --retries 5 --timeout 120 "$_tw"/*.whl
+rm -rf "$_tw"
 
 echo "[extra-deps.gpu] sci stack + torch 2.5.1+cu124 installed"

--- a/docker/sandbox/extra-deps.gpu.sh
+++ b/docker/sandbox/extra-deps.gpu.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# extra-deps.gpu.sh — sandbox-gpu 变体依赖（构建期执行）。
+# = cpu 的 python3 基础 + 预装科学/PDF 栈 + CUDA 12.4 PyTorch。
+# torch 版本/源沿用 legacy 实测配置（legacy/docker/agent_runtime/Dockerfile.base，2026-05-29）。
+# 镜像源经 ENV 注入（见 _python-base.sh）；torch 用专属 whl 源不受其影响。
+set -euo pipefail
+
+# 1) python3 + pip + 镜像源（与 cpu 共享）
+source "$(dirname "$0")/_python-base.sh"
+
+# 2) 科学/PDF 栈（最新稳定，走上面配置的 pip 源）
+pip3 install --break-system-packages \
+  numpy pandas scipy matplotlib scikit-learn pillow pypdf pdfplumber
+
+# 3) CUDA 12.4 runtime wheels（pip 默认源，国内由 PIP_INDEX_URL 指向阿里云/清华）
+pip3 install --break-system-packages \
+  nvidia-cuda-runtime-cu12==12.4.127 nvidia-cuda-nvrtc-cu12==12.4.127 \
+  nvidia-cudnn-cu12==9.1.0.70 nvidia-cublas-cu12==12.4.5.8 \
+  nvidia-cufft-cu12==11.2.1.3 nvidia-curand-cu12==10.3.5.147 \
+  nvidia-cusolver-cu12==11.6.1.9 nvidia-cusparse-cu12==12.3.1.170 \
+  nvidia-nccl-cu12==2.21.5 nvidia-nvtx-cu12==12.4.127 nvidia-nvjitlink-cu12==12.4.127
+
+# 4) PyTorch cu124（官方 whl 源——清华 pytorch-wheels 不同步 cu124 会 404；
+#    此 index-url 是 torch 专属、不受镜像源外置影响。构建时 --network=host 借宿主代理）
+pip3 install --break-system-packages \
+  torch==2.5.1+cu124 torchvision==0.20.1+cu124 torchaudio==2.5.1+cu124 \
+  --index-url https://download.pytorch.org/whl/cu124 \
+  --extra-index-url "${PIP_INDEX_URL:-https://pypi.org/simple/}"
+
+echo "[extra-deps.gpu] sci stack + torch 2.5.1+cu124 installed"

--- a/docker/sandbox/extra-deps.gpu.sh
+++ b/docker/sandbox/extra-deps.gpu.sh
@@ -1,23 +1,32 @@
 #!/usr/bin/env bash
 # extra-deps.gpu.sh — sandbox-gpu 变体依赖（构建期执行）。
-# = cpu 的 python3 基础 + 预装科学/PDF 栈 + CUDA 12.4 PyTorch。
+# = cpu 的 python3 基础 + 预装科学栈 + CUDA 12.4 PyTorch。
 # torch cu124 走上海交大 pytorch-wheels 镜像（国内高速、绕开官方源经代理崩溃，见 §4 注释）。
 # 镜像源经 ENV 注入（见 _python-base.sh）。
+#
+# 瘦身（2026-06-16，第一阶段，见 docs/research/2026-06-16-gpu-sandbox-slimming.md）：
+#   - 所有 pip3 install 加 --no-cache-dir：省 ~2.1GB pip 下载缓存
+#   - torch 2.5.1→2.6.0：wheel 小 133MB，nvidia 依赖钉版不变，仍 cu124（全架构兼容）
+#   - 卸 triton：仅 torch.compile/自定义 kernel 用，本沙盒不用，省 ~0.69GB
+#   合计实测 14.5GB → 9.25GB（省 36%），零架构风险、零功能损失。
 set -euo pipefail
 
 # 1) python3 + pip + 镜像源（与 cpu 共享）
 source "$(dirname "$0")/_python-base.sh"
 
 # 2) 科学/PDF 栈（最新稳定，走上面配置的 pip 源）
-pip3 install --break-system-packages \
+pip3 install --no-cache-dir --break-system-packages \
   numpy pandas scipy matplotlib scikit-learn pillow pypdf pdfplumber
 
 # 3) CUDA 12.4 runtime wheels（pip 默认源，国内由 PIP_INDEX_URL 指向阿里云/清华）
-pip3 install --break-system-packages \
+#    cusparselt 是 torch 2.6.0 新增的独立依赖（2.5.1 时 bundle 在 torch/lib 内）。
+pip3 install --no-cache-dir --break-system-packages \
   nvidia-cuda-runtime-cu12==12.4.127 nvidia-cuda-nvrtc-cu12==12.4.127 \
+  nvidia-cuda-cupti-cu12==12.4.127 \
   nvidia-cudnn-cu12==9.1.0.70 nvidia-cublas-cu12==12.4.5.8 \
   nvidia-cufft-cu12==11.2.1.3 nvidia-curand-cu12==10.3.5.147 \
   nvidia-cusolver-cu12==11.6.1.9 nvidia-cusparse-cu12==12.3.1.170 \
+  nvidia-cusparselt-cu12==0.6.2 \
   nvidia-nccl-cu12==2.21.5 nvidia-nvtx-cu12==12.4.127 nvidia-nvjitlink-cu12==12.4.127
 
 # 4) PyTorch cu124 —— curl 直下上海交大 wheel 文件，再 pip 装本地文件。
@@ -31,16 +40,24 @@ TORCH_WHEEL_BASE="${TORCH_WHEEL_BASE:-https://mirror.sjtu.edu.cn/pytorch-wheels/
 _tw=/tmp/torch-wheels
 mkdir -p "$_tw"
 for whl in \
-  "torch-2.5.1%2Bcu124-cp311-cp311-linux_x86_64.whl" \
-  "torchvision-0.20.1%2Bcu124-cp311-cp311-linux_x86_64.whl" \
-  "torchaudio-2.5.1%2Bcu124-cp311-cp311-linux_x86_64.whl"; do
+  "torch-2.6.0%2Bcu124-cp311-cp311-linux_x86_64.whl" \
+  "torchvision-0.21.0%2Bcu124-cp311-cp311-linux_x86_64.whl" \
+  "torchaudio-2.6.0%2Bcu124-cp311-cp311-linux_x86_64.whl"; do
   # %2B 是 + 的 URL 编码；落地文件名解码回 +
   out="$_tw/$(printf '%s' "$whl" | sed 's/%2B/+/g')"
   echo "[extra-deps.gpu] downloading $out"
   curl -fSL --retry 5 --retry-delay 3 --connect-timeout 30 -o "$out" "$TORCH_WHEEL_BASE/$whl"
 done
 # pip 装本地 wheel；torch 依赖从 PIP_INDEX_URL（阿里云/官方）补齐
-pip3 install --break-system-packages --retries 5 --timeout 120 "$_tw"/*.whl
+pip3 install --no-cache-dir --break-system-packages --retries 5 --timeout 120 "$_tw"/*.whl
 rm -rf "$_tw"
 
-echo "[extra-deps.gpu] sci stack + torch 2.5.1+cu124 installed"
+# 5) 卸 triton —— torch 把它列为硬依赖（会随 torch wheel 装上），但仅 torch.compile/
+#    自定义 kernel 路径需要。本沙盒只跑常规张量/推理/训练，故卸掉省 ~0.69GB。
+#    注意：本镜像是 PEP 668 externally-managed，uninstall 同样需 --break-system-packages，
+#    否则被静默拒绝（2026-06-16 实测漏卸）。不吞 stderr，便于发现问题。
+pip3 uninstall -y --break-system-packages triton
+# 卸载残留的 __pycache__/空目录兜底
+rm -rf /usr/local/lib/python3.11/dist-packages/triton 2>/dev/null || true
+
+echo "[extra-deps.gpu] sci stack + torch 2.6.0+cu124 installed (triton removed, no pip cache)"

--- a/docker/sandbox/extra-deps.sh
+++ b/docker/sandbox/extra-deps.sh
@@ -1,36 +1,11 @@
 #!/usr/bin/env bash
-# =============================================================================
-# extra-deps.sh — 自定义 sandbox 镜像依赖（构建期执行，由 Dockerfile RUN 调用）
-# =============================================================================
-# 这个脚本在 sandbox 镜像构建时运行。默认轻量基线只含 Node + @brainpilot/runtime
-# + Pi SDK，不含 Python / 系统包 / 终端。需要更多依赖时，编辑本文件即可，
-# 无需改 Dockerfile 本体。重新 `docker compose build sandbox` 生效。
-#
-# 镜像源加速：通过 build-arg 注入 APT_MIRROR / NPM_REGISTRY（见 Dockerfile），
-# 此处可直接读取环境变量 $APT_MIRROR / $NPM_REGISTRY。
-#
-# ---------------------------------------------------------------------------
-# 示例 1：安装 Python3 + pip 包
-# ---------------------------------------------------------------------------
-#   set -euo pipefail
-#   apt-get update
-#   apt-get install -y --no-install-recommends python3 python3-pip
-#   pip3 install --no-cache-dir numpy pandas
-#   rm -rf /var/lib/apt/lists/*
-#
-# ---------------------------------------------------------------------------
-# 示例 2：安装系统包（如 git、curl 已在基础镜像，这里加 ripgrep）
-# ---------------------------------------------------------------------------
-#   set -euo pipefail
-#   apt-get update && apt-get install -y --no-install-recommends ripgrep
-#   rm -rf /var/lib/apt/lists/*
-#
-# ---------------------------------------------------------------------------
-# 示例 3：安装 npm 全局工具
-# ---------------------------------------------------------------------------
-#   npm install -g --no-fund --no-audit some-cli-tool
-#
-# ---------------------------------------------------------------------------
-# 默认：不装任何额外依赖（no-op）。删掉下面这行并填入你的命令即可。
-# ---------------------------------------------------------------------------
-echo "[extra-deps] no extra dependencies (lightweight baseline)"
+# extra-deps.sh — cpu sandbox 基线依赖（构建期执行，由 Dockerfile RUN 调用）。
+# 装 python3 + pip + venv，让 agent 能通过 Pi SDK 的 bash 工具运行 Python 代码
+# （persona 指示 agent "write/edit 文件 + bash 运行"）。
+# 不预装科学库 —— agent 按需自装（persona 本就要求 agent 管理依赖），保持镜像轻量。
+# GPU 变体见 extra-deps.gpu.sh。镜像源经 ENV 注入（见 _python-base.sh）。
+set -euo pipefail
+
+source "$(dirname "$0")/_python-base.sh"
+
+echo "[extra-deps] cpu baseline: python3 $(python3 --version 2>&1) installed (no sci libs)"

--- a/docs/research/2026-06-16-gpu-sandbox-slimming.md
+++ b/docs/research/2026-06-16-gpu-sandbox-slimming.md
@@ -1,0 +1,165 @@
+# GPU 沙盒镜像瘦身调研
+
+> 日期：2026-06-16 · 状态：**第一阶段已落地（实测 14.5GB→9.25GB，省 36%）；第二阶段实证后放弃**
+> 镜像：`brainpilot-sandbox-gpu`（当前 0.0.4，**14.5GB** uncompressed / 5.6GB compressed）
+> 工作负载（用户确认）：常规 torch 张量/推理/训练 + 科学计算（scipy/pandas/sklearn）；**不用 torch.compile**
+> GPU 架构：**不确定**，用户倾向选体积小的版本
+
+---
+
+## 1. 14.5GB 构成实测拆解
+
+`docker history` 显示 `extra-deps.gpu.sh` 那一个 RUN 层就占 **8.25GB**。进容器 `du` 拆解：
+
+| 构成 | 大小 | 可否优化 |
+|------|------|---------|
+| `nvidia/` pip 包（CUDA 运行库） | **2.7GB** | ⚠️ torch small-wheel 硬依赖，整体不可删，但**版本可换**（见 §3） |
+| `torch/lib/*.so`（libtorch_cuda 899MB 等） | 1.6GB | ⚠️ 升 torch 版本可小 133MB |
+| `triton` | 556MB | ✅ **可删**（仅 torch.compile/自定义 kernel 用，用户不用） |
+| scipy/pandas/sklearn/sympy/matplotlib… | ~400MB | ⚠️ 用户要保留科学计算 |
+| **`/root/.cache/pip`（pip 下载缓存）** | **2.1GB** | ✅ **纯浪费，必删** |
+| Debian + node + python 基础层 | ~0.7GB | ❌ 基础 |
+
+### 1.1 nvidia 子包细分（2.7GB 大头在哪）
+
+```
+976M  nvidia/cudnn      ← 最大；其中单文件 libcudnn_engines_precompiled.so.9 占 543M
+528M  nvidia/cublas
+281M  nvidia/cufft
+269M  nvidia/cusparse
+241M  nvidia/nccl
+194M  nvidia/cusolver
+ 95M  nvidia/curand
+...
+```
+
+### 1.2 cudnn 内部（976M 里的可裁剪项）
+
+```
+543M  libcudnn_engines_precompiled.so.9   ← 所有 GPU 架构(sm_70~90)的预编译 kernel 合集；pip 包无法按架构裁剪
+230M  libcudnn_adv.so.9                    ← RNN/LSTM 等高级算子；不用循环网络可删
+103M  libcudnn_ops.so.9
+ 82M  libcudnn_heuristic.so.9
+```
+
+---
+
+## 2. 关键架构事实
+
+- **本机无 GPU**（`nvidia-smi` 空），但**已装 nvidia-container-toolkit 1.18.1** → 印证正确架构是 **driver 在宿主机、容器 `--gpus all` 借用**。镜像内**不含也不需要** CUDA driver（正确）。
+- **但 CUDA 运行库（cudnn/cublas 等 2.7GB）必须在容器内**：torch 2.5.1 是 **small wheel**，其 `METADATA` 用 `Requires-Dist` 硬依赖 PyPI 的 `nvidia-*-cu12` 包，`torch/lib` 不再 bundle 这些库。宿主机只提供 driver + `libcuda.so`，**不提供 cudnn/cublas**。
+- **结论：~6.3GB（torch + nvidia 运行库 + 基础层）是硬底**，无法靠"借宿主机"消除。瘦身只能在"删无用 + 换更小版本 + strip"三个方向。
+
+---
+
+## 3. 一手体积数据（交大镜像 + PyPI JSON API 实测，非估算）
+
+### 3.1 torch 本体 wheel（不同 CUDA / 版本）
+
+| 版本 | torch wheel | 备注 |
+|------|------------|------|
+| 2.5.1 **+cu118** | 800MB | 旧 CUDA，不支持 Hopper+ |
+| 2.5.1 **+cu121** | **744MB** | 比 cu124 小 122MB，但不支持 sm_90+ |
+| 2.5.1 **+cu124**（当前） | 866MB | |
+| **2.6.0 +cu124** | **733MB** ⭐ | **比 2.5.1 小 133MB，nvidia 依赖钉版完全相同，仍 cu124（全架构兼容）** |
+
+### 3.2 nvidia 包 cu124 vs cu121（实测 wheel 大小）
+
+| 包 | cu124 版本/大小 | cu121 版本/大小 | 差 |
+|----|----------------|----------------|----|
+| cudnn | 9.1.0.70 / 634MB | 9.1.0.70 / 634MB | 0（同款） |
+| cublas | 12.4.5.8 / 347MB | 12.1.3.1 / **392MB** | cu121 反而 **+45MB** |
+| cusparse | 12.3.1.170 / 198MB | 12.1.0.106 / 187MB | -11MB |
+| cusolver | 11.6.1.9 / 122MB | 11.4.5.107 / 118MB | -4MB |
+| cufft | 11.2.1.3 / 202MB | 11.0.2.54 / **116MB** | -86MB |
+
+> **反直觉结论**：降到 cu121 的 nvidia 包**净收益只有 ~50MB**（cufft 省 86 但 cublas 多 45），加上 torch 本体省 122MB ≈ **总共才省 ~170MB**，却要牺牲 sm_90+（H100/H200/Blackwell）支持。**性价比极差，不推荐为了体积降 cu121。**
+
+---
+
+## 4. 方案对比（按净收益排序）
+
+| # | 措施 | 省多少 | 风险 | 依赖架构? | 推荐 |
+|---|------|-------|------|----------|------|
+| 1 | **清 pip 缓存**（`--no-cache-dir`） | **2.1GB** | 零 | 否 | ✅ 必做 |
+| 2 | **卸载 triton**（不用 torch.compile） | 0.56GB | 零（用户不用） | 否 | ✅ 推荐 |
+| 3 | **升 torch 2.5.1→2.6.0** | 0.13GB | 低（2.6 稳定版，依赖钉版不变） | 否 | ✅ 推荐 |
+| 4 | strip .so 调试符号 + 删 libcudnn_adv（不用RNN） | 0.3–0.8GB | 低-中（需测） | 否 | ⚠️ 可选 |
+| 5 | 降 cu124→cu121 | 仅 ~0.17GB | **高**（丢 sm_90+ 支持） | **是** | ❌ 不推荐 |
+| 6 | C 方案：独立 `cuda-base` 共享层 | 单镜像不变 | 工程量大 | 否 | ⏸ 仅多 GPU 变体时划算 |
+
+### 推荐组合（匹配"架构不确定 + 想要小版本"）
+
+**措施 1 + 2 + 3**：清缓存 + 卸 triton + 升 torch 2.6.0
+- **14.5GB → ~9.1GB**（省 ~5.4GB / 37%）
+- **零架构风险**：仍是 cu124，支持所有 NVIDIA 架构（Ampere/Ada/Hopper/Blackwell 全覆盖）
+- 零功能损失（triton 用户不用；2.6.0 是稳定版）
+
+> 措施 4（strip）可作为第二阶段再叠加，把镜像推到 ~8.5GB，但需逐项测试 import + GPU kernel，留到验证有 GPU 的环境时做。
+
+### 为什么不靠"降 CUDA 版本"省体积
+
+用户倾向"选小版本"，但实测数据表明：**降 cu121 的体积收益（~170MB）微不足道，却牺牲新 GPU 支持**。真正的"小版本"红利在**升 torch 版本**（2.6.0 小 133MB 且全兼容）而非降 CUDA 版本。这是本次调研最反直觉、最有价值的发现。
+
+---
+
+## 5. 落地清单（待用户批准后执行）
+
+1. `docker/sandbox/extra-deps.gpu.sh`：
+   - 所有 `pip3 install` 加 `--no-cache-dir`（或结尾 `rm -rf /root/.cache/pip`）
+   - torch wheel URL：`2.5.1+cu124` → `2.6.0+cu124`（三个 torch/vision/audio 同步升；torchvision 0.20.1→0.21.0，torchaudio 2.5.1→2.6.0）
+   - 安装末尾 `pip3 uninstall -y triton`（或排除其安装）
+2. 重建 + 实测：`python3 -c "import torch,scipy,pandas,sklearn"`、torch CUDA 库链接完整性
+3. 重新打 tag + 推 ACR（GPU 仅推阿里云）
+4. 更新 [[docker-release-push]] 记忆与本文档"实际结果"
+
+---
+
+## 6. 第一阶段实际结果（2026-06-16 落地，已构建验证）
+
+| 项 | 旧 | 新 |
+|----|-----|-----|
+| **DISK 占用** | 14.5GB | **9.25GB**（省 5.25GB / **36%**） |
+| torch | 2.5.1+cu124 | 2.6.0+cu124 |
+| triton | 686MB（在） | ✅ 卸载 |
+| pip 缓存 | 2.1GB | ✅ 清空 |
+| 科学栈 | scipy/pandas/sklearn | ✅ 保留 |
+
+功能验证：`import torch/torchvision/torchaudio`、`nn.Conv2d`、`scipy/pandas/sklearn` 全部 OK。
+
+### 实施踩坑
+
+- **triton 漏卸（首建 10.2GB）**：`pip uninstall -y triton` 在 PEP 668 externally-managed 环境下**需 `--break-system-packages`**，否则被**静默拒绝**（无报错、triton 仍在）。修正后 `Successfully uninstalled triton-3.2.0`。
+- **torch 2.6.0 新增 `nvidia-cusparselt-cu12==0.6.2` 依赖**（2.5.1 时 bundle 在 `torch/lib/libcusparseLt.so`(212MB)，2.6 改独立 pip 包）。§3 手动钉版清单**必须补这个**，否则 `import torch` 缺库崩。
+
+## 7. 第二阶段实证：strip/删库 → **放弃**（2026-06-16）
+
+在镜像内逐项实测，原计划全部落空：
+
+| 候选 | 大小 | 实测 | 结论 |
+|------|------|------|------|
+| **strip 所有 .so 调试符号** | — | `strip --strip-unneeded` 对 libtorch_cuda/libcublas/libcudnn 全部 **省 0MB** | ❌ NVIDIA/torch wheel 早已 strip，体积是真实机器码+多架构 GPU kernel(cubin/PTX) |
+| 删 nccl | 241MB | `import torch` 即崩：`libnccl.so.2: cannot open` | ❌ torch._C 启动期硬加载 |
+| 删 cusparselt | 203MB | `import torch` 即崩：`libcusparseLt.so.0` | ❌ 同上 |
+| 删 cufft | 281MB | `import torch` 即崩：`libcufft.so.11` | ❌ 同上 |
+| 删 libcudnn_adv（RNN/LSTM 算子） | 229MB | import+matmul+Conv2d **OK** | ⚠️ 唯一可删，但牺牲 RNN/LSTM GPU 支持，**本机无 GPU 无法验证生产是否触发**，为 2% 体积冒生产崩险，**不做** |
+
+**关键认知**：torch 2.6 的 `from torch._C import *` 在**启动时硬链接** nccl/cusparselt/cufft 等几乎所有 nvidia 库——它们是"import 期必需"而非"运行期按需"。"删用不到的库"这条路基本不通。
+
+**最终结论**：9.25GB 是安全瘦身极限。剩余是 GPU 加速硬成本（torch 1.6G + nvidia 必需运行库），不再继续。
+
+
+---
+
+## 附：数据采集命令（可复现）
+
+```bash
+# torch wheel 大小
+curl -fsSLI "https://mirror.sjtu.edu.cn/pytorch-wheels/cu124/torch-2.6.0%2Bcu124-cp311-cp311-linux_x86_64.whl" | grep -i content-length
+
+# nvidia 包大小
+curl -fsSL "https://pypi.org/pypi/nvidia-cudnn-cu12/json" | python3 -c "import sys,json;d=json.load(sys.stdin);print([f['size'] for f in d['releases']['9.1.0.70'] if 'x86_64' in f['filename']])"
+
+# 镜像内拆解
+sudo docker run --rm --entrypoint bash brainpilot-sandbox-gpu:0.0.4 -c 'du -sh /usr/local/lib/python3.11/dist-packages/* | sort -rh | head'
+```

--- a/docs/superpowers/plans/2026-06-15-multi-registry-push.md
+++ b/docs/superpowers/plans/2026-06-15-multi-registry-push.md
@@ -42,7 +42,7 @@
 - Create: `scripts/release-images.sh`
 - Test: `scripts/_test-release-images.sh`（临时 driver，验证后删除）
 
-- [ ] **Step 1: 写 SSOT 清单脚本**
+- [x] **Step 1: 写 SSOT 清单脚本**
 
 Create `scripts/release-images.sh`：
 
@@ -83,7 +83,7 @@ remote_repo() {
 }
 ```
 
-- [ ] **Step 2: 写临时 driver 测试映射函数**
+- [x] **Step 2: 写临时 driver 测试映射函数**
 
 Create `scripts/_test-release-images.sh`：
 
@@ -112,7 +112,7 @@ check "${RELEASE_REGISTRIES[0]}" "ghcr|ghcr.io/neuroaihub|flat" "ghcr 默认 reg
 exit $fail
 ```
 
-- [ ] **Step 3: 运行 driver，验证全 PASS**
+- [x] **Step 3: 运行 driver，验证全 PASS**
 
 Run: `bash scripts/_test-release-images.sh`
 Expected: 6 行 PASS，退出码 0：
@@ -125,7 +125,7 @@ PASS: 镜像清单 3 条
 PASS: ghcr 默认 registry
 ```
 
-- [ ] **Step 4: 语法检查 + 删除临时 driver**
+- [x] **Step 4: 语法检查 + 删除临时 driver**
 
 ```bash
 bash -n scripts/release-images.sh
@@ -133,7 +133,7 @@ rm scripts/_test-release-images.sh
 ```
 Expected: 无输出（语法 OK），driver 已删。
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add scripts/release-images.sh
@@ -151,7 +151,7 @@ git commit -m "feat(release): add SSOT image/registry manifest + remote_repo map
 - Create: `scripts/release-mirrors.local.sh`（不提交）
 - Modify: `.gitignore`
 
-- [ ] **Step 1: 写 targets 示范文件（提交版）**
+- [x] **Step 1: 写 targets 示范文件（提交版）**
 
 Create `scripts/release-targets.example.sh`：
 
@@ -162,7 +162,7 @@ RELEASE_REGISTRIES+=( "acr|<实例ID>.cn-<region>.personal.cr.aliyuncs.com/<命�
 RELEASE_REGISTRIES+=( "intranet|<内网IP>:<端口>|flat" )
 ```
 
-- [ ] **Step 2: 写 targets 本地文件（真实地址，不提交）**
+- [x] **Step 2: 写 targets 本地文件（真实地址，不提交）**
 
 Create `scripts/release-targets.local.sh`：
 
@@ -172,7 +172,7 @@ RELEASE_REGISTRIES+=( "acr|crpi-t2q2y3ujes80doq8.cn-beijing.personal.cr.aliyuncs
 RELEASE_REGISTRIES+=( "intranet|10.0.3.125:5000|flat" )
 ```
 
-- [ ] **Step 3: 写 mirrors 示范文件（提交版）**
+- [x] **Step 3: 写 mirrors 示范文件（提交版）**
 
 Create `scripts/release-mirrors.example.sh`：
 
@@ -185,7 +185,7 @@ export APT_MIRROR="http://mirrors.aliyun.com"
 export NPM_REGISTRY="https://registry.npmmirror.com"
 ```
 
-- [ ] **Step 4: 写 mirrors 本地文件（真实源，不提交）**
+- [x] **Step 4: 写 mirrors 本地文件（真实源，不提交）**
 
 Create `scripts/release-mirrors.local.sh`：
 
@@ -197,7 +197,7 @@ export APT_MIRROR="http://mirrors.aliyun.com"
 export NPM_REGISTRY="https://registry.npmmirror.com"
 ```
 
-- [ ] **Step 5: 更新 .gitignore**
+- [x] **Step 5: 更新 .gitignore**
 
 在 `.gitignore` 的 `# Local env files` 段（`.env.*.local` 行之后）追加：
 
@@ -207,7 +207,7 @@ scripts/release-targets.local.sh
 scripts/release-mirrors.local.sh
 ```
 
-- [ ] **Step 6: 验证 local 文件被忽略、example 文件可提交**
+- [x] **Step 6: 验证 local 文件被忽略、example 文件可提交**
 
 Run:
 ```bash
@@ -216,7 +216,7 @@ git status --short scripts/
 ```
 Expected: 第一条命令输出两个 `.local.sh` 路径（确认被忽略）；`git status` 只见 `release-targets.example.sh`、`release-mirrors.example.sh`、`.gitignore` 为待提交（两个 `.local.sh` **不出现**）。
 
-- [ ] **Step 7: 验证清单能正确加载私有目标**
+- [x] **Step 7: 验证清单能正确加载私有目标**
 
 Run:
 ```bash
@@ -224,7 +224,7 @@ bash -c 'cd scripts && source release-images.sh && printf "%s\n" "${RELEASE_REGI
 ```
 Expected: 3 行——ghcr、acr（含 crpi-… 真实地址）、intranet（10.0.3.125:5000）。证明 `release-images.sh` 经 local 文件 append 后有全部 3 个 registry。
 
-- [ ] **Step 8: Commit（只提交 example + gitignore）**
+- [x] **Step 8: Commit（只提交 example + gitignore）**
 
 ```bash
 git add scripts/release-targets.example.sh scripts/release-mirrors.example.sh .gitignore
@@ -238,7 +238,7 @@ git commit -m "feat(release): externalize private registry targets + mirror sour
 **Files:**
 - Modify: `scripts/release-build.sh`（全量重写）
 
-- [ ] **Step 1: 全量重写 build 脚本**
+- [x] **Step 1: 全量重写 build 脚本**
 
 Replace `scripts/release-build.sh` 全部内容为：
 
@@ -301,12 +301,12 @@ echo "==> BUILD DONE: ${built[*]:-(无匹配镜像)}"
 sudo docker images | grep -E 'brainpilot-(main|sandbox)' || true
 ```
 
-- [ ] **Step 2: 语法检查**
+- [x] **Step 2: 语法检查**
 
 Run: `bash -n scripts/release-build.sh`
 Expected: 无输出（语法 OK）。
 
-- [ ] **Step 3: 验证子集匹配逻辑（不实际构建）**
+- [x] **Step 3: 验证子集匹配逻辑（不实际构建）**
 
 把 docker build 行临时替换为 echo 来验证筛选——运行内联测试：
 ```bash
@@ -324,7 +324,7 @@ PASS: main 不匹配 sandbox
 PASS: gpu 精确匹配
 ```
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add scripts/release-build.sh
@@ -339,7 +339,7 @@ git commit -m "refactor(release): build script reads manifest, supports subset +
 - Create: `scripts/release-push.sh`
 - Test: `scripts/_test-release-push.sh`（临时 driver）
 
-- [ ] **Step 1: 写 push 脚本**
+- [x] **Step 1: 写 push 脚本**
 
 Create `scripts/release-push.sh`：
 
@@ -410,7 +410,7 @@ if [ "${#FAIL_LIST[@]}" -gt 0 ]; then
 fi
 ```
 
-- [ ] **Step 2: 写临时 driver 测试参数解析 + 筛选（mock docker）**
+- [x] **Step 2: 写临时 driver 测试参数解析 + 筛选（mock docker）**
 
 Create `scripts/_test-release-push.sh`：
 
@@ -464,7 +464,7 @@ rm -rf "$TMPBIN"
 exit $fail
 ```
 
-- [ ] **Step 3: 运行 driver，验证全 PASS**
+- [x] **Step 3: 运行 driver，验证全 PASS**
 
 Run: `bash scripts/_test-release-push.sh`
 Expected: 全 PASS、退出码 0：
@@ -478,7 +478,7 @@ PASS: 未知参数退出 2
 ```
 （前提：Task 2 的 `release-targets.local.sh` 已存在，ACR 条目才会被加载。）
 
-- [ ] **Step 4: 语法检查 + 删除临时 driver**
+- [x] **Step 4: 语法检查 + 删除临时 driver**
 
 ```bash
 bash -n scripts/release-push.sh
@@ -486,7 +486,7 @@ rm scripts/_test-release-push.sh
 ```
 Expected: 无输出，driver 已删。
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add scripts/release-push.sh
@@ -500,7 +500,7 @@ git commit -m "feat(release): add multi-registry push script (subset/dry-run/fai
 **Files:**
 - Create: `docker/sandbox/_python-base.sh`
 
-- [ ] **Step 1: 写共享脚本**
+- [x] **Step 1: 写共享脚本**
 
 Create `docker/sandbox/_python-base.sh`：
 
@@ -527,12 +527,12 @@ if [ -n "${PIP_INDEX_URL:-}" ]; then
 fi
 ```
 
-- [ ] **Step 2: 语法检查**
+- [x] **Step 2: 语法检查**
 
 Run: `bash -n docker/sandbox/_python-base.sh`
 Expected: 无输出。
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add docker/sandbox/_python-base.sh
@@ -546,7 +546,7 @@ git commit -m "feat(sandbox): shared python3+pip+mirror install fragment"
 **Files:**
 - Modify: `docker/sandbox/extra-deps.sh`（全量重写）
 
-- [ ] **Step 1: 全量重写 cpu extra-deps**
+- [x] **Step 1: 全量重写 cpu extra-deps**
 
 Replace `docker/sandbox/extra-deps.sh` 全部内容为：
 
@@ -566,12 +566,12 @@ echo "[extra-deps] cpu baseline: python3 $(python3 --version 2>&1) installed (no
 
 注：Dockerfile 把脚本及其同目录文件 COPY 到 `/tmp/`，故 `$(dirname "$0")/_python-base.sh` 解析为 `/tmp/_python-base.sh`（Task 8 的 Dockerfile 会一并 COPY）。
 
-- [ ] **Step 2: 语法检查**
+- [x] **Step 2: 语法检查**
 
 Run: `bash -n docker/sandbox/extra-deps.sh`
 Expected: 无输出。
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add docker/sandbox/extra-deps.sh
@@ -585,7 +585,7 @@ git commit -m "feat(sandbox): cpu baseline installs python3 (fixes agent python 
 **Files:**
 - Create: `docker/sandbox/extra-deps.gpu.sh`
 
-- [ ] **Step 1: 写 gpu extra-deps**
+- [x] **Step 1: 写 gpu extra-deps**
 
 Create `docker/sandbox/extra-deps.gpu.sh`：
 
@@ -622,12 +622,12 @@ pip3 install --break-system-packages \
 echo "[extra-deps.gpu] sci stack + torch 2.5.1+cu124 installed"
 ```
 
-- [ ] **Step 2: 语法检查**
+- [x] **Step 2: 语法检查**
 
 Run: `bash -n docker/sandbox/extra-deps.gpu.sh`
 Expected: 无输出。
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add docker/sandbox/extra-deps.gpu.sh
@@ -641,12 +641,12 @@ git commit -m "feat(sandbox): gpu variant deps — sci/pdf stack + torch 2.5.1+c
 **Files:**
 - Modify: `docker/sandbox/Dockerfile`（runtime 阶段 extra-deps 段，当前 28-46 行附近）
 
-- [ ] **Step 1: 读现有 Dockerfile runtime 阶段确认上下文**
+- [x] **Step 1: 读现有 Dockerfile runtime 阶段确认上下文**
 
 Run: `sed -n '26,49p' docker/sandbox/Dockerfile`
 Expected: 看到 `ARG APT_MIRROR=""`、`ARG NPM_REGISTRY=""`、`COPY docker/sandbox/extra-deps.sh /tmp/extra-deps.sh`、`RUN chmod +x ... bash /tmp/extra-deps.sh`、`ENV PORT=8081 ...`。
 
-- [ ] **Step 2: 改 runtime 阶段的 ARG 段**
+- [x] **Step 2: 改 runtime 阶段的 ARG 段**
 
 把现有的（runtime 阶段，约 28-29 行）：
 
@@ -667,7 +667,7 @@ ARG PIP_EXTRA_INDEX_URL=""
 ENV APT_MIRROR=${APT_MIRROR} PIP_INDEX_URL=${PIP_INDEX_URL} PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL}
 ```
 
-- [ ] **Step 3: 改 COPY + RUN 段（按变体选脚本，并带上共享片段）**
+- [x] **Step 3: 改 COPY + RUN 段（按变体选脚本，并带上共享片段）**
 
 把现有的（约 45-46 行）：
 
@@ -686,7 +686,7 @@ COPY docker/sandbox/${SANDBOX_EXTRA_DEPS} /tmp/extra-deps.sh
 RUN chmod +x /tmp/extra-deps.sh /tmp/_python-base.sh && bash /tmp/extra-deps.sh
 ```
 
-- [ ] **Step 4: 验证 Dockerfile 引用一致性**
+- [x] **Step 4: 验证 Dockerfile 引用一致性**
 
 Run:
 ```bash
@@ -694,7 +694,7 @@ grep -n "SANDBOX_EXTRA_DEPS\|_python-base\|extra-deps\|PIP_INDEX_URL" docker/san
 ```
 Expected: 看到 `ARG SANDBOX_EXTRA_DEPS=extra-deps.sh`、`ENV ... PIP_INDEX_URL`、`COPY docker/sandbox/_python-base.sh`、`COPY docker/sandbox/${SANDBOX_EXTRA_DEPS}`、`RUN ... bash /tmp/extra-deps.sh` 各就各位，变量名与 build/push 脚本一致。
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add docker/sandbox/Dockerfile
@@ -709,7 +709,7 @@ git commit -m "feat(sandbox): Dockerfile selects cpu/gpu extra-deps + passes pip
 
 > 重型步骤，需 Docker daemon（`sudo`）。构建走 `release-mirrors.local.sh` 的阿里云源 + 宿主代理。
 
-- [ ] **Step 1: 精确构建 cpu sandbox 单镜像**
+- [x] **Step 1: 精确构建 cpu sandbox 单镜像**
 
 > 注：`release-build.sh sandbox` 的子串匹配会同时命中 `brainpilot-sandbox` 和
 > `brainpilot-sandbox-gpu`（gpu 名也含 "sandbox"）。本步要隔离验证 cpu，故直接用精确
@@ -727,7 +727,7 @@ sudo DOCKER_BUILDKIT=0 docker build --network=host \
 ```
 Expected: 构建成功，末尾 `Successfully tagged brainpilot-sandbox:test`。日志中可见 `[extra-deps] cpu baseline: python3 Python 3.x ... installed`。
 
-- [ ] **Step 2: 验证镜像内有 python3 且 runtime 可启动**
+- [x] **Step 2: 验证镜像内有 python3 且 runtime 可启动**
 
 Run:
 ```bash
@@ -736,7 +736,7 @@ sudo docker run --rm brainpilot-sandbox:test node -e "console.log('node ok')"
 ```
 Expected: 打印 `Python 3.x.y` 和 `node ok`（证明 cpu sandbox 同时具备 Python 与 Node，修复了缺口）。
 
-- [ ] **Step 3: 验证现有 compose 默认路径不回归（静态等价验证）**
+- [x] **Step 3: 验证现有 compose 默认路径不回归（静态等价验证）**
 
 > compose build 默认走 BuildKit（会重现 Docker Hub 拉取被墙问题）且 compose.yml 未传
 > `SANDBOX_EXTRA_DEPS`，在本环境真跑不可靠。改为验证"默认路径等价"：Dockerfile 默认
@@ -754,7 +754,7 @@ PASS: 默认变体=cpu extra-deps.sh
 PASS: compose 未覆盖变体，走 Dockerfile 默认
 ```
 
-- [ ] **Step 4: 清理测试镜像（无需 commit，本 Task 仅验证）**
+- [x] **Step 4: 清理测试镜像（无需 commit，本 Task 仅验证）**
 
 Run: `sudo docker rmi brainpilot-sandbox:test || true`
 
@@ -765,7 +765,7 @@ Run: `sudo docker rmi brainpilot-sandbox:test || true`
 **Files:**
 - Modify: `README.md`（在 "📦 Publishing (maintainers)" 小节后新增 "Docker 镜像发布"）
 
-- [ ] **Step 1: dry-run 核对 registry 全路径**
+- [x] **Step 1: dry-run 核对 registry 全路径**
 
 > push 脚本在 `--dry-run` 下**仍会**对每个镜像做 `docker image inspect`（缺镜像检查不跳过）。
 > 为避免依赖"全部三镜像已构建"，用 `--image main` 缩小到上轮已存在的 main 镜像。
@@ -782,7 +782,7 @@ Expected: 仅 main 的 3 registry × 2 tag = 6 行计划，路径与 §1.1 矩�
 ```
 末尾"推送汇总"列出 6 条 `(dry)` 成功项、0 失败。
 
-- [ ] **Step 2: 在 README 增加 Docker 发布小节**
+- [x] **Step 2: 在 README 增加 Docker 发布小节**
 
 在 `README.md` 的 `## 📦 Publishing (maintainers)` 小节（`@brainpilot/client-cli stays private...` 行）之后，`## 🧪 Testing` 之前，插入：
 
@@ -812,12 +812,12 @@ bash scripts/release-push.sh --image sandbox-gpu --registry acr,intranet  # GPU 
 （ACR / 内网，私有）声明。GPU 镜像约 6GB，推公网 ghcr 可能超时，建议 `--registry acr,intranet`。
 ````
 
-- [ ] **Step 2.5: 校验 README 插入处格式**
+- [x] **Step 2.5: 校验 README 插入处格式**
 
 Run: `grep -n "Docker 镜像发布\|release-build.sh\|release-push.sh\|## 🧪 Testing" README.md`
 Expected: "Docker 镜像发布" 行号在 "## 🧪 Testing" 行号之前；build/push 命令均出现。
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
 git add README.md
@@ -834,7 +834,7 @@ git commit -m "docs(readme): add Docker image build + multi-registry push sectio
 > 依赖 `--network=host` 借宿主 Clash 代理。若代理对该域不通，此步会失败（与设计已知风险一致）。
 > 非阻塞主线交付；可在有条件时单独执行。
 
-- [ ] **Step 1: 单独构建 gpu 变体**
+- [x] **Step 1: 单独构建 gpu 变体**
 
 ```bash
 source scripts/release-mirrors.local.sh
@@ -847,7 +847,7 @@ sudo DOCKER_BUILDKIT=0 docker build --network=host \
 ```
 Expected: 构建成功，日志末尾 `[extra-deps.gpu] sci stack + torch 2.5.1+cu124 installed`。
 
-- [ ] **Step 2: 验证 torch + 科学库可导入**
+- [x] **Step 2: 验证 torch + 科学库可导入**
 
 Run:
 ```bash
@@ -856,7 +856,7 @@ sudo docker run --rm brainpilot-sandbox-gpu:test python3 -c \
 ```
 Expected: 打印 `torch 2.5.1+cu124`，无 ImportError。
 
-- [ ] **Step 3: 清理测试镜像**
+- [x] **Step 3: 清理测试镜像**
 
 Run: `sudo docker rmi brainpilot-sandbox-gpu:test || true`
 
@@ -869,3 +869,18 @@ Run: `sudo docker rmi brainpilot-sandbox-gpu:test || true`
 - Task 11（可选）：GPU 镜像可构建、torch 可导入。
 - `git status` 干净；两个 `.local.sh` 始终未被跟踪（`git check-ignore` 确认）。
 - 全流程可复现：`build → push --dry-run → push` 三步对三个 registry 产出 §1.1 矩阵中的全部路径。
+
+---
+
+## 执行结果（2026-06-15）
+
+- **Task 1-8 + 10**：✅ 完成并各自提交（commit `cb12548`→`a44392d`，8 个 commit + README）。
+- **Task 9（cpu sandbox 真实构建）**：✅ 通过。`brainpilot-sandbox:test` 构建成功（`DOCKER_BUILDKIT=0`
+  经典构建器 + 阿里云 apt/pip 源），镜像内 `python3 --version`=Python 3.11.2、`node` 正常；
+  Dockerfile 默认变体=cpu、compose 未覆盖 → 无回归。测试镜像已清理。
+- **push 脚本修正**：`OK_LIST/FAIL_LIST` 改为显式 `=()` 空数组初始化，否则全成功路径在 `set -u`
+  下因空 `FAIL_LIST` 触发 `unbound variable`（已验证 + 修复，含在 `c30cbe4`）。
+- **Task 11（GPU 镜像）**：⏭️ 未执行（~6GB、torch 下载耗时，标记为可选）。机制已就位
+  （`extra-deps.gpu.sh` + Dockerfile 变体选择），需要时 `bash scripts/release-build.sh sandbox-gpu` 即可。
+- **版本号注意**：根 `package.json` 现为 `0.0.4`；早前会话构建的本地镜像仍是 `0.0.3` 旧原型，
+  正式发布前需重跑 `release-build.sh` 产出 `0.0.4` 镜像再 push。

--- a/docs/superpowers/plans/2026-06-15-multi-registry-push.md
+++ b/docs/superpowers/plans/2026-06-15-multi-registry-push.md
@@ -1,0 +1,871 @@
+# 多镜像源推送机制 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为 BrainPilot 三个 Docker 镜像（main / sandbox / sandbox-gpu）建立 SSOT 清单驱动的本地构建与多 registry（ghcr / ACR / 内网）推送机制，并修复 cpu sandbox 缺 Python 的缺口、新增 GPU 变体，镜像源外置为"模板提交 + 本地私有"。
+
+**Architecture:** 一份 bash 清单 `release-images.sh` 声明镜像与 registry（SSOT），build/push 两个脚本都 source 它。私有信息（ACR 实例 ID、内网 IP、镜像源）外置到 `.local.sh`（gitignore），提交版只含公开默认值。sandbox 的 cpu/gpu 变体共用一个 Dockerfile，靠 build-arg `SANDBOX_EXTRA_DEPS` 选不同依赖脚本；依赖脚本单份提交、镜像源经 build-arg→ENV 变量化注入。
+
+**Tech Stack:** Bash 脚本、Docker 经典构建器（`DOCKER_BUILDKIT=0`）、Node（读 package.json version）、Debian slim 基础镜像 + pip。
+
+参考 spec：`docs/superpowers/specs/2026-06-15-multi-registry-push-design.md`
+
+---
+
+## 文件结构
+
+| 文件 | 责任 |
+|------|------|
+| `scripts/release-images.sh` | SSOT：镜像表 `RELEASE_IMAGES`、registry 表 `RELEASE_REGISTRIES`、`remote_repo()` 映射函数；source 私有 targets/mirrors |
+| `scripts/release-targets.example.sh` | 提交。ACR/内网 registry 条目占位示范 |
+| `scripts/release-targets.local.sh` | 不提交。真实 ACR/内网地址 |
+| `scripts/release-mirrors.example.sh` | 提交。pip/apt 镜像源占位示范 |
+| `scripts/release-mirrors.local.sh` | 不提交。真实镜像源（阿里云/清华） |
+| `scripts/release-build.sh` | 改造：source 清单+镜像源 → 循环构建（支持子集）→ 注入镜像源 build-arg |
+| `scripts/release-push.sh` | 新增：source 清单 → 解析 `--image`/`--registry`/`--dry-run` → tag+push → 失败汇总 |
+| `docker/sandbox/Dockerfile` | 改：`ARG SANDBOX_EXTRA_DEPS` 选脚本 + 镜像源 ARG→ENV 透传 |
+| `docker/sandbox/_python-base.sh` | 新增：cpu/gpu 共享的 python3+pip+镜像源安装段（DRY） |
+| `docker/sandbox/extra-deps.sh` | 改：no-op → source `_python-base.sh`（cpu 基线） |
+| `docker/sandbox/extra-deps.gpu.sh` | 新增：source `_python-base.sh` + 科学/PDF 栈 + torch cu124 |
+| `.gitignore` | 改：加两个 `*.local.sh` |
+| `README.md` | 改：加"Docker 镜像发布"小节 |
+
+**实现顺序**：先 SSOT 清单与映射函数（其余都依赖它）→ 私有/示范文件 → gitignore → build 脚本 → push 脚本 → Dockerfile/依赖脚本 → README。每个 Task 自成可提交单元。
+
+**测试策略**：bash 脚本无单元测试框架，用三种手段验证——(1) `bash -n` 语法检查；(2) 为纯函数（`remote_repo`、参数解析、镜像/registry 筛选）写一次性 driver 脚本断言输出；(3) `--dry-run` 核对端到端计划。重型 docker 构建放最后单独验证（耗时，非每步必跑）。
+
+---
+
+## Task 1: SSOT 清单 + 命名映射函数
+
+**Files:**
+- Create: `scripts/release-images.sh`
+- Test: `scripts/_test-release-images.sh`（临时 driver，验证后删除）
+
+- [ ] **Step 1: 写 SSOT 清单脚本**
+
+Create `scripts/release-images.sh`：
+
+```bash
+#!/usr/bin/env bash
+# release-images.sh — SSOT for image build + multi-registry push.
+# Sourced by release-build.sh and release-push.sh. Defines:
+#   RELEASE_IMAGES      本地镜像 → Dockerfile + 额外 build-arg
+#   RELEASE_REGISTRIES  推送目标 → 前缀 + 命名风格
+#   remote_repo()       本地镜像名 → 某 registry 的完整仓库路径
+# 私有 registry 地址在 release-targets.local.sh（不提交）里 append。
+
+# 本地镜像清单: "本地镜像名|Dockerfile 路径|额外 build-arg(空格分隔，可空)"
+RELEASE_IMAGES=(
+  "brainpilot-main|docker/main/Dockerfile|"
+  "brainpilot-sandbox|docker/sandbox/Dockerfile|SANDBOX_EXTRA_DEPS=extra-deps.sh"
+  "brainpilot-sandbox-gpu|docker/sandbox/Dockerfile|SANDBOX_EXTRA_DEPS=extra-deps.gpu.sh"
+)
+
+# registry 清单: "registry键|前缀|命名风格(flat|acr)"
+# ghcr 地址本就公开，写死在提交版本里。
+RELEASE_REGISTRIES=( "ghcr|ghcr.io/neuroaihub|flat" )
+
+# 私有目标（ACR 实例 ID / 内网 IP）从不提交的本地文件 append。
+_REL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[ -f "$_REL_DIR/release-targets.local.sh" ] && source "$_REL_DIR/release-targets.local.sh"
+
+# remote_repo <本地镜像名> <前缀> <风格>
+#   flat → 前缀/本地名               (brainpilot-main)
+#   acr  → 前缀/去 brainpilot- 前缀  (main)
+remote_repo() {
+  local local_name="$1" prefix="$2" style="$3"
+  case "$style" in
+    flat) echo "${prefix}/${local_name}" ;;
+    acr)  echo "${prefix}/${local_name#brainpilot-}" ;;
+    *)    echo "remote_repo: unknown style '$style'" >&2; return 1 ;;
+  esac
+}
+```
+
+- [ ] **Step 2: 写临时 driver 测试映射函数**
+
+Create `scripts/_test-release-images.sh`：
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+source release-images.sh
+
+fail=0
+check() { # check <实际> <期望> <说明>
+  if [ "$1" = "$2" ]; then echo "PASS: $3"; else echo "FAIL: $3 — got '$1' want '$2'"; fail=1; fi
+}
+
+check "$(remote_repo brainpilot-main ghcr.io/neuroaihub flat)" \
+      "ghcr.io/neuroaihub/brainpilot-main" "ghcr main (flat)"
+check "$(remote_repo brainpilot-sandbox-gpu ghcr.io/neuroaihub flat)" \
+      "ghcr.io/neuroaihub/brainpilot-sandbox-gpu" "ghcr sandbox-gpu (flat)"
+check "$(remote_repo brainpilot-main some/brainpilot acr)" \
+      "some/brainpilot/main" "acr main (短名)"
+check "$(remote_repo brainpilot-sandbox-gpu some/brainpilot acr)" \
+      "some/brainpilot/sandbox-gpu" "acr sandbox-gpu (短名)"
+check "${#RELEASE_IMAGES[@]}" "3" "镜像清单 3 条"
+check "${RELEASE_REGISTRIES[0]}" "ghcr|ghcr.io/neuroaihub|flat" "ghcr 默认 registry"
+
+exit $fail
+```
+
+- [ ] **Step 3: 运行 driver，验证全 PASS**
+
+Run: `bash scripts/_test-release-images.sh`
+Expected: 6 行 PASS，退出码 0：
+```
+PASS: ghcr main (flat)
+PASS: ghcr sandbox-gpu (flat)
+PASS: acr main (短名)
+PASS: acr sandbox-gpu (短名)
+PASS: 镜像清单 3 条
+PASS: ghcr 默认 registry
+```
+
+- [ ] **Step 4: 语法检查 + 删除临时 driver**
+
+```bash
+bash -n scripts/release-images.sh
+rm scripts/_test-release-images.sh
+```
+Expected: 无输出（语法 OK），driver 已删。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/release-images.sh
+git commit -m "feat(release): add SSOT image/registry manifest + remote_repo mapping"
+```
+
+---
+
+## Task 2: 私有目标 / 示范文件 + gitignore
+
+**Files:**
+- Create: `scripts/release-targets.example.sh`
+- Create: `scripts/release-targets.local.sh`（不提交）
+- Create: `scripts/release-mirrors.example.sh`
+- Create: `scripts/release-mirrors.local.sh`（不提交）
+- Modify: `.gitignore`
+
+- [ ] **Step 1: 写 targets 示范文件（提交版）**
+
+Create `scripts/release-targets.example.sh`：
+
+```bash
+# 复制为 release-targets.local.sh 并填入真实地址。local 文件已被 .gitignore 排除。
+# 向 RELEASE_REGISTRIES append 私有推送目标。格式: "键|前缀|风格(flat|acr)"
+RELEASE_REGISTRIES+=( "acr|<实例ID>.cn-<region>.personal.cr.aliyuncs.com/<命名空间>|acr" )
+RELEASE_REGISTRIES+=( "intranet|<内网IP>:<端口>|flat" )
+```
+
+- [ ] **Step 2: 写 targets 本地文件（真实地址，不提交）**
+
+Create `scripts/release-targets.local.sh`：
+
+```bash
+# 私有推送目标 —— 不提交。
+RELEASE_REGISTRIES+=( "acr|crpi-t2q2y3ujes80doq8.cn-beijing.personal.cr.aliyuncs.com/brainpilot|acr" )
+RELEASE_REGISTRIES+=( "intranet|10.0.3.125:5000|flat" )
+```
+
+- [ ] **Step 3: 写 mirrors 示范文件（提交版）**
+
+Create `scripts/release-mirrors.example.sh`：
+
+```bash
+# 复制为 release-mirrors.local.sh 启用国内镜像源加速。local 文件已被 .gitignore 排除。
+# 留空或不创建 local 文件 = 用官方源（pypi.org / deb.debian.org）。
+export PIP_INDEX_URL="https://mirrors.aliyun.com/pypi/simple/"
+export PIP_EXTRA_INDEX_URL="https://pypi.tuna.tsinghua.edu.cn/simple/"
+export APT_MIRROR="http://mirrors.aliyun.com"
+export NPM_REGISTRY="https://registry.npmmirror.com"
+```
+
+- [ ] **Step 4: 写 mirrors 本地文件（真实源，不提交）**
+
+Create `scripts/release-mirrors.local.sh`：
+
+```bash
+# 本机实际镜像源 —— 不提交。legacy 实测：Clash 代理 RST pypi.org，但阿里云正常。
+export PIP_INDEX_URL="https://mirrors.aliyun.com/pypi/simple/"
+export PIP_EXTRA_INDEX_URL="https://pypi.tuna.tsinghua.edu.cn/simple/"
+export APT_MIRROR="http://mirrors.aliyun.com"
+export NPM_REGISTRY="https://registry.npmmirror.com"
+```
+
+- [ ] **Step 5: 更新 .gitignore**
+
+在 `.gitignore` 的 `# Local env files` 段（`.env.*.local` 行之后）追加：
+
+```
+# Release push private config (registry addresses + mirror sources)
+scripts/release-targets.local.sh
+scripts/release-mirrors.local.sh
+```
+
+- [ ] **Step 6: 验证 local 文件被忽略、example 文件可提交**
+
+Run:
+```bash
+git check-ignore scripts/release-targets.local.sh scripts/release-mirrors.local.sh
+git status --short scripts/
+```
+Expected: 第一条命令输出两个 `.local.sh` 路径（确认被忽略）；`git status` 只见 `release-targets.example.sh`、`release-mirrors.example.sh`、`.gitignore` 为待提交（两个 `.local.sh` **不出现**）。
+
+- [ ] **Step 7: 验证清单能正确加载私有目标**
+
+Run:
+```bash
+bash -c 'cd scripts && source release-images.sh && printf "%s\n" "${RELEASE_REGISTRIES[@]}"'
+```
+Expected: 3 行——ghcr、acr（含 crpi-… 真实地址）、intranet（10.0.3.125:5000）。证明 `release-images.sh` 经 local 文件 append 后有全部 3 个 registry。
+
+- [ ] **Step 8: Commit（只提交 example + gitignore）**
+
+```bash
+git add scripts/release-targets.example.sh scripts/release-mirrors.example.sh .gitignore
+git commit -m "feat(release): externalize private registry targets + mirror sources"
+```
+
+---
+
+## Task 3: 改造 build 脚本（循环读清单 + 子集 + 镜像源注入）
+
+**Files:**
+- Modify: `scripts/release-build.sh`（全量重写）
+
+- [ ] **Step 1: 全量重写 build 脚本**
+
+Replace `scripts/release-build.sh` 全部内容为：
+
+```bash
+#!/usr/bin/env bash
+# Release image build — 读 release-images.sh 清单循环构建，打 latest + 版本号两 tag。
+# 用法:
+#   bash scripts/release-build.sh                 # 构建全部镜像
+#   bash scripts/release-build.sh sandbox         # 只构建名字含 "sandbox" 的镜像（子集）
+#   bash scripts/release-build.sh main sandbox-gpu# 多个子集
+# 镜像源/代理来自 release-mirrors.local.sh（不提交），无则用官方源默认。
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+source scripts/release-images.sh
+# 镜像源外置：本地文件存在则覆盖官方源默认值（设 PIP_INDEX_URL/APT_MIRROR/NPM_REGISTRY 等）
+[ -f scripts/release-mirrors.local.sh ] && source scripts/release-mirrors.local.sh
+
+VERSION="$(node -p "require('./package.json').version")"
+PROXY="${BUILD_PROXY:-http://127.0.0.1:7890}"
+
+# 子集匹配：无参数=全建；有参数=镜像名包含任一参数子串才建
+_matches() { # _matches <镜像名> <参数...>
+  local name="$1"; shift
+  local pat
+  for pat in "$@"; do [[ "$name" == *"$pat"* ]] && return 0; done
+  return 1
+}
+
+# 经典构建器：BuildKit 镜像解析器不吃 dockerd 的 systemd 代理、直连被墙的 Docker Hub；
+# 经典构建器走守护进程代理路径（已验证 docker pull 可用）。这些 Dockerfile 无 BuildKit 专属语法。
+# 注：DOCKER_BUILDKIT=0 必须内联给 sudo —— sudo 会清环境变量，export 不生效。
+COMMON=(
+  --network=host
+  --build-arg "HTTP_PROXY=${PROXY}"
+  --build-arg "HTTPS_PROXY=${PROXY}"
+  --build-arg "NPM_REGISTRY=${NPM_REGISTRY:-}"
+  --build-arg "APT_MIRROR=${APT_MIRROR:-}"
+  --build-arg "PIP_INDEX_URL=${PIP_INDEX_URL:-}"
+  --build-arg "PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL:-}"
+)
+
+echo "==> version=${VERSION} proxy=${PROXY} (mirrors: pip=${PIP_INDEX_URL:-官方} apt=${APT_MIRROR:-官方})"
+
+built=()
+for entry in "${RELEASE_IMAGES[@]}"; do
+  IFS='|' read -r name dockerfile extra_arg <<< "$entry"
+  if [ $# -gt 0 ] && ! _matches "$name" "$@"; then
+    echo "==> skip $name (不匹配子集)"
+    continue
+  fi
+  extra=(); [ -n "$extra_arg" ] && extra=( --build-arg "$extra_arg" )
+  echo "==> building $name (tags: latest, $VERSION)"
+  sudo DOCKER_BUILDKIT=0 docker build "${COMMON[@]}" "${extra[@]}" \
+    -f "$dockerfile" -t "$name:latest" -t "$name:$VERSION" .
+  built+=("$name")
+done
+
+echo "==> BUILD DONE: ${built[*]:-(无匹配镜像)}"
+sudo docker images | grep -E 'brainpilot-(main|sandbox)' || true
+```
+
+- [ ] **Step 2: 语法检查**
+
+Run: `bash -n scripts/release-build.sh`
+Expected: 无输出（语法 OK）。
+
+- [ ] **Step 3: 验证子集匹配逻辑（不实际构建）**
+
+把 docker build 行临时替换为 echo 来验证筛选——运行内联测试：
+```bash
+bash -c '
+  _matches() { local name="$1"; shift; local pat; for pat in "$@"; do [[ "$name" == *"$pat"* ]] && return 0; done; return 1; }
+  _matches brainpilot-sandbox-gpu sandbox && echo "PASS: sandbox 匹配 gpu 变体"
+  _matches brainpilot-main sandbox || echo "PASS: main 不匹配 sandbox"
+  _matches brainpilot-sandbox-gpu gpu && echo "PASS: gpu 精确匹配"
+'
+```
+Expected:
+```
+PASS: sandbox 匹配 gpu 变体
+PASS: main 不匹配 sandbox
+PASS: gpu 精确匹配
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/release-build.sh
+git commit -m "refactor(release): build script reads manifest, supports subset + mirror injection"
+```
+
+---
+
+## Task 4: push 脚本（参数解析 + tag/push + dry-run + 失败汇总）
+
+**Files:**
+- Create: `scripts/release-push.sh`
+- Test: `scripts/_test-release-push.sh`（临时 driver）
+
+- [ ] **Step 1: 写 push 脚本**
+
+Create `scripts/release-push.sh`：
+
+```bash
+#!/usr/bin/env bash
+# Release image push — 把本地已构建镜像 tag+push 到选定 registry。不重新构建。
+# 用法:
+#   bash scripts/release-push.sh                                 # 全部镜像 → 全部已配置 registry
+#   bash scripts/release-push.sh --registry acr,intranet         # 只推这些 registry（跳过 ghcr）
+#   bash scripts/release-push.sh --image sandbox-gpu             # 只推名字含该子串的镜像
+#   bash scripts/release-push.sh --image sandbox-gpu --registry acr,intranet
+#   bash scripts/release-push.sh --dry-run                       # 只打印 tag/push 计划，不真推
+set -uo pipefail   # 注意：不用 -e，单个 registry 失败要继续推其他并汇总
+cd "$(dirname "$0")/.."
+
+source scripts/release-images.sh
+VERSION="$(node -p "require('./package.json').version")"
+
+IMAGE_FILTER=""; REGISTRY_FILTER=""; DRY_RUN=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --image)    IMAGE_FILTER="$2"; shift 2 ;;
+    --registry) REGISTRY_FILTER="$2"; shift 2 ;;
+    --dry-run)  DRY_RUN=1; shift ;;
+    *) echo "未知参数: $1" >&2; exit 2 ;;
+  esac
+done
+
+# 逗号分隔列表是否包含某键（精确匹配段）
+_in_csv() { # _in_csv <键> <csv>
+  local key="$1" csv="$2" IFS=','
+  for k in $csv; do [ "$k" = "$key" ] && return 0; done
+  return 1
+}
+
+declare -a OK_LIST FAIL_LIST
+for img_entry in "${RELEASE_IMAGES[@]}"; do
+  IFS='|' read -r img _df _arg <<< "$img_entry"
+  # 镜像子集：--image 是子串匹配（与 build 一致）
+  if [ -n "$IMAGE_FILTER" ] && [[ "$img" != *"$IMAGE_FILTER"* ]]; then continue; fi
+
+  if ! sudo docker image inspect "$img:$VERSION" >/dev/null 2>&1; then
+    echo "缺本地镜像 $img:$VERSION —— 先跑 scripts/release-build.sh"; exit 1
+  fi
+
+  for reg_entry in "${RELEASE_REGISTRIES[@]}"; do
+    IFS='|' read -r key prefix style <<< "$reg_entry"
+    # registry 子集：--registry 是精确键匹配（逗号分隔）
+    if [ -n "$REGISTRY_FILTER" ] && ! _in_csv "$key" "$REGISTRY_FILTER"; then continue; fi
+    repo="$(remote_repo "$img" "$prefix" "$style")"
+    for tag in "$VERSION" latest; do
+      echo "==> $img:$tag → $repo:$tag"
+      [ -n "$DRY_RUN" ] && { OK_LIST+=("(dry) $repo:$tag"); continue; }
+      if sudo docker tag "$img:$tag" "$repo:$tag" && sudo docker push "$repo:$tag"; then
+        OK_LIST+=("$repo:$tag")
+      else
+        FAIL_LIST+=("$repo:$tag")
+      fi
+    done
+  done
+done
+
+echo ""; echo "==== 推送汇总 ===="
+echo "成功 ${#OK_LIST[@]}:"; printf '  ✓ %s\n' "${OK_LIST[@]:-（无）}"
+if [ "${#FAIL_LIST[@]}" -gt 0 ]; then
+  echo "失败 ${#FAIL_LIST[@]}:"; printf '  ✗ %s\n' "${FAIL_LIST[@]}"
+  exit 1
+fi
+```
+
+- [ ] **Step 2: 写临时 driver 测试参数解析 + 筛选（mock docker）**
+
+Create `scripts/_test-release-push.sh`：
+
+```bash
+#!/usr/bin/env bash
+# 用 PATH 注入假 docker，--dry-run 跑通筛选逻辑，断言输出行。
+set -uo pipefail
+cd "$(dirname "$0")/.."
+fail=0
+
+# 假 docker：image inspect 永远成功（假装本地有镜像），其他命令 no-op
+TMPBIN="$(mktemp -d)"
+cat > "$TMPBIN/docker" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+  image) exit 0 ;;   # inspect 成功
+  *) exit 0 ;;
+esac
+EOF
+chmod +x "$TMPBIN/docker"
+# 假 sudo：直接执行后续命令（去掉 sudo 前缀）
+cat > "$TMPBIN/sudo" <<'EOF'
+#!/usr/bin/env bash
+exec "$@"
+EOF
+chmod +x "$TMPBIN/sudo"
+export PATH="$TMPBIN:$PATH"
+
+check_contains() { # check_contains <输出> <期望子串> <说明>
+  if grep -qF "$2" <<<"$1"; then echo "PASS: $3"; else echo "FAIL: $3 — 缺 '$2'"; fail=1; fi
+}
+check_absent() { # check_absent <输出> <不应出现子串> <说明>
+  if grep -qF "$2" <<<"$1"; then echo "FAIL: $3 — 不应含 '$2'"; fail=1; else echo "PASS: $3"; fi
+}
+
+# 1) --dry-run --registry ghcr --image main：只应出现 ghcr/main
+out="$(bash scripts/release-push.sh --dry-run --registry ghcr --image main)"
+check_contains "$out" "ghcr.io/neuroaihub/brainpilot-main" "ghcr main 出现"
+check_absent  "$out" "sandbox" "main 过滤掉 sandbox"
+check_absent  "$out" "crpi-"   "registry=ghcr 时不含 ACR"
+
+# 2) --dry-run --registry acr --image sandbox-gpu：ACR 短名 sandbox-gpu
+out="$(bash scripts/release-push.sh --dry-run --registry acr --image sandbox-gpu)"
+check_contains "$out" "/brainpilot/sandbox-gpu" "ACR 短名 sandbox-gpu"
+check_absent  "$out" "brainpilot-main" "image=sandbox-gpu 过滤掉 main"
+
+# 3) 未知参数退出码 2
+bash scripts/release-push.sh --bogus >/dev/null 2>&1; [ $? -eq 2 ] && echo "PASS: 未知参数退出 2" || { echo "FAIL: 未知参数退出码"; fail=1; }
+
+rm -rf "$TMPBIN"
+exit $fail
+```
+
+- [ ] **Step 3: 运行 driver，验证全 PASS**
+
+Run: `bash scripts/_test-release-push.sh`
+Expected: 全 PASS、退出码 0：
+```
+PASS: ghcr main 出现
+PASS: main 过滤掉 sandbox
+PASS: registry=ghcr 时不含 ACR
+PASS: ACR 短名 sandbox-gpu
+PASS: image=sandbox-gpu 过滤掉 main
+PASS: 未知参数退出 2
+```
+（前提：Task 2 的 `release-targets.local.sh` 已存在，ACR 条目才会被加载。）
+
+- [ ] **Step 4: 语法检查 + 删除临时 driver**
+
+```bash
+bash -n scripts/release-push.sh
+rm scripts/_test-release-push.sh
+```
+Expected: 无输出，driver 已删。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/release-push.sh
+git commit -m "feat(release): add multi-registry push script (subset/dry-run/failure summary)"
+```
+
+---
+
+## Task 5: 共享 python 安装段 `_python-base.sh`
+
+**Files:**
+- Create: `docker/sandbox/_python-base.sh`
+
+- [ ] **Step 1: 写共享脚本**
+
+Create `docker/sandbox/_python-base.sh`：
+
+```bash
+#!/usr/bin/env bash
+# _python-base.sh — cpu/gpu sandbox 共享的 python3 + pip + 镜像源安装段。
+# 由 extra-deps.sh / extra-deps.gpu.sh source。镜像源来自 ENV（Dockerfile 经 build-arg 透传），
+# 为空则用镜像自带官方源（pypi.org / deb.debian.org）。
+set -euo pipefail
+
+# apt 源：APT_MIRROR 注入则替换官方源
+[ -n "${APT_MIRROR:-}" ] && sed -i "s|http://deb.debian.org|$APT_MIRROR|g" \
+  /etc/apt/sources.list.d/*.sources /etc/apt/sources.list 2>/dev/null || true
+apt-get update && apt-get install -y --no-install-recommends python3 python3-pip python3-venv
+rm -rf /var/lib/apt/lists/*
+
+# pip 源：PIP_INDEX_URL 注入则固化 /etc/pip.conf，否则用 pip 官方默认
+if [ -n "${PIP_INDEX_URL:-}" ]; then
+  { echo '[global]'
+    echo "index-url = ${PIP_INDEX_URL}"
+    [ -n "${PIP_EXTRA_INDEX_URL:-}" ] && echo "extra-index-url = ${PIP_EXTRA_INDEX_URL}"
+    echo 'timeout = 60'
+  } > /etc/pip.conf
+fi
+```
+
+- [ ] **Step 2: 语法检查**
+
+Run: `bash -n docker/sandbox/_python-base.sh`
+Expected: 无输出。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docker/sandbox/_python-base.sh
+git commit -m "feat(sandbox): shared python3+pip+mirror install fragment"
+```
+
+---
+
+## Task 6: cpu 依赖脚本改为装 Python
+
+**Files:**
+- Modify: `docker/sandbox/extra-deps.sh`（全量重写）
+
+- [ ] **Step 1: 全量重写 cpu extra-deps**
+
+Replace `docker/sandbox/extra-deps.sh` 全部内容为：
+
+```bash
+#!/usr/bin/env bash
+# extra-deps.sh — cpu sandbox 基线依赖（构建期执行，由 Dockerfile RUN 调用）。
+# 装 python3 + pip + venv，让 agent 能通过 Pi SDK 的 bash 工具运行 Python 代码
+# （persona 指示 agent "write/edit 文件 + bash 运行"）。
+# 不预装科学库 —— agent 按需自装（persona 本就要求 agent 管理依赖），保持镜像轻量。
+# GPU 变体见 extra-deps.gpu.sh。镜像源经 ENV 注入（见 _python-base.sh）。
+set -euo pipefail
+
+source "$(dirname "$0")/_python-base.sh"
+
+echo "[extra-deps] cpu baseline: python3 $(python3 --version 2>&1) installed (no sci libs)"
+```
+
+注：Dockerfile 把脚本及其同目录文件 COPY 到 `/tmp/`，故 `$(dirname "$0")/_python-base.sh` 解析为 `/tmp/_python-base.sh`（Task 8 的 Dockerfile 会一并 COPY）。
+
+- [ ] **Step 2: 语法检查**
+
+Run: `bash -n docker/sandbox/extra-deps.sh`
+Expected: 无输出。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docker/sandbox/extra-deps.sh
+git commit -m "feat(sandbox): cpu baseline installs python3 (fixes agent python exec gap)"
+```
+
+---
+
+## Task 7: gpu 依赖脚本（科学/PDF 栈 + torch cu124）
+
+**Files:**
+- Create: `docker/sandbox/extra-deps.gpu.sh`
+
+- [ ] **Step 1: 写 gpu extra-deps**
+
+Create `docker/sandbox/extra-deps.gpu.sh`：
+
+```bash
+#!/usr/bin/env bash
+# extra-deps.gpu.sh — sandbox-gpu 变体依赖（构建期执行）。
+# = cpu 的 python3 基础 + 预装科学/PDF 栈 + CUDA 12.4 PyTorch。
+# torch 版本/源沿用 legacy 实测配置（legacy/docker/agent_runtime/Dockerfile.base，2026-05-29）。
+# 镜像源经 ENV 注入（见 _python-base.sh）；torch 用专属 whl 源不受其影响。
+set -euo pipefail
+
+# 1) python3 + pip + 镜像源（与 cpu 共享）
+source "$(dirname "$0")/_python-base.sh"
+
+# 2) 科学/PDF 栈（最新稳定，走上面配置的 pip 源）
+pip3 install --break-system-packages \
+  numpy pandas scipy matplotlib scikit-learn pillow pypdf pdfplumber
+
+# 3) CUDA 12.4 runtime wheels（pip 默认源，国内由 PIP_INDEX_URL 指向阿里云/清华）
+pip3 install --break-system-packages \
+  nvidia-cuda-runtime-cu12==12.4.127 nvidia-cuda-nvrtc-cu12==12.4.127 \
+  nvidia-cudnn-cu12==9.1.0.70 nvidia-cublas-cu12==12.4.5.8 \
+  nvidia-cufft-cu12==11.2.1.3 nvidia-curand-cu12==10.3.5.147 \
+  nvidia-cusolver-cu12==11.6.1.9 nvidia-cusparse-cu12==12.3.1.170 \
+  nvidia-nccl-cu12==2.21.5 nvidia-nvtx-cu12==12.4.127 nvidia-nvjitlink-cu12==12.4.127
+
+# 4) PyTorch cu124（官方 whl 源——清华 pytorch-wheels 不同步 cu124 会 404；
+#    此 index-url 是 torch 专属、不受镜像源外置影响。构建时 --network=host 借宿主代理）
+pip3 install --break-system-packages \
+  torch==2.5.1+cu124 torchvision==0.20.1+cu124 torchaudio==2.5.1+cu124 \
+  --index-url https://download.pytorch.org/whl/cu124 \
+  --extra-index-url "${PIP_INDEX_URL:-https://pypi.org/simple/}"
+
+echo "[extra-deps.gpu] sci stack + torch 2.5.1+cu124 installed"
+```
+
+- [ ] **Step 2: 语法检查**
+
+Run: `bash -n docker/sandbox/extra-deps.gpu.sh`
+Expected: 无输出。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docker/sandbox/extra-deps.gpu.sh
+git commit -m "feat(sandbox): gpu variant deps — sci/pdf stack + torch 2.5.1+cu124"
+```
+
+---
+
+## Task 8: Dockerfile 支持变体 + 镜像源透传
+
+**Files:**
+- Modify: `docker/sandbox/Dockerfile`（runtime 阶段 extra-deps 段，当前 28-46 行附近）
+
+- [ ] **Step 1: 读现有 Dockerfile runtime 阶段确认上下文**
+
+Run: `sed -n '26,49p' docker/sandbox/Dockerfile`
+Expected: 看到 `ARG APT_MIRROR=""`、`ARG NPM_REGISTRY=""`、`COPY docker/sandbox/extra-deps.sh /tmp/extra-deps.sh`、`RUN chmod +x ... bash /tmp/extra-deps.sh`、`ENV PORT=8081 ...`。
+
+- [ ] **Step 2: 改 runtime 阶段的 ARG 段**
+
+把现有的（runtime 阶段，约 28-29 行）：
+
+```dockerfile
+ARG APT_MIRROR=""
+ARG NPM_REGISTRY=""
+```
+
+替换为：
+
+```dockerfile
+ARG APT_MIRROR=""
+ARG NPM_REGISTRY=""
+# sandbox 变体选择 + pip 镜像源（build-arg → ENV，供 extra-deps 脚本读取；空则官方源默认）
+ARG SANDBOX_EXTRA_DEPS=extra-deps.sh
+ARG PIP_INDEX_URL=""
+ARG PIP_EXTRA_INDEX_URL=""
+ENV APT_MIRROR=${APT_MIRROR} PIP_INDEX_URL=${PIP_INDEX_URL} PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL}
+```
+
+- [ ] **Step 3: 改 COPY + RUN 段（按变体选脚本，并带上共享片段）**
+
+把现有的（约 45-46 行）：
+
+```dockerfile
+COPY docker/sandbox/extra-deps.sh /tmp/extra-deps.sh
+RUN chmod +x /tmp/extra-deps.sh && bash /tmp/extra-deps.sh
+```
+
+替换为：
+
+```dockerfile
+# 同时 COPY 共享片段 + 选中的变体脚本（cpu: extra-deps.sh / gpu: extra-deps.gpu.sh）。
+# 两个脚本都 source ./_python-base.sh，故 _python-base.sh 必须同目录存在。
+COPY docker/sandbox/_python-base.sh /tmp/_python-base.sh
+COPY docker/sandbox/${SANDBOX_EXTRA_DEPS} /tmp/extra-deps.sh
+RUN chmod +x /tmp/extra-deps.sh /tmp/_python-base.sh && bash /tmp/extra-deps.sh
+```
+
+- [ ] **Step 4: 验证 Dockerfile 引用一致性**
+
+Run:
+```bash
+grep -n "SANDBOX_EXTRA_DEPS\|_python-base\|extra-deps\|PIP_INDEX_URL" docker/sandbox/Dockerfile
+```
+Expected: 看到 `ARG SANDBOX_EXTRA_DEPS=extra-deps.sh`、`ENV ... PIP_INDEX_URL`、`COPY docker/sandbox/_python-base.sh`、`COPY docker/sandbox/${SANDBOX_EXTRA_DEPS}`、`RUN ... bash /tmp/extra-deps.sh` 各就各位，变量名与 build/push 脚本一致。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker/sandbox/Dockerfile
+git commit -m "feat(sandbox): Dockerfile selects cpu/gpu extra-deps + passes pip mirror env"
+```
+
+---
+
+## Task 9: cpu sandbox 真实构建验证
+
+**Files:** 无（验证 Task 5/6/8 的集成）
+
+> 重型步骤，需 Docker daemon（`sudo`）。构建走 `release-mirrors.local.sh` 的阿里云源 + 宿主代理。
+
+- [ ] **Step 1: 精确构建 cpu sandbox 单镜像**
+
+> 注：`release-build.sh sandbox` 的子串匹配会同时命中 `brainpilot-sandbox` 和
+> `brainpilot-sandbox-gpu`（gpu 名也含 "sandbox"）。本步要隔离验证 cpu，故直接用精确
+> docker 命令构建单镜像，不走子集脚本。
+
+Run:
+```bash
+source scripts/release-mirrors.local.sh
+sudo DOCKER_BUILDKIT=0 docker build --network=host \
+  --build-arg HTTP_PROXY=http://127.0.0.1:7890 --build-arg HTTPS_PROXY=http://127.0.0.1:7890 \
+  --build-arg NPM_REGISTRY="$NPM_REGISTRY" --build-arg APT_MIRROR="$APT_MIRROR" \
+  --build-arg PIP_INDEX_URL="$PIP_INDEX_URL" --build-arg PIP_EXTRA_INDEX_URL="$PIP_EXTRA_INDEX_URL" \
+  --build-arg SANDBOX_EXTRA_DEPS=extra-deps.sh \
+  -f docker/sandbox/Dockerfile -t brainpilot-sandbox:test .
+```
+Expected: 构建成功，末尾 `Successfully tagged brainpilot-sandbox:test`。日志中可见 `[extra-deps] cpu baseline: python3 Python 3.x ... installed`。
+
+- [ ] **Step 2: 验证镜像内有 python3 且 runtime 可启动**
+
+Run:
+```bash
+sudo docker run --rm brainpilot-sandbox:test python3 --version
+sudo docker run --rm brainpilot-sandbox:test node -e "console.log('node ok')"
+```
+Expected: 打印 `Python 3.x.y` 和 `node ok`（证明 cpu sandbox 同时具备 Python 与 Node，修复了缺口）。
+
+- [ ] **Step 3: 验证现有 compose 默认路径不回归（静态等价验证）**
+
+> compose build 默认走 BuildKit（会重现 Docker Hub 拉取被墙问题）且 compose.yml 未传
+> `SANDBOX_EXTRA_DEPS`，在本环境真跑不可靠。改为验证"默认路径等价"：Dockerfile 默认
+> `ARG SANDBOX_EXTRA_DEPS=extra-deps.sh`，而 Step 1 已用该默认值构建成功——证明任何不传
+> 该 build-arg 的调用方（含 compose）都会走 cpu 基线，行为只是"多装了 python3"，不破坏启动。
+
+Run:
+```bash
+grep -q 'ARG SANDBOX_EXTRA_DEPS=extra-deps.sh' docker/sandbox/Dockerfile && echo "PASS: 默认变体=cpu extra-deps.sh"
+grep -q 'SANDBOX_EXTRA_DEPS' docker-compose.yml && echo "WARN: compose 显式传了变体（需复核）" || echo "PASS: compose 未覆盖变体，走 Dockerfile 默认"
+```
+Expected:
+```
+PASS: 默认变体=cpu extra-deps.sh
+PASS: compose 未覆盖变体，走 Dockerfile 默认
+```
+
+- [ ] **Step 4: 清理测试镜像（无需 commit，本 Task 仅验证）**
+
+Run: `sudo docker rmi brainpilot-sandbox:test || true`
+
+---
+
+## Task 10: README 文档 + dry-run 端到端核对
+
+**Files:**
+- Modify: `README.md`（在 "📦 Publishing (maintainers)" 小节后新增 "Docker 镜像发布"）
+
+- [ ] **Step 1: dry-run 核对 registry 全路径**
+
+> push 脚本在 `--dry-run` 下**仍会**对每个镜像做 `docker image inspect`（缺镜像检查不跳过）。
+> 为避免依赖"全部三镜像已构建"，用 `--image main` 缩小到上轮已存在的 main 镜像。
+
+Run: `bash scripts/release-push.sh --dry-run --image main`
+Expected: 仅 main 的 3 registry × 2 tag = 6 行计划，路径与 §1.1 矩阵一致：
+```
+==> brainpilot-main:0.0.3 → ghcr.io/neuroaihub/brainpilot-main:0.0.3
+==> brainpilot-main:latest → ghcr.io/neuroaihub/brainpilot-main:latest
+==> brainpilot-main:0.0.3 → crpi-t2q2y3ujes80doq8.cn-beijing.personal.cr.aliyuncs.com/brainpilot/main:0.0.3
+==> brainpilot-main:latest → crpi-…/brainpilot/main:latest
+==> brainpilot-main:0.0.3 → 10.0.3.125:5000/brainpilot-main:0.0.3
+==> brainpilot-main:latest → 10.0.3.125:5000/brainpilot-main:latest
+```
+末尾"推送汇总"列出 6 条 `(dry)` 成功项、0 失败。
+
+- [ ] **Step 2: 在 README 增加 Docker 发布小节**
+
+在 `README.md` 的 `## 📦 Publishing (maintainers)` 小节（`@brainpilot/client-cli stays private...` 行）之后，`## 🧪 Testing` 之前，插入：
+
+````markdown
+### Docker 镜像发布
+
+镜像版本号与 npm 版本一致（根 `package.json` 的 `version`）。三个镜像：`brainpilot-main`、
+`brainpilot-sandbox`（cpu）、`brainpilot-sandbox-gpu`（CUDA torch）。
+
+```bash
+# 一次性：复制示范配置，填入国内镜像源 / 私有 registry 地址（两个 .local 文件均不提交）
+cp scripts/release-mirrors.example.sh scripts/release-mirrors.local.sh   # pip/apt 镜像源
+cp scripts/release-targets.example.sh scripts/release-targets.local.sh   # ACR/内网 registry
+
+# 构建（默认全部；可传子串只建子集）
+bash scripts/release-build.sh                # 全部三个镜像
+bash scripts/release-build.sh main           # 只建 main
+bash scripts/release-build.sh sandbox-gpu    # 只建 GPU 变体（体积大、慢）
+
+# 推送（需先 docker login 各 registry）
+bash scripts/release-push.sh --dry-run                       # 先看计划
+bash scripts/release-push.sh                                 # 全部 → 全部 registry
+bash scripts/release-push.sh --image sandbox-gpu --registry acr,intranet  # GPU 跳过公网 ghcr
+```
+
+推送目标 registry 在 `scripts/release-images.sh`（ghcr，公开）+ `release-targets.local.sh`
+（ACR / 内网，私有）声明。GPU 镜像约 6GB，推公网 ghcr 可能超时，建议 `--registry acr,intranet`。
+````
+
+- [ ] **Step 2.5: 校验 README 插入处格式**
+
+Run: `grep -n "Docker 镜像发布\|release-build.sh\|release-push.sh\|## 🧪 Testing" README.md`
+Expected: "Docker 镜像发布" 行号在 "## 🧪 Testing" 行号之前；build/push 命令均出现。
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(readme): add Docker image build + multi-registry push section"
+```
+
+---
+
+## Task 11: GPU 镜像构建验证（可选 / 重型，需 GPU 主机网络）
+
+**Files:** 无（验证 Task 7 集成）
+
+> ⚠️ 体积大（~6GB）、构建慢（torch 下载）。torch whl 走 `download.pytorch.org` 官方源——
+> 依赖 `--network=host` 借宿主 Clash 代理。若代理对该域不通，此步会失败（与设计已知风险一致）。
+> 非阻塞主线交付；可在有条件时单独执行。
+
+- [ ] **Step 1: 单独构建 gpu 变体**
+
+```bash
+source scripts/release-mirrors.local.sh
+sudo DOCKER_BUILDKIT=0 docker build --network=host \
+  --build-arg HTTP_PROXY=http://127.0.0.1:7890 --build-arg HTTPS_PROXY=http://127.0.0.1:7890 \
+  --build-arg NPM_REGISTRY="$NPM_REGISTRY" --build-arg APT_MIRROR="$APT_MIRROR" \
+  --build-arg PIP_INDEX_URL="$PIP_INDEX_URL" --build-arg PIP_EXTRA_INDEX_URL="$PIP_EXTRA_INDEX_URL" \
+  --build-arg SANDBOX_EXTRA_DEPS=extra-deps.gpu.sh \
+  -f docker/sandbox/Dockerfile -t brainpilot-sandbox-gpu:test .
+```
+Expected: 构建成功，日志末尾 `[extra-deps.gpu] sci stack + torch 2.5.1+cu124 installed`。
+
+- [ ] **Step 2: 验证 torch + 科学库可导入**
+
+Run:
+```bash
+sudo docker run --rm brainpilot-sandbox-gpu:test python3 -c \
+  "import torch, numpy, pandas, scipy, sklearn, matplotlib, pypdf, pdfplumber, PIL; print('torch', torch.__version__)"
+```
+Expected: 打印 `torch 2.5.1+cu124`，无 ImportError。
+
+- [ ] **Step 3: 清理测试镜像**
+
+Run: `sudo docker rmi brainpilot-sandbox-gpu:test || true`
+
+---
+
+## 完成标准
+
+- Task 1-8、10 完成并提交：脚本机制 + Dockerfile + 依赖脚本 + README 全部就位。
+- Task 9 通过：cpu sandbox 含 python3 + node，现有 compose 不回归。
+- Task 11（可选）：GPU 镜像可构建、torch 可导入。
+- `git status` 干净；两个 `.local.sh` 始终未被跟踪（`git check-ignore` 确认）。
+- 全流程可复现：`build → push --dry-run → push` 三步对三个 registry 产出 §1.1 矩阵中的全部路径。

--- a/docs/superpowers/plans/2026-06-15-multi-registry-push.md
+++ b/docs/superpowers/plans/2026-06-15-multi-registry-push.md
@@ -880,7 +880,19 @@ Run: `sudo docker rmi brainpilot-sandbox-gpu:test || true`
   Dockerfile 默认变体=cpu、compose 未覆盖 → 无回归。测试镜像已清理。
 - **push 脚本修正**：`OK_LIST/FAIL_LIST` 改为显式 `=()` 空数组初始化，否则全成功路径在 `set -u`
   下因空 `FAIL_LIST` 触发 `unbound variable`（已验证 + 修复，含在 `c30cbe4`）。
-- **Task 11（GPU 镜像）**：⏭️ 未执行（~6GB、torch 下载耗时，标记为可选）。机制已就位
-  （`extra-deps.gpu.sh` + Dockerfile 变体选择），需要时 `bash scripts/release-build.sh sandbox-gpu` 即可。
-- **版本号注意**：根 `package.json` 现为 `0.0.4`；早前会话构建的本地镜像仍是 `0.0.3` 旧原型，
-  正式发布前需重跑 `release-build.sh` 产出 `0.0.4` 镜像再 push。
+- **Task 11（GPU 镜像）**：✅ 已构建并验证。`brainpilot-sandbox-gpu:0.0.4`（14.5GB 解压）构建成功，
+  `torch 2.5.1+cu124`（cuda build 12.4）+ numpy/pandas/scipy/sklearn/matplotlib/pypdf/pdfplumber/PIL
+  全部可导入。**torch 下载坑（重要）**：官方 download.pytorch.org 把 torch wheel 302 到 Cloudflare R2，
+  该流经 Clash 代理限速崩溃+哈希不匹配（连续两次构建在 908MB torch 处失败）。pip `--index-url` 指交大
+  也无效（交大 simple 索引登记的也是 R2 URL）。**解法**：直接拼交大 wheel 文件 URL（`/cu124/<wheel>`）
+  会 302 到交大自有 S3（s3.jcloud.sjtu.edu.cn，国内 ~13MB/s），故 `extra-deps.gpu.sh` 改为 curl 直下
+  三个 wheel 再 pip 装本地文件，依赖仍走阿里云 PyPI（commit `269b571`）。
+
+### 实际发布状态（2026-06-16）
+| 镜像 | ghcr（公网） | ACR（阿里云） | 内网 10.0.3.125 |
+|------|:---:|:---:|:---:|
+| main | ❌ denied（PAT 缺 write:packages 或 org 无包写权限） | ✅ 0.0.4+latest | ✅ 0.0.4+latest |
+| sandbox (cpu) | 未推 | ✅ 0.0.4+latest | ✅ 0.0.4+latest |
+| sandbox-gpu | 不推（按定） | 🔄 推送中（仅 ACR，14.5GB） | 不推 |
+
+- **ghcr 待修**：需带 `write:packages` 的 PAT 重新 `docker login ghcr.io -u GTC2333`，或 org owner 给包写权限。

--- a/docs/superpowers/specs/2026-06-15-multi-registry-push-design.md
+++ b/docs/superpowers/specs/2026-06-15-multi-registry-push-design.md
@@ -1,0 +1,388 @@
+# 多镜像源推送机制 — 设计文档
+
+- **日期**: 2026-06-15
+- **状态**: 设计已确认，待写实现计划
+- **范围**: BrainPilot Docker 镜像的构建与多 registry 推送机制，含 cpu/gpu sandbox 变体的依赖设计
+
+---
+
+## 1. 背景与目标
+
+BrainPilot 当前有 Docker 镜像构建（`docker/main/Dockerfile`、`docker/sandbox/Dockerfile`）和
+本地构建脚本 `scripts/release-build.sh`，但**没有任何镜像推送机制**——README 只有 npm 发布流程，
+CI 无镜像推送 workflow。
+
+本设计要解决：
+
+1. 把镜像**推送到三个 registry**（公开分发 + 国内加速 + 内网部署）。
+2. 从同一套源产出**三个镜像**：`main`、`sandbox`（cpu）、`sandbox-gpu`。
+3. 镜像版本号**与 npm 版本一致**（根 `package.json` 的 `version`，由 `scripts/sync-versions.js` 维护）。
+4. 触发方式为**本地脚本**（非 CI）——因为内网 registry 只能从可访问内网的机器推。
+5. 开源仓库**不泄露**私有基础设施地址（ACR 实例 ID、内网 IP）。
+
+### 1.1 推送目标矩阵
+
+| 镜像 | ghcr.io（owner `neuroaihub`） | ACR（命名空间 `brainpilot`） | 内网（insecure registry） |
+|------|------|------|------|
+| main | `ghcr.io/neuroaihub/brainpilot-main` | `crpi-…cn-beijing.personal.cr.aliyuncs.com/brainpilot/main` | `10.0.3.125:5000/brainpilot-main` |
+| sandbox (cpu) | `…/brainpilot-sandbox` | `…/brainpilot/sandbox` | `…/brainpilot-sandbox` |
+| sandbox-gpu | `…/brainpilot-sandbox-gpu` | `…/brainpilot/sandbox-gpu` | `…/brainpilot-sandbox-gpu` |
+
+- ghcr / 内网为**扁平命名**（`brainpilot-<组件>`，无命名空间层）。
+- ACR 有命名空间层 `brainpilot`，故仓库名取**短名**（`main`/`sandbox`/`sandbox-gpu`），与控制台已建仓库对应。
+- 每个镜像打两个 tag：`<version>`（当前 `0.0.3`）+ `latest`。
+
+### 1.2 认证状态（前置条件，不在脚本内处理）
+
+凭证靠**预先 `docker login`**，存于 `/root/.docker/config.json`（不在仓库内、不进设计文件）。
+
+| Registry | 认证 | 已登录账号 |
+|----------|------|-----------|
+| ghcr.io | `docker login` | `GTC2333` |
+| crpi-…cn-beijing.personal.cr.aliyuncs.com | `docker login` | `gtc23333` |
+| 10.0.3.125:5000 | insecure registry，免登录（daemon.json 已配 `insecure-registries`） | — |
+
+> ghcr 与 ACR 是两个不同账号，注意区分。
+
+---
+
+## 2. 总体架构
+
+三个关注点，独立、清晰接口衔接：
+
+```
+┌─────────────────────┐   ┌──────────────────────┐   ┌─────────────────────┐
+│  1. 镜像清单 (SSOT)  │ → │  2. 构建 (build)      │ → │  3. 推送 (push)     │
+│  release-images.sh  │   │  release-build.sh    │   │  release-push.sh    │
+│  + 地址外置 .local   │   │  本地产出 3 个镜像    │   │  fan-out tag/push    │
+└─────────────────────┘   └──────────────────────┘   └─────────────────────┘
+        声明                    读清单驱动构建              读清单驱动推送
+```
+
+**核心原则：单一数据源（SSOT）。** 一份清单声明镜像与 registry，build 与 push 脚本都读它，
+不各自硬编码。加镜像 / 加 registry = 改清单一处。
+
+**build 与 push 分离**的理由：
+
+1. 构建慢（main 含 vite build，gpu 含 torch），推送可能因网络重试 —— 分开可单独重跑。
+2. 推送是不可逆外向操作，独立脚本便于"先构建验证、再决定推哪些 registry"。
+3. 三套 registry 网络条件不同，push 脚本支持只推子集（如 6GB 的 gpu 镜像跳过公网 ghcr）。
+
+---
+
+## 3. 组件一：镜像清单 SSOT（`scripts/release-images.sh`）
+
+被 build/push 脚本 `source`。两张表 + 一个命名映射函数 + 地址外置。
+
+### 3.1 本地镜像清单
+
+```bash
+# 格式: "本地镜像名|Dockerfile 路径|额外 build-arg(空格分隔，可空)"
+RELEASE_IMAGES=(
+  "brainpilot-main|docker/main/Dockerfile|"
+  "brainpilot-sandbox|docker/sandbox/Dockerfile|SANDBOX_EXTRA_DEPS=extra-deps.sh"
+  "brainpilot-sandbox-gpu|docker/sandbox/Dockerfile|SANDBOX_EXTRA_DEPS=extra-deps.gpu.sh"
+)
+```
+
+`sandbox` 与 `sandbox-gpu` **共用** `docker/sandbox/Dockerfile`，仅靠 build-arg `SANDBOX_EXTRA_DEPS`
+选择 COPY 哪个依赖脚本（见 §6）。
+
+### 3.2 registry 清单 + 地址外置（安全）
+
+```bash
+# ghcr 地址本就公开，直接写死在提交版本里
+RELEASE_REGISTRIES=( "ghcr|ghcr.io/neuroaihub|flat" )
+
+# ACR 实例 ID / 内网 IP 属"敏感但非机密"，外置到不提交的本地文件
+[ -f scripts/release-targets.local.sh ] && source scripts/release-targets.local.sh
+```
+
+`scripts/release-targets.local.sh`（**`.gitignore`，不提交**）：
+
+```bash
+# 私有推送目标 —— 不提交。复制 release-targets.example.sh 填入真实地址。
+RELEASE_REGISTRIES+=( "acr|crpi-t2q2y3ujes80doq8.cn-beijing.personal.cr.aliyuncs.com/brainpilot|acr" )
+RELEASE_REGISTRIES+=( "intranet|10.0.3.125:5000|flat" )
+```
+
+`scripts/release-targets.example.sh`（**提交**，占位示范）：
+
+```bash
+# 复制为 release-targets.local.sh 并填入真实地址。local 文件已被 .gitignore 排除。
+RELEASE_REGISTRIES+=( "acr|<实例ID>.cn-<region>.personal.cr.aliyuncs.com/<命名空间>|acr" )
+RELEASE_REGISTRIES+=( "intranet|<内网IP>:<端口>|flat" )
+```
+
+此模式沿用仓库已有约定（`.env` 私有 + `models.example.json` 占位）。
+
+### 3.3 命名映射函数
+
+```bash
+# remote_repo <本地镜像名> <前缀> <风格>
+#   flat → 前缀/本地名         (brainpilot-main)
+#   acr  → 前缀/去 brainpilot- 前缀的短名  (main)
+remote_repo() {
+  local local_name="$1" prefix="$2" style="$3"
+  case "$style" in
+    flat) echo "${prefix}/${local_name}" ;;
+    acr)  echo "${prefix}/${local_name#brainpilot-}" ;;
+  esac
+}
+```
+
+映射结果即 §1.1 矩阵（已与 ACR 控制台仓库 `main`/`sandbox`/`sandbox-gpu` 对应）。
+
+### 3.4 为何用 bash 数组而非 JSON/YAML
+
+脚本是 bash、无额外依赖（jq 不一定装）；条目少（3+3）可读性足够；与现有 `scripts/*.sh` 风格一致。
+
+---
+
+## 4. 组件二：build 脚本（`scripts/release-build.sh`）
+
+把现有硬编码两条 build 改为**循环遍历镜像清单**。
+
+```bash
+source scripts/release-images.sh
+VERSION="$(node -p "require('./package.json').version")"
+# 经典构建器：BuildKit 镜像解析器不吃 dockerd 的 systemd 代理、直连被墙的 Docker Hub；
+# 经典构建器走守护进程代理路径（已验证 docker pull 可用）。这些 Dockerfile 无 BuildKit 专属语法。
+COMMON=( --network=host
+         --build-arg "HTTP_PROXY=${PROXY}" --build-arg "HTTPS_PROXY=${PROXY}"
+         --build-arg "NPM_REGISTRY=https://registry.npmmirror.com"
+         --build-arg "APT_MIRROR=http://mirrors.aliyun.com" )
+
+for entry in "${RELEASE_IMAGES[@]}"; do
+  IFS='|' read -r name dockerfile extra_arg <<< "$entry"
+  # 支持子集：bash release-build.sh sandbox-gpu 只建匹配项（默认全建）
+  [ $# -gt 0 ] && ! _matches "$name" "$@" && continue
+  extra=(); [ -n "$extra_arg" ] && extra=( --build-arg "$extra_arg" )
+  echo "==> building $name (tags: latest, $VERSION)"
+  sudo DOCKER_BUILDKIT=0 docker build "${COMMON[@]}" "${extra[@]}" \
+    -f "$dockerfile" -t "$name:latest" -t "$name:$VERSION" .
+done
+```
+
+要点：
+
+- `sudo DOCKER_BUILDKIT=0 docker build` —— 不能用 `export`，`sudo` 会清环境变量。
+- `--network=host` 让 RUN 步骤借宿主 Clash 代理（`127.0.0.1:7890`）。
+- 子集构建对 gpu（几 GB、慢）尤其有用。
+
+---
+
+## 5. 组件三：push 脚本（`scripts/release-push.sh`）
+
+把本地已构建镜像 `tag` + `push` 到选定 registry。**不重新构建**，只搬运。
+
+### 5.1 用法
+
+```bash
+bash scripts/release-push.sh                                  # 全部镜像 → 全部已配置 registry
+bash scripts/release-push.sh --registry acr,intranet          # 只推这两个（跳过公网 ghcr）
+bash scripts/release-push.sh --image sandbox-gpu              # 只推某镜像
+bash scripts/release-push.sh --image sandbox-gpu --registry acr,intranet  # 组合
+bash scripts/release-push.sh --dry-run                        # 只打印 tag/push，不真推
+```
+
+`--registry` 子集很重要：**sandbox-gpu 约 6GB，推 ghcr（公网）可能超时**，可只推国内+内网。
+
+### 5.2 核心逻辑
+
+```bash
+source scripts/release-images.sh
+VERSION="$(node -p "require('./package.json').version")"
+
+for img in <筛选后的本地镜像>; do
+  sudo docker image inspect "$img:$VERSION" >/dev/null 2>&1 \
+    || { echo "缺 $img:$VERSION，先跑 release-build.sh"; exit 1; }
+  for reg in <筛选后的 registry>; do
+    IFS='|' read -r key prefix style <<< "$reg"
+    repo="$(remote_repo "$img" "$prefix" "$style")"
+    for tag in "$VERSION" latest; do
+      echo "==> $img:$tag → $repo:$tag"
+      [ -n "$DRY_RUN" ] && continue
+      sudo docker tag  "$img:$tag" "$repo:$tag"
+      sudo docker push "$repo:$tag" || RECORD_FAILURE "$repo:$tag"
+    done
+  done
+done
+PRINT_SUMMARY   # 每个 镜像×registry×tag 的成功/失败
+```
+
+### 5.3 错误处理
+
+- **本地镜像缺失** → 明确报错"先跑 release-build.sh"，不静默跳过。
+- **某 registry push 失败**（网络/超时） → 记录失败项**继续推其他**，结尾汇总；不用全局 `set -e`
+  中途退出，避免一个 registry 挂掉前功尽弃。
+- **未登录** → docker push 自报 unauthorized；脚本开头可选做 login 状态检查给友好提示。
+- **结尾打印推送清单** → 一眼看清推了什么去哪。
+
+### 5.4 安全边界
+
+push 脚本读 `release-images.sh` 的 registry 清单，ACR/内网地址来自不提交的 `release-targets.local.sh`。
+开源仓库里的 push 脚本只能看到 ghcr 默认目标，私有地址不泄露（§3.2）。
+
+---
+
+## 6. Dockerfile 改动：sandbox cpu/gpu 变体
+
+`docker/sandbox/Dockerfile` 把写死的 `extra-deps.sh` 改为 build-arg 选择：
+
+```dockerfile
+ARG SANDBOX_EXTRA_DEPS=extra-deps.sh          # 默认 cpu 基线，向后兼容现有 compose 构建
+COPY docker/sandbox/${SANDBOX_EXTRA_DEPS} /tmp/extra-deps.sh
+RUN chmod +x /tmp/extra-deps.sh && bash /tmp/extra-deps.sh
+```
+
+`main` 镜像不变（纯 Node 代理，不跑代码、不需 Python）。
+
+---
+
+## 7. 镜像依赖设计（关键，超出"推送"但直接决定镜像内容）
+
+### 7.1 依赖矩阵（已定）
+
+| 镜像 | 基础 | 运行时入口 | Python | 预装科学库 | torch | 体积估计 |
+|------|------|-----------|:---:|:---:|:---:|------|
+| **main** | node:22-slim | `backend-core/dist/server.js`（无状态代理） | ❌ | ❌ | ❌ | ~750MB |
+| **sandbox** (cpu) | node:22-slim | `runtime/dist/server.js`（Pi SDK） | ✅ python3+pip+venv | ❌ agent 自装 | ❌ | ~280MB |
+| **sandbox-gpu** | node:22-slim | 同 sandbox | ✅ python3+pip+venv | ✅ 见 §7.4 | ✅ cu124 | ~6GB |
+
+### 7.2 为何只有 sandbox 系列需要 Python
+
+代码查证（`packages/*/package.json` + `personas.ts` + Pi SDK）：
+
+- **main** 跑 `backend-core`，是 stateless byte-passthrough 代理（CLAUDE.md 修正4），**从不执行用户代码** →
+  纯 Node，绝不需要 Python。
+- **sandbox** 跑 `runtime` + Pi SDK，**agent 在此执行代码**。Pi SDK 提供 `bash` 工具（`createBashTool`），
+  coding persona 明确指示 agent *"Use `write`/`edit` to author files and `bash` to run them"*
+  （`personas.ts`）。agent 写 `analysis.py` 后 `bash: python3 analysis.py` —— 当前 cpu 基线是
+  `node:22-slim` + no-op extra-deps，**容器内无 `python3`，会 `command not found`**。故 cpu sandbox
+  必须装 Python。
+
+> 这是当前代码已存在的缺口：cpu sandbox 的 agent 一写 Python 就失败。本设计一并修复。
+
+### 7.3 node:22-slim vs python:3.12-slim（基础镜像选型说明）
+
+二者同为 Debian slim，仅预装语言运行时不同（node vs python），**并存互不影响**（各自 bin/包管理/依赖目录独立，
+仅共享 OS 系统库）。BrainPilot runtime 是 **Node 程序**，故 sandbox 必须以 `node:22-slim` 为底，
+再 `apt-get install python3` 加装 Python（GPU 能力是额外叠加）。这与 legacy 相反（legacy runtime 是
+Python，故以 `python:3.12-slim` 为底加装 node）—— 架构从 Python 改为 TS，基础镜像主次随之反转。
+我们只借用 legacy 的 **torch 版本与镜像源策略**，不借其基础镜像。
+
+> Debian 12+ 系统 Python 标记为 externally-managed，容器内 pip 安装用 `--break-system-packages`
+> （容器一次性，不怕"弄脏"系统 Python）。
+
+### 7.4 sandbox cpu 依赖脚本（`docker/sandbox/extra-deps.sh`，由 no-op 改为）
+
+装 `python3 + pip + venv`，**不预装**任何科学库（agent 按需自装，persona 本就要求 agent 管理依赖）。
+保持 cpu 镜像轻量（~280MB），符合 Dockerfile "lightweight baseline" 注释。
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+[ -n "${APT_MIRROR:-}" ] && sed -i "s|http://deb.debian.org|$APT_MIRROR|g" \
+  /etc/apt/sources.list.d/*.sources /etc/apt/sources.list 2>/dev/null || true
+apt-get update && apt-get install -y --no-install-recommends python3 python3-pip python3-venv
+rm -rf /var/lib/apt/lists/*
+# pip 默认源固化为阿里云（legacy 实测：Clash 代理 RST pypi.org，但 aliyun 正常）
+printf '%s\n' '[global]' \
+  'index-url = https://mirrors.aliyun.com/pypi/simple/' \
+  'extra-index-url = https://pypi.tuna.tsinghua.edu.cn/simple/' \
+  'trusted-host = mirrors.aliyun.com pypi.tuna.tsinghua.edu.cn' \
+  'timeout = 60' > /etc/pip.conf
+```
+
+### 7.5 sandbox-gpu 依赖脚本（`docker/sandbox/extra-deps.gpu.sh`，新增）
+
+= cpu 的 Python 基础 + **预装科学/PDF 栈** + **CUDA torch cu124**。
+
+**预装清单（已定，方案 A）**：
+
+- 数值/数据：`numpy pandas scipy`
+- 可视化：`matplotlib`
+- 机器学习：`scikit-learn`
+- PDF：`pypdf`（纯文本）+ `pdfplumber`（表格）
+- 图像：`pillow`
+
+**版本策略**：`torch` 钉死 `2.5.1+cu124`（CUDA 必须精确匹配）；科学库装最新稳定不钉（向后兼容好）。
+**不含** transformers/HuggingFace 栈。
+
+torch 版本/源沿用 legacy 实测配置（`legacy/docker/agent_runtime/Dockerfile.base`，2026-05-29 实测）：
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+# ---- 1. 复用 cpu 脚本的 python3 + pip 源固化 ----
+#  （实现时可 source extra-deps.sh 的公共段，或抽出 _python-base.sh 共享，避免重复）
+[ -n "${APT_MIRROR:-}" ] && sed -i "s|http://deb.debian.org|$APT_MIRROR|g" \
+  /etc/apt/sources.list.d/*.sources /etc/apt/sources.list 2>/dev/null || true
+apt-get update && apt-get install -y --no-install-recommends python3 python3-pip python3-venv
+rm -rf /var/lib/apt/lists/*
+printf '%s\n' '[global]' 'index-url = https://mirrors.aliyun.com/pypi/simple/' \
+  'extra-index-url = https://pypi.tuna.tsinghua.edu.cn/simple/' \
+  'trusted-host = mirrors.aliyun.com pypi.tuna.tsinghua.edu.cn' 'timeout = 60' > /etc/pip.conf
+
+# ---- 2. 科学/PDF 栈（最新稳定，走阿里云 pip 源）----
+pip3 install --break-system-packages \
+  numpy pandas scipy matplotlib scikit-learn pillow pypdf pdfplumber
+
+# ---- 3. CUDA 12.4 runtime wheels（清华 PyPI）----
+pip3 install --break-system-packages \
+  nvidia-cuda-runtime-cu12==12.4.127 nvidia-cuda-nvrtc-cu12==12.4.127 \
+  nvidia-cudnn-cu12==9.1.0.70 nvidia-cublas-cu12==12.4.5.8 \
+  nvidia-cufft-cu12==11.2.1.3 nvidia-curand-cu12==10.3.5.147 \
+  nvidia-cusolver-cu12==11.6.1.9 nvidia-cusparse-cu12==12.3.1.170 \
+  nvidia-nccl-cu12==2.21.5 nvidia-nvtx-cu12==12.4.127 nvidia-nvjitlink-cu12==12.4.127 \
+  --index-url https://pypi.tuna.tsinghua.edu.cn/simple/
+
+# ---- 4. PyTorch cu124（官方 whl 源——清华 pytorch-wheels 不同步 cu124 会 404）----
+#  构建时 --network=host 借宿主 Clash 代理访问 download.pytorch.org
+pip3 install --break-system-packages \
+  torch==2.5.1+cu124 torchvision==0.20.1+cu124 torchaudio==2.5.1+cu124 \
+  --index-url https://download.pytorch.org/whl/cu124 \
+  --extra-index-url https://pypi.tuna.tsinghua.edu.cn/simple/
+```
+
+> GPU 运行期访问显卡靠 `docker run --gpus all`（nvidia runtime），与镜像无关；torch cu124 wheel
+> 自带 CUDA 运行库，故基础镜像无需 CUDA 镜像。
+
+---
+
+## 8. 文件清单
+
+| 文件 | 动作 | 说明 |
+|------|------|------|
+| `scripts/release-images.sh` | 新增 | SSOT 清单：镜像表 + registry 表 + `remote_repo()` + source local |
+| `scripts/release-targets.example.sh` | 新增（提交） | ACR/内网占位示范 |
+| `scripts/release-targets.local.sh` | 新增（**不提交**） | 真实 ACR/内网地址 |
+| `scripts/release-build.sh` | 改造 | 改为循环读清单 + 子集构建（已有原型，重构） |
+| `scripts/release-push.sh` | 新增 | 子集筛选 + dry-run + 缺镜像检查 + 失败汇总 |
+| `docker/sandbox/Dockerfile` | 改 | `ARG SANDBOX_EXTRA_DEPS` 选依赖脚本 |
+| `docker/sandbox/extra-deps.sh` | 改 | no-op → python3+pip+venv（cpu 基线） |
+| `docker/sandbox/extra-deps.gpu.sh` | 新增 | python3 + 科学/PDF 栈 + torch cu124 |
+| `.gitignore` | 改 | 加 `scripts/release-targets.local.sh` |
+| `README.md` | 改 | 加"Docker 镜像发布"小节（镜像版本号 = npm 版本） |
+
+---
+
+## 9. 验证方式
+
+1. **build 子集**：`bash scripts/release-build.sh sandbox` 只建 cpu sandbox，验证 python3 装入
+   （`docker run --rm brainpilot-sandbox:latest python3 --version`）。
+2. **dry-run push**：`bash scripts/release-push.sh --dry-run` 打印全部 tag/push 计划，核对三 registry 路径。
+3. **真推子集**：`bash scripts/release-push.sh --image main --registry acr` 先推一个最小目标验证认证。
+4. **gpu 单独**：gpu 镜像体积大、构建慢，单独 `bash scripts/release-build.sh sandbox-gpu` 验证 torch
+   导入（`docker run --rm brainpilot-sandbox-gpu:latest python3 -c "import torch; print(torch.__version__)"`）。
+5. **现有 compose 不回归**：`docker compose build` 默认 build-arg 走 cpu 基线，行为不变。
+
+---
+
+## 10. 范围外（不在本设计）
+
+- **CI 自动推送**：本期为本地脚本。内网 registry 决定至少一份必须本地推；以后可把脚本搬进 workflow。
+- **GPU 运行期编排**：`--gpus all` / compose GPU 配置不在本设计（仅负责把 gpu 镜像构建+推送出去）。
+- **npm 包发布**：已有 `npm run release` 流程，不动。
+- **registry 镜像清理/保留策略**：旧 tag 清理不在本期。

--- a/docs/superpowers/specs/2026-06-15-multi-registry-push-design.md
+++ b/docs/superpowers/specs/2026-06-15-multi-registry-push-design.md
@@ -145,13 +145,17 @@ remote_repo() {
 
 ```bash
 source scripts/release-images.sh
+# 镜像源外置（§7.4-pre）：本地文件存在则覆盖官方源默认值
+[ -f scripts/release-mirrors.local.sh ] && source scripts/release-mirrors.local.sh
 VERSION="$(node -p "require('./package.json').version")"
 # 经典构建器：BuildKit 镜像解析器不吃 dockerd 的 systemd 代理、直连被墙的 Docker Hub；
 # 经典构建器走守护进程代理路径（已验证 docker pull 可用）。这些 Dockerfile 无 BuildKit 专属语法。
 COMMON=( --network=host
-         --build-arg "HTTP_PROXY=${PROXY}" --build-arg "HTTPS_PROXY=${PROXY}"
-         --build-arg "NPM_REGISTRY=https://registry.npmmirror.com"
-         --build-arg "APT_MIRROR=http://mirrors.aliyun.com" )
+         --build-arg "HTTP_PROXY=${PROXY:-}" --build-arg "HTTPS_PROXY=${PROXY:-}"
+         --build-arg "NPM_REGISTRY=${NPM_REGISTRY:-}"
+         --build-arg "APT_MIRROR=${APT_MIRROR:-}"
+         --build-arg "PIP_INDEX_URL=${PIP_INDEX_URL:-}"
+         --build-arg "PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL:-}" )
 
 for entry in "${RELEASE_IMAGES[@]}"; do
   IFS='|' read -r name dockerfile extra_arg <<< "$entry"
@@ -168,6 +172,8 @@ done
 
 - `sudo DOCKER_BUILDKIT=0 docker build` —— 不能用 `export`，`sudo` 会清环境变量。
 - `--network=host` 让 RUN 步骤借宿主 Clash 代理（`127.0.0.1:7890`）。
+- 镜像源（apt/pip/npm）来自 `release-mirrors.local.sh`（不提交），经 build-arg 注入容器；
+  无本地文件则传空、容器内落到官方源默认值。
 - 子集构建对 gpu（几 GB、慢）尤其有用。
 
 ---
@@ -228,10 +234,16 @@ push 脚本读 `release-images.sh` 的 registry 清单，ACR/内网地址来自�
 
 ## 6. Dockerfile 改动：sandbox cpu/gpu 变体
 
-`docker/sandbox/Dockerfile` 把写死的 `extra-deps.sh` 改为 build-arg 选择：
+`docker/sandbox/Dockerfile` 把写死的 `extra-deps.sh` 改为 build-arg 选择，并把镜像源 build-arg
+透传为 ENV 供依赖脚本读取：
 
 ```dockerfile
 ARG SANDBOX_EXTRA_DEPS=extra-deps.sh          # 默认 cpu 基线，向后兼容现有 compose 构建
+ARG APT_MIRROR=""
+ARG PIP_INDEX_URL=""
+ARG PIP_EXTRA_INDEX_URL=""
+# build-arg → ENV，使 extra-deps 脚本能读到镜像源（空则脚本落官方源默认）
+ENV APT_MIRROR=${APT_MIRROR} PIP_INDEX_URL=${PIP_INDEX_URL} PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL}
 COPY docker/sandbox/${SANDBOX_EXTRA_DEPS} /tmp/extra-deps.sh
 RUN chmod +x /tmp/extra-deps.sh && bash /tmp/extra-deps.sh
 ```
@@ -275,24 +287,57 @@ Python，故以 `python:3.12-slim` 为底加装 node）—— 架构从 Python �
 > Debian 12+ 系统 Python 标记为 externally-managed，容器内 pip 安装用 `--break-system-packages`
 > （容器一次性，不怕"弄脏"系统 Python）。
 
+### 7.4-pre 镜像源外置（模板提交 + 本地实际）
+
+依赖脚本里有两类内容，外置策略不同：
+
+| 内容 | 环境相关 | 处理 |
+|------|:---:|------|
+| **镜像源**（pip index-url、apt 源） | ✅ | 本地配（国内阿里云/清华，国外官方） |
+| **依赖清单**（装哪些包、torch 版本） | ❌ | 单份提交（项目定义，不因机器变，避免漂移） |
+
+**机制**：依赖脚本**单份提交**且不写死阿里云——改用环境变量（`PIP_INDEX_URL` / `PIP_EXTRA_INDEX_URL`
+/ `APT_MIRROR`），变量为空时落到**官方源默认值**。变量值由 **build 脚本从本地镜像源文件读取并经
+build-arg 注入容器**（容器隔离，无法 source 宿主文件，故必须经 build-arg 传入）。
+
+- `scripts/release-mirrors.example.sh`（**提交**，占位示范）：
+
+  ```bash
+  # 复制为 release-mirrors.local.sh 启用国内镜像源加速。local 文件已被 .gitignore 排除。
+  # 留空或不创建 local 文件 = 用官方源（pypi.org / deb.debian.org）。
+  export PIP_INDEX_URL="https://mirrors.aliyun.com/pypi/simple/"
+  export PIP_EXTRA_INDEX_URL="https://pypi.tuna.tsinghua.edu.cn/simple/"
+  export APT_MIRROR="http://mirrors.aliyun.com"
+  ```
+
+- `scripts/release-mirrors.local.sh`（**不提交**）：你的实际镜像源。
+- build 脚本：`[ -f scripts/release-mirrors.local.sh ] && source scripts/release-mirrors.local.sh`，
+  再把 `PIP_INDEX_URL` 等转为 `--build-arg` 传入（与现有 `NPM_REGISTRY`/`APT_MIRROR` build-arg 同理）。
+
+> 注意：legacy 实测宿主 Clash 代理对 `pypi.org` 的 TLS 在 ClientHello 后被 RST，但阿里云正常。
+> 故在本网络环境**实际构建时务必创建 `release-mirrors.local.sh` 指向阿里云**，否则官方源默认值会失败。
+> 提交版用官方源默认是为了开源用户在不被墙的网络下开箱可用。
+
 ### 7.4 sandbox cpu 依赖脚本（`docker/sandbox/extra-deps.sh`，由 no-op 改为）
 
 装 `python3 + pip + venv`，**不预装**任何科学库（agent 按需自装，persona 本就要求 agent 管理依赖）。
-保持 cpu 镜像轻量（~280MB），符合 Dockerfile "lightweight baseline" 注释。
+保持 cpu 镜像轻量（~280MB），符合 Dockerfile "lightweight baseline" 注释。镜像源来自注入的环境变量
+（§7.4-pre），空则官方源。
 
 ```bash
 #!/usr/bin/env bash
 set -euo pipefail
+# apt 源：APT_MIRROR 注入则替换，否则用镜像自带官方源
 [ -n "${APT_MIRROR:-}" ] && sed -i "s|http://deb.debian.org|$APT_MIRROR|g" \
   /etc/apt/sources.list.d/*.sources /etc/apt/sources.list 2>/dev/null || true
 apt-get update && apt-get install -y --no-install-recommends python3 python3-pip python3-venv
 rm -rf /var/lib/apt/lists/*
-# pip 默认源固化为阿里云（legacy 实测：Clash 代理 RST pypi.org，但 aliyun 正常）
-printf '%s\n' '[global]' \
-  'index-url = https://mirrors.aliyun.com/pypi/simple/' \
-  'extra-index-url = https://pypi.tuna.tsinghua.edu.cn/simple/' \
-  'trusted-host = mirrors.aliyun.com pypi.tuna.tsinghua.edu.cn' \
-  'timeout = 60' > /etc/pip.conf
+# pip 源：注入则固化，否则不写 /etc/pip.conf（用 pip 官方默认 pypi.org）
+if [ -n "${PIP_INDEX_URL:-}" ]; then
+  { echo '[global]'; echo "index-url = ${PIP_INDEX_URL}";
+    [ -n "${PIP_EXTRA_INDEX_URL:-}" ] && echo "extra-index-url = ${PIP_EXTRA_INDEX_URL}";
+    echo 'timeout = 60'; } > /etc/pip.conf
+fi
 ```
 
 ### 7.5 sandbox-gpu 依赖脚本（`docker/sandbox/extra-deps.gpu.sh`，新增）
@@ -315,35 +360,35 @@ torch 版本/源沿用 legacy 实测配置（`legacy/docker/agent_runtime/Docker
 ```bash
 #!/usr/bin/env bash
 set -euo pipefail
-# ---- 1. 复用 cpu 脚本的 python3 + pip 源固化 ----
-#  （实现时可 source extra-deps.sh 的公共段，或抽出 _python-base.sh 共享，避免重复）
+# ---- 1. python3 + pip + 镜像源（与 cpu 脚本同逻辑，实现时抽 _python-base.sh 共享避免重复）----
 [ -n "${APT_MIRROR:-}" ] && sed -i "s|http://deb.debian.org|$APT_MIRROR|g" \
   /etc/apt/sources.list.d/*.sources /etc/apt/sources.list 2>/dev/null || true
 apt-get update && apt-get install -y --no-install-recommends python3 python3-pip python3-venv
 rm -rf /var/lib/apt/lists/*
-printf '%s\n' '[global]' 'index-url = https://mirrors.aliyun.com/pypi/simple/' \
-  'extra-index-url = https://pypi.tuna.tsinghua.edu.cn/simple/' \
-  'trusted-host = mirrors.aliyun.com pypi.tuna.tsinghua.edu.cn' 'timeout = 60' > /etc/pip.conf
+if [ -n "${PIP_INDEX_URL:-}" ]; then
+  { echo '[global]'; echo "index-url = ${PIP_INDEX_URL}";
+    [ -n "${PIP_EXTRA_INDEX_URL:-}" ] && echo "extra-index-url = ${PIP_EXTRA_INDEX_URL}";
+    echo 'timeout = 60'; } > /etc/pip.conf
+fi
 
-# ---- 2. 科学/PDF 栈（最新稳定，走阿里云 pip 源）----
+# ---- 2. 科学/PDF 栈（最新稳定，走上面配置的 pip 源）----
 pip3 install --break-system-packages \
   numpy pandas scipy matplotlib scikit-learn pillow pypdf pdfplumber
 
-# ---- 3. CUDA 12.4 runtime wheels（清华 PyPI）----
+# ---- 3. CUDA 12.4 runtime wheels（pip 默认源，国内由 release-mirrors.local 指向清华/阿里云）----
 pip3 install --break-system-packages \
   nvidia-cuda-runtime-cu12==12.4.127 nvidia-cuda-nvrtc-cu12==12.4.127 \
   nvidia-cudnn-cu12==9.1.0.70 nvidia-cublas-cu12==12.4.5.8 \
   nvidia-cufft-cu12==11.2.1.3 nvidia-curand-cu12==10.3.5.147 \
   nvidia-cusolver-cu12==11.6.1.9 nvidia-cusparse-cu12==12.3.1.170 \
-  nvidia-nccl-cu12==2.21.5 nvidia-nvtx-cu12==12.4.127 nvidia-nvjitlink-cu12==12.4.127 \
-  --index-url https://pypi.tuna.tsinghua.edu.cn/simple/
+  nvidia-nccl-cu12==2.21.5 nvidia-nvtx-cu12==12.4.127 nvidia-nvjitlink-cu12==12.4.127
 
-# ---- 4. PyTorch cu124（官方 whl 源——清华 pytorch-wheels 不同步 cu124 会 404）----
-#  构建时 --network=host 借宿主 Clash 代理访问 download.pytorch.org
+# ---- 4. PyTorch cu124（官方 whl 源——清华 pytorch-wheels 不同步 cu124 会 404；
+#      此 index-url 是 torch 专属、不受镜像源外置影响。构建时 --network=host 借宿主 Clash 代理）----
 pip3 install --break-system-packages \
   torch==2.5.1+cu124 torchvision==0.20.1+cu124 torchaudio==2.5.1+cu124 \
   --index-url https://download.pytorch.org/whl/cu124 \
-  --extra-index-url https://pypi.tuna.tsinghua.edu.cn/simple/
+  --extra-index-url "${PIP_INDEX_URL:-https://pypi.org/simple/}"
 ```
 
 > GPU 运行期访问显卡靠 `docker run --gpus all`（nvidia runtime），与镜像无关；torch cu124 wheel
@@ -358,12 +403,14 @@ pip3 install --break-system-packages \
 | `scripts/release-images.sh` | 新增 | SSOT 清单：镜像表 + registry 表 + `remote_repo()` + source local |
 | `scripts/release-targets.example.sh` | 新增（提交） | ACR/内网占位示范 |
 | `scripts/release-targets.local.sh` | 新增（**不提交**） | 真实 ACR/内网地址 |
-| `scripts/release-build.sh` | 改造 | 改为循环读清单 + 子集构建（已有原型，重构） |
+| `scripts/release-mirrors.example.sh` | 新增（提交） | 镜像源占位示范（pip/apt） |
+| `scripts/release-mirrors.local.sh` | 新增（**不提交**） | 真实镜像源（阿里云/清华） |
+| `scripts/release-build.sh` | 改造 | 循环读清单 + 子集构建 + 注入镜像源 build-arg（已有原型，重构） |
 | `scripts/release-push.sh` | 新增 | 子集筛选 + dry-run + 缺镜像检查 + 失败汇总 |
-| `docker/sandbox/Dockerfile` | 改 | `ARG SANDBOX_EXTRA_DEPS` 选依赖脚本 |
-| `docker/sandbox/extra-deps.sh` | 改 | no-op → python3+pip+venv（cpu 基线） |
-| `docker/sandbox/extra-deps.gpu.sh` | 新增 | python3 + 科学/PDF 栈 + torch cu124 |
-| `.gitignore` | 改 | 加 `scripts/release-targets.local.sh` |
+| `docker/sandbox/Dockerfile` | 改 | `ARG SANDBOX_EXTRA_DEPS` 选依赖脚本 + 镜像源 ARG→ENV 透传 |
+| `docker/sandbox/extra-deps.sh` | 改 | no-op → python3+pip+venv（cpu 基线，镜像源变量化） |
+| `docker/sandbox/extra-deps.gpu.sh` | 新增 | python3 + 科学/PDF 栈 + torch cu124（镜像源变量化） |
+| `.gitignore` | 改 | 加 `scripts/release-targets.local.sh`、`scripts/release-mirrors.local.sh` |
 | `README.md` | 改 | 加"Docker 镜像发布"小节（镜像版本号 = npm 版本） |
 
 ---

--- a/packages/web/src/config.ts
+++ b/packages/web/src/config.ts
@@ -1,3 +1,7 @@
 export const runtimeConfig = {
   useMockBackend: import.meta.env.VITE_USE_MOCK_BACKEND === "1",
+  // Multi-user auth is OFF by default: this repo is single-user and must not
+  // show a login screen. A downstream multi-user deployment re-enables the full
+  // login/register/me flow by building with VITE_AUTH_ENABLED=1.
+  authEnabled: import.meta.env.VITE_AUTH_ENABLED === "1",
 };

--- a/packages/web/src/contexts/AuthContext.tsx
+++ b/packages/web/src/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
 import { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useState } from "react";
 import { User } from "../contracts/backend";
 import { api, clearStoredToken, getStoredToken, storeToken } from "../utils/api";
+import { runtimeConfig } from "../config";
 import { tg } from "../i18n/translate";
 
 interface AuthContextValue {
@@ -16,7 +17,50 @@ interface AuthContextValue {
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
+// Single-user bypass identity (auth disabled). Kept stable so `token` —
+// which other contexts use as a "ready to connect" gate — is always truthy
+// and the login overlay (gated on `!user`) never renders.
+const LOCAL_USER: User = {
+  id: "local",
+  username: "local",
+  createdAt: "1970-01-01T00:00:00.000Z",
+};
+const LOCAL_TOKEN = "local";
+
+/**
+ * AuthProvider has two modes, selected at build time by VITE_AUTH_ENABLED:
+ *
+ * - auth DISABLED (default, this single-user repo): a bypass that reports an
+ *   always-signed-in local user with a fixed token. No login screen, no
+ *   network calls; login/register/logout are no-ops.
+ * - auth ENABLED (downstream multi-user deployment, VITE_AUTH_ENABLED=1):
+ *   the real bootstrap/login/register/logout flow in RealAuthProvider.
+ */
 export function AuthProvider({ children }: { children: ReactNode }) {
+  if (!runtimeConfig.authEnabled) {
+    return <BypassAuthProvider>{children}</BypassAuthProvider>;
+  }
+  return <RealAuthProvider>{children}</RealAuthProvider>;
+}
+
+function BypassAuthProvider({ children }: { children: ReactNode }) {
+  const value = useMemo<AuthContextValue>(
+    () => ({
+      user: LOCAL_USER,
+      token: LOCAL_TOKEN,
+      isBootstrapping: false,
+      isSubmitting: false,
+      error: null,
+      login: async () => {},
+      register: async () => {},
+      logout: () => {},
+    }),
+    [],
+  );
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+function RealAuthProvider({ children }: { children: ReactNode }) {
   const [token, setToken] = useState<string | null>(() => getStoredToken());
   const [user, setUser] = useState<User | null>(null);
   const [isBootstrapping, setIsBootstrapping] = useState(true);

--- a/scripts/release-build.sh
+++ b/scripts/release-build.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Release image build — 读 release-images.sh 清单循环构建，打 latest + 版本号两 tag。
+# 用法:
+#   bash scripts/release-build.sh                 # 构建全部镜像
+#   bash scripts/release-build.sh sandbox         # 只构建名字含 "sandbox" 的镜像（子集）
+#   bash scripts/release-build.sh main sandbox-gpu# 多个子集
+# 镜像源/代理来自 release-mirrors.local.sh（不提交），无则用官方源默认。
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+source scripts/release-images.sh
+# 镜像源外置：本地文件存在则覆盖官方源默认值（设 PIP_INDEX_URL/APT_MIRROR/NPM_REGISTRY 等）
+[ -f scripts/release-mirrors.local.sh ] && source scripts/release-mirrors.local.sh
+
+VERSION="$(node -p "require('./package.json').version")"
+PROXY="${BUILD_PROXY:-http://127.0.0.1:7890}"
+
+# 子集匹配：无参数=全建；有参数=镜像名包含任一参数子串才建
+_matches() { # _matches <镜像名> <参数...>
+  local name="$1"; shift
+  local pat
+  for pat in "$@"; do [[ "$name" == *"$pat"* ]] && return 0; done
+  return 1
+}
+
+# 经典构建器：BuildKit 镜像解析器不吃 dockerd 的 systemd 代理、直连被墙的 Docker Hub；
+# 经典构建器走守护进程代理路径（已验证 docker pull 可用）。这些 Dockerfile 无 BuildKit 专属语法。
+# 注：DOCKER_BUILDKIT=0 必须内联给 sudo —— sudo 会清环境变量，export 不生效。
+COMMON=(
+  --network=host
+  --build-arg "HTTP_PROXY=${PROXY}"
+  --build-arg "HTTPS_PROXY=${PROXY}"
+  --build-arg "NPM_REGISTRY=${NPM_REGISTRY:-}"
+  --build-arg "APT_MIRROR=${APT_MIRROR:-}"
+  --build-arg "PIP_INDEX_URL=${PIP_INDEX_URL:-}"
+  --build-arg "PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL:-}"
+)
+
+echo "==> version=${VERSION} proxy=${PROXY} (mirrors: pip=${PIP_INDEX_URL:-官方} apt=${APT_MIRROR:-官方})"
+
+built=()
+for entry in "${RELEASE_IMAGES[@]}"; do
+  IFS='|' read -r name dockerfile extra_arg <<< "$entry"
+  if [ $# -gt 0 ] && ! _matches "$name" "$@"; then
+    echo "==> skip $name (不匹配子集)"
+    continue
+  fi
+  extra=(); [ -n "$extra_arg" ] && extra=( --build-arg "$extra_arg" )
+  echo "==> building $name (tags: latest, $VERSION)"
+  sudo DOCKER_BUILDKIT=0 docker build "${COMMON[@]}" "${extra[@]}" \
+    -f "$dockerfile" -t "$name:latest" -t "$name:$VERSION" .
+  built+=("$name")
+done
+
+echo "==> BUILD DONE: ${built[*]:-(无匹配镜像)}"
+sudo docker images | grep -E 'brainpilot-(main|sandbox)' || true

--- a/scripts/release-images.sh
+++ b/scripts/release-images.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# release-images.sh — SSOT for image build + multi-registry push.
+# Sourced by release-build.sh and release-push.sh. Defines:
+#   RELEASE_IMAGES      本地镜像 → Dockerfile + 额外 build-arg
+#   RELEASE_REGISTRIES  推送目标 → 前缀 + 命名风格
+#   remote_repo()       本地镜像名 → 某 registry 的完整仓库路径
+# 私有 registry 地址在 release-targets.local.sh（不提交）里 append。
+
+# 本地镜像清单: "本地镜像名|Dockerfile 路径|额外 build-arg(空格分隔，可空)"
+RELEASE_IMAGES=(
+  "brainpilot-main|docker/main/Dockerfile|"
+  "brainpilot-sandbox|docker/sandbox/Dockerfile|SANDBOX_EXTRA_DEPS=extra-deps.sh"
+  "brainpilot-sandbox-gpu|docker/sandbox/Dockerfile|SANDBOX_EXTRA_DEPS=extra-deps.gpu.sh"
+)
+
+# registry 清单: "registry键|前缀|命名风格(flat|acr)"
+# ghcr 地址本就公开，写死在提交版本里。
+RELEASE_REGISTRIES=( "ghcr|ghcr.io/neuroaihub|flat" )
+
+# 私有目标（ACR 实例 ID / 内网 IP）从不提交的本地文件 append。
+_REL_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[ -f "$_REL_DIR/release-targets.local.sh" ] && source "$_REL_DIR/release-targets.local.sh"
+
+# remote_repo <本地镜像名> <前缀> <风格>
+#   flat → 前缀/本地名               (brainpilot-main)
+#   acr  → 前缀/去 brainpilot- 前缀  (main)
+remote_repo() {
+  local local_name="$1" prefix="$2" style="$3"
+  case "$style" in
+    flat) echo "${prefix}/${local_name}" ;;
+    acr)  echo "${prefix}/${local_name#brainpilot-}" ;;
+    *)    echo "remote_repo: unknown style '$style'" >&2; return 1 ;;
+  esac
+}

--- a/scripts/release-mirrors.example.sh
+++ b/scripts/release-mirrors.example.sh
@@ -1,0 +1,6 @@
+# 复制为 release-mirrors.local.sh 启用国内镜像源加速。local 文件已被 .gitignore 排除。
+# 留空或不创建 local 文件 = 用官方源（pypi.org / deb.debian.org）。
+export PIP_INDEX_URL="https://mirrors.aliyun.com/pypi/simple/"
+export PIP_EXTRA_INDEX_URL="https://pypi.tuna.tsinghua.edu.cn/simple/"
+export APT_MIRROR="http://mirrors.aliyun.com"
+export NPM_REGISTRY="https://registry.npmmirror.com"

--- a/scripts/release-push.sh
+++ b/scripts/release-push.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Release image push — 把本地已构建镜像 tag+push 到选定 registry。不重新构建。
+# 用法:
+#   bash scripts/release-push.sh                                 # 全部镜像 → 全部已配置 registry
+#   bash scripts/release-push.sh --registry acr,intranet         # 只推这些 registry（跳过 ghcr）
+#   bash scripts/release-push.sh --image sandbox-gpu             # 只推名字含该子串的镜像
+#   bash scripts/release-push.sh --image sandbox-gpu --registry acr,intranet
+#   bash scripts/release-push.sh --dry-run                       # 只打印 tag/push 计划，不真推
+set -uo pipefail   # 注意：不用 -e，单个 registry 失败要继续推其他并汇总
+cd "$(dirname "$0")/.."
+
+source scripts/release-images.sh
+VERSION="$(node -p "require('./package.json').version")"
+
+IMAGE_FILTER=""; REGISTRY_FILTER=""; DRY_RUN=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --image)    IMAGE_FILTER="$2"; shift 2 ;;
+    --registry) REGISTRY_FILTER="$2"; shift 2 ;;
+    --dry-run)  DRY_RUN=1; shift ;;
+    *) echo "未知参数: $1" >&2; exit 2 ;;
+  esac
+done
+
+# 逗号分隔列表是否包含某键（精确匹配段）
+_in_csv() { # _in_csv <键> <csv>
+  local key="$1" csv="$2" IFS=','
+  for k in $csv; do [ "$k" = "$key" ] && return 0; done
+  return 1
+}
+
+declare -a OK_LIST=() FAIL_LIST=()   # 显式空数组初始化：否则 set -u 下空 FAIL_LIST 触发 unbound variable
+for img_entry in "${RELEASE_IMAGES[@]}"; do
+  IFS='|' read -r img _df _arg <<< "$img_entry"
+  # 镜像子集：--image 是子串匹配（与 build 一致）
+  if [ -n "$IMAGE_FILTER" ] && [[ "$img" != *"$IMAGE_FILTER"* ]]; then continue; fi
+
+  if ! sudo docker image inspect "$img:$VERSION" >/dev/null 2>&1; then
+    echo "缺本地镜像 $img:$VERSION —— 先跑 scripts/release-build.sh"; exit 1
+  fi
+
+  for reg_entry in "${RELEASE_REGISTRIES[@]}"; do
+    IFS='|' read -r key prefix style <<< "$reg_entry"
+    # registry 子集：--registry 是精确键匹配（逗号分隔）
+    if [ -n "$REGISTRY_FILTER" ] && ! _in_csv "$key" "$REGISTRY_FILTER"; then continue; fi
+    repo="$(remote_repo "$img" "$prefix" "$style")"
+    for tag in "$VERSION" latest; do
+      echo "==> $img:$tag → $repo:$tag"
+      [ -n "$DRY_RUN" ] && { OK_LIST+=("(dry) $repo:$tag"); continue; }
+      if sudo docker tag "$img:$tag" "$repo:$tag" && sudo docker push "$repo:$tag"; then
+        OK_LIST+=("$repo:$tag")
+      else
+        FAIL_LIST+=("$repo:$tag")
+      fi
+    done
+  done
+done
+
+echo ""; echo "==== 推送汇总 ===="
+echo "成功 ${#OK_LIST[@]}:"; printf '  ✓ %s\n' "${OK_LIST[@]:-（无）}"
+if [ "${#FAIL_LIST[@]}" -gt 0 ]; then
+  echo "失败 ${#FAIL_LIST[@]}:"; printf '  ✗ %s\n' "${FAIL_LIST[@]}"
+  exit 1
+fi

--- a/scripts/release-targets.example.sh
+++ b/scripts/release-targets.example.sh
@@ -1,0 +1,4 @@
+# 复制为 release-targets.local.sh 并填入真实地址。local 文件已被 .gitignore 排除。
+# 向 RELEASE_REGISTRIES append 私有推送目标。格式: "键|前缀|风格(flat|acr)"
+RELEASE_REGISTRIES+=( "acr|<实例ID>.cn-<region>.personal.cr.aliyuncs.com/<命名空间>|acr" )
+RELEASE_REGISTRIES+=( "intranet|<内网IP>:<端口>|flat" )


### PR DESCRIPTION
## 背景

用户反馈：打开应用后仍然出现登录界面。

根因：认证功能只在前端 (`packages/web`) 完整实现，但**后端没有 `/api/auth/*` 路由**。真实后端下 `api.auth.me()` 落到 SPA fallback，`user` 永远是 `null`，于是 `DesktopShell.tsx` 中 `{!user || isBootstrapping ? <LoginPanel /> : null}` 的登录浮层永不消失。

本仓库定位为**单用户、无需登录**，但后续会有另一个仓库复用本机封装的 Docker / npm 包来做**多用户**，因此不能写死删除认证，而要做成**可开关**。

## 改动

- **`config.ts`**：新增开关 `authEnabled`，由构建期环境变量 `VITE_AUTH_ENABLED` 驱动，**默认关闭**。
- **`AuthContext.tsx`**：`AuthProvider` 改为构建期二选一：
  - **认证关闭（默认，本仓库）** → `BypassAuthProvider`：恒返回固定本地用户 + 固定 token，`isBootstrapping` 立即为 `false`，`login/register/logout` 为空操作。登录浮层永不出现，且各 Context 用作"连接开关"的 `token` 始终有效（SSE / sandbox / session / terminal 照常工作）。
  - **认证开启（`VITE_AUTH_ENABLED=1`，下游多用户仓库）** → `RealAuthProvider`：原有 `me()` 引导 / `login` / `register` / `logout` 流程**原封不动保留**。

UI 消费方（`DesktopShell`、`SettingsDialog`、`TerminalDrawer` 等）零改动。

## 多用户仓库如何重新开启

```bash
# 在 packages/web 构建时设置环境变量
VITE_AUTH_ENABLED=1 npm run build
```
（前提是下游后端提供 `/api/auth/login|register|me` 接口。）

## 验证

- `npm run typecheck`、`packages/web` 的 `vitest`（25 passed）、`vite build` 全部通过。
- 真实端到端：从源码构建 → `bnpt init` + `up` 起真后端 + runtime（后端 serve web/dist）→ 浏览器打开 `http://127.0.0.1:9100/` → **直接进入主工作区，无登录界面**。
- 确认 dist 产物中旁路逻辑已编译进去（固定本地用户 `id:"local"` 存在）。

> 注：basic 单用户模式下后端不提供 `/api/sandbox/*` 路由，界面会显示"请先启动 sandbox"——这是**既有现象，与本次登录改动无关**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)