### PR TITLE
fix: trace endpoint + stuck "thinking" spinner (#23, #24)

### DIFF
--- a/packages/backend-core/src/app.ts
+++ b/packages/backend-core/src/app.ts
@@ -87,6 +87,7 @@ export function createApp(options: CreateAppOptions): Hono {
   api.put("/sessions/:id", forwardRename());
   api.delete("/sessions/:id", forward("deleteSession", { idParam: "id" }));
   api.get("/sessions/:id/state", forward("getSessionState", { idParam: "id" }));
+  api.get("/sessions/:id/trace", forward("getTrace", { idParam: "id" }));
   api.post("/sessions/:id/messages", forward("sendMessage", { idParam: "id", withBody: true }));
   api.post("/sessions/:id/interrupt", forward("interrupt", { idParam: "id", withBody: true }));
   api.get("/sessions/:id/agents", forward("listAgents", { idParam: "id" }));

--- a/packages/backend-core/test/app.test.ts
+++ b/packages/backend-core/test/app.test.ts
@@ -91,6 +91,36 @@ describe("Hono app — REST forwarding", () => {
     expect(fetchFn).toHaveBeenCalledTimes(1);
   });
 
+  it("GET /api/sessions/:id/trace forwards to the runtime (not the SPA fallback)", async () => {
+    // Same class as the /metrics regression: the SPA calls
+    // GET /api/sessions/:id/trace, but the route was missing from the /api
+    // table, so it fell through to the static fallback and returned index.html
+    // (200 text/html) — the frontend then choked with "Unexpected token '<'".
+    const graphBody = '{"meta":{"sessionId":"abc","createdAt":"2026-01-01T00:00:00.000Z"},"nodes":[]}';
+    const fetchFn = vi.fn(async (url: string) => {
+      expect(url).toBe("http://runtime.test/sessions/abc/trace");
+      return new Response(graphBody, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const root = await mkdtemp(path.join(tmpdir(), "bp-web-trace-"));
+    await writeFile(path.join(root, "index.html"), "<!doctype html><title>BP</title>");
+    const app = createApp({
+      orchestrator: fakeOrchestrator(),
+      fetchFn: fetchFn as never,
+      webRoot: root,
+    });
+    const res = await app.request("/api/sessions/abc/trace");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    expect(await res.json()).toEqual({
+      meta: { sessionId: "abc", createdAt: "2026-01-01T00:00:00.000Z" },
+      nodes: [],
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
   it("GET /api/health returns ok without touching the runtime", async () => {
     const fetchFn = vi.fn();
     const app = createApp({

--- a/packages/protocol/src/http.ts
+++ b/packages/protocol/src/http.ts
@@ -179,6 +179,8 @@ export const RUNTIME_ROUTES = {
   getSession: { method: "GET", path: "/sessions/:id" },
   deleteSession: { method: "DELETE", path: "/sessions/:id" },
   getSessionState: { method: "GET", path: "/sessions/:id/state" },
+  /** Graph of Trace (reasoning DAG) for a session. */
+  getTrace: { method: "GET", path: "/sessions/:id/trace" },
   sendMessage: { method: "POST", path: "/sessions/:id/messages" },
   /** Canonical AG-UI event stream (§15.4). */
   sessionEvents: { method: "GET", path: "/sse/:id" },

--- a/packages/runtime/src/__tests__/server.test.ts
+++ b/packages/runtime/src/__tests__/server.test.ts
@@ -68,6 +68,13 @@ describe("HTTP server (RUNTIME_ROUTES)", () => {
     const state = await a.request(`/sessions/${id}/state`);
     expect(state.status).toBe(200);
 
+    // trace (Graph of Trace) — returns { meta, nodes } for an existing session
+    const trace = await a.request(`/sessions/${id}/trace`);
+    expect(trace.status).toBe(200);
+    const graph = (await trace.json()) as { meta: { sessionId: string }; nodes: unknown[] };
+    expect(graph.meta.sessionId).toBe(id);
+    expect(Array.isArray(graph.nodes)).toBe(true);
+
     // interrupt
     const intr = await a.request(`/sessions/${id}/interrupt`, { method: "POST" });
     expect(intr.status).toBe(200);
@@ -82,6 +89,7 @@ describe("HTTP server (RUNTIME_ROUTES)", () => {
     const a = app();
     expect((await a.request("/sessions/nope")).status).toBe(404);
     expect((await a.request("/sessions/nope/state")).status).toBe(404);
+    expect((await a.request("/sessions/nope/trace")).status).toBe(404);
     const del = await a.request("/sessions/nope", { method: "DELETE" });
     expect(del.status).toBe(404);
   });

--- a/packages/runtime/src/server.ts
+++ b/packages/runtime/src/server.ts
@@ -57,6 +57,11 @@ export function createServer(opts: SessionManagerOptions & { manager?: SessionMa
     return state ? c.json(state) : c.json({ error: "not found" }, 404);
   });
 
+  app.get("/sessions/:id/trace", (c) => {
+    const graph = manager.getTrace(c.req.param("id"));
+    return graph ? c.json(graph) : c.json({ error: "not found" }, 404);
+  });
+
   app.post("/sessions/:id/messages", async (c) => {
     const id = c.req.param("id");
     const body = await safeBody(c);

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -12,7 +12,7 @@
 import { mkdir, readFile, writeFile, readdir, rm, stat } from "node:fs/promises";
 import { join, resolve, sep } from "node:path";
 import { randomUUID } from "node:crypto";
-import type { AgUiEvent, AgentStatus, FileContent, FileEntry, Session } from "@brainpilot/protocol";
+import type { AgUiEvent, AgentStatus, FileContent, FileEntry, Session, TraceGraph } from "@brainpilot/protocol";
 import { EventBus } from "./event-bus.js";
 import { Mailbox } from "./mailbox.js";
 import { GraphOfTrace } from "./trace.js";
@@ -451,6 +451,12 @@ export class SessionManager {
       agents: this.listAgents(sessionId),
       lastActivityTs: new Date(entry.lastActivityAt).toISOString(),
     };
+  }
+
+  /** The session's Graph of Trace (reasoning DAG), or undefined if no session. */
+  getTrace(sessionId: string): TraceGraph | undefined {
+    const entry = this.sessions.get(sessionId);
+    return entry?.trace.getGraph();
   }
 
   metrics(): { activeSessions: number; runningAgents: number; lastActivityAt: string | null; memRss: number } {

--- a/packages/web/src/__tests__/newUiEvents.test.ts
+++ b/packages/web/src/__tests__/newUiEvents.test.ts
@@ -193,3 +193,44 @@ describe("reducer passthrough", () => {
     expect(reduceMessagesForEvent(existing, { type: "WHATEVER" } as WebSocketEvent)).toBe(existing);
   });
 });
+
+// Regression: a START with no matching END leaves a message stuck at
+// streaming:true, so the activity group shows "智能体思考中" forever. The run
+// terminators (RUN_FINISHED / RUN_ERROR) must sweep dangling streaming flags.
+describe("run terminators clear dangling streaming flags", () => {
+  const open = (agent: string): ChatMessage => ({
+    id: `m-${agent}`,
+    role: "assistant",
+    content: "partial…",
+    createdAt: new Date().toISOString(),
+    agent,
+    streaming: true,
+    kind: "text",
+  });
+
+  it("RUN_FINISHED clears streaming on the run agent's messages", () => {
+    const out = reduceMessagesForEvent([open("principal")], {
+      type: "RUN_FINISHED",
+      agentName: "principal",
+    } as WebSocketEvent);
+    expect(out[0]!.streaming).toBe(false);
+  });
+
+  it("RUN_FINISHED leaves OTHER agents' messages streaming (multi-agent isolation)", () => {
+    const out = reduceMessagesForEvent([open("worker")], {
+      type: "RUN_FINISHED",
+      agentName: "principal",
+    } as WebSocketEvent);
+    expect(out[0]!.streaming).toBe(true);
+  });
+
+  it("RUN_ERROR clears streaming AND appends an error message", () => {
+    const out = reduceMessagesForEvent([open("principal")], {
+      type: "RUN_ERROR",
+      agentName: "principal",
+      message: "boom",
+    } as WebSocketEvent);
+    expect(out[0]!.streaming).toBe(false);
+    expect(out.some((m) => m.kind === "error" && m.content === "boom")).toBe(true);
+  });
+});

--- a/packages/web/src/contexts/messageReducer.ts
+++ b/packages/web/src/contexts/messageReducer.ts
@@ -57,6 +57,27 @@ export function eventSessionId(event: WebSocketEvent): string | undefined {
 }
 
 /**
+ * Clear `streaming` on any message still marked in-progress for a finished run.
+ * A START with no matching END (interrupt, mid-run error, dropped END) would
+ * otherwise leave a message stuck at streaming:true, and the activity group
+ * shows "智能体思考中" forever. RUN_FINISHED / RUN_ERROR are the authoritative
+ * terminators: once a run ends, nothing under that agent can still be streaming.
+ * Scoped to `agentName` so a finishing sub-agent never clears another agent's
+ * still-live spinner in a multi-agent run (undefined sweeps all, as a fallback).
+ */
+function sweepStreaming(messages: ChatMessage[], agentName?: string): ChatMessage[] {
+  let changed = false;
+  const next = messages.map((m) => {
+    if (m.streaming && (!agentName || m.agent === agentName)) {
+      changed = true;
+      return { ...m, streaming: false };
+    }
+    return m;
+  });
+  return changed ? next : messages;
+}
+
+/**
  * Convert an AG-UI message (from MESSAGES_SNAPSHOT) into a UI ChatMessage.
  */
 export function agUiMessageToChatMessage(msg: AgUiMessage): ChatMessage {
@@ -278,8 +299,10 @@ export function reduceMessagesForEvent(existing: ChatMessage[], event: WebSocket
 
     case "RUN_ERROR": {
       const message = event.message ?? "Run error";
+      // Run is over → sweep any dangling streaming flag before appending error.
+      const swept = sweepStreaming(existing, event.agentName);
       return [
-        ...existing,
+        ...swept,
         {
           id: generateUUID(),
           role: "system",
@@ -326,9 +349,14 @@ export function reduceMessagesForEvent(existing: ChatMessage[], event: WebSocket
       return existing;
     }
 
+    // RUN_FINISHED is the authoritative end of a run: sweep any message left
+    // streaming because its END never arrived (interrupt / dropped END), so the
+    // "thinking" spinner reliably clears.
+    case "RUN_FINISHED":
+      return sweepStreaming(existing, event.agentName);
+
     // Lifecycle / brackets / extensions — no message-list change
     case "RUN_STARTED":
-    case "RUN_FINISHED":
     case "REASONING_START":
     case "REASONING_END":
       return existing;


### PR DESCRIPTION
Fixes #23
Fixes #24

Two frontend runtime bugs surfaced from the Web UI. Root-caused line-by-line, fixed with TDD (red → green), verified end-to-end on a live mock backend.

## #23 — Trace view crashed with `Unexpected token '<', "<!doctype "... is not valid JSON`

`GET /api/sessions/:id/trace` had **no route on any layer** (protocol / backend-core / runtime). The request fell through to the SPA static fallback (`app.get("/*", serveStatic(index.html))`), returning `index.html` (`<!doctype html>`, **200 text/html**), and the frontend's `handleJson()` choked on the HTML.

The data already existed — each session owns a `GraphOfTrace` with `getGraph()` returning a `TraceGraph` — it was just never exposed over HTTP.

**Fix:** add the endpoint chain, mirroring the existing `getSessionState` plumbing:
- `runtime/session-manager.ts`: `getTrace(sessionId)` → `entry.trace.getGraph()`
- `runtime/server.ts`: `GET /sessions/:id/trace` (404 JSON if missing)
- `protocol/http.ts`: `RUNTIME_ROUTES.getTrace`
- `backend-core/app.ts`: `forward("getTrace", { idParam: "id" })`

No frontend change: `api.ts` already fetches this path and `normalizeTraceGraph` already consumes `{ meta, nodes }`.

## #24 — "智能体思考中" spinner never cleared after the agent finished

The spinner is driven by per-message `streaming: true`, cleared **only** by each message's own END event (keyed by id). The run terminators did nothing to it: `RUN_FINISHED` was a reducer no-op and `RUN_ERROR` only appended an error message. So any START without a matching END (interrupt, mid-run error, dropped END) left a message stuck `streaming: true` and the activity group showed "thinking" forever.

**Fix:** make `RUN_FINISHED` / `RUN_ERROR` the authoritative terminators — they now sweep dangling `streaming` flags via a `sweepStreaming(messages, agentName)` helper. **Scoped to `event.agentName`** so a finishing sub-agent never clears another agent's still-live spinner in a multi-agent run.

> Note: a related id-reuse smell (`textMessageStart`/`reasoningMessageStart` share `currentMessageId` in `mas-agent.ts`) is intentionally **out of scope** here — it isn't the direct cause of the stuck spinner, and the terminal sweep already backstops every dangling case. Tracked for #24 follow-up.

## Tests & verification

- **Unit (TDD, red → green):**
  - `runtime/server.test.ts`: `GET /sessions/:id/trace` → 200 `{ meta, nodes }`; unknown session → 404 JSON
  - `backend-core/app.test.ts`: `/api/sessions/:id/trace` forwards to the runtime (not the SPA fallback) — same regression class as the prior `/metrics` test
  - `web/newUiEvents.test.ts`: terminators clear streaming; OTHER agents' messages stay streaming (multi-agent isolation); `RUN_ERROR` both sweeps and appends the error
- **Full suite green:** 267 non-web + 28 web tests; `typecheck` + `build` clean
- **End-to-end (live mock backend):**
  - `scripts/smoke-e2e.sh` passes; event sequence shows `RUN_FINISHED agent=principal` (confirms the agent-scoped sweep)
  - Live `curl`: `GET /api/sessions/{id}/trace` → 200 `application/json` `{"meta":{…},"nodes":[]}`; unknown session → 404 `application/json` `{"error":"not found"}` (no HTML fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)