### PR TITLE
fix(web): configurable Vite base for subpath deploy (#25)

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -4,7 +4,13 @@
   "license": "Apache-2.0",
   "type": "module",
   "files": [
-    "dist"
+    "dist",
+    "src",
+    "index.html",
+    "vite.config.ts",
+    "tsconfig.json",
+    "tsconfig.app.json",
+    "tsconfig.node.json"
   ],
   "repository": {
     "type": "git",

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -4,5 +4,10 @@ import react from "@vitejs/plugin-react";
 // vite is deduped to a single version at the monorepo root (see root
 // package.json `overrides`), so `react()` types match and no cast is needed.
 export default defineConfig({
+  // Asset base path. Defaults to "/" so the single-machine open-source deploy
+  // (backend-core serves the dist at root /*) is unaffected. Downstream hosts
+  // can rebuild under a subpath with e.g. `BP_WEB_BASE=/app/ npm run build`
+  // (issue #25). API_BASE stays absolute "/api" — the gateway lives at root.
+  base: process.env.BP_WEB_BASE ?? "/",
   plugins: [react()],
 });


### PR DESCRIPTION
Fixes #25

The closed-source hosting layer wants to serve a marketing site at root `/` and mount `@brainpilot/web` under `/app` behind one Hono process. Today the app builds with Vite's default `base: "/"`, so `dist/index.html` hardcodes root-absolute asset URLs (`/assets/*`) that collide with the marketing site's own `/assets/*` when served under a subpath.

Verified against the source first: there is **no browser router** (`<DesktopShell/>` only; `window.location` is used solely to build the terminal WS URL from `host`), and `API_BASE = "/api"` is a separate absolute constant. So **only the asset base needs to move**.

## Changes (both backward-compatible)

**1. `packages/web/vite.config.ts`** — `base: process.env.BP_WEB_BASE ?? "/"`
- Single-machine (env unset): `base: "/"` → byte-for-byte unchanged. backend-core still serves dist at root `/*`.
- Cloud: `BP_WEB_BASE=/app/ npm run build` → assets resolve to `/app/assets/*`, self-contained under `/app`. `API_BASE` stays `/api` (gateway at root).

**2. `packages/web/package.json` `files`** — add `src`, `index.html`, `vite.config.ts`, `tsconfig{,.app,.node}.json` alongside `dist`, so a downstream consumer can rebuild with a custom base from the published artifact (`build` = `tsc -b && vite build`; the project references need all three tsconfigs). `@brainpilot/protocol` is a published devDependency, so the rebuild resolves cleanly.

No source/runtime logic changes; no router changes.

## Verification

- `vite build` (default) → `/assets/*` (unchanged)
- `BP_WEB_BASE=/app/ vite build` → `/app/assets/*`, **no stray root-absolute `/assets/*`**
- `npm pack --dry-run` lists `src/`, `index.html`, `vite.config.ts`, `tsconfig*.json` next to `dist/`
- Web tests: **28/28 green**

> Note: `tsc -b` for the full `npm run build` currently fails on a **pre-existing** `TS7006` in `src/mocks/backend.ts:608` (`profile.models` untyped) that also exists on `development` — unrelated to this change. The asset-base fix was verified via `vite build` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)