### PR TITLE
ci: blackbox-fast 加 probes 单测 + web-journeys 套件（从 testbed 下沉）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,10 @@ jobs:
         if: steps.detect.outputs.present == 'true'
         run: node testbed/suites/demo-bundle.test.mjs
 
+      - name: probes 单测（质量探针，纯函数，零依赖）
+        if: steps.detect.outputs.present == 'true'
+        run: node testbed/suites/probes.test.mjs
+
       - name: 起 mock 实例 + 跑 contract/scenarios（零 token）
         if: steps.detect.outputs.present == 'true'
         env:
@@ -86,4 +90,5 @@ jobs:
           cd testbed/suites
           node contract.mjs --base-url http://127.0.0.1:19020/api
           node run-scenarios.mjs --base-url http://127.0.0.1:19020/api --data-dir "$DATA"
+          node web-journeys.mjs --base-url http://127.0.0.1:19020/api
 


### PR DESCRIPTION
testbed 分支 CI 已试稳的两步下沉到 development，保持 `.github/workflows/ci.yml` 跨分支一致（避免 development→testbed 合并时 ci.yml 冲突）。

## 改动

`blackbox-fast` job 加两步：
- **probes 单测**：`node testbed/suites/probes.test.mjs`（质量探针纯函数，65 fixture，零依赖）
- **web-journeys**：`node testbed/suites/web-journeys.mjs`（Web UI 用户旅程契约，零 token，对同一 mock 实例跑）

## 为什么安全 / 不 gate development

两步都在 `if: steps.detect.outputs.present == 'true'`（detect `testbed/suites` 是否存在）守卫内。**development 分支没有 `testbed/` 目录**，detect=false → 两步自动 skip → 不会让 development 的 PR 变红、不 gate development。

`testbed` 分支自包含（有 `testbed/`），这两步在那里真跑——已在 testbed CI 验绿（run 27678076036，blackbox-fast success，日志确认 web-journeys 实际执行）。

本 PR 仅同步 workflow 文件，使两分支 ci.yml 一致；不改任何引擎/测试代码。

🤖 Generated with [Claude Code](https://claude.com/claude-code)