### PR TITLE
fix: JSON-404 guard for /api/* (#30) + persist session rename (#29)

### DIFF
--- a/packages/backend-core/src/app.ts
+++ b/packages/backend-core/src/app.ts
@@ -84,7 +84,7 @@ export function createApp(options: CreateAppOptions): Hono {
   api.get("/sessions", forward("listSessions"));
   api.post("/sessions", forward("createSession", { withBody: true }));
   api.get("/sessions/:id", forward("getSession", { idParam: "id" }));
-  api.put("/sessions/:id", forwardRename());
+  api.put("/sessions/:id", forward("updateSession", { idParam: "id", withBody: true }));
   api.delete("/sessions/:id", forward("deleteSession", { idParam: "id" }));
   api.get("/sessions/:id/state", forward("getSessionState", { idParam: "id" }));
   api.get("/sessions/:id/trace", forward("getTrace", { idParam: "id" }));
@@ -179,6 +179,12 @@ export function createApp(options: CreateAppOptions): Hono {
   // Mount the API under /api (the SPA's API_BASE).
   app.route("/api", api);
 
+  // #30: any unmatched /api/* (any method) returns a JSON 404 — never the SPA
+  // index.html. Sits between the API routes and the static fallback, and is
+  // unconditional (independent of serveWeb) so an unimplemented route can't fall
+  // through to text/html (which the frontend's handleJson chokes on).
+  app.all("/api/*", (c) => c.json({ error: "not found" }, 404));
+
   // ---- Static web serving with SPA fallback ----------------------------
   if (options.serveWeb !== false) {
     app.use("/*", serveStatic({ root: webRoot }));
@@ -208,26 +214,6 @@ export function createApp(options: CreateAppOptions): Hono {
         body: body && body.length > 0 ? body : undefined,
         headers,
         query: query && query.length > 0 ? query : undefined,
-      });
-      return relay(c, upstream);
-    };
-  }
-
-  // The SPA's PUT /sessions/:id (rename) has no dedicated runtime route in
-  // §15.4; forward it to the runtime's getSession path with PUT semantics via
-  // a raw forward so the runtime can handle/ignore it. We reuse sendMessage's
-  // session path shape but keep method PUT by hitting getSession's path.
-  function forwardRename() {
-    return async (c: import("hono").Context) => {
-      const rc = await getClient();
-      const id = c.req.param("id") ?? "";
-      const body = await c.req.text();
-      // getSession route path is `/sessions/:id`; issue a PUT against it.
-      const url = rc.urlFor("getSession", { id });
-      const upstream = await (options.fetchFn ?? fetch)(url, {
-        method: "PUT",
-        headers: { "content-type": c.req.header("content-type") ?? "application/json" },
-        body: body && body.length > 0 ? body : undefined,
       });
       return relay(c, upstream);
     };

--- a/packages/backend-core/test/app.test.ts
+++ b/packages/backend-core/test/app.test.ts
@@ -121,6 +121,53 @@ describe("Hono app — REST forwarding", () => {
     expect(fetchFn).toHaveBeenCalledTimes(1);
   });
 
+  // #29: session rename. The SPA PUTs /api/sessions/:id {title}; this must
+  // proxy to the runtime's updateSession route (PUT /sessions/:id) with the
+  // body intact — not the old forwardRename hack that PUT the GET path.
+  it("PUT /api/sessions/:id forwards rename to the runtime updateSession route", async () => {
+    const fetchFn = vi.fn(async (url: string, init: RequestInit) => {
+      expect(url).toBe("http://runtime.test/sessions/abc");
+      expect(init.method).toBe("PUT");
+      expect(init.body).toBe('{"title":"Renamed"}');
+      return new Response('{"id":"abc","title":"Renamed"}', {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const app = createApp({
+      orchestrator: fakeOrchestrator(),
+      fetchFn: fetchFn as never,
+      serveWeb: false,
+    });
+    const res = await app.request("/api/sessions/abc", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: '{"title":"Renamed"}',
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ id: "abc", title: "Renamed" });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  // #30: any unmatched /api/* returns a JSON 404, for every method, and never
+  // touches the runtime (no fetchFn call) nor the SPA static fallback.
+  it.each(["GET", "POST", "PUT", "DELETE"])(
+    "%s /api/<unknown> returns a JSON 404 (not SPA HTML / plain-text)",
+    async (method) => {
+      const fetchFn = vi.fn();
+      const app = createApp({
+        orchestrator: fakeOrchestrator(),
+        fetchFn: fetchFn as never,
+        serveWeb: false,
+      });
+      const res = await app.request("/api/__definitely_unknown__", { method });
+      expect(res.status).toBe(404);
+      expect(res.headers.get("content-type")).toContain("application/json");
+      expect(await res.json()).toEqual({ error: "not found" });
+      expect(fetchFn).not.toHaveBeenCalled();
+    },
+  );
+
   it("GET /api/health returns ok without touching the runtime", async () => {
     const fetchFn = vi.fn();
     const app = createApp({

--- a/packages/protocol/src/http.ts
+++ b/packages/protocol/src/http.ts
@@ -27,7 +27,7 @@ import { z } from "zod";
 import { AgUiEventSchema } from "./events.js";
 import { AgentStatusSchema, SessionSchema, SessionStateSnapshotSchema } from "./domain.js";
 
-export type HttpMethod = "GET" | "POST" | "DELETE";
+export type HttpMethod = "GET" | "POST" | "PUT" | "DELETE";
 
 export interface RouteDef {
   readonly method: HttpMethod;
@@ -177,6 +177,8 @@ export const RUNTIME_ROUTES = {
   createSession: { method: "POST", path: "/sessions" },
   listSessions: { method: "GET", path: "/sessions" },
   getSession: { method: "GET", path: "/sessions/:id" },
+  /** Update session metadata (currently just `title`); persists to meta.json. */
+  updateSession: { method: "PUT", path: "/sessions/:id" },
   deleteSession: { method: "DELETE", path: "/sessions/:id" },
   getSessionState: { method: "GET", path: "/sessions/:id/state" },
   /** Graph of Trace (reasoning DAG) for a session. */

--- a/packages/runtime/src/__tests__/server.test.ts
+++ b/packages/runtime/src/__tests__/server.test.ts
@@ -85,6 +85,36 @@ describe("HTTP server (RUNTIME_ROUTES)", () => {
     expect((await evict.json()) as { evicted: boolean }).toMatchObject({ evicted: true });
   });
 
+  it("PUT /sessions/:id renames and the new title survives a re-GET (#29)", async () => {
+    const a = app();
+    const created = await a.request("/sessions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "Untitled session" }),
+    });
+    const { id } = (await created.json()) as { id: string };
+
+    const put = await a.request(`/sessions/${id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "Renamed" }),
+    });
+    expect(put.status).toBe(200);
+    expect((await put.json()) as { title: string }).toMatchObject({ id, title: "Renamed" });
+
+    // re-GET: the new title is the persisted state, not the optimistic one
+    const got = (await (await a.request(`/sessions/${id}`)).json()) as { title: string };
+    expect(got.title).toBe("Renamed");
+
+    // a blank title is ignored (idempotent) — keeps the existing title
+    const blank = await a.request(`/sessions/${id}`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "   " }),
+    });
+    expect((await blank.json()) as { title: string }).toMatchObject({ title: "Renamed" });
+  });
+
   it("404s for unknown session", async () => {
     const a = app();
     expect((await a.request("/sessions/nope")).status).toBe(404);
@@ -92,6 +122,12 @@ describe("HTTP server (RUNTIME_ROUTES)", () => {
     expect((await a.request("/sessions/nope/trace")).status).toBe(404);
     const del = await a.request("/sessions/nope", { method: "DELETE" });
     expect(del.status).toBe(404);
+    const put = await a.request("/sessions/nope", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "x" }),
+    });
+    expect(put.status).toBe(404);
   });
 });
 

--- a/packages/runtime/src/server.ts
+++ b/packages/runtime/src/server.ts
@@ -46,6 +46,13 @@ export function createServer(opts: SessionManagerOptions & { manager?: SessionMa
     return s ? c.json(s) : c.json({ error: "not found" }, 404);
   });
 
+  // #29: rename — PUT the session title and persist it to meta.json.
+  app.put("/sessions/:id", async (c) => {
+    const body = (await c.req.json().catch(() => ({}))) as { title?: unknown };
+    const s = await manager.renameSession(c.req.param("id"), body?.title);
+    return s ? c.json(s) : c.json({ error: "not found" }, 404);
+  });
+
   app.delete("/sessions/:id", async (c) => {
     const id = c.req.param("id");
     const deleted = await manager.deleteSession(id);

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -280,6 +280,22 @@ export class SessionManager {
     return e ? this.toSession(e) : undefined;
   }
 
+  /**
+   * Update a session's title and persist it to meta.json (#29). A blank or
+   * non-string title is ignored (idempotent) so the call can't wipe a title.
+   * Returns the updated session, or undefined if the session is unknown.
+   */
+  async renameSession(id: string, title?: unknown): Promise<Session | undefined> {
+    const e = this.sessions.get(id);
+    if (!e) return undefined;
+    if (typeof title === "string" && title.trim().length > 0) {
+      e.title = title.trim();
+    }
+    this.touch(e);
+    await this.writeMeta(e);
+    return this.toSession(e);
+  }
+
   listSessions(): Session[] {
     return [...this.sessions.values()].map((e) => this.toSession(e));
   }


### PR DESCRIPTION
Fixes #30 and #29 — two cohesive route-layer bugs (#30 is the systemic root cause; #29 is one route that slipped through it).

## #30 — Unmatched `/api/*` returns SPA HTML instead of JSON 404 (systemic root cause)

`backend-core` had no catch-all guard for the `/api` namespace, so any unimplemented `/api/*` path fell through to the SPA static fallback:
- GET → `200 text/html` (`index.html`)
- POST/PUT/DELETE → `404 text/plain` (Hono default)

The frontend's `handleJson()` then crashed with `Unexpected token '<'`. This is the common root cause behind #18/#19/#23/#28/#29.

**Fix:** add an unconditional guard between the API routes and the static fallback:
```ts
app.route("/api", api);
app.all("/api/*", (c) => c.json({ error: "not found" }, 404));
```
Now every current/future unimplemented `/api/*` (any method) is a clean, parseable JSON 404; the SPA `index.html` fallback applies only to non-`/api` GET paths. It sits outside the `serveWeb` branch so it holds in tests too.

## #29 — Session rename silently lost (`PUT /api/sessions/:id` → 404)

`forwardRename()` PUT the rename to the runtime's **getSession** path (GET-only) → 404. The runtime could write the title (`writeMeta`) but had no route to trigger it, so the title reverted on refresh — silent data loss.

**Fix (3 layers):**
- **protocol:** add `updateSession: { method: "PUT", path: "/sessions/:id" }` to `RUNTIME_ROUTES` (and `"PUT"` to `HttpMethod`, previously missing — the old hack hardcoded the method outside the route table).
- **runtime:** `SessionManager.renameSession(id, title)` reusing the existing `writeMeta`/`toSession` (blank/non-string titles ignored, idempotent) + a `PUT /sessions/:id` handler.
- **backend:** replace the bespoke `forwardRename()` with the generic `forward("updateSession", …)` and delete the hack — same pattern as every other proxied route.

## Tests & verification
- `app.test.ts`: + rename-forward case, + 4-method JSON-404 case (asserts `application/json` + no runtime call).
- `server.test.ts`: + rename persists across a re-GET (and a blank title is a no-op), + `PUT /sessions/nope → 404`.
- `npm run typecheck` ✅, `BP_MOCK=1 npx vitest run` ✅ **273 passed**, `npm run build` ✅.
- Manual end-to-end with the issues' own curl repros: unmatched `/api/*` → `404 application/json {"error":"not found"}`; rename → `200` and the new title survives a re-GET **and is written to `meta.json` on disk**.

## Scope
Out of scope (separate PRs): #28 (MCP CRUD), #21 (trust-front auth removal), #20 (memory watchdog). No npm version bump (development-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)