### PR TITLE
fix(runtime): consume BP_MEM_LIMIT_MB with opt-in memory watchdog (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,31 @@ single-user, local-process setup and needs none of these variables.
 
 A Docker-free local path also exists (`@brainpilot/app`, `brainpilot up`) — see the npm Quick Start above. It runs a single user on the local orchestrator; deployment-mode variables do not apply.
 
+### Memory budget (`BP_MEM_LIMIT_MB`, optional)
+
+For container deployments that cap memory (`docker run --memory` / a cgroup
+ceiling), you can also tell the runtime its budget so it **self-throttles before
+the kernel OOM-kills it**. Set `BP_MEM_LIMIT_MB` to the per-container budget in MB:
+
+```bash
+BP_MEM_LIMIT_MB=2048          # MB of container RSS the runtime should stay under
+NODE_OPTIONS=--max-old-space-size=1536   # ~75% of the budget — set this at the launcher
+```
+
+- **Strictly opt-in.** Unset → no change at all (the runtime runs to host RAM as
+  today; this is the correct default for single-user self-hosting). Only the
+  cgroup `--memory` ceiling, if any, applies.
+- **When set,** a soft watchdog watches RSS; past **~85%** of the budget it refuses
+  new sessions/messages and emits a system message, rather than accepting work it
+  can't hold. The kernel OOM-killer + Docker `restart` policy remain the backstop.
+- **The heap cap is the launcher's job.** The runtime never sets
+  `--max-old-space-size` for you (a non-empty default would wrongly cap single-user
+  heaps); pass it via `NODE_OPTIONS` at ~75% of the budget if you want a V8 ceiling.
+- **Recommended floor: ~2 GB** for a single-user sandbox running the full platform
+  (runtime + agents + their tool subprocesses). The dominant driver is concurrent
+  agents × model-context size (each agent holds its message history) plus transient
+  bash/tool subprocess RSS; raise the budget for heavier multi-agent research.
+
 ## 🤖 Using a third-party / custom model
 
 By default BrainPilot talks to Pi's built-in Anthropic endpoint. Pi does **not**

--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -39,6 +39,12 @@ COPY --from=builder /app/package.json ./package.json
 
 # Deployment mode is chosen at run time via compose env (BP_RUNTIME_URL → static,
 # BP_ORCHESTRATOR=docker → dynamic). Without those, the image defaults to local.
+#
+# Optional memory budget (issue #20 / R-4): a host that caps container memory can
+# set BP_MEM_LIMIT_MB=<budget MB> to make the runtime soft-throttle at ~85% before
+# the kernel OOM-kills it. Pair it with a V8 heap cap at the launcher (the runtime
+# never sets one itself), e.g. NODE_OPTIONS=--max-old-space-size=<~75% of budget>.
+# Both are strictly opt-in: unset → no behavior change.
 ENV PORT=9001 BP_HOST=0.0.0.0
 EXPOSE 9001
 

--- a/packages/backend-core/src/server.ts
+++ b/packages/backend-core/src/server.ts
@@ -62,7 +62,8 @@ export async function startServer(
     await orchestrator.stopRuntime();
   };
 
-  // Graceful shutdown on signals (best-effort; CLI/PM2 may also manage this).
+  // Graceful shutdown on signals. Containers run no PM2 inside; a fatal/OOM
+  // cleanly exits and Docker's `restart` policy is the backstop (§R-4 / #20).
   const onSignal = (): void => {
     void stop().finally(() => process.exit(0));
   };

--- a/packages/protocol/src/http.ts
+++ b/packages/protocol/src/http.ts
@@ -55,6 +55,13 @@ export const MetricsResponseSchema = z.object({
   lastActivityAt: z.string().nullable(),
   /** Resident set size in bytes. */
   memRss: z.number(),
+  /**
+   * Container memory budget in bytes (BP_MEM_LIMIT_MB, §R-4). Null when the
+   * opt-in budget is unset — i.e. single-user / no in-runtime throttle.
+   */
+  memLimitBytes: z.number().nullable(),
+  /** memRss / memLimitBytes, or null when no budget is set. */
+  memRatio: z.number().nullable(),
 });
 export type MetricsResponse = z.infer<typeof MetricsResponseSchema>;
 

--- a/packages/protocol/test/http.test.ts
+++ b/packages/protocol/test/http.test.ts
@@ -25,6 +25,8 @@ describe("Runtime HTTP contract", () => {
         runningAgents: 1,
         lastActivityAt: "2026-06-12T00:00:00Z",
         memRss: 12345,
+        memLimitBytes: 1048576,
+        memRatio: 0.5,
       }).runningAgents,
     ).toBe(1);
     expect(
@@ -33,6 +35,8 @@ describe("Runtime HTTP contract", () => {
         runningAgents: 0,
         lastActivityAt: null,
         memRss: 0,
+        memLimitBytes: null,
+        memRatio: null,
       }).lastActivityAt,
     ).toBeNull();
   });

--- a/packages/runtime/src/__tests__/mem-watchdog.test.ts
+++ b/packages/runtime/src/__tests__/mem-watchdog.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { MemWatchdog, parseMemLimitMb } from "../mem-watchdog.js";
+
+describe("parseMemLimitMb", () => {
+  it("parses a positive MB value to bytes", () => {
+    expect(parseMemLimitMb({ BP_MEM_LIMIT_MB: "2048" })).toBe(2048 * 1024 * 1024);
+    expect(parseMemLimitMb({ BP_MEM_LIMIT_MB: "1" })).toBe(1024 * 1024);
+  });
+
+  it("treats unset / empty / non-positive / unparseable as disabled (null)", () => {
+    expect(parseMemLimitMb({})).toBeNull();
+    expect(parseMemLimitMb({ BP_MEM_LIMIT_MB: "" })).toBeNull();
+    expect(parseMemLimitMb({ BP_MEM_LIMIT_MB: "   " })).toBeNull();
+    expect(parseMemLimitMb({ BP_MEM_LIMIT_MB: "0" })).toBeNull();
+    expect(parseMemLimitMb({ BP_MEM_LIMIT_MB: "-512" })).toBeNull();
+    expect(parseMemLimitMb({ BP_MEM_LIMIT_MB: "abc" })).toBeNull();
+  });
+});
+
+describe("MemWatchdog", () => {
+  const LIMIT = 1000;
+
+  it("isOverSoftLimit honors the 85% threshold", () => {
+    let rss = 0;
+    const wd = new MemWatchdog({ limitBytes: LIMIT, readRss: () => rss });
+    rss = 840; // below 85% of 1000
+    expect(wd.isOverSoftLimit()).toBe(false);
+    rss = 850; // exactly at the threshold
+    expect(wd.isOverSoftLimit()).toBe(true);
+    rss = 999;
+    expect(wd.isOverSoftLimit()).toBe(true);
+  });
+
+  it("snapshot reports rss, limit, and ratio", () => {
+    const wd = new MemWatchdog({ limitBytes: LIMIT, readRss: () => 500 });
+    expect(wd.snapshot()).toEqual({ limitBytes: LIMIT, rss: 500, ratio: 0.5 });
+  });
+
+  it("fires onThrottle once on the rising edge, not every tick", () => {
+    let rss = 100;
+    const fired: number[] = [];
+    const wd = new MemWatchdog({
+      limitBytes: LIMIT,
+      readRss: () => rss,
+      onThrottle: (s) => fired.push(s.rss),
+    });
+
+    wd.tick(); // under threshold -> no fire
+    expect(fired).toHaveLength(0);
+
+    rss = 900; // cross the threshold
+    wd.tick();
+    wd.tick(); // still over -> must NOT re-fire
+    expect(fired).toEqual([900]);
+
+    rss = 100; // fall back below -> re-arm
+    wd.tick();
+    rss = 950; // spike again -> fires once more
+    wd.tick();
+    expect(fired).toEqual([900, 950]);
+  });
+
+  it("start/stop is idempotent and does not hold the event loop", () => {
+    const wd = new MemWatchdog({ limitBytes: LIMIT, readRss: () => 0, pollMs: 10 });
+    wd.start();
+    wd.start(); // no double timer
+    wd.stop();
+    wd.stop(); // safe to call twice
+  });
+});

--- a/packages/runtime/src/__tests__/server.test.ts
+++ b/packages/runtime/src/__tests__/server.test.ts
@@ -25,9 +25,17 @@ describe("HTTP server (RUNTIME_ROUTES)", () => {
   it("GET /metrics", async () => {
     const res = await app().request("/metrics");
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { activeSessions: number; memRss: number };
+    const body = (await res.json()) as {
+      activeSessions: number;
+      memRss: number;
+      memLimitBytes: number | null;
+      memRatio: number | null;
+    };
     expect(body.activeSessions).toBe(0);
     expect(body.memRss).toBeGreaterThan(0);
+    // Opt-in budget unset by default → null (single-user / no throttle).
+    expect(body.memLimitBytes).toBeNull();
+    expect(body.memRatio).toBeNull();
   });
 
   it("full session lifecycle over HTTP", async () => {

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -116,3 +116,49 @@ async function waitFor(pred: () => boolean, timeoutMs = 2000): Promise<void> {
     await new Promise((r) => setTimeout(r, 5));
   }
 }
+
+describe("SessionManager memory watchdog (§R-4 / #20)", () => {
+  it("is fully opt-out when no budget is set (identical to today)", async () => {
+    const m = new SessionManager({ persist: false, agentFactory: mockAgentFactory });
+    const s = await m.createSession({ title: "ok" });
+    const res = await m.sendMessage(s.id, "hi");
+    expect(res.accepted).toBe(true);
+    const metrics = m.metrics();
+    expect(metrics.memLimitBytes).toBeNull();
+    expect(metrics.memRatio).toBeNull();
+  });
+
+  it("refuses new sessions when RSS is over the soft limit", async () => {
+    // Budget 1000B, injected RSS 900B (>85%) => over the soft threshold.
+    const m = new SessionManager({
+      persist: false,
+      agentFactory: mockAgentFactory,
+      memLimitBytes: 1000,
+      readRss: () => 900,
+    });
+    await expect(m.createSession({ title: "nope" })).rejects.toThrow(/memory budget/);
+  });
+
+  it("refuses messages over the soft limit and emits a warning system_message", async () => {
+    let rss = 100; // start healthy so the session can be created
+    const m = new SessionManager({
+      persist: false,
+      agentFactory: mockAgentFactory,
+      memLimitBytes: 1000,
+      readRss: () => rss,
+    });
+    const s = await m.createSession({ title: "tight" });
+    const events: AgUiEvent[] = [];
+    m.subscribe(s.id, (e) => events.push(e));
+
+    rss = 900; // now over 85%
+    const res = await m.sendMessage(s.id, "hello");
+    expect(res.accepted).toBe(false);
+    expect(events.some((e) => e.type === "system_message")).toBe(true);
+
+    const metrics = m.metrics();
+    expect(metrics.memLimitBytes).toBe(1000);
+    expect(metrics.memRatio).toBeCloseTo(0.9);
+  });
+});
+

--- a/packages/runtime/src/mem-watchdog.ts
+++ b/packages/runtime/src/mem-watchdog.ts
@@ -1,0 +1,107 @@
+/**
+ * Memory watchdog (§R-4 / issue #20) — opt-in, in-process soft defense against
+ * the container memory budget.
+ *
+ * The hosted instance-per-user layer injects `BP_MEM_LIMIT_MB` and enforces a
+ * hard cgroup ceiling. This watchdog lets the runtime *self-throttle* before
+ * the kernel OOM-kills it: past a soft threshold (default 85% of the budget)
+ * the SessionManager refuses new sessions/messages and emits a system message.
+ *
+ * STRICT OPT-IN: `BP_MEM_LIMIT_MB` unset (or non-positive / unparseable) means
+ * the feature is entirely disabled — identical behavior to today. We never
+ * invent a ceiling for single-user self-hosting; the cgroup `--memory` (when
+ * present) remains the only backstop in that case.
+ *
+ * The RSS reader and interval are injectable so the policy is unit-testable
+ * without real memory pressure or wall-clock timers.
+ */
+
+/**
+ * Parse `BP_MEM_LIMIT_MB` into a byte budget. Returns `null` (feature off)
+ * unless the value is a positive, finite number of megabytes.
+ */
+export function parseMemLimitMb(env: NodeJS.ProcessEnv = process.env): number | null {
+  const raw = env.BP_MEM_LIMIT_MB;
+  if (raw === undefined || raw.trim() === "") return null;
+  const mb = Number(raw);
+  if (!Number.isFinite(mb) || mb <= 0) return null;
+  return Math.floor(mb) * 1024 * 1024;
+}
+
+export interface MemWatchdogOptions {
+  /** Budget in bytes (typically from {@link parseMemLimitMb}). */
+  limitBytes: number;
+  /** Fraction of the budget at which to start throttling (default 0.85). */
+  softRatio?: number;
+  /** Poll interval in ms (default 2000). */
+  pollMs?: number;
+  /** RSS reader; default reads the real process RSS. Injected in tests. */
+  readRss?: () => number;
+  /**
+   * Called once on the rising edge into the throttled state (not every tick),
+   * so the caller can emit a single warning rather than spamming.
+   */
+  onThrottle?: (snapshot: MemSnapshot) => void;
+}
+
+export interface MemSnapshot {
+  limitBytes: number;
+  rss: number;
+  /** rss / limitBytes. */
+  ratio: number;
+}
+
+export class MemWatchdog {
+  private readonly limitBytes: number;
+  private readonly softRatio: number;
+  private readonly pollMs: number;
+  private readonly readRss: () => number;
+  private readonly onThrottle?: (snapshot: MemSnapshot) => void;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private throttling = false;
+
+  constructor(opts: MemWatchdogOptions) {
+    this.limitBytes = opts.limitBytes;
+    this.softRatio = opts.softRatio ?? 0.85;
+    this.pollMs = opts.pollMs ?? 2000;
+    this.readRss = opts.readRss ?? (() => process.memoryUsage().rss);
+    this.onThrottle = opts.onThrottle;
+  }
+
+  /** Current footprint relative to the budget. */
+  snapshot(): MemSnapshot {
+    const rss = this.readRss();
+    return { limitBytes: this.limitBytes, rss, ratio: rss / this.limitBytes };
+  }
+
+  /** True once RSS has reached the soft threshold — the signal to refuse work. */
+  isOverSoftLimit(): boolean {
+    return this.readRss() >= this.limitBytes * this.softRatio;
+  }
+
+  /** Begin polling. The interval is `unref()`d so it never holds the process open. */
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => this.tick(), this.pollMs);
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** Evaluate the threshold; fire {@link MemWatchdogOptions.onThrottle} on the rising edge. */
+  tick(): void {
+    const over = this.isOverSoftLimit();
+    if (over && !this.throttling) {
+      this.throttling = true;
+      this.onThrottle?.(this.snapshot());
+    } else if (!over && this.throttling) {
+      // Fell back below the threshold — re-arm so a later spike warns again.
+      this.throttling = false;
+    }
+  }
+}

--- a/packages/runtime/src/server.ts
+++ b/packages/runtime/src/server.ts
@@ -203,6 +203,13 @@ export function startServer(opts: StartServerOptions = {}): {
 
   const server = serve({ fetch: app.fetch, port });
 
+  // §R-4: surface the opt-in memory budget at boot (only when active).
+  const memLimitMb = process.env.BP_MEM_LIMIT_MB;
+  if (memLimitMb && Number(memLimitMb) > 0) {
+    // eslint-disable-next-line no-console
+    console.log(`[runtime] memory budget: ${Number(memLimitMb)}MB (soft watchdog @85%)`);
+  }
+
   // §7 L4 global safety net.
   const onFatal = async (err: unknown) => {
     try {
@@ -221,6 +228,7 @@ export function startServer(opts: StartServerOptions = {}): {
     port,
     close: () =>
       new Promise<void>((resolve) => {
+        manager.shutdown();
         (server as { close: (cb?: () => void) => void }).close(() => resolve());
       }),
   };

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -23,6 +23,7 @@ import { selectFactory, isMockMode } from "./agent-factory.js";
 import { personaFor } from "./personas.js";
 import { McpBridge, loadMcpServersConfig } from "./mcp-bridge.js";
 import { resolveSessionProvider, type SessionProviderRef } from "./provider-config.js";
+import { MemWatchdog, parseMemLimitMb } from "./mem-watchdog.js";
 import type { AgentRole, AgentSessionFactory, EventListener, SystemTool } from "./types.js";
 
 interface SessionEntry {
@@ -52,6 +53,15 @@ export interface SessionManagerOptions {
   persist?: boolean;
   /** Override the external MCP bridge (default: real stdio bridge). Tests inject a fake. */
   mcpBridge?: McpBridge;
+  /**
+   * Memory budget in bytes (issue #20 / R-4). When set, an opt-in soft watchdog
+   * refuses new work past ~85% of the budget. Defaults to `BP_MEM_LIMIT_MB`
+   * (parsed to bytes); `null`/absent → feature disabled, no behavior change.
+   * Tests inject this directly.
+   */
+  memLimitBytes?: number | null;
+  /** Override the watchdog's RSS reader (tests inject; default reads real RSS). */
+  readRss?: () => number;
 }
 
 /** Roles inferred from agent name. */
@@ -74,11 +84,25 @@ export class SessionManager {
   private mcpTools: SystemTool[] = [];
   private mcpLoaded = false;
 
+  // Opt-in memory watchdog (§R-4 / issue #20). Null when no budget is set.
+  private readonly memWatchdog: MemWatchdog | null;
+
   constructor(opts: SessionManagerOptions = {}) {
     this.dataRoot = opts.dataRoot ?? process.env.BP_DATA_DIR ?? join(process.cwd(), ".bp-data");
     this.agentFactory = opts.agentFactory ?? selectFactory();
     this.persist = opts.persist ?? true;
     this.mcpBridge = opts.mcpBridge ?? null;
+
+    const limitBytes = opts.memLimitBytes ?? parseMemLimitMb(process.env);
+    this.memWatchdog =
+      limitBytes != null
+        ? new MemWatchdog({
+            limitBytes,
+            readRss: opts.readRss,
+            onThrottle: (snap) => this.onMemoryThrottle(snap),
+          })
+        : null;
+    this.memWatchdog?.start();
   }
 
   /**
@@ -225,6 +249,9 @@ export class SessionManager {
   async createSession(
     input: { id?: string; title?: string; providerId?: string; modelId?: string } = {},
   ): Promise<Session> {
+    if (this.memWatchdog?.isOverSoftLimit()) {
+      throw new Error("memory budget exceeded: refusing new session");
+    }
     const id = input.id ?? randomUUID();
     if (this.sessions.has(id)) return this.toSession(this.sessions.get(id)!);
     const nowIso = new Date().toISOString();
@@ -337,6 +364,17 @@ export class SessionManager {
     const entry = this.sessions.get(sessionId);
     if (!entry) throw new Error(`session not found: ${sessionId}`);
     this.touch(entry);
+    // §R-4: refuse new runs past the soft memory threshold. The HTTP `accepted`
+    // flag alone isn't surfaced by the web, so also emit a system message.
+    if (this.memWatchdog?.isOverSoftLimit()) {
+      entry.bus.emit(
+        ev.systemMessage(sessionId, "warning", "内存接近上限,暂不接受新任务,请稍后重试。", {
+          agent: agentName,
+          recoverable: true,
+        }),
+      );
+      return { accepted: false };
+    }
     const agent = await this.ensureAgent(sessionId, agentName);
     entry.runActive = true;
     entry.activeRunId = `run_${randomUUID()}`;
@@ -475,18 +513,51 @@ export class SessionManager {
     return entry?.trace.getGraph();
   }
 
-  metrics(): { activeSessions: number; runningAgents: number; lastActivityAt: string | null; memRss: number } {
+  metrics(): {
+    activeSessions: number;
+    runningAgents: number;
+    lastActivityAt: string | null;
+    memRss: number;
+    memLimitBytes: number | null;
+    memRatio: number | null;
+  } {
     let runningAgents = 0;
     for (const e of this.sessions.values()) {
       for (const a of e.agents.values()) if (a.status === "running") runningAgents++;
     }
+    const snap = this.memWatchdog?.snapshot() ?? null;
     return {
       activeSessions: this.sessions.size,
       runningAgents,
       lastActivityAt: this.lastActivityAt ? new Date(this.lastActivityAt).toISOString() : null,
       memRss: process.memoryUsage().rss,
+      // null when the opt-in budget is unset (single-user) — keeps the metric meaningful.
+      memLimitBytes: snap ? snap.limitBytes : null,
+      memRatio: snap ? snap.ratio : null,
     };
   }
+
+  /**
+   * Stop background work (memory watchdog). Called on graceful shutdown so the
+   * poll interval doesn't outlive the manager. Idempotent.
+   */
+  shutdown(): void {
+    this.memWatchdog?.stop();
+  }
+
+  /**
+   * Rising-edge handler when RSS crosses the soft memory threshold (§R-4).
+   * Warns every currently-loaded session once so in-flight users see the
+   * back-off; new sessions/messages are then refused at their entry points.
+   */
+  private onMemoryThrottle(snap: { rss: number; limitBytes: number }): void {
+    const mb = (n: number) => Math.round(n / (1024 * 1024));
+    const msg = `内存使用接近容器上限 (${mb(snap.rss)}MB / ${mb(snap.limitBytes)}MB),正在限流,暂不接受新任务。`;
+    for (const [id, entry] of this.sessions) {
+      entry.bus.emit(ev.systemMessage(id, "warning", msg, { recoverable: true }));
+    }
+  }
+
 
   /* ----------------------------- SSE/events ---------------------------- */
 


### PR DESCRIPTION
Fixes #20

The hosted instance-per-user layer injects `BP_MEM_LIMIT_MB` + a hard cgroup ceiling, but the runtime never read the budget — a runaway session only ever hit the wall and got OOM-killed, with no chance to self-throttle or flush first. This adds **opt-in** in-process awareness (R-4).

## Design constraint: strict opt-in (per the issue)

`BP_MEM_LIMIT_MB` **unset → zero behavior change**, identical to today. We never invent a ceiling for single-user self-hosting; the cgroup `--memory`, if any, stays the only backstop. The runtime also **never picks the number** — the deployer owns it.

| Deployment | cgroup `--memory` | `BP_MEM_LIMIT_MB` | Runtime |
|---|---|---|---|
| Hosted multi-user | set | injected | soft self-defense @85%, kernel OOM as backstop |
| Single-user, nothing set | unset | unset | runs as today, no in-runtime throttle |
| Single-user, `--memory` only | set | unset | hard wall, no pre-emptive defense |

## Changes

- **`mem-watchdog.ts`** (new): `parseMemLimitMb()` (positive MB → bytes, else `null`/off) + `MemWatchdog` with an injectable RSS reader/interval. Soft threshold 85%; `onThrottle` fires once on the rising edge (no spam). Interval `unref()`d.
- **`session-manager.ts`**: reads the budget (or injected `memLimitBytes`); over the soft limit it refuses `createSession` (throws) and `sendMessage` (`accepted:false` **+** a `warning` `system_message`, because the web doesn't branch on `accepted` alone). `metrics()` gains `memLimitBytes`/`memRatio`. Watchdog stopped on shutdown.
- **`protocol/http.ts`**: `MetricsResponseSchema` + two nullable fields (additive).
- **`runtime/server.ts`**: boot log when budget active; `close()` stops the watchdog.
- **`backend-core/server.ts`**: drop the stale PM2 comment — containers rely on Docker `restart` (#4).
- **Docs** (README + `docker/main/Dockerfile`): opt-in env semantics, the **launcher-owned** `NODE_OPTIONS=--max-old-space-size` heap cap (runtime never sets one — a non-empty default would wrongly cap single-user heaps, #3), and a **~2 GB recommended floor** for a single-user full-platform sandbox (#5).

### Out of scope (deliberate)
- Heap cap re-exec (#3) — left to the launcher via `NODE_OPTIONS`, documented only.
- Graceful self-restart on a hard threshold — kernel OOM + Docker `restart` remains the backstop (#4).

## Tests & verification

- **New `mem-watchdog.test.ts`**: `parseMemLimitMb` valid/invalid; 85% threshold; rising-edge-only `onThrottle`; idempotent start/stop.
- **`session-manager.test.ts`**: opt-out path identical to today + `metrics` nulls (the key regression guard); over-limit refuses sessions; over-limit `sendMessage` → `accepted:false` + `system_message`.
- **`server.test.ts`** / **`protocol/http.test.ts`**: metrics carries the new fields (null by default).
- **Suites:** runtime **76/76**, protocol green, full **259 tests pass**. `typecheck` gate clean.
  > The 3 failing `@brainpilot/app` CLI test *files* are a **pre-existing** vite `packageEntryFailure` on `development` (verified by stashing this branch) — unrelated to this change; 0 test assertions fail.
- **Live boot:** `BP_MEM_LIMIT_MB=4096` → `/metrics` `memLimitBytes=4294967296`, `memRatio≈0.016` + boot log; unset → `memLimitBytes/memRatio: null`, no log.

> #5 floor recommendation (~2 GB) will be posted as an issue reply for the hosted layer's sizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)