### PR TITLE
fix(web): tolerate response-shape mismatches in sessions.list + getEvents

### DIFF
--- a/packages/web/src/__tests__/api.test.ts
+++ b/packages/web/src/__tests__/api.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { api } from "../utils/api";
+
+// These exercise the real-fetch path (runtimeConfig.useMockBackend is false in
+// tests — VITE_USE_MOCK_BACKEND is unset). We stub globalThis.fetch and a
+// minimal localStorage so authHeaders()/getStoredToken() don't blow up in the
+// node test environment.
+
+type FetchResponseInit = {
+  ok?: boolean;
+  status?: number;
+  contentType?: string;
+  json?: unknown;
+  /** When set, res.json() rejects with this (mirrors a non-JSON body). */
+  jsonThrows?: boolean;
+};
+
+function makeResponse(init: FetchResponseInit): Response {
+  const status = init.status ?? (init.ok === false ? 500 : 200);
+  const ok = init.ok ?? (status >= 200 && status < 300);
+  const headers = new Map<string, string>();
+  if (init.contentType) headers.set("content-type", init.contentType);
+  return {
+    ok,
+    status,
+    headers: { get: (k: string) => headers.get(k.toLowerCase()) ?? null },
+    json: async () => {
+      if (init.jsonThrows) throw new SyntaxError("Unexpected token '<'");
+      return init.json;
+    },
+    text: async () => (typeof init.json === "string" ? init.json : JSON.stringify(init.json ?? "")),
+  } as unknown as Response;
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+  vi.stubGlobal("localStorage", {
+    getItem: () => null,
+    setItem: () => undefined,
+    removeItem: () => undefined,
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("api.sessions.list — unwraps { sessions } and tolerates shape", () => {
+  it("unwraps the runtime's { sessions: [...] } envelope", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({ contentType: "application/json", json: { sessions: [{ id: "a" }, { id: "b" }] } }),
+    );
+    const out = await api.sessions.list();
+    expect(out).toHaveLength(2);
+    expect(out[0].id).toBe("a");
+  });
+
+  it("tolerates a bare array response (legacy / mock shape)", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({ contentType: "application/json", json: [{ id: "x" }] }),
+    );
+    const out = await api.sessions.list();
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe("x");
+  });
+
+  it("returns [] (never throws .map) for an unexpected shape", async () => {
+    fetchMock.mockResolvedValueOnce(makeResponse({ contentType: "application/json", json: {} }));
+    await expect(api.sessions.list()).resolves.toEqual([]);
+  });
+
+  it("returns [] for a null body", async () => {
+    fetchMock.mockResolvedValueOnce(makeResponse({ contentType: "application/json", json: null }));
+    await expect(api.sessions.list()).resolves.toEqual([]);
+  });
+});
+
+describe("api.sessions.getEvents — tolerates SSE / non-JSON responses", () => {
+  it("returns the events array for a JSON { events } body", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({ contentType: "application/json", json: { events: [{ type: "RUN_STARTED" }] } }),
+    );
+    const out = await api.sessions.getEvents("s1");
+    expect(out).toHaveLength(1);
+  });
+
+  it("returns [] (does NOT throw) when the endpoint is an SSE stream", async () => {
+    // /sessions/:id/events is wired to sseHandler in backend-core → text/event-stream.
+    // Calling res.json() on it would reject; getEvents must short-circuit to [].
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({ contentType: "text/event-stream", jsonThrows: true }),
+    );
+    await expect(api.sessions.getEvents("s1")).resolves.toEqual([]);
+  });
+
+  it("returns [] for a non-ok response", async () => {
+    fetchMock.mockResolvedValueOnce(makeResponse({ ok: false, status: 404, contentType: "application/json", json: { error: "not found" } }));
+    await expect(api.sessions.getEvents("s1")).resolves.toEqual([]);
+  });
+});

--- a/packages/web/src/utils/api.ts
+++ b/packages/web/src/utils/api.ts
@@ -294,8 +294,19 @@ export const api = {
       if (runtimeConfig.useMockBackend) {
         return mockBackend.listSessions();
       }
-      const raw = await handleJson<unknown[]>(await fetch(`${API_BASE}/sessions`, { headers: authHeaders() }));
-      return raw.map((item) => normalizeSession(item as Parameters<typeof normalizeSession>[0]));
+      // Runtime returns the protocol envelope `{ sessions: [...] }` (see
+      // ListSessionsResponseSchema). Unwrap it; tolerate a bare array (legacy /
+      // mock) and fall back to [] so an unexpected shape never throws
+      // `.map is not a function` into SessionContext's error banner.
+      const raw = await handleJson<{ sessions?: unknown[] } | unknown[]>(
+        await fetch(`${API_BASE}/sessions`, { headers: authHeaders() }),
+      );
+      const list = Array.isArray(raw)
+        ? raw
+        : Array.isArray((raw as { sessions?: unknown[] })?.sessions)
+          ? (raw as { sessions: unknown[] }).sessions
+          : [];
+      return list.map((item) => normalizeSession(item as Parameters<typeof normalizeSession>[0]));
     },
 
     async get(sessionId: string): Promise<Session> {
@@ -437,9 +448,15 @@ export const api = {
       if (runtimeConfig.useMockBackend) {
         return mockBackend.getSessionEvents(sessionId);
       }
-      const raw = await handleJson<{ events?: unknown[] }>(
-        await fetch(`${API_BASE}/sessions/${sessionId}/events`, { headers: authHeaders() }),
-      );
+      // `/sessions/:id/events` is an SSE alias in backend-core (sseHandler), not
+      // a JSON route — so res.json() would reject. Treat any non-ok / non-JSON
+      // response as "no events" and let callers (demoBundle) use their ordered
+      // fallback instead of crashing on a stream body.
+      const res = await fetch(`${API_BASE}/sessions/${sessionId}/events`, { headers: authHeaders() });
+      if (!res.ok) return [];
+      const contentType = res.headers.get("content-type") || "";
+      if (!contentType.includes("application/json")) return [];
+      const raw = (await res.json().catch(() => ({}))) as { events?: unknown[] };
       return Array.isArray(raw.events) ? (raw.events as RawAgUiEvent[]) : [];
     },
 


### PR DESCRIPTION
## Summary

Fixes two frontend↔backend **contract bugs** where the route *exists* and returns a valid JSON/stream body, but the SPA reads the **wrong shape**. This is a different class from the missing-route bugs (#18/#19/#23) already handled systemically by the #30 `app.all(\"/api/*\")` JSON-404 guard — that guard turns *missing* routes into clean 404s, but it can't catch a route that returns the wrong shape.

### 1. `sessions.list()` — `(intermediate value).map is not a function` under the chat box

`api.sessions.list()` called `raw.map(...)` on `GET /sessions` assuming a bare array, but the runtime returns the protocol envelope `{ sessions: [...] }` (`ListSessionsResponseSchema`, `runtime/src/server.ts`). `raw` was the object, `raw.map` was `undefined`, and it threw. `SessionContext.refreshSessions` caught the error and stored `err.message`, which `PromptComposer` renders in its error banner — so the message sat under the chat box on **every page load, with no console error**. (V8 labels it `(intermediate value)` because Vite inlines `raw` into `(await handleJson(...)).map(...)`.)

**Fix:** unwrap `{ sessions }`, tolerate a bare array (legacy/mock), fall back to `[]` so an unexpected shape never throws into the error banner.

### 2. `getEvents()` — parsing an SSE stream as JSON breaks demo-bundle export

`api.sessions.getEvents()` ran `res.json()` on `/sessions/:id/events`, but backend-core wires that path to an **SSE stream** (`sseHandler`, `backend-core/src/app.ts`), not a JSON route. `res.json()` rejects on the `text/event-stream` body. Its only caller (`components/demo/demoBundle.ts`) is unwrapped, so demo export crashed against a real backend.

**Fix:** short-circuit to `[]` on non-ok / non-JSON responses, so `demoBundle` uses its existing `ordered` timeline fallback.

## Tests

Adds `packages/web/src/__tests__/api.test.ts` (7 cases): envelope unwrap, bare-array tolerance, unexpected-shape fallback, `getEvents` JSON / SSE / non-ok. Written TDD (5 red → green).

## Verification

- `packages/web` tests: **35 passed** (incl. 7 new)
- `npm run typecheck` (protocol/runtime/backend-core/cli/client-cli) ✅
- `packages/web`: `tsc -b` + `vite build` ✅

## Out of scope

- **#28** (MCP routes) and **#21** (drop built-in auth) — explicitly excluded.
- No change to the backend `/sessions/:id/events` SSE semantics (front-end defensive fallback only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)