### PR TITLE
fix(web): keep activity block in-progress across ReAct rounds

### DIFF
--- a/packages/web/src/__tests__/messageGroups.test.ts
+++ b/packages/web/src/__tests__/messageGroups.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { buildRenderItems } from "../contexts/messageGroups";
+import type { ChatMessage } from "../contracts/backend";
+
+// Folded "activity" blocks (reasoning + tool steps) must stay "in progress"
+// while their owning agent's run is still active, even when no single step is
+// momentarily streaming. Without run-active awareness the per-message streaming
+// flags all clear between ReAct rounds and the block flashes "完成思考" in the
+// gap before the next round. See messageGroups.ts buildRenderItems.
+
+// A folded step (reasoning/tool) — these are the only kinds that group into an
+// activity block; assistant text / user / errors render standalone.
+function step(over: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id: over.id ?? `s-${Math.random().toString(36).slice(2)}`,
+    role: "assistant",
+    content: "",
+    createdAt: new Date().toISOString(),
+    agent: "principal",
+    streaming: false,
+    kind: "thinking",
+    ...over,
+  };
+}
+
+describe("buildRenderItems — activity block run-active awareness", () => {
+  it("without runningAgents, block streaming derives only from step flags (legacy behavior)", () => {
+    const streamingBlock = buildRenderItems([step({ streaming: true })]);
+    expect(streamingBlock[0]).toMatchObject({ type: "activity", streaming: true });
+
+    const doneBlock = buildRenderItems([step({ streaming: false })]);
+    expect(doneBlock[0]).toMatchObject({ type: "activity", streaming: false });
+  });
+
+  it("keeps a block in progress when its agent's run is active but no step is streaming (the bug)", () => {
+    // Between ReAct rounds: every step's END already cleared streaming, but the
+    // principal run has NOT finished — the block must NOT show as done.
+    const items = buildRenderItems(
+      [step({ agent: "principal", streaming: false, kind: "tool" })],
+      new Set(["principal"]),
+    );
+    expect(items[0]).toMatchObject({ type: "activity", streaming: true });
+  });
+
+  it("marks a block done when its agent is idle and no step is streaming", () => {
+    const items = buildRenderItems(
+      [step({ agent: "principal", streaming: false })],
+      new Set<string>(), // principal not running anymore
+    );
+    expect(items[0]).toMatchObject({ type: "activity", streaming: false });
+  });
+
+  it("falls back to 'principal' for unattributed steps", () => {
+    const items = buildRenderItems([step({ agent: undefined, streaming: false })], new Set(["principal"]));
+    expect(items[0]).toMatchObject({ type: "activity", streaming: true });
+  });
+
+  it("multi-agent: an idle agent's block shows done even while another agent is still running", () => {
+    // worker has finished (not in the running set); expert is still running.
+    // Each block is scoped to its own agent's run state.
+    const workerStep = step({ id: "w1", agent: "worker", streaming: false, kind: "tool" });
+    const userBreak: ChatMessage = {
+      id: "u1",
+      role: "user",
+      content: "next",
+      createdAt: new Date().toISOString(),
+      agent: "user",
+      streaming: false,
+      kind: "text",
+    };
+    const expertStep = step({ id: "e1", agent: "expert", streaming: false, kind: "thinking" });
+
+    const items = buildRenderItems([workerStep, userBreak, expertStep], new Set(["expert"]));
+    const activities = items.filter((i) => i.type === "activity");
+    expect(activities).toHaveLength(2);
+    // worker block (agent idle) → done; expert block (agent running) → in progress
+    expect(activities[0]).toMatchObject({ streaming: false });
+    expect(activities[1]).toMatchObject({ streaming: true });
+  });
+});

--- a/packages/web/src/components/chat/MessageStream.tsx
+++ b/packages/web/src/components/chat/MessageStream.tsx
@@ -23,6 +23,13 @@ interface MessageStreamProps {
   onAskUserSubmit?: (requestId: string, answer: string) => void;
   /** 修正6 — cancel a pending auto-retry. Omitted in read-only contexts. */
   onRetryCancel?: () => void;
+  /**
+   * Names of agents whose run is currently active (RUN_STARTED..RUN_FINISHED).
+   * Keeps a folded activity block "in progress" across ReAct rounds even when
+   * no single step is momentarily streaming. Omitted in read-only contexts
+   * (demo replay), where messages are already terminal.
+   */
+  runningAgents?: ReadonlySet<string>;
 }
 
 // Whether this message participates in same-agent avatar merging. User
@@ -65,13 +72,17 @@ function MessageStreamImpl({
   ariaLabel,
   onAskUserSubmit,
   onRetryCancel,
+  runningAgents,
 }: MessageStreamProps) {
   const t = useT();
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const stackRef = useRef<HTMLDivElement | null>(null);
   const isPinnedRef = useRef(true);
 
-  const renderItems = useMemo(() => buildRenderItems(messages), [messages]);
+  const renderItems = useMemo(
+    () => buildRenderItems(messages, runningAgents),
+    [messages, runningAgents],
+  );
 
   // Avatar merging: a mergeable assistant/system row whose immediately
   // preceding render item is a mergeable single from the same agent hides its

--- a/packages/web/src/components/chat/PromptComposer.tsx
+++ b/packages/web/src/components/chat/PromptComposer.tsx
@@ -55,6 +55,16 @@ export function PromptComposer() {
   const isAgentRunning = agents.some((a) => a.status === "running");
   const lastAssistantStreaming = visibleMessages[visibleMessages.length - 1]?.role === "assistant" && visibleMessages[visibleMessages.length - 1]?.streaming;
 
+  // Agents whose run is still active. Threaded to MessageStream so a folded
+  // activity block stays "in progress" across ReAct rounds — without this, the
+  // per-message streaming flags all clear between rounds and the block flashes
+  // "完成思考" in the gap. Memoized so its identity is stable for MessageStream's
+  // memo() (a fresh Set each render would defeat the memoization).
+  const runningAgents = useMemo(
+    () => new Set(agents.filter((a) => a.status === "running").map((a) => a.name)),
+    [agents],
+  );
+
   useEffect(() => {
     let cancelled = false;
     void api.ui.promptSuggestions().then((suggestions) => {
@@ -235,6 +245,7 @@ export function PromptComposer() {
             messages={visibleMessages}
             autoScroll
             showTiming
+            runningAgents={runningAgents}
             onAskUserSubmit={(requestId, answer) => void respondToInput(requestId, answer)}
             onRetryCancel={() => void interruptCurrent()}
           />

--- a/packages/web/src/contexts/messageGroups.ts
+++ b/packages/web/src/contexts/messageGroups.ts
@@ -33,17 +33,34 @@ function isStandalone(message: ChatMessage): boolean {
  * standalone. The activity group id is its first step's id so the native
  * <details> DOM node is reused across re-renders, preserving the user's
  * expand/collapse toggle without explicit React state.
+ *
+ * `runningAgents` is the authoritative set of agent names whose run is still
+ * active (RUN_STARTED..RUN_FINISHED, sourced from `session_state`). An activity
+ * block is "in progress" if any of its steps is still streaming OR its owning
+ * agent's run is still active. Without this, the per-message `streaming` flags
+ * all go false between ReAct rounds (each message's END clears it), so the
+ * block would flash "思考过程 · N 步" (done) in the gap before the next round —
+ * AG-UI explicitly warns against treating a message/tool END as run completion.
+ * Omitting `runningAgents` (e.g. demo replay, where messages are already
+ * terminal) preserves the original streaming-flag-only behavior.
  */
-export function buildRenderItems(messages: ChatMessage[]): RenderItem[] {
+export function buildRenderItems(
+  messages: ChatMessage[],
+  runningAgents?: ReadonlySet<string>,
+): RenderItem[] {
   const items: RenderItem[] = [];
   let buffer: ChatMessage[] = [];
+  // A step keeps its block "in progress" while its owning agent's run is active.
+  // Steps default to the principal agent when unattributed, matching how the
+  // reducer/UI fall back elsewhere.
+  const agentActive = (s: ChatMessage) => runningAgents?.has(s.agent ?? "principal") ?? false;
   const flush = () => {
     if (buffer.length === 0) return;
     items.push({
       type: "activity",
       id: buffer[0].id,
       steps: buffer,
-      streaming: buffer.some((s) => s.streaming),
+      streaming: buffer.some((s) => s.streaming || agentActive(s)),
     });
     buffer = [];
   };


### PR DESCRIPTION
## 问题

多轮 ReAct 时,折叠的「思考过程」活动块在**第一轮结束就显示「完成思考」**(字幕「思考过程 · N 步」),随后 agent 又继续输出——完成判定提前触发。

## 根因

折叠块的完成态由逐条消息的 streaming 标志推断:`buildRenderItems` 里 `buffer.some(s => s.streaming)`。每条消息的 END(`TEXT_MESSAGE_END`/`REASONING_MESSAGE_END`/`TOOL_CALL_END`)会清掉自己的 streaming 标志,于是 ReAct **轮间空档**整块没有 streaming 步骤 → 字幕切成「思考过程 · N 步」(done)。

调研三方一致:**「agent 完成」的权威信号是 run 边界**,不是 message/tool END:
- **Pi SDK**:`AgentSession.prompt()` 只在整轮 ReAct 全部结束(`agent_end` listeners settle)后才 resolve;一次 run 内有多个 `turn_end`。
- **AG-UI**:`RUN_STARTED..RUN_FINISHED` 是 run 的强制边界;`TEXT_MESSAGE_END`/`TOOL_CALL_END` 只关闭单条消息/单个工具调用,**协议明确点名**把它们当 run 完成是反模式。
- **legacy**:靠 principal `running→idle` 边沿发唯一一次 `RUN_FINISHED`,故意不信内层 per-round 信号。

runtime 侧本就正确(`mas-agent.ts` 只在 `prompt()` resolve 后发一次 `RUN_FINISHED`);全局「智能体思考中」toast 也正确。**bug 仅在前端折叠块。**

## 改动

把「当前在运行的 agent 集合」(派生自 `session_state`,既有的 run-state 权威源)下传到 `buildRenderItems`:块「进行中」= `有步骤在 streaming` **或** `其所属 agent 仍在 running 集合`。按 agent scope(与 `RUN_FINISHED` 的 `agentName` 隔离语义一致)。

- `messageGroups.ts` — `buildRenderItems(messages, runningAgents?)`
- `MessageStream.tsx` — 加可选 prop `runningAgents`,透传
- `PromptComposer.tsx` — `useMemo` 派生稳定集合并下传
- `DemoView.tsx` — 不改(回放消息已终态,省略 prop = 旧行为,零回归)
- 新增 `__tests__/messageGroups.test.ts` — 旧行为保持 / bug 回归 / idle 收敛 / principal fallback / 多 agent 隔离

## 终态收敛

`RUN_FINISHED` 到达 → reducer `sweepStreaming` 清 streaming + `session_state` 置 agent idle 移出集合,两者满足后块才显示完成。期间任一未完只会**多停留**在进行中(安全方向,绝不再提前报完成)。

## 验证

- `npm run typecheck` ✅
- `packages/web` vitest:**40 passed**(含新增 5)✅
- `packages/web` vite build ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)