### PR TITLE
fix(backend): add /api/mcp-servers CRUD routes (closes #28)

### DIFF
--- a/packages/backend-core/src/app.ts
+++ b/packages/backend-core/src/app.ts
@@ -27,6 +27,10 @@ import {
   updateProfile,
   deleteProfile,
   setSelectedProfile,
+  readMcpServers,
+  createMcpServer,
+  updateMcpServer,
+  deleteMcpServer,
   type StoredProviderProfile,
 } from "./config.js";
 
@@ -174,6 +178,29 @@ export function createApp(options: CreateAppOptions): Hono {
     const p = profiles.find((x) => x.id === c.req.param("id"));
     if (!p) return c.json({ error: "not found" }, 404);
     return c.json(toHttpProfile(p, selectedProfileId));
+  });
+
+  // ---- MCP Servers CRUD (disk-backed: bp_template/mcp_servers.json) ----
+  api.get("/mcp-servers", async (c) => {
+    return c.json(await readMcpServers(dataDir));
+  });
+  api.post("/mcp-servers", async (c) => {
+    const body = await safeJson(c);
+    const name = typeof body.name === "string" ? body.name.trim() : "";
+    const config = body.config && typeof body.config === "object" ? (body.config as Record<string, unknown>) : null;
+    if (!name || !config) return c.json({ error: "name and config are required" }, 400);
+    return c.json(await createMcpServer(dataDir, name, config), 201);
+  });
+  api.put("/mcp-servers/:name", async (c) => {
+    const config = await safeJson(c);
+    const entry = await updateMcpServer(dataDir, c.req.param("name"), config);
+    if (!entry) return c.json({ error: "not found" }, 404);
+    return c.json(entry);
+  });
+  api.delete("/mcp-servers/:name", async (c) => {
+    const ok = await deleteMcpServer(dataDir, c.req.param("name"));
+    if (!ok) return c.json({ error: "not found" }, 404);
+    return c.body(null, 204);
   });
 
   // Mount the API under /api (the SPA's API_BASE).

--- a/packages/backend-core/src/config.ts
+++ b/packages/backend-core/src/config.ts
@@ -412,3 +412,74 @@ export function formatProviderGuidance(report: ProviderConfigReport): string[] {
     "No key needed for a test run:  BP_MOCK=1 brainpilot up",
   ];
 }
+
+/* ----------------------- MCP server config CRUD ----------------------- *
+ * The runtime reads `mcp_servers.json` from disk (`loadMcpServersConfig` in
+ * mcp-bridge.ts); these functions let the Settings → MCP tab persist entries
+ * through the same file so the UI and disk stay in sync.
+ *
+ * Disk format (keyed map):   { mcpServers: { name: spec } }
+ * HTTP format (flat array):  [{ name, ...spec }]
+ * -------------------------------------------------------------------------- */
+
+export function mcpServersPath(dataDir: string): string {
+  return path.join(dataDir, "bp_template", "mcp_servers.json");
+}
+
+type McpSpec = Record<string, unknown>;
+
+interface McpServersFile {
+  mcpServers: Record<string, McpSpec>;
+}
+
+async function readMcpServersRaw(dataDir: string): Promise<Record<string, McpSpec>> {
+  const raw = await readJsonSafe(mcpServersPath(dataDir));
+  if (raw && typeof (raw as Record<string, unknown>).mcpServers === "object") {
+    return (raw as unknown as McpServersFile).mcpServers;
+  }
+  return {};
+}
+
+async function writeMcpServersRaw(dataDir: string, servers: Record<string, McpSpec>): Promise<void> {
+  const target = mcpServersPath(dataDir);
+  await fs.mkdir(path.dirname(target), { recursive: true });
+  const tmp = `${target}.tmp`;
+  await fs.writeFile(tmp, JSON.stringify({ mcpServers: servers }, null, 2), { encoding: "utf8", mode: 0o600 });
+  await fs.rename(tmp, target);
+}
+
+export async function readMcpServers(dataDir: string): Promise<Array<{ name: string } & McpSpec>> {
+  const servers = await readMcpServersRaw(dataDir);
+  return Object.entries(servers).map(([name, spec]) => ({ name, ...spec }));
+}
+
+export async function createMcpServer(
+  dataDir: string,
+  name: string,
+  spec: McpSpec,
+): Promise<{ name: string } & McpSpec> {
+  const servers = await readMcpServersRaw(dataDir);
+  servers[name] = spec;
+  await writeMcpServersRaw(dataDir, servers);
+  return { name, ...spec };
+}
+
+export async function updateMcpServer(
+  dataDir: string,
+  name: string,
+  spec: McpSpec,
+): Promise<({ name: string } & McpSpec) | null> {
+  const servers = await readMcpServersRaw(dataDir);
+  if (!(name in servers)) return null;
+  servers[name] = spec;
+  await writeMcpServersRaw(dataDir, servers);
+  return { name, ...spec };
+}
+
+export async function deleteMcpServer(dataDir: string, name: string): Promise<boolean> {
+  const servers = await readMcpServersRaw(dataDir);
+  if (!(name in servers)) return false;
+  delete servers[name];
+  await writeMcpServersRaw(dataDir, servers);
+  return true;
+}

--- a/packages/backend-core/test/mcp-servers.test.ts
+++ b/packages/backend-core/test/mcp-servers.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createApp } from "../src/app.js";
+import type { Orchestrator, RuntimeHandle } from "../src/orchestrator.js";
+
+function fakeOrchestrator(): Orchestrator {
+  return {
+    async ensureRuntime(): Promise<RuntimeHandle> {
+      return { baseUrl: "http://runtime.test" };
+    },
+    async health() {
+      return true;
+    },
+    async stopRuntime() {},
+  };
+}
+
+async function setup() {
+  const dataDir = await mkdtemp(join(tmpdir(), "bp-mcp-api-"));
+  const app = createApp({
+    orchestrator: fakeOrchestrator(),
+    serveWeb: false,
+    dataDir,
+  });
+  return { app, dataDir };
+}
+
+function post(app: ReturnType<typeof createApp>, body: unknown) {
+  return app.request("/api/mcp-servers", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function put(app: ReturnType<typeof createApp>, name: string, body: unknown) {
+  return app.request(`/api/mcp-servers/${name}`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function del(app: ReturnType<typeof createApp>, name: string) {
+  return app.request(`/api/mcp-servers/${name}`, { method: "DELETE" });
+}
+
+describe("MCP Servers CRUD (/api/mcp-servers)", () => {
+  it("GET returns empty array when no config file exists", async () => {
+    const { app } = await setup();
+    const res = await app.request("/api/mcp-servers");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([]);
+  });
+
+  it("GET returns servers from an existing mcp_servers.json", async () => {
+    const { app, dataDir } = await setup();
+    await mkdir(join(dataDir, "bp_template"), { recursive: true });
+    await writeFile(
+      join(dataDir, "bp_template", "mcp_servers.json"),
+      JSON.stringify({ mcpServers: { fs: { type: "stdio", command: "npx" } } }),
+    );
+    const res = await app.request("/api/mcp-servers");
+    expect(res.status).toBe(200);
+    const list = await res.json();
+    expect(list).toHaveLength(1);
+    expect(list[0]).toEqual({ name: "fs", type: "stdio", command: "npx" });
+  });
+
+  it("POST creates a server and returns it with 201", async () => {
+    const { app } = await setup();
+    const res = await post(app, {
+      name: "my-api",
+      config: { type: "http", url: "https://host/mcp", headers: { Authorization: "Bearer t" } },
+    });
+    expect(res.status).toBe(201);
+    const entry = await res.json();
+    expect(entry.name).toBe("my-api");
+    expect(entry.type).toBe("http");
+    expect(entry.url).toBe("https://host/mcp");
+    expect(entry.headers).toEqual({ Authorization: "Bearer t" });
+  });
+
+  it("POST with an existing name overwrites", async () => {
+    const { app } = await setup();
+    await post(app, { name: "s", config: { type: "stdio", command: "old" } });
+    await post(app, { name: "s", config: { type: "stdio", command: "new" } });
+    const list = await (await app.request("/api/mcp-servers")).json();
+    expect(list).toHaveLength(1);
+    expect(list[0].command).toBe("new");
+  });
+
+  it("POST returns 400 when name or config is missing", async () => {
+    const { app } = await setup();
+    expect((await post(app, { config: { type: "stdio" } })).status).toBe(400);
+    expect((await post(app, { name: "x" })).status).toBe(400);
+    expect((await post(app, {})).status).toBe(400);
+  });
+
+  it("PUT updates an existing server", async () => {
+    const { app } = await setup();
+    await post(app, { name: "s", config: { type: "stdio", command: "a" } });
+    const res = await put(app, "s", { type: "stdio", command: "b" });
+    expect(res.status).toBe(200);
+    expect((await res.json()).command).toBe("b");
+  });
+
+  it("PUT returns 404 for a missing server", async () => {
+    const { app } = await setup();
+    const res = await put(app, "nope", { type: "stdio", command: "x" });
+    expect(res.status).toBe(404);
+  });
+
+  it("DELETE removes an existing server and returns 204", async () => {
+    const { app } = await setup();
+    await post(app, { name: "s", config: { type: "sse", url: "http://x/sse" } });
+    const res = await del(app, "s");
+    expect(res.status).toBe(204);
+    const list = await (await app.request("/api/mcp-servers")).json();
+    expect(list).toHaveLength(0);
+  });
+
+  it("DELETE returns 404 for a missing server", async () => {
+    const { app } = await setup();
+    expect((await del(app, "nope")).status).toBe(404);
+  });
+
+  it("persists the runtime's {mcpServers: ...} disk format", async () => {
+    const { app, dataDir } = await setup();
+    await post(app, { name: "kb", config: { type: "http", url: "http://host/mcp" } });
+    const raw = JSON.parse(
+      await readFile(join(dataDir, "bp_template", "mcp_servers.json"), "utf8"),
+    );
+    expect(raw).toEqual({
+      mcpServers: { kb: { type: "http", url: "http://host/mcp" } },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #28 — the Settings → MCP tab calls `GET/POST/PUT/DELETE /api/mcp-servers` but backend-core had no such routes. Requests fell through to the JSON 404 guard, making the UI non-functional outside mock mode.

- **`config.ts`**: add `readMcpServers()`, `createMcpServer()`, `updateMcpServer()`, `deleteMcpServer()` — backed by the same `bp_template/mcp_servers.json` the runtime reads. Atomic writes (`.tmp` → `rename`, `0o600`).
- **`app.ts`**: 4 routes on the `api` sub-router:
  - `GET /mcp-servers` → list (array of `{name, ...spec}`)
  - `POST /mcp-servers` → create (body `{name, config}`, 201)
  - `PUT /mcp-servers/:name` → update (body = config)
  - `DELETE /mcp-servers/:name` → remove (204)
- **`test/mcp-servers.test.ts`**: 10 integration tests — CRUD happy path, edge cases (missing name, missing server, overwrite), and disk format verification.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` — 292/292 tests pass (including 10 new)
- [ ] Manual: `BP_MOCK=1 brainpilot up`, open Settings → MCP, add/edit/remove a server

🤖 Generated with [Claude Code](https://claude.com/claude-code)