### PR TITLE
fix: stop self-hosted auth bootstrap redirect loop (closes #38)

### DIFF
--- a/packages/backend-core/src/app.ts
+++ b/packages/backend-core/src/app.ts
@@ -81,6 +81,16 @@ export function createApp(options: CreateAppOptions): Hono {
 
   api.get("/version", (c) => c.json({ name: "@brainpilot/backend-core", version: "0.1.0" }));
 
+  // ---- Identity (backend-local) ----------------------------------------
+  // Trust-front (#21): hosted deployments resolve identity at the upstream
+  // gateway, which intercepts /api/auth/me before it reaches us. For
+  // self-hosted `bp --up` there is no gateway, so we answer locally with a
+  // single default identity. Without this the SPA's auth bootstrap 404s into a
+  // hosted-login redirect loop (#38). Shape matches the web `User` contract.
+  api.get("/auth/me", (c) =>
+    c.json({ id: "local", username: "local", createdAt: new Date(0).toISOString() }),
+  );
+
   // ---- Metrics (proxied to runtime; idle-reclaim source, §15.4 修正2) --
   api.get("/metrics", forward("metrics"));
 

--- a/packages/backend-core/test/auth-me.test.ts
+++ b/packages/backend-core/test/auth-me.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createApp } from "../src/app.js";
+import type { Orchestrator, RuntimeHandle } from "../src/orchestrator.js";
+
+function fakeOrchestrator(): Orchestrator {
+  return {
+    async ensureRuntime(): Promise<RuntimeHandle> {
+      return { baseUrl: "http://runtime.test" };
+    },
+    async health() {
+      return true;
+    },
+    async stopRuntime() {},
+  };
+}
+
+async function setup() {
+  const dataDir = await mkdtemp(join(tmpdir(), "bp-authme-api-"));
+  const app = createApp({
+    orchestrator: fakeOrchestrator(),
+    serveWeb: false,
+    dataDir,
+  });
+  return { app, dataDir };
+}
+
+// Trust-front (#21/#35) moved auth to an upstream gateway. Self-hosted `bp --up`
+// has no gateway, so the SPA's GET /api/auth/me must resolve locally instead of
+// hitting the JSON-404 guard — otherwise the frontend loops on /account/login (#38).
+describe("self-hosted auth identity (/api/auth/me)", () => {
+  it("GET returns 200 with a default local identity", async () => {
+    const { app } = await setup();
+    const res = await app.request("/api/auth/me");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      id: "local",
+      username: "local",
+      createdAt: "1970-01-01T00:00:00.000Z",
+    });
+  });
+
+  it("does NOT fall through to the /api/* JSON-404 guard", async () => {
+    const { app } = await setup();
+    const res = await app.request("/api/auth/me");
+    expect(res.status).not.toBe(404);
+  });
+});

--- a/packages/web/src/contexts/AuthContext.tsx
+++ b/packages/web/src/contexts/AuthContext.tsx
@@ -11,20 +11,11 @@ interface AuthContextValue {
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
-// Where to send the browser when the upstream gateway reports we're not
-// authenticated. Login/register/account live in the hosted shell, not here.
-const HOSTED_LOGIN_PATH = "/account/login";
-
-function redirectToHostedLogin() {
-  const redirect = encodeURIComponent(window.location.pathname + window.location.search);
-  window.location.assign(`${HOSTED_LOGIN_PATH}?redirect=${redirect}`);
-}
-
 /**
  * Trust-front auth: the open-source frontend does NOT authenticate. The hosted
  * gateway owns auth and carries identity via an httpOnly cookie. We only read the
- * resolved identity (GET /api/auth/me) for display; on failure we hand off to the
- * hosted login page. There is no login/register/logout UI here.
+ * resolved identity (GET /api/auth/me) for display. There is no login/register/
+ * logout UI here.
  */
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
@@ -42,11 +33,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         }
       } catch {
         if (cancelled) return;
-        // Not authenticated upstream — defer to the hosted login. We still flip
-        // isAuthReady so the shell stops showing the bootstrapping splash while
-        // the navigation is in flight.
+        // No identity resolved. In self-hosted `bp --up` there is no hosted
+        // gateway/login to hand off to, so redirecting here would loop (#38).
+        // Fall back to a local anonymous identity and let the app render.
+        setUser({ id: "local", username: "local", createdAt: new Date(0).toISOString() });
         setIsAuthReady(true);
-        redirectToHostedLogin();
       }
     }
 


### PR DESCRIPTION
## Problem

Self-hosted `npm run bp -- --up` made the web UI **continuously refresh and flicker** — the page never settled. It is served as a built static SPA by backend-core (not a Vite dev server), so this is **not HMR** but a client-side **redirect → reload loop**:

1. On mount, `AuthProvider` calls `api.auth.me()` → `GET /api/auth/me`.
2. Self-hosted backend-core had **no `/api/auth/*` route**, so the request hit the `app.all("/api/*", → JSON 404)` guard and `me()` threw.
3. The bootstrap `catch` ran `redirectToHostedLogin()` → `window.location.assign("/account/login?…")`.
4. `/account/login` is a non-`/api` GET → SPA fallback served the **same `index.html`**.
5. SPA re-mounted → `me()` 404 → redirect → **infinite loop**.

Trust-front (#21 / #35) assumes an upstream gateway owns `/api/auth/me` and `/account/login`. Single-machine `bp --up` has no gateway, so `me()` always 404s and the frontend had no exit path. (Distinct from #34, which was response-shape mismatch; this is a control-flow loop.)

## Fix (two-sided)

- **backend-core** (`src/app.ts`): serve `GET /api/auth/me` locally, returning a default local identity (shape matches the web `User` contract). Hosted deployments override this at the gateway, which intercepts the route upstream.
- **web** (`src/contexts/AuthContext.tsx`): on `me()` failure, fall back to a local anonymous identity instead of unconditionally redirecting to the hosted login — defense in depth so a missing/erroring endpoint can never produce a redirect loop. Removes the now-unused `redirectToHostedLogin`/`HOSTED_LOGIN_PATH`.

## Tests

- New `packages/backend-core/test/auth-me.test.ts` (TDD: red → green) — asserts `GET /api/auth/me` returns 200 with the local identity and no longer falls through to the JSON-404 guard.
- Frontend: no unit test — web has no jsdom/RTL and vitest runs `environment: "node"`; covered by typecheck + build + manual e2e (avoids pulling in test deps).

## Verification

- `npm run typecheck` ✅
- `npm run test` ✅ 294/294 (32 files)
- `npm run build` ✅ (web TS compiles clean; no unused-symbol errors)
- Manual: `bp --up --no-open` → `curl /api/auth/me` returns 200 local user; served `index.html` references the freshly built bundle; no refresh/flicker.

Closes #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)