### PR TITLE
fix: resolve issues #41–#45 (status port, user-message replay, error redaction, hidden WIP UI)

### DIFF
--- a/packages/cli/src/commands/down-status.test.ts
+++ b/packages/cli/src/commands/down-status.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { down } from "./down.js";
 import { status } from "./status.js";
-import { writePid, readPid } from "../process-control.js";
+import { writePid, readPid, writeServerState, readServerState } from "../process-control.js";
 import { dataPaths } from "../paths.js";
 
 let dir: string;
@@ -66,6 +66,22 @@ describe("down", () => {
     expect(procs.signals).toHaveLength(0);
     expect(await readPid(p.backendPid)).toBeNull();
   });
+
+  it("removes the persisted server state on down (#41)", async () => {
+    const root = join(dir, "bp");
+    const p = dataPaths(root);
+    await writePid(p.backendPid, 1234);
+    await writeServerState(p.serverState, {
+      pid: 1234,
+      port: 9801,
+      runtimePort: 9802,
+      host: "127.0.0.1",
+    });
+    const procs = fakeProcs(new Set([1234]));
+
+    await down({ dir: root }, { ...procs, log: () => {} });
+    expect(await readServerState(p.serverState)).toBeNull();
+  });
 });
 
 describe("status", () => {
@@ -103,5 +119,51 @@ describe("status", () => {
     expect(report.pid).toBe(555);
     expect(report.healthy).toBe(true);
     expect(report.metrics).toEqual({ activeSessions: 2, runningAgents: 3 });
+  });
+
+  it("reports the persisted custom port from server.json without --port (#41)", async () => {
+    const root = join(dir, "bp");
+    const p = dataPaths(root);
+    await writePid(p.backendPid, 555);
+    await writeServerState(p.serverState, {
+      pid: 555,
+      port: 9801,
+      runtimePort: 9802,
+      host: "127.0.0.1",
+    });
+
+    const probed: string[] = [];
+    const fetchFn = (async (url: string | URL) => {
+      probed.push(String(url));
+      if (String(url).endsWith("/api/health")) return new Response("ok", { status: 200 });
+      return new Response("", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const report = await status({ dir: root }, { isAlive: () => true, fetchFn, log: () => {} });
+
+    expect(report.backendPort).toBe(9801);
+    expect(report.runtimePort).toBe(9802);
+    expect(report.healthy).toBe(true);
+    expect(probed.some((u) => u.includes(":9801/api/health"))).toBe(true);
+  });
+
+  it("lets an explicit --port override server.json (#41)", async () => {
+    const root = join(dir, "bp");
+    const p = dataPaths(root);
+    await writePid(p.backendPid, 555);
+    await writeServerState(p.serverState, {
+      pid: 555,
+      port: 9801,
+      runtimePort: 9802,
+      host: "127.0.0.1",
+    });
+
+    const report = await status(
+      { dir: root, port: 9701 },
+      { isAlive: () => true, fetchFn: (async () => new Response("ok", { status: 200 })) as unknown as typeof fetch, log: () => {} },
+    );
+
+    expect(report.backendPort).toBe(9701);
+    expect(report.runtimePort).toBe(9702);
   });
 });

--- a/packages/cli/src/commands/down.ts
+++ b/packages/cli/src/commands/down.ts
@@ -6,7 +6,7 @@
  */
 import pc from "picocolors";
 import { resolveDataDir, dataPaths } from "../paths.js";
-import { stop, removePid, type ProcessControlDeps } from "../process-control.js";
+import { stop, removePid, removeServerState, type ProcessControlDeps } from "../process-control.js";
 
 export interface DownOptions {
   dir?: string;
@@ -42,6 +42,9 @@ export async function down(
 
   // Backend owns the runtime; clean any leftover runtime pid file regardless.
   await removePid(p.runtimePid);
+  // Drop the persisted server state so a later `status` doesn't report a dead
+  // server's ports (issue #41).
+  await removeServerState(p.serverState);
 
   if (result.pid === null) {
     log(pc.yellow("No running backend found (no pid file)."));

--- a/packages/cli/src/commands/status.ts
+++ b/packages/cli/src/commands/status.ts
@@ -5,7 +5,7 @@
  */
 import pc from "picocolors";
 import { resolveDataDir, dataPaths } from "../paths.js";
-import { readPid, isRunning, type ProcessControlDeps } from "../process-control.js";
+import { readPid, isRunning, readServerState, type ProcessControlDeps } from "../process-control.js";
 import { DEFAULT_PORT } from "../scaffold.js";
 
 export interface StatusOptions {
@@ -40,7 +40,13 @@ export async function status(
   const fetchFn = deps.fetchFn ?? fetch;
   const dataDir = resolveDataDir({ dir: options.dir, env, cwd: deps.cwd });
   const p = dataPaths(dataDir);
-  const port = options.port ?? (Number(env.BP_PORT) || DEFAULT_PORT);
+  // Port precedence (issue #41): explicit --port > persisted server.json
+  // (written by detached `up`) > BP_PORT > DEFAULT_PORT.
+  const state = await readServerState(p.serverState);
+  const port =
+    options.port ?? state?.port ?? (Number(env.BP_PORT) || DEFAULT_PORT);
+  const runtimePort =
+    options.port === undefined && state ? state.runtimePort : port + 1;
   const host = "127.0.0.1";
   const url = `http://${host}:${port}`;
 
@@ -74,7 +80,7 @@ export async function status(
     running,
     pid,
     backendPort: port,
-    runtimePort: port + 1,
+    runtimePort,
     url,
     healthy,
     ...(metrics ? { metrics } : {}),

--- a/packages/cli/src/commands/up.test.ts
+++ b/packages/cli/src/commands/up.test.ts
@@ -8,7 +8,7 @@ import {
   PortInUseError,
   type ResolvedUpConfig,
 } from "./up.js";
-import { readPid } from "../process-control.js";
+import { readPid, readServerState } from "../process-control.js";
 import type { StartServerOptions, RunningServer } from "@brainpilot/backend-core";
 
 let dir: string;
@@ -191,6 +191,9 @@ describe("up — detached start", () => {
     expect(result.pid).toBe(4242);
     const pidFromFile = await readPid(join(root, ".runtime", "backend.pid"));
     expect(pidFromFile).toBe(4242);
+    // issue #41: detached up persists resolved ports for `status`.
+    const state = await readServerState(join(root, ".runtime", "server.json"));
+    expect(state).toEqual({ pid: 4242, port: 9700, runtimePort: 9701, host: "127.0.0.1" });
   });
 });
 

--- a/packages/cli/src/commands/up.ts
+++ b/packages/cli/src/commands/up.ts
@@ -20,7 +20,7 @@ import { isMockMode } from "@brainpilot/runtime";
 import pc from "picocolors";
 import { resolveDataDir, dataPaths } from "../paths.js";
 import { scaffold, isScaffolded, DEFAULT_PORT } from "../scaffold.js";
-import { writePid } from "../process-control.js";
+import { writePid, writeServerState } from "../process-control.js";
 import { resolveWebDist } from "../web-dist.js";
 
 export interface UpOptions {
@@ -177,7 +177,16 @@ export async function up(
     );
   }
   const pid = await deps.spawnDetached(cfg);
-  await writePid(dataPaths(dataDir).backendPid, pid);
+  const paths = dataPaths(dataDir);
+  await writePid(paths.backendPid, pid);
+  // issue #41: persist the resolved ports so `status` (which has no --port)
+  // probes the real backend rather than the default. `down` removes this.
+  await writeServerState(paths.serverState, {
+    pid,
+    port: cfg.port,
+    runtimePort: cfg.runtimePort,
+    host: cfg.host,
+  });
   log(pc.green(`BrainPilot backend started (pid ${pid}) at ${pc.bold(url)}`));
   if (open) await maybeOpen(deps, url);
   return { config: cfg, url, pid };

--- a/packages/cli/src/paths.ts
+++ b/packages/cli/src/paths.ts
@@ -50,6 +50,8 @@ export interface DataPaths {
   runtimeLog: string;
   backendPid: string;
   runtimePid: string;
+  /** Runtime state for a detached server (resolved ports/pid) — issue #41. */
+  serverState: string;
 }
 
 /** Build all derived paths from a data dir. Pure — no filesystem access. */
@@ -75,6 +77,7 @@ export function dataPaths(dataDir: string): DataPaths {
     runtimeLog: join(logsDir, "runtime.log"),
     backendPid: join(runtimeDir, "backend.pid"),
     runtimePid: join(runtimeDir, "runtime.pid"),
+    serverState: join(runtimeDir, "server.json"),
   };
 }
 

--- a/packages/cli/src/process-control.ts
+++ b/packages/cli/src/process-control.ts
@@ -54,6 +54,53 @@ export async function removePid(pidFile: string): Promise<void> {
   await rm(pidFile, { force: true });
 }
 
+/**
+ * Persisted runtime state for a detached server (issue #41). Written by `up`,
+ * read by `status` so it reports the actual ports without a repeated `--port`,
+ * removed by `down`.
+ */
+export interface ServerState {
+  pid: number;
+  port: number;
+  runtimePort: number;
+  host: string;
+}
+
+/** Write the detached server state file, creating parent dirs. */
+export async function writeServerState(
+  stateFile: string,
+  state: ServerState,
+): Promise<void> {
+  await mkdir(dirname(stateFile), { recursive: true });
+  await writeFile(stateFile, JSON.stringify(state), "utf8");
+}
+
+/** Read the detached server state, or null if missing/unparseable. */
+export async function readServerState(
+  stateFile: string,
+): Promise<ServerState | null> {
+  try {
+    const raw = await readFile(stateFile, "utf8");
+    const parsed = JSON.parse(raw) as Partial<ServerState>;
+    if (
+      typeof parsed.port === "number" &&
+      typeof parsed.runtimePort === "number" &&
+      typeof parsed.host === "string" &&
+      typeof parsed.pid === "number"
+    ) {
+      return parsed as ServerState;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Remove the detached server state file (no error if absent). */
+export async function removeServerState(stateFile: string): Promise<void> {
+  await rm(stateFile, { force: true });
+}
+
 /** Is the process recorded in `pidFile` currently alive? */
 export async function isRunning(
   pidFile: string,

--- a/packages/protocol/src/http.ts
+++ b/packages/protocol/src/http.ts
@@ -120,6 +120,19 @@ export const SendMessageRequestSchema = z.object({
   content: z.string(),
   /** Target agent; defaults to principal. */
   agent: z.string().optional(),
+  /**
+   * Optional client-supplied metadata (issue #42). The web composer sends the
+   * `uuid` it used for the optimistic user bubble so the runtime can persist a
+   * matching `TEXT_MESSAGE_CHUNK` (role:"user") under the same id — on reload
+   * the replayed event dedupes against the optimistic one by id rather than
+   * duplicating it.
+   */
+  data: z
+    .object({
+      uuid: z.string().optional(),
+      timestamp: z.string().optional(),
+    })
+    .optional(),
 });
 export type SendMessageRequest = z.infer<typeof SendMessageRequestSchema>;
 

--- a/packages/runtime/src/__tests__/agent-error.test.ts
+++ b/packages/runtime/src/__tests__/agent-error.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { normalizeAgentError } from "../agent-error.js";
+
+describe("normalizeAgentError (#45)", () => {
+  const noKeyRaw = [
+    "No API key found for the selected model.",
+    "",
+    "Use /login to log into a provider via OAuth or API key. See:",
+    "  /home/u/app/node_modules/@earendil-works/pi-coding-agent/docs/providers.md",
+    "  /home/u/app/node_modules/@earendil-works/pi-coding-agent/docs/models.md",
+  ].join("\n");
+
+  it("replaces the no-key SDK error with a Settings → Providers message", () => {
+    const out = normalizeAgentError(noKeyRaw);
+    expect(out).toContain("设置 → Providers");
+  });
+
+  it("never leaks /login or node_modules paths for the no-key case", () => {
+    const out = normalizeAgentError(noKeyRaw);
+    expect(out).not.toMatch(/\/login/i);
+    expect(out).not.toMatch(/node_modules/);
+  });
+
+  it("does not mention the BP_MOCK test switch", () => {
+    const out = normalizeAgentError(noKeyRaw);
+    expect(out).not.toMatch(/BP_MOCK/i);
+  });
+
+  it("redacts paths/login from other errors while keeping the message", () => {
+    const raw =
+      "Tool failed: cannot read config.\nUse /login first.\n/srv/app/node_modules/pkg/docs/x.md";
+    const out = normalizeAgentError(raw);
+    expect(out).toContain("Tool failed: cannot read config.");
+    expect(out).not.toMatch(/\/login/i);
+    expect(out).not.toMatch(/node_modules/);
+  });
+
+  it("leaves a clean error untouched", () => {
+    const raw = "Rate limit exceeded, retry in 30s.";
+    expect(normalizeAgentError(raw)).toBe(raw);
+  });
+
+  it("handles empty input", () => {
+    expect(normalizeAgentError("")).toBe("");
+  });
+});

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -55,6 +55,39 @@ describe("SessionManager (mock mode)", () => {
     expect(agents.map((a) => a.name)).toContain("principal");
   });
 
+  it("persists the user message as a role:user CHUNK with the client uuid (#42)", async () => {
+    const s = await m.createSession();
+    const events: AgUiEvent[] = [];
+    m.subscribe(s.id, (e) => events.push(e));
+
+    await m.sendMessage(s.id, "hello from user", "principal", { uuid: "u-123" });
+    await waitFor(() => events.some((e) => e.type === "RUN_FINISHED"));
+
+    const chunk = events.find((e) => e.type === "TEXT_MESSAGE_CHUNK") as
+      | (AgUiEvent & { message_id: string; role: string; delta: string })
+      | undefined;
+    expect(chunk).toBeDefined();
+    expect(chunk?.role).toBe("user");
+    expect(chunk?.message_id).toBe("u-123");
+    expect(chunk?.delta).toBe("hello from user");
+    expect(() => parseEvent(chunk as AgUiEvent)).not.toThrow();
+  });
+
+  it("falls back to a generated id when the client omits uuid (#42)", async () => {
+    const s = await m.createSession();
+    const events: AgUiEvent[] = [];
+    m.subscribe(s.id, (e) => events.push(e));
+
+    await m.sendMessage(s.id, "no uuid here");
+    await waitFor(() => events.some((e) => e.type === "TEXT_MESSAGE_CHUNK"));
+
+    const chunk = events.find((e) => e.type === "TEXT_MESSAGE_CHUNK") as
+      | (AgUiEvent & { message_id: string; role: string })
+      | undefined;
+    expect(chunk?.role).toBe("user");
+    expect(chunk?.message_id).toBeTruthy();
+  });
+
   it("passes app-controlled skill dirs (template + session) to the factory", async () => {
     const seen: string[][] = [];
     const spyFactory: typeof mockAgentFactory = async (params) => {

--- a/packages/runtime/src/agent-error.ts
+++ b/packages/runtime/src/agent-error.ts
@@ -1,0 +1,62 @@
+/**
+ * agent-error.ts — normalize raw agent/SDK error messages before they reach
+ * the user-facing event stream and events.jsonl (issue #45).
+ *
+ * Two jobs:
+ *  1. Recognize the "no provider / no API key" case and replace the raw Pi SDK
+ *     guidance (which points at `/login` and absolute node_modules doc paths)
+ *     with a product-level message that points at BrainPilot's own Settings →
+ *     Providers flow.
+ *  2. Redact local filesystem leakage (absolute node_modules paths, `/login`
+ *     hints) from any other error, so we never persist or display internal
+ *     install paths.
+ *
+ * Language follows the existing runtime system_message convention (Chinese).
+ */
+
+/** Product-level recovery message for a missing provider/key. */
+const NO_PROVIDER_MESSAGE =
+  "未配置任何 provider。请打开 设置 → Providers 添加一个 provider。";
+
+/** Heuristics for the "no key / no provider configured" class of error. */
+function isNoProviderError(raw: string): boolean {
+  return /no api key|no provider|api key found|api key for the selected model/i.test(
+    raw,
+  );
+}
+
+/**
+ * Strip local-path / `/login` leakage from an arbitrary error string while
+ * keeping its semantic content. Best-effort — drops lines that are purely an
+ * absolute node_modules doc path or a `/login` hint, and scrubs any inline
+ * absolute path that reaches into node_modules.
+ */
+function redact(raw: string): string {
+  return raw
+    .split("\n")
+    .filter((line) => {
+      const t = line.trim();
+      if (/use \/login/i.test(t)) return false;
+      // A line that is just an absolute path into node_modules (doc pointer).
+      if (/^\/?\S*node_modules\/\S+$/.test(t)) return false;
+      return true;
+    })
+    .map((line) =>
+      // Scrub any remaining inline absolute node_modules path.
+      line.replace(/\/\S*node_modules\/\S+/g, "").trimEnd(),
+    )
+    .join("\n")
+    .replace(/\n{2,}/g, "\n")
+    .trim();
+}
+
+/**
+ * Normalize a raw agent error message for user display + persistence.
+ * - No-provider/no-key errors → a product-level Settings → Providers message.
+ * - Everything else → the original message with local paths / `/login` redacted.
+ */
+export function normalizeAgentError(raw: string): string {
+  if (!raw) return raw;
+  if (isNoProviderError(raw)) return NO_PROVIDER_MESSAGE;
+  return redact(raw);
+}

--- a/packages/runtime/src/events.ts
+++ b/packages/runtime/src/events.ts
@@ -61,6 +61,19 @@ export const ev = {
   textMessageEnd(ctx: Ctx, messageId: string): AgUiEvent {
     return { type: "TEXT_MESSAGE_END", ...envelope(ctx), message_id: messageId } as AgUiEvent;
   },
+  /**
+   * Atomic text message (issue #42). CHUNK is the AG-UI shorthand for the
+   * START→CONTENT→END triad; the client transformer/reducer expands it. We use
+   * it with role:"user" to persist + replay the user's own prompt as a bubble
+   * in the event stream. AG-UI's canonical carrier for user input is
+   * `RunAgentInput.messages`/`MESSAGES_SNAPSHOT`, but BrainPilot's whole
+   * history/replay path is the events.jsonl stream, and the spec explicitly
+   * permits a single role:"user" CHUNK to echo a user bubble into the output
+   * stream — which is exactly this case.
+   */
+  textMessageChunk(ctx: Ctx, messageId: string, delta: string, role = "assistant"): AgUiEvent {
+    return { type: "TEXT_MESSAGE_CHUNK", ...envelope(ctx), message_id: messageId, role, delta } as AgUiEvent;
+  },
   reasoningMessageStart(ctx: Ctx, messageId: string): AgUiEvent {
     return { type: "REASONING_MESSAGE_START", ...envelope(ctx), message_id: messageId } as AgUiEvent;
   },

--- a/packages/runtime/src/mas-agent.ts
+++ b/packages/runtime/src/mas-agent.ts
@@ -13,6 +13,7 @@
 import type { AgUiEvent, AgentState } from "@brainpilot/protocol";
 import type { EventBus } from "./event-bus.js";
 import { ev, newMessageId, newRunId } from "./events.js";
+import { normalizeAgentError } from "./agent-error.js";
 import type {
   AgentRole,
   IAgentSession,
@@ -99,8 +100,12 @@ export class MasAgent {
       );
       if (this._status !== "error") this.setStatus("idle");
     } catch (err) {
-      const message = (err as Error)?.message ?? String(err);
-      this.recordError(message, (err as Error)?.stack);
+      const raw = (err as Error)?.message ?? String(err);
+      // issue #45: never surface raw SDK guidance (/login, node_modules paths)
+      // — normalize to a product message / redact local paths before it hits
+      // the event stream, events.jsonl, and lastError.
+      const message = normalizeAgentError(raw);
+      this.recordError(message);
       this.bus.emit(
         ev.runError({ sessionId: this.sessionId, agentName: this.name, runId: this.currentRunId }, message),
       );

--- a/packages/runtime/src/server.ts
+++ b/packages/runtime/src/server.ts
@@ -75,7 +75,9 @@ export function createServer(opts: SessionManagerOptions & { manager?: SessionMa
     const parsed = SendMessageRequestSchema.safeParse(body);
     if (!parsed.success) return c.json({ error: "invalid body" }, 400);
     if (!manager.getSession(id)) return c.json({ error: "not found" }, 404);
-    const res = await manager.sendMessage(id, parsed.data.content, parsed.data.agent ?? "principal");
+    const res = await manager.sendMessage(id, parsed.data.content, parsed.data.agent ?? "principal", {
+      uuid: parsed.data.data?.uuid,
+    });
     return c.json(res);
   });
 

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -360,7 +360,12 @@ export class SessionManager {
   /* ----------------------------- messaging ----------------------------- */
 
   /** Send a user message to an agent (default principal). §7 L3 isolated. */
-  async sendMessage(sessionId: string, content: string, agentName = "principal"): Promise<{ accepted: boolean; runId?: string }> {
+  async sendMessage(
+    sessionId: string,
+    content: string,
+    agentName = "principal",
+    opts: { uuid?: string } = {},
+  ): Promise<{ accepted: boolean; runId?: string }> {
     const entry = this.sessions.get(sessionId);
     if (!entry) throw new Error(`session not found: ${sessionId}`);
     this.touch(entry);
@@ -379,6 +384,14 @@ export class SessionManager {
     entry.runActive = true;
     entry.activeRunId = `run_${randomUUID()}`;
     const runId = entry.activeRunId;
+    // issue #42: persist + broadcast the user's own prompt as a role:"user"
+    // CHUNK *before* the agent runs, so SSE replay reconstructs the full
+    // transcript (user + assistant). The web composer's optimistic bubble uses
+    // the same `uuid`, so the reducer dedupes the replayed event by id rather
+    // than duplicating it. Fall back to a fresh id if the client omitted one.
+    entry.bus.emit(
+      ev.textMessageChunk({ sessionId, agentName, runId }, opts.uuid ?? randomUUID(), content, "user"),
+    );
     // Fire-and-track: don't block the HTTP response on the full run.
     void agent
       .prompt(content)

--- a/packages/web/src/components/chat/PromptComposer.tsx
+++ b/packages/web/src/components/chat/PromptComposer.tsx
@@ -21,6 +21,10 @@ export function PromptComposer() {
   // 可用命令（已通过真实 API 测试 /context ✅ /cost ✅；/compact 由 SDK 内置 ✅）
   // 不可用命令（已移除）：/usage ❌ /clear ❌ /init ❌
   const DEFAULT_SLASH_COMMANDS = ["/compact", "/context", "/cost"];
+  // issue #43: temporarily hide the whole slash-command button until the
+  // dynamic command list (GET /sessions/:id/commands) is implemented backend
+  // side. Flip to true to restore. Code below is kept intact for that.
+  const SHOW_SLASH_COMMANDS = false;
   const [slashCommands, setSlashCommands] = useState<string[]>(DEFAULT_SLASH_COMMANDS);
 
   const [showCommands, setShowCommands] = useState(false);
@@ -77,29 +81,10 @@ export function PromptComposer() {
     };
   }, []);
 
-  useEffect(() => {
-    let cancelled = false;
-    if (!currentSession) {
-      setSlashCommands(DEFAULT_SLASH_COMMANDS);
-      return;
-    }
-    void api.sessions.commands(currentSession.id).then((res) => {
-      if (!cancelled) {
-        // Only override defaults when the backend actually returned commands
-        if (res.commands.length > 0) {
-          setSlashCommands(res.commands);
-        }
-      }
-    }).catch(() => {
-      if (!cancelled) {
-        // Keep defaults on API failure so the button stays visible
-        setSlashCommands(DEFAULT_SLASH_COMMANDS);
-      }
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [currentSession?.id]);
+  // issue #43: the dynamic slash-command list (GET /sessions/:id/commands) is
+  // not implemented on the backend yet — fetching it 404'd on every selected
+  // session. The whole slash-command button is hidden below until that lands,
+  // so we no longer fetch and just keep the local DEFAULT_SLASH_COMMANDS.
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -280,7 +265,7 @@ export function PromptComposer() {
               <IconButton label={t("chat.aria.attachContext")}>
                 <Plus size={18} />
               </IconButton>
-              {slashCommands.length > 0 && (
+              {SHOW_SLASH_COMMANDS && slashCommands.length > 0 && (
                 <div className="command-picker" ref={commandsRef}>
                   <IconButton
                     label={t("chat.command")}

--- a/packages/web/src/components/sidebar/Sidebar.tsx
+++ b/packages/web/src/components/sidebar/Sidebar.tsx
@@ -1,12 +1,10 @@
 import {
-  Clock3,
   Check,
   MessageCircle,
   MessageSquarePlus,
   MonitorPlay,
   PanelLeft,
   PenLine,
-  Plug,
   Search,
   Settings,
   Trash2,
@@ -80,6 +78,11 @@ export function Sidebar({ isCollapsed, activePage, onOpenDemo, onGoWorkspace, on
           <PenLine size={16} />
           <span>{t("sidebar.newChat")}</span>
         </button>
+        {/*
+          issue #44: 插件 / 自动化 have no view yet — as clickable no-op buttons
+          they read as broken navigation. Hidden until the views exist; the
+          i18n keys (sidebar.plugins / sidebar.automations) are kept. Re-add the
+          Plug / Clock3 lucide imports when restoring these.
         <button className="nav-item" type="button">
           <Plug size={16} />
           <span>{t("sidebar.plugins")}</span>
@@ -88,6 +91,7 @@ export function Sidebar({ isCollapsed, activePage, onOpenDemo, onGoWorkspace, on
           <Clock3 size={16} />
           <span>{t("sidebar.automations")}</span>
         </button>
+        */}
         <button
           className={`nav-item ${activePage === "demo" ? "is-active" : ""}`}
           onClick={onOpenDemo}


### PR DESCRIPTION
修复 QA(@HaoxuanLiTHUAI)对 `v0.0.5` 提的 5 个 issue。真 bug 修根因(#41/#42/#45),未就绪的 UI 先隐藏入口、保留代码待后续(#43/#44)。

## 改动

- **#42** 🔴 刷新后用户消息丢失(数据完整性)
  `SessionManager.sendMessage` 从不发用户消息事件,故 `events.jsonl` 仅含 assistant 事件,replay 丢用户气泡。改为 agent 运行前发单个 `TEXT_MESSAGE_CHUNK`(`role:"user"`),message_id 复用前端 `data.uuid`,reducer 按 id 去重(与乐观气泡合并,不重复)。

- **#41** `status` 读不到 detached `up --port` 的自定义端口
  `up` 写 `.runtime/server.json`;`status` 端口优先级 `--port > server.json > BP_PORT > DEFAULT`;`down` 清理。

- **#45** 无 key 首条消息泄露 SDK `/login` 与 `node_modules` 路径
  新增 `normalizeAgentError`:无 provider→指向 设置→Providers(不含 mock);其它错误脱敏路径/`/login`。`RUN_ERROR`/`system_message`/`lastError` 统一用归一化结果;不再持久化调用栈。

- **#43** 前端请求未实现的 `/sessions/:id/commands` → 404
  移除该 fetch 并临时隐藏整个 slash 命令按钮(代码保留)。

- **#44** 侧边栏 `插件`/`自动化` 点击无反应
  临时隐藏这两个入口(i18n/代码保留)。

## 验证

- `npm run typecheck` ✅
- 非 web 测试 **305 passed**(新增 #42/#41/#45 单测)✅
- web `build` ✅ + web 测试 **40 passed** ✅
- `bash scripts/smoke-e2e.sh` ✅ —— 流首出现 `[TEXT_MESSAGE_CHUNK]`,#42 端到端贯通

Closes #41
Closes #42
Closes #43
Closes #44
Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)