### PR TITLE
fix(backend): make ensureRuntime single-flight + backstop orphan runtime (#58)

### DIFF
--- a/packages/backend-core/src/local-orchestrator.ts
+++ b/packages/backend-core/src/local-orchestrator.ts
@@ -114,6 +114,22 @@ export class LocalProcessOrchestrator implements Orchestrator {
   private stopping = false;
   private gaveUp = false;
   private lastEnv: NodeJS.ProcessEnv = {};
+  /**
+   * In-flight startup promise (issue #58). ensureRuntime() is single-flight:
+   * concurrent first-run callers share this one promise instead of each
+   * spawning their own runtime child (which raced for the port and crashed the
+   * losers with EADDRINUSE). Null when no startup is in progress.
+   */
+  private starting: Promise<RuntimeHandle> | null = null;
+  /**
+   * Set once the runtime has become healthy at least once (issue #58). The
+   * crash-restart self-heal (§11A.5) is only meant for a runtime that was
+   * healthy and later died — NOT for a first-start spawn that immediately
+   * exits (e.g. a duplicate that lost the port race). While this is false, an
+   * exiting child does not trigger a restart; ensureRuntime's waitForHealth
+   * surfaces the failure instead.
+   */
+  private everHealthy = false;
 
   constructor(options: LocalOrchestratorOptions = {}) {
     this.opts = {
@@ -175,12 +191,30 @@ export class LocalProcessOrchestrator implements Orchestrator {
       return this.handle;
     }
 
-    this.lastEnv = this.buildEnv(opts?.env);
-    this.spawnChild(this.lastEnv);
+    // Single-flight (issue #58): if a startup is already in progress, every
+    // concurrent caller rides the same promise rather than spawning its own
+    // runtime child. This is what prevents the cold-start spawn storm where N
+    // simultaneous requests each spawned a runtime and N-1 crashed on
+    // EADDRINUSE. opts.dataDir/port from a piggybacking caller are ignored on
+    // purpose — a given backend/data-dir has exactly one runtime.
+    if (this.starting) {
+      return this.starting;
+    }
 
-    await this.waitForHealth();
-    this.handle = { baseUrl: this.baseUrl };
-    return this.handle;
+    this.starting = (async () => {
+      this.lastEnv = this.buildEnv(opts?.env);
+      this.spawnChild(this.lastEnv);
+      await this.waitForHealth();
+      this.handle = { baseUrl: this.baseUrl };
+      return this.handle;
+    })();
+
+    try {
+      return await this.starting;
+    } finally {
+      // Clear so a later call can retry (e.g. if waitForHealth threw).
+      this.starting = null;
+    }
   }
 
   async health(): Promise<boolean> {
@@ -190,6 +224,7 @@ export class LocalProcessOrchestrator implements Orchestrator {
 
   async stopRuntime(): Promise<void> {
     this.stopping = true;
+    this.everHealthy = false;
     const child = this.child;
     this.child = null;
     this.handle = null;
@@ -286,6 +321,17 @@ export class LocalProcessOrchestrator implements Orchestrator {
 
   private async handleExit(err: Error): Promise<void> {
     if (this.stopping || this.gaveUp) return;
+    // Issue #58: a child that exits before the runtime ever became healthy is a
+    // failed *startup*, not a crash of a running service. The restart self-heal
+    // (§11A.5) is only for an already-healthy runtime that later died. A
+    // first-start exit (e.g. a duplicate spawn that lost the port race and got
+    // EADDRINUSE) must NOT enter the restart loop — that loop is what flooded
+    // runtime.log and clobbered this.child. Just drop the child and let
+    // ensureRuntime's waitForHealth surface the failure.
+    if (!this.everHealthy) {
+      this.child = null;
+      return;
+    }
     const now = Date.now();
     this.restartTimestamps = this.restartTimestamps.filter(
       (ts) => now - ts < this.opts.restartWindowMs,
@@ -313,7 +359,12 @@ export class LocalProcessOrchestrator implements Orchestrator {
     const deadline = Date.now() + this.opts.healthTimeoutMs;
     // Poll until healthy or timeout. Spacing is small for local startup.
     for (;;) {
-      if (await this.opts.healthProbe(this.baseUrl)) return;
+      if (await this.opts.healthProbe(this.baseUrl)) {
+        // Mark healthy so a later abnormal exit is eligible for the restart
+        // self-heal (issue #58) — first-start exits before this are not.
+        this.everHealthy = true;
+        return;
+      }
       if (Date.now() >= deadline) {
         throw new Error(
           `runtime did not become healthy at ${this.baseUrl} within ` +

--- a/packages/backend-core/test/local-orchestrator.test.ts
+++ b/packages/backend-core/test/local-orchestrator.test.ts
@@ -189,6 +189,85 @@ describe("LocalProcessOrchestrator restart logic", () => {
   });
 });
 
+describe("LocalProcessOrchestrator single-flight + first-start failure (#58)", () => {
+  it("is single-flight: concurrent ensureRuntime() spawns the runtime only once", async () => {
+    const proc = makeFakeProc();
+    const spawnFn = vi.fn(() => proc);
+    // Health gated on a switch we flip after the concurrent calls are in flight,
+    // so all callers must share the one in-flight startup promise.
+    let healthy = false;
+    const orch = new LocalProcessOrchestrator({
+      runtimeServerPath: "/s.js",
+      spawnFn,
+      healthProbe: async () => healthy,
+      sleep: async () => {},
+      healthTimeoutMs: 1000,
+    });
+
+    const calls = Array.from({ length: 12 }, () => orch.ensureRuntime());
+    // Let the first call spawn + start polling, then become healthy.
+    await Promise.resolve();
+    healthy = true;
+    const handles = await Promise.all(calls);
+
+    expect(spawnFn).toHaveBeenCalledTimes(1);
+    for (const h of handles) {
+      expect(h.baseUrl).toBe(handles[0]!.baseUrl);
+    }
+  });
+
+  it("does NOT enter the restart loop when a first-start child exits before ever being healthy", async () => {
+    const procs: ReturnType<typeof makeFakeProc>[] = [];
+    const spawnFn = vi.fn(() => {
+      const p = makeFakeProc();
+      procs.push(p);
+      return p;
+    });
+    // Never healthy: simulates a duplicate that lost the port race (EADDRINUSE)
+    // and exits. waitForHealth should time out; the exit must not restart.
+    const orch = new LocalProcessOrchestrator({
+      runtimeServerPath: "/s.js",
+      spawnFn,
+      healthProbe: async () => false,
+      sleep: async () => {},
+      healthTimeoutMs: 0,
+    });
+
+    await expect(orch.ensureRuntime()).rejects.toThrow(/did not become healthy/);
+    // The child "crashes" after the failed startup — must not trigger a restart.
+    procs[0]!.emitExit(1, null);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(spawnFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("can retry a fresh startup after a first-start failure", async () => {
+    const procs: ReturnType<typeof makeFakeProc>[] = [];
+    const spawnFn = vi.fn(() => {
+      const p = makeFakeProc();
+      procs.push(p);
+      return p;
+    });
+    let healthy = false;
+    const orch = new LocalProcessOrchestrator({
+      runtimeServerPath: "/s.js",
+      spawnFn,
+      healthProbe: async () => healthy,
+      sleep: async () => {},
+      healthTimeoutMs: 0,
+    });
+
+    await expect(orch.ensureRuntime()).rejects.toThrow(/did not become healthy/);
+    expect(spawnFn).toHaveBeenCalledTimes(1);
+
+    // starting was cleared, so a later call retries with a fresh spawn.
+    healthy = true;
+    const handle = await orch.ensureRuntime();
+    expect(handle.baseUrl).toBe("http://127.0.0.1:8081");
+    expect(spawnFn).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe("Orchestrator interface conformance", () => {
   it("LocalProcessOrchestrator implements ensureRuntime/health/stopRuntime", () => {
     const orch = new LocalProcessOrchestrator();

--- a/packages/cli/src/commands/down-status.test.ts
+++ b/packages/cli/src/commands/down-status.test.ts
@@ -82,6 +82,36 @@ describe("down", () => {
     await down({ dir: root }, { ...procs, log: () => {} });
     expect(await readServerState(p.serverState)).toBeNull();
   });
+
+  it("backstops an orphaned runtime via runtime.pid (#58)", async () => {
+    const root = join(dir, "bp");
+    const p = dataPaths(root);
+    // Backend already gone, but the orchestrator lost track of the runtime, so
+    // runtime.pid still points at a live runtime on port+1.
+    await writePid(p.backendPid, 1000);
+    await writePid(p.runtimePid, 2000);
+    const procs = fakeProcs(new Set([1000, 2000]));
+
+    await down({ dir: root }, { ...procs, log: () => {} });
+
+    // Both the backend and the orphaned runtime must be signalled.
+    expect(procs.signals).toContainEqual({ pid: 1000, sig: "SIGTERM" });
+    expect(procs.signals).toContainEqual({ pid: 2000, sig: "SIGTERM" });
+    // And the runtime pid file is cleaned up by stop().
+    expect(await readPid(p.runtimePid)).toBeNull();
+  });
+
+  it("is a no-op for the runtime when no runtime.pid file exists (#58)", async () => {
+    const root = join(dir, "bp");
+    const p = dataPaths(root);
+    await writePid(p.backendPid, 1234);
+    const procs = fakeProcs(new Set([1234]));
+
+    const res = await down({ dir: root }, { ...procs, log: () => {} });
+    expect(res.stopped).toBe(true);
+    // Only the backend was signalled; no runtime pid to chase.
+    expect(procs.signals).toEqual([{ pid: 1234, sig: "SIGTERM" }]);
+  });
 });
 
 describe("status", () => {

--- a/packages/cli/src/commands/down.ts
+++ b/packages/cli/src/commands/down.ts
@@ -1,12 +1,14 @@
 /**
  * commands/down.ts — stop the detached backend (TS_PI_REFACTOR_DESIGN §11A.4).
  * Reads `.runtime/backend.pid`, gracefully stops it (SIGTERM→SIGKILL). The
- * backend's own LocalProcessOrchestrator stops the runtime child on shutdown,
- * but we also clean up a stale runtime.pid if present.
+ * backend's own LocalProcessOrchestrator normally stops the runtime child on
+ * shutdown, but if the orchestrator lost track of it (issue #58 — the spawn
+ * storm could orphan the surviving runtime on port+1), we also stop whatever
+ * `.runtime/runtime.pid` points at as a backstop.
  */
 import pc from "picocolors";
 import { resolveDataDir, dataPaths } from "../paths.js";
-import { stop, removePid, removeServerState, type ProcessControlDeps } from "../process-control.js";
+import { stop, removeServerState, type ProcessControlDeps } from "../process-control.js";
 
 export interface DownOptions {
   dir?: string;
@@ -40,8 +42,17 @@ export async function down(
     sleep: deps.sleep,
   });
 
-  // Backend owns the runtime; clean any leftover runtime pid file regardless.
-  await removePid(p.runtimePid);
+  // Backstop the runtime (issue #58): the backend normally kills its runtime
+  // child and removes runtime.pid on shutdown, in which case this stop() reads
+  // no pid and is a no-op. But if the orchestrator lost track during a failed
+  // spawn storm, the real runtime can survive as an orphan on port+1 — stop()
+  // reads runtime.pid and actually SIGTERM/SIGKILLs it. Idempotent either way.
+  await stop(p.runtimePid, {
+    timeoutMs: options.timeoutMs,
+    isAlive: deps.isAlive,
+    signal: deps.signal,
+    sleep: deps.sleep,
+  });
   // Drop the persisted server state so a later `status` doesn't report a dead
   // server's ports (issue #41).
   await removeServerState(p.serverState);


### PR DESCRIPTION
## Summary

Fixes #58 — a cold-start concurrency race in `LocalProcessOrchestrator`.

On a fresh self-hosted local backend, multiple concurrent runtime-backed requests raced inside `ensureRuntime()`. It was not single-flight, so N concurrent first-run callers each spawned a runtime child and N-1 crashed with `EADDRINUSE`. The crashes then drove the restart self-heal loop (flooding `runtime.log`) and clobbered `this.child`, so `brainpilot down` lost track of the surviving runtime and left it orphaned on `port+1`.

## Changes

- **single-flight** (`local-orchestrator.ts` `ensureRuntime`): concurrent callers share one in-flight startup promise; the runtime is spawned exactly once per backend/data-dir. This removes the spawn storm at the root.
- **`everHealthy` guard** (`handleExit`/`waitForHealth`/`stopRuntime`): a child that exits before the runtime ever became healthy is a failed *startup*, not a crash of a running service — it no longer enters the restart loop or floods the log. The §11A.5 self-heal stays intact for an already-healthy runtime that later dies.
- **`down` backstop** (`commands/down.ts`): `down` now `stop()`s whatever `.runtime/runtime.pid` points at (read pid → SIGTERM → SIGKILL → remove file), reaping an orphaned runtime even when the orchestrator lost track. Idempotent — a no-op on the normal shutdown path.

## Tests

- orchestrator: single-flight (12 concurrent → 1 spawn), first-start-exit does not restart, retry-after-failure, self-heal regression (already-healthy crash still restarts).
- `down`: backstops an orphaned runtime via `runtime.pid`; no-op when no `runtime.pid` exists.
- Full gates green: typecheck, 345 non-web tests, web 40 tests + build, `scripts/smoke-e2e.sh`.

## Manual verification (QA repro)

```
BP_MOCK=1 node packages/cli/dist/bin.js up --detach --no-open --port 10131 --dir <fresh>
# 12 concurrent GET /api/sessions
```

- `runtime.log` shows a single `listening on :10132` line — **no `EADDRINUSE`, no restart noise** (vs. the QA report's repeated `listening` + `fatal EADDRINUSE`).
- After `down`, neither `:10131` nor `:10132` is left listening; pid files cleaned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)