### PR TITLE
fix: reject empty provider models (#61) + route composer uploads to session workspace (#60)

### DIFF
--- a/packages/backend-core/test/app.test.ts
+++ b/packages/backend-core/test/app.test.ts
@@ -401,6 +401,22 @@ describe("Hono app — local config routes", () => {
       expect(res.status).toBe(400);
     });
 
+    it("rejects an empty models array with 400 (#61)", async () => {
+      const { app } = await provApp();
+      const res = await postProfile(app, { name: "empty-first", base_url: "", api_key: "sk-empty", models: [] });
+      expect(res.status).toBe(400);
+      // The empty-models profile must not have been persisted or activated.
+      expect((await app.request("/api/provider/profiles/active")).status).toBe(204);
+      const list = (await (await app.request("/api/provider/profiles")).json()) as unknown[];
+      expect(list).toHaveLength(0);
+    });
+
+    it("rejects a create with no models field at all with 400 (#61)", async () => {
+      const { app } = await provApp();
+      const res = await postProfile(app, { name: "no-models", base_url: "https://x", api_key: "sk-x" });
+      expect(res.status).toBe(400);
+    });
+
     it("does not persist or activate an invalid profile", async () => {
       const { app } = await provApp();
       await postProfile(app, { name: "", base_url: "https://x", api_key: "sk-x", models: ["m"] });

--- a/packages/protocol/src/domain.ts
+++ b/packages/protocol/src/domain.ts
@@ -229,19 +229,25 @@ export const ProviderProfileSchema = z.object({
 export type ProviderProfile = z.infer<typeof ProviderProfileSchema>;
 
 /**
- * #50: validation SSOT for the provider-profile create/update *wire body* (the
- * snake_case shape the SPA POSTs/PUTs). The backend safeParses against these
- * before persisting, so malformed input 400s instead of silently producing an
- * unusable active profile (empty name, `models:"m"` coerced to `[]`).
+ * #50 / #61: validation SSOT for the provider-profile create/update *wire body*
+ * (the snake_case shape the SPA POSTs/PUTs). The backend safeParses against
+ * these before persisting, so malformed input 400s instead of silently
+ * producing an unusable active profile (empty name, `models:"m"` coerced to
+ * `[]`, or — #61 — an empty `models: []` that becomes the active provider with
+ * no selectable model).
  *
- * `models`, when present, must be an array of non-empty strings — a non-array
- * value (e.g. the string "m") is a hard error, not a silent empty list.
+ * `models` must be a non-empty array of non-empty strings: a non-array value
+ * (e.g. the string "m") is a hard error, and an empty list `[]` is rejected
+ * too. On *create* the field is required — a fresh install's first profile is
+ * auto-selected as active, so it must carry at least one usable model. On
+ * *update* (the `.partial()` schema) the field may be omitted to leave models
+ * unchanged, but when present it still must be non-empty.
  */
 const modelsField = z
   .array(z.string().trim().min(1), {
     message: "models must be an array of non-empty strings",
   })
-  .optional();
+  .min(1, "models must not be empty");
 
 export const ProviderProfileCreateSchema = z.object({
   name: z.string().trim().min(1, "name is required"),
@@ -257,7 +263,11 @@ export const ProviderProfileCreateSchema = z.object({
 });
 export type ProviderProfileCreate = z.infer<typeof ProviderProfileCreateSchema>;
 
-/** Update is a partial patch: every field optional, but same shape rules when present. */
+/**
+ * Update is a partial patch: every field optional (omitting `models` leaves it
+ * unchanged), but each field keeps its create-time rule when present — so a
+ * supplied `models` must still be a non-empty array (#61).
+ */
 export const ProviderProfileUpdateSchema = ProviderProfileCreateSchema.partial();
 export type ProviderProfileUpdate = z.infer<typeof ProviderProfileUpdateSchema>;
 

--- a/packages/runtime/src/__tests__/server.test.ts
+++ b/packages/runtime/src/__tests__/server.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, writeFile, readFile, readdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createServer } from "../server.js";
@@ -230,6 +230,39 @@ describe("workspace file routes", () => {
       body: JSON.stringify({ path: "" }),
     });
     expect(res.status).toBe(400);
+  });
+
+  // #60: a composer upload staged under workspaces/local/ (the draft sandbox id)
+  // must be drained into the real session workspace before the agent runs, so
+  // the agent's cwd (workspaces/<sid>/) contains the file the user attached.
+  it("drains a staged local upload into the session workspace on sendMessage (#60)", async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), "bp-drain-"));
+    const manager = new SessionManager({ persist: true, dataRoot, agentFactory: mockAgentFactory });
+
+    // Simulate the draft-composer upload: web POSTs against the "local" sandbox
+    // id because the real session does not exist yet.
+    await manager.writeSessionFile(
+      "local",
+      "/workspace/attachment-probe.txt",
+      Buffer.from("probe payload").toString("base64"),
+    );
+
+    // The real session is created when the prompt is sent.
+    const session = await manager.createSession({ title: "Draft" });
+    await manager.sendMessage(session.id, "Please summarize the uploaded attachment.");
+
+    // The file now lives in the agent's cwd (the session workspace)...
+    const inSession = await readFile(
+      join(dataRoot, "workspaces", session.id, "attachment-probe.txt"),
+      "utf8",
+    );
+    expect(inSession).toBe("probe payload");
+
+    // ...and the staging area was drained so it can't leak into a later session.
+    const staged = await readdir(join(dataRoot, "workspaces", "local"));
+    expect(staged).toEqual([]);
+
+    manager.shutdown();
   });
 });
 

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -9,7 +9,7 @@
  * Persistence (§5): config/history/state live under `<dataRoot>/.bp/{sid}/`,
  * work files under `<dataRoot>/workspaces/{sid}/`.
  */
-import { mkdir, readFile, writeFile, readdir, rm, stat } from "node:fs/promises";
+import { mkdir, readFile, writeFile, readdir, rm, stat, rename } from "node:fs/promises";
 import { join, resolve, sep, dirname } from "node:path";
 import { randomUUID } from "node:crypto";
 import type { AgUiEvent, AgentStatus, FileContent, FileEntry, Session, TraceGraph } from "@brainpilot/protocol";
@@ -131,6 +131,16 @@ export class SessionManager {
   private workspaceDir(sid: string): string {
     return join(this.dataRoot, "workspaces", sid);
   }
+  /**
+   * #60: composer uploads in single-user mode are POSTed against the literal
+   * sandbox id `"local"` (the web `LOCAL_SANDBOX.id`), because a file can be
+   * attached in the draft composer *before* the real session exists. They land
+   * in `workspaces/local/` — but the agent's cwd is `workspaces/<sessionId>/`,
+   * so without this it can't read the file the user just attached. We treat
+   * `workspaces/local/` as a staging area and drain it into the real session
+   * workspace right before the agent runs (see drainLocalUploads).
+   */
+  private static readonly UPLOAD_STAGING_SID = "local";
   private historyPath(sid: string, agent: string): string {
     return join(this.bpDir(sid), "history", `${agent}.jsonl`);
   }
@@ -253,6 +263,81 @@ export class SessionManager {
     const root = this.workspaceDir(sid);
     const relOut = abs === root ? "" : abs.slice(root.length + 1);
     return { path: relOut, size: buf.byteLength };
+  }
+
+  /**
+   * #60: drain the composer upload staging area (`workspaces/local/`) into a
+   * real session's workspace so the agent — whose cwd is `workspaces/<sid>/` —
+   * can read files the user attached in the draft composer (when no real
+   * session id existed yet, the web uploads against the literal `"local"`
+   * sandbox id). Called right before the agent runs.
+   *
+   * Move semantics: each staged entry is renamed into the session workspace
+   * (an existing same-named entry in the session is left untouched and the
+   * staged copy is discarded), then the staging area is emptied so files never
+   * leak into the next session. No-op when the target IS the staging sid, or
+   * when the staging dir is missing/empty. Best-effort: never throws — a copy
+   * failure must not block the user's prompt.
+   */
+  private async drainLocalUploads(sessionId: string): Promise<void> {
+    if (sessionId === SessionManager.UPLOAD_STAGING_SID) return;
+    const stagingDir = this.workspaceDir(SessionManager.UPLOAD_STAGING_SID);
+    let names: string[];
+    try {
+      names = await readdir(stagingDir);
+    } catch {
+      return; // no staging dir → nothing was uploaded in the draft
+    }
+    if (names.length === 0) return;
+    const destDir = this.workspaceDir(sessionId);
+    try {
+      await mkdir(destDir, { recursive: true });
+    } catch {
+      /* best-effort */
+    }
+    for (const name of names) {
+      const from = join(stagingDir, name);
+      const to = join(destDir, name);
+      try {
+        // Don't clobber an existing session file; just drop the staged copy.
+        let exists = false;
+        try {
+          await stat(to);
+          exists = true;
+        } catch {
+          /* target absent → safe to move */
+        }
+        if (exists) {
+          await rm(from, { recursive: true, force: true });
+          continue;
+        }
+        await rename(from, to);
+      } catch {
+        // rename failed (e.g. cross-device, or `from` is a directory on some
+        // platforms): fall back to a content copy so the file still reaches the
+        // session, then remove the staged copy. Best-effort, never throws.
+        try {
+          await this.copyEntry(from, to);
+          await rm(from, { recursive: true, force: true });
+        } catch {
+          /* give up on this entry */
+        }
+      }
+    }
+  }
+
+  /** Recursively copy a file or directory tree (drainLocalUploads fallback). */
+  private async copyEntry(from: string, to: string): Promise<void> {
+    const st = await stat(from);
+    if (st.isDirectory()) {
+      await mkdir(to, { recursive: true });
+      for (const child of await readdir(from)) {
+        await this.copyEntry(join(from, child), join(to, child));
+      }
+      return;
+    }
+    await mkdir(dirname(to), { recursive: true });
+    await writeFile(to, await readFile(from));
   }
 
   /**
@@ -408,6 +493,10 @@ export class SessionManager {
       return { accepted: false };
     }
     const agent = await this.ensureAgent(sessionId, agentName);
+    // #60: pull any composer uploads staged under workspaces/local/ into this
+    // session's workspace (the agent's cwd) before it runs, so it can read the
+    // file the user just attached. No-op when nothing was staged.
+    await this.drainLocalUploads(sessionId);
     entry.runActive = true;
     entry.activeRunId = `run_${randomUUID()}`;
     const runId = entry.activeRunId;


### PR DESCRIPTION
## What

Two follow-ups surfaced by QA on `development` after PR #59. Bundled into one PR as discussed.

### #61 — Provider profile validation still allowed an empty models list
The #50 hardening rejected a non-array `models`, but `models: []` (or omitting the field on create) still returned `201` and became the auto-selected active provider with **no usable model** — recreating exactly the unusable-active-provider class #50 was meant to close.

- Tighten the protocol SSOT (`modelsField` in `packages/protocol/src/domain.ts`) to a **non-empty** array.
- **Create** now requires at least one model; **update** (the `.partial()` schema) may omit `models` but must be non-empty when present.
- The imperative `createProfile` scaffold path is unaffected (still defaults to `[]`); only the HTTP wire body is guarded.

### #60 — Composer upload stored files in `workspaces/local/`, not the session workspace
A file attached in the draft composer is uploaded against the literal `LOCAL_SANDBOX` id (`"local"`) because no real session exists yet, so it lands in `workspaces/local/`. But the agent's cwd is `workspaces/<sessionId>/`, so it could **never read the file the user just attached**.

- Treat `workspaces/local/` as a staging area and **drain it into the real session workspace** in `sendMessage()`, right before the agent runs.
- `rename` with a recursive-copy fallback (cross-device); existing session files are not clobbered; staging is emptied so files never leak into a later session. Best-effort — a copy failure never blocks the prompt.

## Tests
- `app.test.ts`: empty-array and absent-models create both `400` and stay inactive (#61).
- `server.test.ts`: a staged `local` upload is drained into the session workspace on `sendMessage`, and staging ends empty (#60).
- Full gates green: `typecheck`, `npm test` (348), web test (40) + build, `smoke-e2e`.
- Verified end-to-end against a fresh `BP_MOCK` instance for both issues; clean `down` with no orphan ports.

Closes #60, #61 (manually — PR targets `development`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
