### PR TITLE
fix: keep Agents panel live during a session (closes #70)

### DIFF
--- a/packages/runtime/src/__tests__/state-authority.test.ts
+++ b/packages/runtime/src/__tests__/state-authority.test.ts
@@ -45,6 +45,55 @@ describe("state authority (§10)", () => {
     expect(after.memRss).toBeGreaterThan(0);
   });
 
+  // #70: the runtime must push CUSTOM:session_state snapshots so the web Agents
+  // panel updates live (without a reload/reselect). Previously the builder
+  // existed but was never called, leaving the panel blank until a /state poll.
+  it("emits CUSTOM:session_state snapshots on send + status transitions", async () => {
+    const m = new SessionManager({ persist: false, agentFactory: mockAgentFactory });
+    const s = await m.createSession();
+
+    type Snap = {
+      runState: { active: boolean; runId: string | null };
+      agents: Array<{ name: string; status: string }>;
+    };
+    const snapshots: Snap[] = [];
+    m.subscribe(s.id, (e) => {
+      if (e.type === "CUSTOM" && (e as { name?: string }).name === "session_state") {
+        snapshots.push((e as { value: Snap }).value);
+      }
+    });
+
+    await m.sendMessage(s.id, "hello");
+    await waitFor(() => {
+      const agents = m.listAgents(s.id);
+      return agents.length > 0 && agents[0]!.status === "idle";
+    });
+
+    // At least: initial frame (active) + running + idle.
+    expect(snapshots.length).toBeGreaterThanOrEqual(2);
+
+    // The first frame is the explicit initial one from sendMessage: run active,
+    // principal already present.
+    const first = snapshots[0]!;
+    expect(first.runState.active).toBe(true);
+    expect(first.agents.some((a) => a.name === "principal")).toBe(true);
+
+    // Somewhere we saw principal running, and the final snapshot is idle.
+    expect(
+      snapshots.some((sn) => sn.agents.some((a) => a.name === "principal" && a.status === "running")),
+    ).toBe(true);
+    const last = snapshots[snapshots.length - 1]!;
+    expect(last.agents.find((a) => a.name === "principal")?.status).toBe("idle");
+
+    // Reconnect snapshot: the ring buffer replay ends on the latest
+    // session_state, so a re-subscribing client recovers the idle state.
+    const replay = m.recentEvents(s.id).filter(
+      (e) => e.type === "CUSTOM" && (e as { name?: string }).name === "session_state",
+    );
+    const lastReplay = replay[replay.length - 1] as { value: Snap };
+    expect(lastReplay.value.agents.find((a) => a.name === "principal")?.status).toBe("idle");
+  });
+
   it("evict stops agents and drops the session from memory", async () => {
     const m = new SessionManager({ persist: false, agentFactory: mockAgentFactory });
     const s = await m.createSession();

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -500,6 +500,12 @@ export class SessionManager {
     entry.runActive = true;
     entry.activeRunId = `run_${randomUUID()}`;
     const runId = entry.activeRunId;
+    // #70: emit an initial session_state frame here — onStatusChange only fires
+    // on a status *change*, and ensureAgent creates the agent as idle without
+    // emitting, so without this the panel stays empty until the first
+    // setStatus("running"). This first frame carries runState.active=true + the
+    // freshly-ensured agent.
+    this.emitSessionState(entry);
     // issue #42: persist + broadcast the user's own prompt as a role:"user"
     // CHUNK *before* the agent runs, so SSE replay reconstructs the full
     // transcript (user + assistant). The web composer's optimistic bubble uses
@@ -587,7 +593,13 @@ export class SessionManager {
       role,
       session,
       bus: entry.bus,
-      onStatusChange: () => this.touch(entry),
+      // #70: keep the touch (idle-reclaim) AND push an authoritative live
+      // snapshot so the web Agents panel updates without a reload/reselect.
+      // setStatus early-returns on no-op transitions, so this never storms.
+      onStatusChange: () => {
+        this.touch(entry);
+        this.emitSessionState(entry);
+      },
     });
     entry.agents.set(name, agent);
     if (!entry.tasks.has(name)) entry.tasks.set(name, "");
@@ -620,6 +632,24 @@ export class SessionManager {
       };
       return out;
     });
+  }
+
+  /**
+   * #70: emit the authoritative live snapshot as a `CUSTOM:session_state`
+   * event. This is the wholesale source the web Agents panel replaces its
+   * agents list from; it is pushed on every agent status transition
+   * (`onStatusChange`) plus an initial frame in `sendMessage`. The ring buffer
+   * replays the last frame on reconnect, so a re-subscribing client recovers
+   * the current snapshot. Shape matches `SessionStateSnapshotSchema`.
+   */
+  private emitSessionState(entry: SessionEntry): void {
+    entry.bus.emit(
+      ev.custom({ sessionId: entry.id }, "session_state", {
+        runState: { active: entry.runActive, runId: entry.activeRunId },
+        agents: this.listAgents(entry.id),
+        lastActivityTs: new Date(entry.lastActivityAt).toISOString(),
+      }),
+    );
   }
 
   getSessionState(sessionId: string): {

--- a/packages/web/src/__tests__/agentsReducer.test.ts
+++ b/packages/web/src/__tests__/agentsReducer.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { reduceAgentsForEvent } from "../contexts/agentsReducer";
+import type { AgentStatus, WebSocketEvent } from "../contracts/backend";
+
+// #70: events arrive post-normalizeAgUiEvent (camelCase). agent_status_update's
+// authoritative agent key is the top-level `name` field; status is one of
+// idle|running|error|stopped (retrying normalized to running).
+
+const ev = (name: string, status: string): WebSocketEvent =>
+  ({ type: "agent_status_update", name, status } as WebSocketEvent);
+
+describe("reduceAgentsForEvent (#70)", () => {
+  it("appends an unknown agent with empty task", () => {
+    const out = reduceAgentsForEvent([], ev("librarian", "running"));
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ name: "librarian", status: "running", task: "", alive: true });
+  });
+
+  it("updates a known agent's status but preserves its task", () => {
+    const prev: AgentStatus[] = [
+      { name: "librarian", status: "idle", task: "读文档", updatedAt: "t0", alive: true },
+    ];
+    const out = reduceAgentsForEvent(prev, ev("librarian", "running"));
+    expect(out[0]!.status).toBe("running");
+    expect(out[0]!.task).toBe("读文档"); // task preserved
+    expect(out).not.toBe(prev); // new reference on change
+  });
+
+  it("returns the same reference on a no-op status", () => {
+    const prev: AgentStatus[] = [
+      { name: "principal", status: "running", task: "", updatedAt: "t0", alive: true },
+    ];
+    expect(reduceAgentsForEvent(prev, ev("principal", "running"))).toBe(prev);
+  });
+
+  it("ignores non agent_status_update events (same reference)", () => {
+    const prev: AgentStatus[] = [
+      { name: "principal", status: "idle", task: "", updatedAt: "t0", alive: true },
+    ];
+    expect(reduceAgentsForEvent(prev, { type: "RUN_STARTED" } as WebSocketEvent)).toBe(prev);
+  });
+
+  it("ignores events with an empty name", () => {
+    const prev: AgentStatus[] = [];
+    expect(reduceAgentsForEvent(prev, ev("", "running"))).toBe(prev);
+  });
+
+  it("marks a stopped agent as not alive", () => {
+    const out = reduceAgentsForEvent([], ev("librarian", "stopped"));
+    expect(out[0]).toMatchObject({ status: "stopped", alive: false });
+  });
+
+  it("normalizes retrying to running for the panel", () => {
+    const out = reduceAgentsForEvent([], ev("principal", "retrying"));
+    expect(out[0]!.status).toBe("running");
+  });
+
+  it("merges multiple agents independently", () => {
+    let agents: AgentStatus[] = [];
+    agents = reduceAgentsForEvent(agents, ev("principal", "running"));
+    agents = reduceAgentsForEvent(agents, ev("librarian", "running"));
+    agents = reduceAgentsForEvent(agents, ev("principal", "idle"));
+    expect(agents).toHaveLength(2);
+    expect(agents.find((a) => a.name === "principal")!.status).toBe("idle");
+    expect(agents.find((a) => a.name === "librarian")!.status).toBe("running");
+  });
+});

--- a/packages/web/src/contexts/SessionContext.tsx
+++ b/packages/web/src/contexts/SessionContext.tsx
@@ -14,6 +14,7 @@ import {
   generateUUID,
   reduceMessagesForEvent,
 } from "./messageReducer";
+import { reduceAgentsForEvent } from "./agentsReducer";
 
 export interface AgentMessageFilter {
   hideMessages: boolean;
@@ -506,6 +507,46 @@ export function SessionProvider({ children }: { children: ReactNode }) {
         continue;
       }
     }
+
+    // #70: keep the Agents panel live between session_state snapshots by merging
+    // standalone agent_status_update events. session_state (above) remains the
+    // wholesale authority; this applies single-agent deltas on top so the panel
+    // updates on the first run without a reload/reselect. The queue is already
+    // scoped to the current session (queueRef.get(sid)), so background-session
+    // events don't leak in here.
+    setAgents((current) => {
+      let nextAgents = current;
+      const appended: AgentStatus[] = [];
+      for (const event of queue) {
+        if (event.type !== "agent_status_update") continue;
+        const before = nextAgents;
+        nextAgents = reduceAgentsForEvent(nextAgents, event);
+        if (nextAgents.length > before.length) {
+          appended.push(nextAgents[nextAgents.length - 1]!);
+        }
+      }
+      if (appended.length > 0) {
+        // Apply the same default filters session_state uses for newly seen
+        // agents (trace: hide messages/tools; all: hide hooks).
+        setAgentFilters((cur) => {
+          let changed = false;
+          const nf = { ...cur };
+          for (const agent of appended) {
+            if (!cur[agent.name]) {
+              changed = true;
+              const isTrace = agent.name === "trace";
+              nf[agent.name] = {
+                hideMessages: isTrace,
+                hideTools: isTrace,
+                hideHooks: true,
+              };
+            }
+          }
+          return changed ? nf : cur;
+        });
+      }
+      return nextAgents;
+    });
 
     // Process all events through the message reducer.
     setMessagesBySession((current) => {

--- a/packages/web/src/contexts/agentsReducer.ts
+++ b/packages/web/src/contexts/agentsReducer.ts
@@ -1,0 +1,49 @@
+import type { AgentStatus, WebSocketEvent } from "../contracts/backend";
+
+/**
+ * #70: merge a single `agent_status_update` event into the Agents-panel list.
+ *
+ * The runtime emits `agent_status_update` on every agent status transition
+ * (idle/running/error/stopped). The panel's authoritative source is the
+ * wholesale `CUSTOM:session_state` snapshot, but those arrive only on
+ * transitions too — between them, and on the very first run, this incremental
+ * merge keeps the panel live without a reload/reselect.
+ *
+ * Merge rules:
+ *  - non-`agent_status_update` events return the same reference (no-op);
+ *  - the agent key is the event's top-level `name` (schema field; camelize
+ *    leaves the single word `name`/`status` untouched);
+ *  - a name not in the list is appended (task="" — the event carries no task);
+ *  - a known name has its status/updatedAt/alive updated but its **task
+ *    preserved** (only session_state / a /state poll carry task);
+ *  - a no-op status change returns the same reference to avoid a re-render;
+ *  - `retrying`/`auto_retry*` is normalized to `running` so the panel never
+ *    shows a non-canonical status (the auto-retry chat card is produced
+ *    independently by the message reducer).
+ */
+const RETRY_STATUSES = new Set(["retrying", "auto_retry", "auto_retry_start"]);
+
+export function reduceAgentsForEvent(
+  agents: AgentStatus[],
+  event: WebSocketEvent,
+): AgentStatus[] {
+  const e = event as Record<string, unknown>;
+  if (e.type !== "agent_status_update") return agents;
+
+  const name = String(e.name ?? "");
+  if (!name) return agents;
+
+  const rawStatus = String(e.status ?? "idle");
+  const status = RETRY_STATUSES.has(rawStatus.toLowerCase()) ? "running" : rawStatus;
+  const updatedAt = typeof e.updatedAt === "string" ? e.updatedAt : new Date().toISOString();
+  const alive = status !== "stopped";
+
+  const idx = agents.findIndex((a) => a.name === name);
+  if (idx === -1) {
+    return [...agents, { name, status, task: "", updatedAt, alive }];
+  }
+  if (agents[idx]!.status === status) return agents; // no-op → stable reference
+  const next = agents.slice();
+  next[idx] = { ...agents[idx]!, status, updatedAt, alive };
+  return next;
+}


### PR DESCRIPTION
## Problem (#70)

The Agents panel (`AgentNetwork`, "0/6 在线") stayed blank during a live session until a page reload/reselect, even though the backend had agent state (`GET /sessions/:id/agents` returned it, and the event log contained `agent_status_update`). First-run UX looked like no agent ever ran, while chat and trace worked.

## Root cause (two layers, verified)

1. **The runtime never emitted `CUSTOM:session_state`.** The `ev.custom` builder existed (`runtime/src/events.ts`) but had **zero call sites** — yet the web treats `session_state` as the authoritative snapshot for the panel (`SessionContext.tsx`), so the panel never received a push.
2. **The web dropped standalone `agent_status_update` events** for the panel. `messageReducer` only mapped `retrying` → auto_retry chat card; plain `running/idle/error/stopped` were discarded and never updated the agents list.

## Fix

**Backend (`@brainpilot/runtime`)** — new `emitSessionState(entry)` pushes a `CUSTOM:session_state` snapshot (shape = `SessionStateSnapshotSchema`) on every agent status transition (`onStatusChange`) plus an explicit initial frame in `sendMessage` (since `onStatusChange` only fires on a *change* and `ensureAgent` creates the agent idle without emitting). The SSE ring buffer replays the latest frame, so a reconnecting client recovers the current snapshot.

**Frontend (`@brainpilot/web`)** — new pure `reduceAgentsForEvent` merges single-agent `agent_status_update` deltas into the agents list (append unknown with empty `task`; update known `status`/`alive` while **preserving `task`** — the event carries none; `retrying` normalized to `running`). Wired into the `SessionContext` queue drain **after** the `session_state` authority pass, so the snapshot replaces wholesale and deltas layer on top. `session_state` remains the wholesale authority; the backstop `/state` fetch is unchanged.

## Tests

- `runtime/state-authority.test.ts`: asserts `session_state` frames are emitted on send + transitions (initial frame `runState.active=true` + principal; running→idle), and the ring-buffer replay ends on the latest (idle) snapshot.
- `web/agentsReducer.test.ts` (new, 8 cases): append/update-preserving-task/no-op-same-ref/non-target/empty-name/stopped→not-alive/retrying→running/multi-agent.

## Gates

`typecheck` ✅ · root `npm test` 357 ✅ · web test 48 ✅ · web build ✅ · `smoke-e2e.sh` ✅ — the smoke stream now shows `CUSTOM session_state` + `agent_status_update` on the wire (absent before this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)