### PR TITLE
fix: persist provider Test result so the card stops showing unknown (closes #69)

### DIFF
--- a/packages/backend-core/src/app.ts
+++ b/packages/backend-core/src/app.ts
@@ -34,6 +34,7 @@ import {
   updateProfile,
   deleteProfile,
   setSelectedProfile,
+  setProfileHealth,
   readMcpServers,
   createMcpServer,
   updateMcpServer,
@@ -225,15 +226,18 @@ export function createApp(options: CreateAppOptions): Hono {
       { baseUrl: p.baseUrl, apiKey: p.apiKey },
       { fetchFn: options.fetchFn, timeoutMs: options.providerProbeTimeoutMs },
     );
-    // model_health stays empty this round (per-model probing is future work);
-    // health_status reflects the real probe outcome.
-    return c.json({
-      ...toHttpProfile(p, selectedProfileId),
-      health_status: result.status === "error" ? "unavailable" : result.status,
-      health_checked_at: Date.now(),
-      health_message: result.message ?? "",
-      health_latency_ms: result.latencyMs ?? null,
+    // #69: persist the probe outcome so a later GET /provider/profiles (card
+    // refresh / reopen) keeps the same health instead of reverting to
+    // "unknown". model_health stays empty this round (per-model probing is
+    // future work). ProbeStatus "error" maps to the HealthStatus "unavailable".
+    const healthStatus = result.status === "error" ? "unavailable" : result.status;
+    const saved = await setProfileHealth(dataDir, p.id, {
+      healthStatus,
+      healthCheckedAt: Date.now(),
+      healthMessage: result.message ?? "",
+      healthLatencyMs: result.latencyMs ?? null,
     });
+    return c.json(toHttpProfile(saved ?? p, selectedProfileId));
   });
 
   // ---- MCP Servers CRUD (disk-backed: bp_template/mcp_servers.json) ----
@@ -374,7 +378,12 @@ function toHttpProfile(
     api_key_masked: maskKey(p.apiKey),
     created_at: p.createdAt,
     updated_at: p.updatedAt,
-    health_status: "unknown",
+    // #69: surface the persisted probe result instead of a hardcoded
+    // "unknown", so the Settings card reflects the last test across reloads.
+    health_status: p.healthStatus ?? "unknown",
+    health_checked_at: p.healthCheckedAt,
+    health_message: p.healthMessage ?? "",
+    health_latency_ms: p.healthLatencyMs ?? null,
     model_health: [],
   };
 }

--- a/packages/backend-core/src/config.ts
+++ b/packages/backend-core/src/config.ts
@@ -11,7 +11,7 @@
  */
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import type { ProviderApi } from "@brainpilot/protocol";
+import type { ProviderApi, HealthStatus } from "@brainpilot/protocol";
 
 export interface ResolvedProvider {
   /** API key, if any layer supplied one. */
@@ -124,6 +124,13 @@ export interface StoredProviderProfile {
   icon?: string;
   iconColor?: string;
   notes?: string;
+  /** #69: last connectivity-probe result, persisted so the Settings card
+   *  reflects the test outcome across reads/reopens instead of "unknown".
+   *  Written by POST /provider/profiles/:id/test. */
+  healthStatus?: HealthStatus;
+  healthCheckedAt?: number;
+  healthMessage?: string;
+  healthLatencyMs?: number | null;
   createdAt: number;
   updatedAt: number;
 }
@@ -210,6 +217,33 @@ export async function updateProfile(
   }
   if (typeof patch.apiKey === "string" && patch.apiKey.length > 0) profile.apiKey = patch.apiKey;
   profile.updatedAt = Date.now();
+  await writeProviders(dataDir, file);
+  return profile;
+}
+
+/**
+ * #69: persist the latest connectivity-probe result on a profile. Kept
+ * separate from updateProfile (which is for user-edited fields and bumps
+ * updatedAt) — a health write must not look like a profile edit. Returns the
+ * updated profile, or undefined if the id is unknown.
+ */
+export async function setProfileHealth(
+  dataDir: string,
+  id: string,
+  health: {
+    healthStatus: HealthStatus;
+    healthCheckedAt: number;
+    healthMessage?: string;
+    healthLatencyMs?: number | null;
+  },
+): Promise<StoredProviderProfile | undefined> {
+  const file = await readProviders(dataDir);
+  const profile = file.profiles.find((p) => p.id === id);
+  if (!profile) return undefined;
+  profile.healthStatus = health.healthStatus;
+  profile.healthCheckedAt = health.healthCheckedAt;
+  profile.healthMessage = health.healthMessage ?? "";
+  profile.healthLatencyMs = health.healthLatencyMs ?? null;
   await writeProviders(dataDir, file);
   return profile;
 }

--- a/packages/backend-core/test/app.test.ts
+++ b/packages/backend-core/test/app.test.ts
@@ -515,5 +515,43 @@ describe("Hono app — local config routes", () => {
       const res = await app.request("/api/provider/profiles/nope/test", { method: "POST" });
       expect(res.status).toBe(404);
     });
+
+    // #69: the probe result must be persisted, so a later GET (card refresh /
+    // reopen) keeps the tested status instead of reverting to "unknown".
+    it("persists the probe result across list + health reads", async () => {
+      const fetchFn = vi.fn(async () => new Response("forbidden", { status: 403 }));
+      const { app, id } = await makeProfile(fetchFn);
+
+      // before any test: unknown
+      const before = (await (await app.request("/api/provider/profiles")).json()) as Array<{
+        id: string;
+        health_status: string;
+      }>;
+      expect(before.find((p) => p.id === id)?.health_status).toBe("unknown");
+
+      // test → 403 maps to "unavailable"
+      const test = await app.request(`/api/provider/profiles/${id}/test`, { method: "POST" });
+      const tested = (await test.json()) as { health_status: string; health_checked_at: number; health_message: string };
+      expect(tested.health_status).toBe("unavailable");
+      expect(tested.health_checked_at).toBeGreaterThan(0);
+      expect(tested.health_message).toContain("403");
+
+      // list still reflects the tested status (no longer unknown)
+      const list = (await (await app.request("/api/provider/profiles")).json()) as Array<{
+        id: string;
+        health_status: string;
+        health_checked_at?: number;
+      }>;
+      const fromList = list.find((p) => p.id === id);
+      expect(fromList?.health_status).toBe("unavailable");
+      expect(fromList?.health_checked_at).toBeGreaterThan(0);
+
+      // and the dedicated health endpoint too
+      const health = (await (await app.request("/api/provider/profiles/health")).json()) as Array<{
+        id: string;
+        health_status: string;
+      }>;
+      expect(health.find((p) => p.id === id)?.health_status).toBe("unavailable");
+    });
   });
 });


### PR DESCRIPTION
## Problem (#69)

`POST /provider/profiles/:id/test` runs a real probe (#55) and returns a useful `health_status`, but the result was **not persisted**: `toHttpProfile` hardcoded `health_status: "unknown"` and `providers.json` stored no health metadata. So after a test, the card immediately reverted to `状态：unknown` — and any later `GET /provider/profiles` / `/provider/profiles/health` (which the web's `mergeHealth` runs) overwrote the optimistic toast update back to unknown.

## Fix (backend-only)

- `StoredProviderProfile` gains `healthStatus` / `healthCheckedAt` / `healthMessage` / `healthLatencyMs`.
- New `setProfileHealth(dataDir, id, health)` persists the probe outcome — kept separate from `updateProfile` (which is for user-edited fields and bumps `updatedAt`); a health write must not look like a profile edit.
- The `/test` route now persists the result before responding (`ProbeStatus "error"` → `HealthStatus "unavailable"`).
- `toHttpProfile` surfaces the persisted health instead of the hardcoded `"unknown"`, so the list and health endpoints stay consistent across refresh/reopen.

**No frontend change needed**: `normalizeProviderProfile` already reads `health_status`/`health_checked_at`, and `mergeHealth` no longer overwrites with unknown once the endpoints return the real value.

Did **not** extend `ProviderProfileSchema` with `healthMessage`/`healthLatencyMs` — that schema is the subject of #68 (adapter/isShared); keeping this PR focused on persistence. The stored profile + HTTP output already carry those fields.

## Tests

`app.test.ts` (#69): a probed profile (403 → `unavailable`) keeps its status across later `GET /provider/profiles` **and** `/provider/profiles/health` reads, with `health_checked_at` set.

## Gates

`typecheck` ✅ · root `npm test` 358 ✅ · web test 48 ✅ · web build ✅ · `smoke-e2e.sh` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)