### PR TITLE
docs: document the runtime's activity-based liveness contract (closes #67, R-3)

### DIFF
--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -1,0 +1,61 @@
+# @brainpilot/runtime
+
+The orchestration runtime for **BrainPilot** — the open-source, single-user
+multi-agent platform built on TypeScript + the [Pi SDK](https://pi.dev). This
+package owns the agent lifecycle and is the **state authority**: a Principal
+agent coordinating specialist agents over a file-based mailbox, exposed as a
+Hono + SSE server.
+
+It is consumed by `@brainpilot/backend-core` (which proxies to it as a stateless
+byte-passthrough) and, in hosted deployments, by the platform layer.
+
+## What lives here
+
+- `SessionManager` — session lifecycle, agent registry, **state authority**
+  (`status = idle | running | error | stopped`), `metrics()`.
+- `MasAgent` — per-agent wrapper over a Pi `AgentSession`; emits AG-UI events.
+- System tools + access control, the external-MCP bridge, Graph-of-Trace.
+- The Hono server (`./server`) with the SSE event stream.
+
+All wire types come from `@brainpilot/protocol` (the zod SSOT).
+
+## Liveness contract (R-3)
+
+The runtime imposes **no fixed wall-clock cap on a single agent turn.** A
+multi-hour research run is never killed by a timer. Liveness is
+**activity-based, not duration-based.**
+
+**Guarantees:**
+
+1. **No per-turn / per-prompt hard timeout.** There is no `120s`-style cap; the
+   TS runtime has no turn cap at all. (The only `timeout` in this package is the
+   provider connectivity **probe**, unrelated to agent turns.)
+2. **A turn ends only on a real terminal condition** — the agent finishes the
+   run, the run errors, or it is **explicitly aborted** via
+   `SessionManager.interrupt(sessionId, agentName?)` (user stop) or
+   `SessionManager.evictSession(sessionId)` (idle reclaim / shutdown). The
+   runtime never aborts a turn on a timer of its own.
+3. **No inactivity timeout either.** Silence is not treated as death.
+
+**Liveness signal** — `SessionManager.metrics()` (served at `GET /metrics`) is
+the authority a hosting layer should use:
+
+| field | meaning |
+|-------|---------|
+| `runningAgents` | count of agents currently in `status === "running"` |
+| `lastActivityAt` | ISO timestamp, advanced on **every** emitted event / state change (prompt accepted, status transition, run finished, …) |
+
+**"Still alive" = `runningAgents > 0`, or a recently-advanced `lastActivityAt`.**
+An idle reaper must key off these — never off elapsed wall-clock since the
+prompt started. As long as a long-running agent keeps `runningAgents > 0` (or
+keeps advancing `lastActivityAt`), it must not be reaped.
+
+**Bash / tool calls** run inside the Pi SDK. The runtime adds no bash tool of
+its own and configures no Pi turn/tool timeout. A separately configurable
+per-tool timeout (e.g. a ~30min bash default) would belong at the Pi-SDK tool
+layer and would not change the turn-liveness contract above.
+
+**Validate end-to-end:** start a session, issue a prompt that runs longer than
+any historical timeout, and poll `GET /metrics` — the run stays alive
+(`runningAgents > 0`, `lastActivityAt` advancing) until the agent itself
+completes, with no runtime-initiated abort.


### PR DESCRIPTION
## Ask (#67, platform R-3)

Confirm and document whether the runtime imposes a fixed per-prompt wall-clock timeout (the old Python backend used ~120s), and if so replace it with a no-activity timeout. The platform needs a documented contract it can rely on.

## Finding (verified)

The TS runtime imposes **no fixed wall-clock cap on a single agent turn at all** — there is no `timeout` / `setTimeout` / `deadline` / inactivity constant anywhere in `packages/runtime/src` that bounds a turn. The only `timeout` in the package is the provider connectivity **probe** (#55), unrelated to agent turns. So there was nothing to replace: the contract already matches R-3.

A turn ends only on a real terminal condition: the agent finishes, the run errors, or it is **explicitly aborted** (`SessionManager.interrupt` = user stop, or `evictSession` = idle reclaim/shutdown). The runtime never aborts a turn on a timer of its own, and there is no inactivity timeout either.

## Liveness signal

`SessionManager.metrics()` (`GET /metrics`) is the authority:
- `runningAgents` — agents in `status === "running"`
- `lastActivityAt` — advanced by `touch()` on **every** emitted event / state change

"Still alive" = `runningAgents > 0` or a recently-advanced `lastActivityAt`. An idle reaper should key off these, never elapsed wall-clock — which is exactly what the platform's reaper already does.

Bash / tool calls run inside the Pi SDK; the runtime adds no bash tool and configures no Pi turn/tool timeout. A configurable per-tool timeout would belong at the Pi-SDK layer and wouldn't change the turn contract.

## Change

Documentation only — added the contract to `packages/runtime/README.md` (CLAUDE.md and `docs/` are gitignored; the package README is in-tree and ships with the npm package, so the platform can reference it). **No code logic change** — the runtime already behaves as R-3 requires.

## Gates

`typecheck` ✅ · root `npm test` 364 ✅ (docs-only change; ran to confirm no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)