### PR TITLE
fix: stop env-only bootstrap from persisting the plaintext API key (closes #65)

### DIFF
--- a/packages/backend-core/src/app.ts
+++ b/packages/backend-core/src/app.ts
@@ -379,7 +379,10 @@ function toHttpProfile(
     icon_color: p.iconColor ?? "#111111",
     notes: p.notes ?? "",
     is_active: p.id === selectedId,
-    api_key_masked: maskKey(p.apiKey),
+    // #65: an env-bootstrapped profile stores no key — show its env source
+    // instead of an empty mask so the UI doesn't look misconfigured.
+    api_key_masked: p.apiKeyEnv ? `env:$${p.apiKeyEnv}` : maskKey(p.apiKey),
+    api_key_env: p.apiKeyEnv,
     created_at: p.createdAt,
     updated_at: p.updatedAt,
     // #69: surface the persisted probe result instead of a hardcoded

--- a/packages/backend-core/src/config.ts
+++ b/packages/backend-core/src/config.ts
@@ -124,6 +124,12 @@ export interface StoredProviderProfile {
    *  precise wire value. Optional; absent → treated as "auto". */
   adapter?: ProviderAdapter;
   apiKey: string;
+  /** #65: name of an env var the key is read from at request time, instead of
+   *  persisting the plaintext secret. Set by the env bootstrap so a self-hosted
+   *  user who supplies ANTHROPIC_API_KEY via the environment never has it copied
+   *  into providers.json. When set, apiKey is left empty on disk and the runtime
+   *  falls back to its env gateway path (which reads the same env var). */
+  apiKeyEnv?: string;
   models: string[];
   icon?: string;
   iconColor?: string;
@@ -194,6 +200,7 @@ export async function createProfile(
     api: input.api ?? "anthropic-messages",
     adapter: input.adapter,
     apiKey: input.apiKey ?? "",
+    apiKeyEnv: input.apiKeyEnv,
     models: input.models ?? [],
     icon: input.icon,
     iconColor: input.iconColor,
@@ -220,7 +227,12 @@ export async function updateProfile(
   for (const k of ["name", "baseUrl", "api", "adapter", "models", "icon", "iconColor", "notes"] as const) {
     if (patch[k] !== undefined) writable[k] = patch[k];
   }
-  if (typeof patch.apiKey === "string" && patch.apiKey.length > 0) profile.apiKey = patch.apiKey;
+  if (typeof patch.apiKey === "string" && patch.apiKey.length > 0) {
+    profile.apiKey = patch.apiKey;
+    // #65: the user is now intentionally persisting a key in Settings — drop the
+    // env reference so the stored key (not the env var) is the source of truth.
+    delete profile.apiKeyEnv;
+  }
   profile.updatedAt = Date.now();
   await writeProviders(dataDir, file);
   return profile;
@@ -429,12 +441,30 @@ export async function bootstrapEnvProvider(
     return null;
   }
 
+  // #65: do NOT copy the plaintext env key into providers.json. Record only the
+  // *name* of the env var the key came from; the profile is created with an
+  // empty apiKey, so at request time both resolveProvider (backend) and
+  // resolveSessionProvider (runtime) skip the empty key and fall back to the
+  // env gateway path, which reads the same env var. The profile still exists so
+  // the user sees an active "Environment" provider + model in Settings (#51),
+  // but the secret stays in the environment, never on disk.
+  const keySources =
+    resolved.source === "dotenv"
+      ? (await parseDotenv(configPaths(dataDir).dotenv))
+      : env;
+  const apiKeyEnv =
+    (keySources.ANTHROPIC_API_KEY && "ANTHROPIC_API_KEY") ||
+    (keySources.BP_API_KEY && "BP_API_KEY") ||
+    (keySources.OPENAI_API_KEY && "OPENAI_API_KEY") ||
+    "ANTHROPIC_API_KEY";
+
   return createProfile(dataDir, {
     name: "Environment",
     baseUrl: resolved.baseUrl ?? "",
-    apiKey: resolved.apiKey,
+    apiKey: "", // #65: never persisted; resolved from apiKeyEnv at request time
+    apiKeyEnv,
     models: resolved.model ? [resolved.model] : [],
-    notes: "Auto-created from environment variables on first launch.",
+    notes: `Auto-created from environment variables on first launch. The API key is read from $${apiKeyEnv} at request time and is not stored on disk.`,
   });
 }
 

--- a/packages/backend-core/test/config.test.ts
+++ b/packages/backend-core/test/config.test.ts
@@ -267,6 +267,48 @@ describe("#51 bootstrapEnvProvider", () => {
     expect(selectedProfileId).toBe(profiles[0].id);
   });
 
+  // #65: the plaintext env key must never be copied into providers.json. The
+  // profile records only the env var *name* (apiKeyEnv) with an empty apiKey;
+  // the runtime falls back to its env gateway path at request time.
+  it("does not persist the plaintext env key (records apiKeyEnv instead)", async () => {
+    const dir = await tmp();
+    await bootstrapEnvProvider(dir, {
+      ANTHROPIC_API_KEY: "sk-SECRET-do-not-store",
+      ANTHROPIC_BASE_URL: "https://gateway.example.com/api",
+      ANTHROPIC_MODEL: "env-anthropic-model",
+    });
+    const { profiles } = await readProviders(dir);
+    expect(profiles[0].apiKey).toBe("");
+    expect(profiles[0].apiKeyEnv).toBe("ANTHROPIC_API_KEY");
+
+    // The strongest guarantee: the secret appears nowhere in the file on disk.
+    const raw = await readFile(path.join(dir, "bp_template", "providers.json"), "utf8");
+    expect(raw).not.toContain("sk-SECRET-do-not-store");
+  });
+
+  it("records the matching env var name for non-Anthropic keys", async () => {
+    const dir = await tmp();
+    await bootstrapEnvProvider(dir, { BP_API_KEY: "sk-bp-secret" });
+    const { profiles } = await readProviders(dir);
+    expect(profiles[0].apiKey).toBe("");
+    expect(profiles[0].apiKeyEnv).toBe("BP_API_KEY");
+    const raw = await readFile(path.join(dir, "bp_template", "providers.json"), "utf8");
+    expect(raw).not.toContain("sk-bp-secret");
+  });
+
+  it("clears apiKeyEnv when the user later saves a real key in Settings", async () => {
+    const dir = await tmp();
+    const created = await bootstrapEnvProvider(dir, {
+      ANTHROPIC_API_KEY: "sk-env",
+      ANTHROPIC_BASE_URL: "https://g/api",
+      ANTHROPIC_MODEL: "m",
+    });
+    await updateProfile(dir, created!.id, { apiKey: "sk-user-typed" });
+    const { profiles } = await readProviders(dir);
+    expect(profiles[0].apiKey).toBe("sk-user-typed");
+    expect(profiles[0].apiKeyEnv).toBeUndefined();
+  });
+
   it("does nothing when there is no env key", async () => {
     const dir = await tmp();
     const created = await bootstrapEnvProvider(dir, {});


### PR DESCRIPTION
## Problem (#65)

When BrainPilot is started via the documented env-only path (`ANTHROPIC_API_KEY` + `ANTHROPIC_BASE_URL` + `ANTHROPIC_MODEL`), `bootstrapEnvProvider` copied the **full plaintext key** from the environment into `bp_template/providers.json`. Self-hosted users who supply secrets via env vars / Docker secrets / launchd / a secret manager expect the secret to stay ephemeral — not be written to a local config file. (The HTTP response masked the key correctly, but the file on disk held the full secret.)

## Fix (backend-only)

The env bootstrap now records only the **name** of the env var the key came from, never the key itself:

- `StoredProviderProfile.apiKeyEnv` — the env var name; `createProfile` carries it.
- `bootstrapEnvProvider` writes `apiKey: ""` + `apiKeyEnv` (detected from the same precedence `resolveProvider` uses: `ANTHROPIC_API_KEY` > `BP_API_KEY` > `OPENAI_API_KEY`).
- At request time the empty key makes **both** `resolveProvider` (backend) and `resolveSessionProvider` (runtime) skip the profile and fall back to the **env gateway path** (`resolveGatewayModel`), which reads the same env var via `$ANTHROPIC_API_KEY`. So nothing breaks — verified the runtime already runs purely from env in this path.
- The profile is still created + selected, so the user still sees an active "Environment" provider + model in Settings (**#51 intent preserved**).
- `toHttpProfile` shows `env:$VAR` as the masked key (+ `api_key_env`) so the card doesn't look misconfigured.
- `updateProfile` clears `apiKeyEnv` when the user later types a real key in Settings — that's intentional persistence (a different trust model, as the issue notes).

This matches the issue's first two suggested fixes (keep it ephemeral / write an env reference). No frontend change needed: the card renders `apiKeyMasked` directly.

## Tests

`config.test.ts`: bootstrap records `apiKeyEnv` with empty `apiKey` and the secret appears **nowhere** in `providers.json` (asserted for both `ANTHROPIC_API_KEY` and `BP_API_KEY`); a user-typed key clears the env reference.

## Gates

`typecheck` ✅ · root `npm test` 367 ✅ · web test 48 ✅ · web build ✅ · `smoke-e2e.sh` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)