### PR TITLE
fix: derive provider api from adapter instead of defaulting it (closes #75)

### DIFF
--- a/packages/backend-core/src/app.ts
+++ b/packages/backend-core/src/app.ts
@@ -21,6 +21,7 @@ import {
   McpServerConfigSchema,
   ProviderProfileCreateSchema,
   ProviderProfileUpdateSchema,
+  deriveProviderApi,
 } from "@brainpilot/protocol";
 import { RuntimeClient } from "./runtime-client.js";
 import { probeProvider } from "./provider-probe.js";
@@ -369,7 +370,10 @@ function toHttpProfile(
     id: p.id,
     name: p.name,
     base_url: p.baseUrl,
-    api: p.api ?? "anthropic-messages",
+    // #75: echo the effective api — explicit, else derived from adapter, else
+    // the default — so the response never shows a value that contradicts the
+    // adapter (e.g. adapter:"openai" + api:"anthropic-messages").
+    api: p.api ?? deriveProviderApi(p.adapter) ?? "anthropic-messages",
     // #68 (R-10): coarse adapter family + sharing flag. Single-user open-source
     // is never shared, so is_shared is always false here.
     adapter: p.adapter ?? "auto",

--- a/packages/backend-core/src/config.ts
+++ b/packages/backend-core/src/config.ts
@@ -12,6 +12,7 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import type { ProviderApi, ProviderAdapter, HealthStatus } from "@brainpilot/protocol";
+import { deriveProviderApi } from "@brainpilot/protocol";
 
 export interface ResolvedProvider {
   /** API key, if any layer supplied one. */
@@ -197,7 +198,12 @@ export async function createProfile(
     id: input.id ?? newId(),
     name: input.name ?? "Provider",
     baseUrl: input.baseUrl ?? "",
-    api: input.api ?? "anthropic-messages",
+    // #75: do not unconditionally default api to anthropic-messages — that
+    // short-circuited the runtime's adapter fallback (an `adapter:"openai"`
+    // profile got `api:"anthropic-messages"`, a contradictory state). Precedence:
+    // explicit api → derived from adapter → default. Persist only an explicit or
+    // adapter-derived api; leave it unset otherwise so the runtime resolves it.
+    api: input.api ?? deriveProviderApi(input.adapter),
     adapter: input.adapter,
     apiKey: input.apiKey ?? "",
     apiKeyEnv: input.apiKeyEnv,

--- a/packages/backend-core/test/app.test.ts
+++ b/packages/backend-core/test/app.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, writeFile, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { createRequire } from "node:module";
 import path from "node:path";
@@ -476,6 +476,53 @@ describe("Hono app — local config routes", () => {
       const b = (await noAdapter.json()) as { adapter: string; is_shared: boolean };
       expect(b.adapter).toBe("auto");
       expect(b.is_shared).toBe(false);
+    });
+
+    // #75: adapter without an explicit api must NOT be overridden by a default
+    // anthropic-messages — the echoed api derives from the adapter, and the
+    // stored profile carries no contradictory api.
+    it("derives api from adapter when api is omitted, no contradictory default (#75)", async () => {
+      const { app, dir } = await provApp();
+      const res = await postProfile(app, {
+        name: "adapter-openai-no-api",
+        adapter: "openai",
+        base_url: "https://example.invalid/v1",
+        api_key: "sk-x",
+        models: ["m"],
+      });
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as { api: string; adapter: string };
+      // echo reflects the derived wire value, not anthropic-messages
+      expect(body.adapter).toBe("openai");
+      expect(body.api).toBe("openai-completions");
+
+      // the stored profile must not contain the contradictory default
+      const stored = JSON.parse(
+        await readFile(path.join(dir, "bp_template", "providers.json"), "utf8"),
+      ) as { profiles: Array<{ adapter?: string; api?: string }> };
+      expect(stored.profiles[0].adapter).toBe("openai");
+      expect(stored.profiles[0].api).toBe("openai-completions");
+    });
+
+    it("adapter=anthropic derives anthropic-messages; auto falls back to default (#75)", async () => {
+      const { app } = await provApp();
+      const ant = await postProfile(app, { name: "A", adapter: "anthropic", base_url: "https://x", api_key: "k", models: ["m"] });
+      expect(((await ant.json()) as { api: string }).api).toBe("anthropic-messages");
+      const auto = await postProfile(app, { name: "B", adapter: "auto", base_url: "https://x", api_key: "k", models: ["m"] });
+      expect(((await auto.json()) as { api: string }).api).toBe("anthropic-messages");
+    });
+
+    it("explicit api still wins over adapter (#75)", async () => {
+      const { app } = await provApp();
+      const res = await postProfile(app, {
+        name: "explicit",
+        adapter: "anthropic",
+        api: "openai-responses",
+        base_url: "https://x",
+        api_key: "k",
+        models: ["m"],
+      });
+      expect(((await res.json()) as { api: string }).api).toBe("openai-responses");
     });
 
     it("rejects an unknown adapter value with 400 (#68)", async () => {

--- a/packages/protocol/src/domain.ts
+++ b/packages/protocol/src/domain.ts
@@ -238,6 +238,26 @@ export type ProviderApi = z.infer<typeof ProviderApiSchema>;
 export const ProviderAdapterSchema = z.enum(["auto", "openai", "anthropic"]);
 export type ProviderAdapter = z.infer<typeof ProviderAdapterSchema>;
 
+/**
+ * #75: single source of truth for adapter→api derivation, shared by the backend
+ * (so create/echo never persist a default that contradicts the adapter) and the
+ * runtime (so the wire value it writes matches). `anthropic`→anthropic-messages,
+ * `openai`→openai-completions; `auto`/undefined → undefined (caller falls back
+ * to its own default). Keeping this in protocol prevents the two layers from
+ * drifting (the footgun #75 surfaced: backend defaulting api to
+ * anthropic-messages short-circuited the runtime's adapter fallback).
+ */
+export function deriveProviderApi(adapter?: ProviderAdapter): ProviderApi | undefined {
+  switch (adapter) {
+    case "anthropic":
+      return "anthropic-messages";
+    case "openai":
+      return "openai-completions";
+    default:
+      return undefined;
+  }
+}
+
 export const ProviderProfileSchema = z.object({
   id: z.string(),
   name: z.string(),

--- a/packages/runtime/src/pi-provider.ts
+++ b/packages/runtime/src/pi-provider.ts
@@ -22,6 +22,7 @@
  */
 import { mkdirSync, writeFileSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { deriveProviderApi, type ProviderAdapter } from "@brainpilot/protocol";
 
 /** The synthetic provider id under which the auto-generated gateway lives. */
 export const GATEWAY_PROVIDER = "bp-gateway";
@@ -61,24 +62,6 @@ export interface SessionProviderConfig {
   adapter?: string;
   apiKey: string;
   modelId?: string;
-}
-
-/**
- * #68: derive the precise Pi wire `api` from the coarse `adapter` family when
- * no explicit `api` is set. `anthropic`→anthropic-messages,
- * `openai`→openai-completions; `auto`/unknown → undefined (caller falls back to
- * the default). This keeps `api` (precise, #63) authoritative while letting the
- * UI/hosted layer declare intent via the coarser `adapter`.
- */
-function deriveApiFromAdapter(adapter?: string): string | undefined {
-  switch (adapter) {
-    case "anthropic":
-      return "anthropic-messages";
-    case "openai":
-      return "openai-completions";
-    default:
-      return undefined;
-  }
 }
 
 export interface ResolvedProvider {
@@ -230,7 +213,7 @@ export function resolveSessionModel(
           // derived from `adapter` (coarse family, #68) → default. Pi's
           // ModelRegistry accepts any known api; azure-openai-responses derives
           // api-version/deployment from the Azure base URL.
-          api: cfg.api ?? deriveApiFromAdapter(cfg.adapter) ?? "anthropic-messages",
+          api: cfg.api ?? deriveProviderApi(cfg.adapter as ProviderAdapter | undefined) ?? "anthropic-messages",
           // Placeholder — the real key is injected via setRuntimeApiKey below.
           apiKey: `$BP_PROVIDER_${sanitize(cfg.providerId).toUpperCase()}`,
           models: [


### PR DESCRIPTION
## Problem (#75 — regression from #68/PR #73)

PR #73 added the coarse `adapter` field and made the runtime derive the precise wire `api` from it when `api` is unset. But `createProfile` still did `api: input.api ?? "anthropic-messages"`, so a profile created with `adapter: "openai"` and no explicit `api` was stored as `api: "anthropic-messages"` — a contradictory state that **short-circuited the runtime's adapter fallback** and routed OpenAI-compatible providers through the Anthropic wire protocol.

## Fix

Precedence everywhere becomes **explicit api → derived from adapter → default**:

- New shared `deriveProviderApi(adapter)` in `@brainpilot/protocol` — single source of truth for adapter→api, so backend and runtime can't drift. `anthropic`→`anthropic-messages`, `openai`→`openai-completions`, `auto`/undefined→undefined.
- `createProfile`: `api: input.api ?? deriveProviderApi(input.adapter)` — persists only an explicit or adapter-derived api, never a contradictory default.
- `toHttpProfile` echoes the **effective** api (explicit → derived → default) so the response never contradicts the adapter.
- runtime `pi-provider` imports the shared helper instead of its own local copy (removes the duplicate that caused the drift).

## Tests

`app.test.ts` (#75): create with `adapter:"openai"` and no api echoes `api:"openai-completions"` and stores no contradictory api; `anthropic`→`anthropic-messages`; `auto`→default; explicit api still wins.

## Gates

`typecheck` ✅ · backend-core tests (incl. new #75 cases) ✅ · root `npm test` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)