### PR TITLE
feat: ask_user — let principal prompt the terminal user mid-turn

### DIFF
--- a/docs/superpowers/plans/2026-06-18-ask-user.md
+++ b/docs/superpowers/plans/2026-06-18-ask-user.md
@@ -1,0 +1,710 @@
+# ask_user Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the `principal` agent ask the terminal user a question mid-turn, block until the user answers, then resume the same turn.
+
+**Architecture:** A new `ask_user` system tool blocks on a deferred promise inside its `execute`. The tool emits a `user_input_request` AG-UI event (consumed by the already-built frontend `AskUserCard`). The deferred lives in `SessionEntry.pendingInputs` and is reached via a `ToolDeps.requestUserInput` callback (mirroring the existing `ensureAgent` delegation). The frontend POSTs the answer to the existing `/sessions/:id/messages` endpoint; `SendMessageRequestSchema` is widened to accept a `user_input_response` body, and the server routes it to `manager.resolveInput(...)` which resolves the deferred so the turn continues.
+
+**Tech Stack:** TypeScript (NodeNext ESM), zod (protocol SSOT), Hono (runtime HTTP), vitest. All tests run under `BP_MOCK=1` (no API). Spec: `docs/superpowers/specs/2026-06-18-ask-user-design.md`.
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `packages/protocol/src/http.ts` | Modify (~line 119) | Widen `SendMessageRequestSchema` to a union accepting the answer body. |
+| `packages/runtime/src/events.ts` | Modify (`ev` object) | Add `ev.userInputRequest(...)` builder. |
+| `packages/runtime/src/tools/system-tools.ts` | Modify | Add `requestUserInput` to `ToolDeps`; add `createAskUserTool`; register it; add `ask_user` to `AGENT_TOOL_CONFIG.principal`. |
+| `packages/runtime/src/session-manager.ts` | Modify | Add `Deferred<T>`; `pendingInputs` field; `requestUserInput`/`resolveInput` methods; wire callback into `ToolDeps`; reject pending on `interrupt`/`evictSession`. |
+| `packages/runtime/src/server.ts` | Modify (~line 73) | Route `user_input_response` bodies to `manager.resolveInput`. |
+| `packages/runtime/src/__tests__/tool-access.test.ts` | Modify | Assert `ask_user` is principal-only. |
+| `packages/runtime/src/__tests__/ask-user.test.ts` | Create | Unit + integration tests for the full ask_user loop. |
+
+> **Dependency order:** protocol → runtime events/tools/manager → server → tests. Build bottom-up: `npm run typecheck` after protocol changes before runtime consumes them.
+
+---
+
+## Task 1: Widen `SendMessageRequestSchema` (protocol)
+
+**Files:**
+- Modify: `packages/protocol/src/http.ts:119-137`
+- Test: `packages/protocol/src/__tests__/http.test.ts` (create if absent — check first with `ls packages/protocol/src/__tests__/`)
+
+- [ ] **Step 1: Write the failing test**
+
+Check whether a protocol test file exists: `ls packages/protocol/src/__tests__/ 2>/dev/null`. If `http.test.ts` exists, append the `describe` block; otherwise create the file with this content:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { SendMessageRequestSchema } from "../http.js";
+
+describe("SendMessageRequestSchema", () => {
+  it("accepts a normal send-message body", () => {
+    const r = SendMessageRequestSchema.safeParse({ content: "hello", agent: "principal" });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts a user_input_response answer body", () => {
+    const r = SendMessageRequestSchema.safeParse({
+      type: "user_input_response",
+      session_id: "s1",
+      request_id: "req_123",
+      answer: "option A",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects a body that is neither (no content, no answer)", () => {
+    const r = SendMessageRequestSchema.safeParse({ foo: "bar" });
+    expect(r.success).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/protocol && npx vitest run src/__tests__/http.test.ts`
+Expected: FAIL — the answer-body case fails because the current schema requires `content`.
+
+- [ ] **Step 3: Implement the union schema**
+
+In `packages/protocol/src/http.ts`, replace the existing `SendMessageRequestSchema` definition (currently at lines 119-137, the `z.object({ content... })`) with a discriminated-friendly union. Keep the existing object as a named member so the inferred type still exposes `content`/`agent`/`data`:
+
+```ts
+/** A normal user message injected into the session. */
+export const SendMessageContentSchema = z.object({
+  content: z.string(),
+  /** Target agent; defaults to principal. */
+  agent: z.string().optional(),
+  /**
+   * Optional client-supplied metadata (issue #42). The web composer sends the
+   * `uuid` it used for the optimistic user bubble so the runtime can persist a
+   * matching `TEXT_MESSAGE_CHUNK` (role:"user") under the same id.
+   */
+  data: z
+    .object({
+      uuid: z.string().optional(),
+      timestamp: z.string().optional(),
+    })
+    .optional(),
+});
+
+/** A reply to an outstanding ask_user (user_input_request) — see events.ts. */
+export const UserInputResponseBodySchema = z.object({
+  type: z.literal("user_input_response"),
+  session_id: z.string(),
+  request_id: z.string(),
+  answer: z.string(),
+});
+
+/**
+ * POST /sessions/:id/messages accepts EITHER a normal message OR an ask_user
+ * reply. The answer body is matched by its `type` literal; everything else is
+ * treated as a content message.
+ */
+export const SendMessageRequestSchema = z.union([
+  UserInputResponseBodySchema,
+  SendMessageContentSchema,
+]);
+export type SendMessageRequest = z.infer<typeof SendMessageRequestSchema>;
+export type UserInputResponseBody = z.infer<typeof UserInputResponseBodySchema>;
+```
+
+> Note: order matters — put `UserInputResponseBodySchema` first so a body carrying `type:"user_input_response"` is not silently accepted as a content message (it would fail `content` required anyway, but explicit ordering avoids ambiguity). The existing `SendMessageResponseSchema` (lines 139-144) stays unchanged.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/protocol && npx vitest run src/__tests__/http.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Typecheck the protocol package**
+
+Run: `npm run typecheck`
+Expected: no errors. (If `server.ts` now errors on `parsed.data.content`, that's expected — Task 5 fixes the server. If you want a green typecheck here, do Task 5 before re-running; otherwise proceed and the error resolves at Task 5.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/protocol/src/http.ts packages/protocol/src/__tests__/http.test.ts
+git commit -m "feat(protocol): accept user_input_response on /messages body
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Add `ev.userInputRequest` builder (runtime events)
+
+**Files:**
+- Modify: `packages/runtime/src/events.ts` (inside the `ev` object, after `agentStatusUpdate`)
+- Test: `packages/runtime/src/__tests__/event-mapping.test.ts` (append) — verify file exists first; if the assertion style differs, adapt to match existing tests in that file.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/runtime/src/__tests__/event-mapping.test.ts`:
+
+```ts
+import { ev } from "../events.js";
+import { parseEvent } from "@brainpilot/protocol";
+
+describe("ev.userInputRequest", () => {
+  it("builds a valid user_input_request event", () => {
+    const e = ev.userInputRequest(
+      { sessionId: "s1", runId: "run_1" },
+      { request_id: "req_1", agent: "principal", question: "Pick one", options: ["a", "b"], allow_free_text: true },
+    );
+    const parsed = parseEvent(e); // throws if invalid against the protocol union
+    expect(parsed.type).toBe("user_input_request");
+    expect((parsed as any).request_id).toBe("req_1");
+    expect((parsed as any).question).toBe("Pick one");
+    expect((parsed as any).options).toEqual(["a", "b"]);
+    expect((parsed as any).session_id).toBe("s1");
+  });
+});
+```
+
+> `event-mapping.test.ts` already imports `describe/it/expect` from vitest at the top — do not re-import them. If it does not, add `import { describe, it, expect } from "vitest";`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/runtime && npx vitest run src/__tests__/event-mapping.test.ts -t "userInputRequest"`
+Expected: FAIL — `ev.userInputRequest is not a function`.
+
+- [ ] **Step 3: Implement the builder**
+
+In `packages/runtime/src/events.ts`, add this entry to the `ev` object (place it right after the `agentStatusUpdate` builder, before the closing of the object). The envelope helper already injects `session_id`/`run_id`/`agent_name`/`_ts`:
+
+```ts
+  userInputRequest(
+    ctx: Ctx,
+    req: { request_id: string; agent: string; question: string; options?: string[]; allow_free_text?: boolean },
+  ): AgUiEvent {
+    return {
+      type: "user_input_request",
+      ...envelope(ctx),
+      request_id: req.request_id,
+      agent: req.agent,
+      question: req.question,
+      options: req.options,
+      allow_free_text: req.allow_free_text,
+    } as AgUiEvent;
+  },
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/runtime && npx vitest run src/__tests__/event-mapping.test.ts -t "userInputRequest"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/runtime/src/events.ts packages/runtime/src/__tests__/event-mapping.test.ts
+git commit -m "feat(runtime): add ev.userInputRequest event builder
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Add `ask_user` tool + access control (runtime tools)
+
+**Files:**
+- Modify: `packages/runtime/src/tools/system-tools.ts` (`ToolDeps` interface ~line 14; new tool fn; `allSystemTools` ~line 212; `AGENT_TOOL_CONFIG` ~line 231)
+- Modify: `packages/runtime/src/__tests__/tool-access.test.ts` (the `deps()` helper ~line 11; add assertions)
+
+- [ ] **Step 1: Write the failing test**
+
+In `packages/runtime/src/__tests__/tool-access.test.ts`, first update the `deps()` helper (lines 11-20) to satisfy the new `ToolDeps` field:
+
+```ts
+function deps(name: string): ToolDeps {
+  return {
+    sessionId: "s",
+    fromAgent: name,
+    mailbox: new Mailbox("s"),
+    trace: new GraphOfTrace("s"),
+    ensureAgent: async () => {},
+    destroyAgent: async () => {},
+    requestUserInput: async () => "stub-answer",
+  };
+}
+```
+
+Then add a new test inside the `describe("tool access control (§9)", ...)` block:
+
+```ts
+  it("principal can ask_user; experts and trace cannot", () => {
+    expect(systemToolNamesForRole("principal", "principal")).toContain("ask_user");
+    expect(systemToolNamesForRole("expert", "librarian")).not.toContain("ask_user");
+    expect(systemToolNamesForRole("trace", "trace")).not.toContain("ask_user");
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/runtime && npx vitest run src/__tests__/tool-access.test.ts -t "ask_user"`
+Expected: FAIL — `ask_user` not in principal's tool names.
+
+- [ ] **Step 3: Add `requestUserInput` to `ToolDeps`**
+
+In `packages/runtime/src/tools/system-tools.ts`, extend the `ToolDeps` interface (currently lines 14-23) by adding this field after `destroyAgent`:
+
+```ts
+  /** Ask the terminal user a question; resolves with their answer. Blocks the turn. */
+  requestUserInput: (req: {
+    question: string;
+    options?: string[];
+    allow_free_text?: boolean;
+  }) => Promise<string>;
+```
+
+- [ ] **Step 4: Add the `createAskUserTool` factory**
+
+In the same file, add this function (place it after `createSendMessageTool`, before `createCreateAgentTool`):
+
+```ts
+export function createAskUserTool(deps: ToolDeps): SystemTool {
+  return {
+    name: "ask_user",
+    description:
+      "Ask the human user a question and wait for their answer. Use when you need a decision or information only the user can provide. Returns the user's answer as text.",
+    parameters: {
+      type: "object",
+      properties: {
+        question: { type: "string", description: "The question to show the user" },
+        options: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional choices to offer the user",
+        },
+        allow_free_text: {
+          type: "boolean",
+          description: "Whether the user may type a free-text answer (default true)",
+        },
+      },
+      required: ["question"],
+    },
+    execute: async (params: Record<string, unknown>) => {
+      const answer = await deps.requestUserInput({
+        question: String(params.question ?? ""),
+        options: Array.isArray(params.options) ? (params.options as string[]) : undefined,
+        allow_free_text:
+          typeof params.allow_free_text === "boolean" ? params.allow_free_text : undefined,
+      });
+      return ok(answer);
+    },
+  };
+}
+```
+
+- [ ] **Step 5: Register the tool and grant it to principal**
+
+In `allSystemTools` (lines 212-224), add `createAskUserTool(deps),` to the `tools` array (after `createSendMessageTool(deps),`).
+
+In `AGENT_TOOL_CONFIG` (line 232), add `"ask_user"` to the principal list:
+
+```ts
+  principal: ["send_message", "create_agent", "destroy_agent", "record_trace", "ask_user"],
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cd packages/runtime && npx vitest run src/__tests__/tool-access.test.ts`
+Expected: PASS (all tests in the file, including the new ask_user one).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/runtime/src/tools/system-tools.ts packages/runtime/src/__tests__/tool-access.test.ts
+git commit -m "feat(runtime): add ask_user system tool, principal-only
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: `pendingInputs` + `requestUserInput`/`resolveInput` (SessionManager)
+
+**Files:**
+- Modify: `packages/runtime/src/session-manager.ts` (`SessionEntry` interface lines 29-45; entry literal lines 385-399; `ToolDeps` construction lines 554-565; `interrupt` lines 533-542; `evictSession` lines 456-470; add two methods + a `Deferred` helper)
+- Test: `packages/runtime/src/__tests__/ask-user.test.ts` (create)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `packages/runtime/src/__tests__/ask-user.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { parseEvent, type AgUiEvent } from "@brainpilot/protocol";
+import { SessionManager } from "../session-manager.js";
+import { mockAgentFactory } from "../agent-factory.js";
+
+function mgr(): SessionManager {
+  return new SessionManager({ persist: false, agentFactory: mockAgentFactory });
+}
+
+describe("ask_user (SessionManager)", () => {
+  let m: SessionManager;
+  beforeEach(() => {
+    m = mgr();
+  });
+
+  it("emits user_input_request and resolves the turn on answer", async () => {
+    const session = await m.createSession({ title: "T" });
+    const events: AgUiEvent[] = [];
+    m.subscribe(session.id, (e) => events.push(e));
+
+    // Drive the mock agent to call ask_user via the prompt control protocol.
+    const res = await m.sendMessage(
+      session.id,
+      'please decide [[tool:ask_user {"question":"Pick A or B"}]]',
+    );
+    expect(res.accepted).toBe(true);
+
+    // The request event should appear without us answering yet.
+    await new Promise((r) => setTimeout(r, 20));
+    const req = events.find((e) => e.type === "user_input_request") as any;
+    expect(req).toBeTruthy();
+    expect(req.question).toBe("Pick A or B");
+    expect(typeof req.request_id).toBe("string");
+
+    // Answer it; the blocked tool execute resolves and the turn finishes.
+    const okResolved = m.resolveInput(session.id, req.request_id, "A");
+    expect(okResolved).toBe(true);
+
+    await new Promise((r) => setTimeout(r, 20));
+    const toolEnd = events.find(
+      (e) => e.type === "TOOL_CALL_RESULT" && (e as any).content?.includes("A"),
+    );
+    expect(toolEnd).toBeTruthy();
+  });
+
+  it("resolveInput returns false for unknown request_id", async () => {
+    const session = await m.createSession({ title: "T" });
+    expect(m.resolveInput(session.id, "nope", "x")).toBe(false);
+    expect(m.resolveInput("no-session", "nope", "x")).toBe(false);
+  });
+
+  it("interrupt rejects pending inputs", async () => {
+    const session = await m.createSession({ title: "T" });
+    const events: AgUiEvent[] = [];
+    m.subscribe(session.id, (e) => events.push(e));
+    await m.sendMessage(session.id, 'decide [[tool:ask_user {"question":"Q"}]]');
+    await new Promise((r) => setTimeout(r, 20));
+    expect(events.find((e) => e.type === "user_input_request")).toBeTruthy();
+
+    await m.interrupt(session.id);
+    await new Promise((r) => setTimeout(r, 20));
+    // After interrupt, answering the (now-cleared) request is stale.
+    const req = events.find((e) => e.type === "user_input_request") as any;
+    expect(m.resolveInput(session.id, req.request_id, "late")).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/runtime && npx vitest run src/__tests__/ask-user.test.ts`
+Expected: FAIL — `m.resolveInput is not a function`.
+
+- [ ] **Step 3: Add a `Deferred` helper**
+
+In `packages/runtime/src/session-manager.ts`, add this small helper near the top of the file (after the imports, before `interface SessionEntry` at line 29):
+
+```ts
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: Error) => void;
+}
+
+function makeDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: Error) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+```
+
+- [ ] **Step 4: Add `pendingInputs` to `SessionEntry`**
+
+In the `SessionEntry` interface (lines 29-45), add after `activeRunId`:
+
+```ts
+  /** Outstanding ask_user requests, keyed by request_id (§ ask_user). */
+  pendingInputs: Map<string, Deferred<string>>;
+```
+
+In the entry literal (lines 385-399), add after `activeRunId: null,`:
+
+```ts
+      pendingInputs: new Map(),
+```
+
+- [ ] **Step 5: Add `requestUserInput` and `resolveInput` methods**
+
+Add these two methods to the `SessionManager` class (place them right after `sendMessage`, before `interrupt` at line 533):
+
+```ts
+  /**
+   * Ask the terminal user a question on behalf of `agent`. Emits a
+   * `user_input_request` event and returns a promise that resolves when
+   * `resolveInput` is called with the matching request_id, or rejects if the
+   * session is interrupted/evicted. Blocks the calling tool's turn.
+   */
+  private requestUserInput(
+    entry: SessionEntry,
+    agent: string,
+    req: { question: string; options?: string[]; allow_free_text?: boolean },
+  ): Promise<string> {
+    const requestId = `req_${randomUUID()}`;
+    const deferred = makeDeferred<string>();
+    entry.pendingInputs.set(requestId, deferred);
+    entry.bus.emit(
+      ev.userInputRequest(
+        { sessionId: entry.id, runId: entry.activeRunId ?? undefined },
+        { request_id: requestId, agent, question: req.question, options: req.options, allow_free_text: req.allow_free_text },
+      ),
+    );
+    return deferred.promise;
+  }
+
+  /**
+   * Resolve an outstanding ask_user request. Returns false when the session or
+   * request_id is unknown/already consumed (stale answer). Pure lookup; never
+   * throws — the server handles 404 for unknown sessions before calling.
+   */
+  resolveInput(sessionId: string, requestId: string, answer: string): boolean {
+    const entry = this.sessions.get(sessionId);
+    const deferred = entry?.pendingInputs.get(requestId);
+    if (!entry || !deferred) return false;
+    entry.pendingInputs.delete(requestId);
+    deferred.resolve(answer);
+    this.touch(entry);
+    return true;
+  }
+```
+
+- [ ] **Step 6: Wire the callback into `ToolDeps`**
+
+In `ensureAgent`, in the `deps` object literal (lines 554-565), add after `destroyAgent`:
+
+```ts
+      requestUserInput: (req) => this.requestUserInput(entry, name, req),
+```
+
+> `entry` is in scope at this point — `ensureAgent` fetches it via `this.sessions.get(sessionId)` at line 548. Confirm the local variable is named `entry`; if it is named differently, use that name. `name` is the agent name parameter of `ensureAgent`.
+
+- [ ] **Step 7: Reject pending inputs on `interrupt`**
+
+In `interrupt` (lines 533-542), after the loop that aborts agents and before `return`, add:
+
+```ts
+    for (const [id, d] of entry.pendingInputs) {
+      d.reject(new Error("interrupted"));
+      entry.pendingInputs.delete(id);
+    }
+```
+
+> Place this after `entry.runActive = false; entry.activeRunId = null;`. The variable for the session is `entry` in that method.
+
+- [ ] **Step 8: Reject pending inputs on `evictSession`**
+
+In `evictSession` (lines 456-470), inside the function after fetching `e` and before `this.sessions.delete(id)`, add:
+
+```ts
+    for (const [id2, d] of e.pendingInputs) {
+      d.reject(new Error("evicted"));
+      e.pendingInputs.delete(id2);
+    }
+```
+
+> The session variable in `evictSession` is `e` (per lines 457-468). Use `id2` to avoid shadowing the `id` parameter.
+
+- [ ] **Step 9: Run test to verify it passes**
+
+Run: `cd packages/runtime && npx vitest run src/__tests__/ask-user.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 10: Run the full runtime suite to check for regressions**
+
+Run: `cd packages/runtime && BP_MOCK=1 npx vitest run`
+Expected: all pass (existing + new).
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add packages/runtime/src/session-manager.ts packages/runtime/src/__tests__/ask-user.test.ts
+git commit -m "feat(runtime): pending-input registry + requestUserInput/resolveInput
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Route `user_input_response` in the server
+
+**Files:**
+- Modify: `packages/runtime/src/server.ts:73-83` (the `/sessions/:id/messages` handler)
+- Test: `packages/runtime/src/__tests__/server.test.ts` (append)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `packages/runtime/src/__tests__/server.test.ts` (inside the existing top-level `describe`, reuse the `app()` helper defined at the top of that file):
+
+```ts
+  it("POST /messages with user_input_response resolves or reports stale", async () => {
+    const a = app();
+    const created = await a.request("/sessions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "T" }),
+    });
+    const { id } = (await created.json()) as { id: string };
+
+    // No outstanding request → stale, but still 200.
+    const res = await a.request(`/sessions/${id}/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        type: "user_input_response",
+        session_id: id,
+        request_id: "req_missing",
+        answer: "x",
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: "stale" });
+  });
+
+  it("POST /messages still accepts a normal content body", async () => {
+    const a = app();
+    const created = await a.request("/sessions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "T" }),
+    });
+    const { id } = (await created.json()) as { id: string };
+    const res = await a.request(`/sessions/${id}/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ content: "hello" }),
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).accepted).toBe(true);
+  });
+```
+
+> Verify the create-session route shape matches the existing tests in `server.test.ts` (look for an existing `POST /sessions` test and copy its request/response handling exactly). Adjust the body/field names if the existing tests differ.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/runtime && npx vitest run src/__tests__/server.test.ts -t "user_input_response"`
+Expected: FAIL — current handler returns `{accepted}` (or 400), not `{status:"stale"}`.
+
+- [ ] **Step 3: Update the handler**
+
+In `packages/runtime/src/server.ts`, replace the `/sessions/:id/messages` handler body (lines 73-83) with branching logic:
+
+```ts
+  app.post("/sessions/:id/messages", async (c) => {
+    const id = c.req.param("id");
+    const body = await safeBody(c);
+    const parsed = SendMessageRequestSchema.safeParse(body);
+    if (!parsed.success) return c.json({ error: "invalid body" }, 400);
+    if (!manager.getSession(id)) return c.json({ error: "not found" }, 404);
+
+    // ask_user reply branch: resolve the outstanding request.
+    if ("type" in parsed.data && parsed.data.type === "user_input_response") {
+      const okResolved = manager.resolveInput(id, parsed.data.request_id, parsed.data.answer);
+      return c.json({ status: okResolved ? "ok" : "stale" });
+    }
+
+    // Normal message branch.
+    const res = await manager.sendMessage(id, parsed.data.content, parsed.data.agent ?? "principal", {
+      uuid: parsed.data.data?.uuid,
+    });
+    return c.json(res);
+  });
+```
+
+> `SendMessageRequestSchema` is already imported in `server.ts` (it was used by the old handler). Confirm the import list at the top of `server.ts` still resolves; no new import is needed because `resolveInput` is a method on the existing `manager`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/runtime && npx vitest run src/__tests__/server.test.ts`
+Expected: PASS (existing + 2 new).
+
+- [ ] **Step 5: Typecheck the whole repo**
+
+Run: `npm run typecheck`
+Expected: no errors across all non-web packages.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/runtime/src/server.ts packages/runtime/src/__tests__/server.test.ts
+git commit -m "feat(runtime): route user_input_response to resolveInput on /messages
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run all non-web tests**
+
+Run: `npm test`
+Expected: all pass.
+
+- [ ] **Step 2: Run web tests (frontend already implements the consumer; confirm nothing broke)**
+
+Run: `cd packages/web && npm test`
+Expected: all pass. (No web code changed; this confirms the protocol schema change didn't break any web import of `SendMessageRequest`.)
+
+- [ ] **Step 3: Typecheck + build**
+
+Run: `npm run typecheck && npm run build`
+Expected: clean.
+
+- [ ] **Step 4: Smoke test (optional, end-to-end)**
+
+Run: `bash scripts/smoke-e2e.sh`
+Expected: passes (backend→runtime mock→SSE→client).
+
+- [ ] **Step 5: Final commit if any verification fixes were needed**
+
+```bash
+git add -A
+git commit -m "test(ask_user): full-suite verification fixes
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+> If no fixes were needed, skip this commit.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:**
+- §4.1 protocol schema widen → Task 1 ✓
+- §4.2 `ev.userInputRequest` → Task 2 ✓; `ask_user` tool + `ToolDeps.requestUserInput` + `AGENT_TOOL_CONFIG.principal` → Task 3 ✓; `pendingInputs` + `requestUserInput`/`resolveInput` + interrupt/evict reject → Task 4 ✓
+- §4.3 web zero-change → verified in Task 6 Step 2 ✓
+- §5 data flow → exercised by Task 4 integration test ✓
+- §6 error handling: stale id → Task 5 test ✓; interrupt reject → Task 4 test ✓; evict reject → Task 4 Step 8 ✓; leak protection (delete on resolve) → Task 4 Step 5 ✓
+- §7 tests all under BP_MOCK → all tasks ✓
+- §8 non-goals (no timeout timer, no status enum, no new route, experts can't ask) → respected; experts-can't-ask asserted in Task 3 ✓
+
+**Type consistency:** `requestUserInput(req)` signature identical in `ToolDeps` (Task 3) and the manager callback (Task 4 Step 6). `resolveInput(sessionId, requestId, answer): boolean` identical in Task 4 (definition), Task 4 test, and Task 5 (server call). `ev.userInputRequest(ctx, req)` shape identical in Task 2 (definition) and Task 4 (call site). `Deferred<T>`/`makeDeferred` defined once (Task 4 Step 3), used in Task 4 Steps 5/7/8.
+
+**Note on Task 1 Step 5:** the protocol typecheck may surface a transient error in `server.ts` (`parsed.data.content` on a union) until Task 5 lands — this is expected and documented; the repo-wide typecheck goes green at Task 5 Step 5.

--- a/docs/superpowers/specs/2026-06-18-ask-user-design.md
+++ b/docs/superpowers/specs/2026-06-18-ask-user-design.md
@@ -1,0 +1,159 @@
+# ask_user — 设计文档
+
+**日期**: 2026-06-18
+**状态**: 已确认设计,待实现
+**作用域**: 让 principal agent 能主动向终端用户提问并阻塞等待回答,再继续当前 turn。
+
+---
+
+## 1. 背景与问题
+
+BrainPilot 的 agent(基于 Pi SDK)目前是**单向回合制**:用户发消息 → `agent.prompt()` 一口气把整个 turn 跑到底 → 回消息。agent 在 turn 中途**无法**停下来向终端用户提问并等待输入。
+
+但这个功能其实**做了一半**——协议层和前端已就绪,缺的是 runtime 一侧的接线:
+
+**已实现(无需改动):**
+- 协议:`UserInputRequestEventSchema` / `UserInputResponseEventSchema`(`packages/protocol/src/events.ts:341-367`),已纳入 `AgUiEventSchema` union(行 409-410)。
+- 前端:`AskUserCard.tsx` 渲染问题卡片;`respondToInput()` 把回答 POST 回去(`packages/web/src/utils/api.ts:404-423`);`newUiEvents.ts` / `messageReducer.ts` 消费 `user_input_request`。
+
+**缺失(本设计补齐):**
+1. runtime 没有 `ask_user` 工具暴露给 Pi。
+2. runtime 不发射 `user_input_request` 事件(`ev` 无对应 builder)。
+3. runtime 没有按 `request_id` 恢复挂起调用的机制。
+4. 前端把回答 POST 到 `/sessions/:id/messages`,body 形如 `{type, session_id, request_id, answer}` ——**没有 `content` 字段**,会被 `SendMessageRequestSchema`(只认 `content`)挡成 400(`packages/protocol/src/http.ts:119-137`、`packages/runtime/src/server.ts:73-83`)。
+
+---
+
+## 2. 核心机制
+
+`ask_user` 工具的 `execute` 内 `await` 一个**挂起的 deferred promise** → 由于 Pi 与 mock 两条路径都是 `await tool.execute(args)`(`packages/runtime/src/mock-agent.ts:100`),turn 自然停在这里;server 收到回答后按 `request_id` resolve 该 deferred → `execute` 返回 → turn 继续。
+
+无需新增 status 枚举、无需改状态机:等待期间 `status` 保持 `running`,"在等你"这一语义完全靠已实现的 `user_input_request` 事件 → `AskUserCard` 表达。
+
+---
+
+## 3. 已确认决策
+
+| 决策点 | 结论 | 理由 |
+|---|---|---|
+| 谁能调用 ask_user | **仅 principal** | 符合"只有 principal 面向用户"的现有架构;专家需要信息时走 `send_message` 让 principal 转问。语义最干净,实现最小。 |
+| 等待期间 session 状态 | `status` 保持 **running**,事件驱动 UI | 不动 status 枚举和状态机;与前端已实现的 `AskUserCard` 天然契合。 |
+| 超时 | **不超时**(无限等) | 用户离开再回来仍能回答。`timeout_sec` 作为协议可选字段保留,本版**不实现**定时器。 |
+| 取消 | `interrupt` 主动 **reject** 挂起项 | 纯 `await deferred` 未必被 `agent.abort()` 中断,故 `interrupt` 必须显式 reject 该 session 所有 `pendingInputs`,让 await 抛错、turn 干净结束。 |
+| 回答接收入口 | **复用 `/messages`** | 前端零改动;放宽 schema 后在 server handler 内按 `type` 分流。 |
+| 挂起登记表归属 | `SessionEntry.pendingInputs: Map`,经 `ToolDeps` 回调访问 | 仿现有 `ensureAgent`/`destroyAgent` 的委托模式(`ToolDeps` 里无原始对象,只有回调)。登记表逻辑极薄(Map + Deferred),内联进 `SessionEntry` 与 `mailbox`/`trace`/`agents`/`tasks` 容器一致,无需独立模块。 |
+
+---
+
+## 4. 改动清单(按 package,自底向上)
+
+### 4.1 `@brainpilot/protocol`
+
+**`src/http.ts` — 放宽 `/messages` 入参**
+
+`SendMessageRequestSchema` 改为接受两种 body 的联合:
+- 现有发消息形:`{ content: string, agent?: string, data?: {...} }`
+- 回答形:`{ type: "user_input_response", session_id: string, request_id: string, answer: string }`
+
+其余 schema(`UserInputRequestEventSchema` 等)已存在,不动。`RUNTIME_ROUTES` 不变(复用 `sendMessage` 路由)。
+
+### 4.2 `@brainpilot/runtime`
+
+**`src/events.ts`** — 新增 builder:
+```ts
+ev.userInputRequest(ctx, {
+  request_id, agent, question, options?, allow_free_text?
+}): AgUiEvent  // type: "user_input_request"
+```
+
+**`src/tools/system-tools.ts`**
+- `ToolDeps` 接口新增回调:
+  ```ts
+  requestUserInput: (req: {
+    question: string; options?: string[]; allow_free_text?: boolean;
+  }) => Promise<string>;
+  ```
+- 新增 `createAskUserTool(deps)`:
+  - 参数 schema:`{ question (required), options?: string[], allow_free_text?: boolean }`
+  - `execute`: `const answer = await deps.requestUserInput({...}); return ok(answer);`
+- `allSystemTools(deps)` 注册 `createAskUserTool`。
+- `AGENT_TOOL_CONFIG.principal` 追加 `"ask_user"`。
+
+**`src/session-manager.ts`**
+- `SessionEntry` 新增字段 `pendingInputs: Map<string, Deferred<string>>`(创建 session 时初始化空 Map)。
+- 在 `ensureAgent` 构造 `ToolDeps` 处(`session-manager.ts:554-565`),注入 `requestUserInput` 回调,闭包捕获 `this`、`sessionId`、`name`(发问的 agent)。
+- 新方法 `requestUserInput(entry, agent, req)`:
+  1. `request_id = randomUUID()`
+  2. `entry.bus.emit(ev.userInputRequest({sessionId, runId: entry.activeRunId}, {request_id, agent, ...req}))`
+  3. 建 deferred,存入 `entry.pendingInputs.set(request_id, deferred)`
+  4. `return deferred.promise`
+- 新方法 `resolveInput(sessionId, request_id, answer): boolean`:
+  - 找到 entry 与 deferred → `deferred.resolve(answer)` → `pendingInputs.delete(request_id)` → 返回 `true`
+  - 找不到(session 不存在、未知 / 已消费 request_id)→ 返回 `false`(纯查表,不抛错;server 在调用前已用 `getSession` 处理 404)
+- `interrupt`(`session-manager.ts:533-542`):abort 各 agent 后,遍历 `entry.pendingInputs` 全部 `reject(new Error("interrupted"))` 并 `clear()`。
+- `evictSession`(`session-manager.ts:~460`):清理时 reject 并清空 `pendingInputs`,防 promise 泄漏。
+- 需要一个小 `Deferred<T>` 工具(`{promise, resolve, reject}`),就近定义或放入小工具模块。
+
+**`src/server.ts`** — `/messages` handler(`server.ts:73-83`)分流:
+- 解析 body 后,若 `body.type === "user_input_response"`:
+  - `const okResolved = await manager.resolveInput(id, body.request_id, body.answer)`
+  - 返回 `{ status: okResolved ? "ok" : "stale" }`(HTTP 200;session 不存在仍按现有逻辑 404)
+- 否则走现有 `sendMessage(...)` 分支。
+
+### 4.3 `@brainpilot/web`
+
+**零改动。** `respondToInput()` 已在发送正确的 body。
+
+---
+
+## 5. 数据流
+
+```
+principal turn 中调 ask_user(question)
+  └─ tool.execute → deps.requestUserInput()
+       ├─ request_id = randomUUID()
+       ├─ bus.emit(user_input_request)  ──SSE──▶ 前端渲染 AskUserCard
+       └─ await deferred  ← turn 阻塞于此(status 仍 running)
+                                  │
+用户在卡片作答 → respondToInput()  │
+  └─ POST /messages {type:user_input_response, request_id, answer}
+       └─ server 分流 → manager.resolveInput(request_id, answer)
+            └─ deferred.resolve(answer) + map.delete
+                 └─ ask_user.execute 返回 answer → principal turn 继续
+```
+
+**取消路径**:`interrupt` → reject 所有 `pendingInputs` → `ask_user.execute` 抛错 → turn 干净结束。
+
+---
+
+## 6. 错误处理
+
+| 场景 | 处理 |
+|---|---|
+| 未知 / 已消费 `request_id`(重复回答、已取消) | `resolveInput` 返回 `false`;server 回 `{status:"stale"}`,HTTP 200 |
+| session 不存在 | 沿用现有 `/messages` 404 逻辑 |
+| 等待时 `interrupt` | deferred reject → 工具 throw → turn 终止 |
+| 等待时 `evictSession` | deferred reject + 清空 map,无悬挂 promise |
+| deferred 泄漏防护 | resolve/reject 后**必从 map 删除**条目 |
+
+---
+
+## 7. 测试(全程 `BP_MOCK=1`,不烧 quota)
+
+mock agent 在 `mock-agent.ts:100` 同样 `await tool.execute(args)`,故 deferred 阻塞在 mock 路径下完全生效,链路可端到端测试。
+
+- **单元(session-manager)**:`requestUserInput`/`resolveInput` 配对成功;`resolveInput` 未知 id 返回 `false`;`interrupt` reject 所有挂起项;`evictSession` 清空挂起项。
+- **协议(http)**:`SendMessageRequestSchema` 接受两种 body;拒绝非法 body。
+- **集成(mock 驱动)**:principal prompt 含 `[[tool:ask_user {"question":"X"}]]` → 断言 SSE 出现 `user_input_request` 且 prompt promise 尚未 resolve → 调 `resolveInput` → 断言 prompt 完成、tool result == answer。
+- **server**:POST `/messages` 带 `user_input_response` → 200 且 `resolveInput` 被调用;stale id → `{status:"stale"}`。
+- **访问控制(tool-access)**:`ask_user` 仅 principal 可见,专家不可见。
+
+---
+
+## 8. 非目标(YAGNI)
+
+- 不实现 `timeout_sec` 定时器(字段保留)。
+- 不让专家 agent 直接 ask_user(走 principal 转问)。
+- 不新增 status 枚举值(如 `waiting`)。
+- 不新增专用 HTTP 路由(复用 `/messages`)。
+- 前端不做任何改动。

--- a/packages/protocol/src/__tests__/http.test.ts
+++ b/packages/protocol/src/__tests__/http.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { SendMessageRequestSchema } from "../http.js";
+
+describe("SendMessageRequestSchema", () => {
+  it("accepts a normal send-message body", () => {
+    const r = SendMessageRequestSchema.safeParse({ content: "hello", agent: "principal" });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts a user_input_response answer body", () => {
+    const r = SendMessageRequestSchema.safeParse({
+      type: "user_input_response",
+      session_id: "s1",
+      request_id: "req_123",
+      answer: "option A",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects a body that is neither (no content, no answer)", () => {
+    const r = SendMessageRequestSchema.safeParse({ foo: "bar" });
+    expect(r.success).toBe(false);
+  });
+});

--- a/packages/protocol/src/http.ts
+++ b/packages/protocol/src/http.ts
@@ -116,7 +116,8 @@ export type GetSessionStateResponse = z.infer<typeof GetSessionStateResponseSche
  * POST /sessions/:id/messages  (inject user message)
  * ------------------------------------------------------------------ */
 
-export const SendMessageRequestSchema = z.object({
+/** A normal user message injected into the session. */
+export const SendMessageContentSchema = z.object({
   content: z.string(),
   /** Target agent; defaults to principal. */
   agent: z.string().optional(),
@@ -134,7 +135,26 @@ export const SendMessageRequestSchema = z.object({
     })
     .optional(),
 });
+
+/** A reply to an outstanding ask_user (user_input_request) — see events.ts. */
+export const UserInputResponseBodySchema = z.object({
+  type: z.literal("user_input_response"),
+  session_id: z.string(),
+  request_id: z.string(),
+  answer: z.string(),
+});
+
+/**
+ * POST /sessions/:id/messages accepts EITHER a normal message OR an ask_user
+ * reply. The answer body is matched by its `type` literal; everything else is
+ * treated as a content message.
+ */
+export const SendMessageRequestSchema = z.union([
+  UserInputResponseBodySchema,
+  SendMessageContentSchema,
+]);
 export type SendMessageRequest = z.infer<typeof SendMessageRequestSchema>;
+export type UserInputResponseBody = z.infer<typeof UserInputResponseBodySchema>;
 
 export const SendMessageResponseSchema = z.object({
   accepted: z.boolean(),

--- a/packages/runtime/src/__tests__/ask-user.test.ts
+++ b/packages/runtime/src/__tests__/ask-user.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { parseEvent, type AgUiEvent } from "@brainpilot/protocol";
+import { SessionManager } from "../session-manager.js";
+import { mockAgentFactory } from "../agent-factory.js";
+
+function mgr(): SessionManager {
+  return new SessionManager({ persist: false, agentFactory: mockAgentFactory });
+}
+
+describe("ask_user (SessionManager)", () => {
+  let m: SessionManager;
+  beforeEach(() => {
+    m = mgr();
+  });
+
+  it("emits user_input_request and resolves the turn on answer", async () => {
+    const session = await m.createSession({ title: "T" });
+    const events: AgUiEvent[] = [];
+    m.subscribe(session.id, (e) => events.push(e));
+
+    // Drive the mock agent to call ask_user via the prompt control protocol.
+    const res = await m.sendMessage(
+      session.id,
+      'please decide [[tool:ask_user {"question":"Pick A or B"}]]',
+    );
+    expect(res.accepted).toBe(true);
+
+    // The request event should appear without us answering yet.
+    await new Promise((r) => setTimeout(r, 20));
+    const req = events.find((e) => e.type === "user_input_request") as any;
+    expect(req).toBeTruthy();
+    expect(req.question).toBe("Pick A or B");
+    expect(typeof req.request_id).toBe("string");
+
+    // Answer it; the blocked tool execute resolves and the turn finishes.
+    const okResolved = m.resolveInput(session.id, req.request_id, "A");
+    expect(okResolved).toBe(true);
+
+    await new Promise((r) => setTimeout(r, 20));
+    const toolEnd = events.find(
+      (e) => e.type === "TOOL_CALL_RESULT" && (e as any).content?.includes("A"),
+    );
+    expect(toolEnd).toBeTruthy();
+  });
+
+  it("resolveInput returns false for unknown request_id", async () => {
+    const session = await m.createSession({ title: "T" });
+    expect(m.resolveInput(session.id, "nope", "x")).toBe(false);
+    expect(m.resolveInput("no-session", "nope", "x")).toBe(false);
+  });
+
+  it("interrupt rejects pending inputs", async () => {
+    const session = await m.createSession({ title: "T" });
+    const events: AgUiEvent[] = [];
+    m.subscribe(session.id, (e) => events.push(e));
+    await m.sendMessage(session.id, 'decide [[tool:ask_user {"question":"Q"}]]');
+    await new Promise((r) => setTimeout(r, 20));
+    expect(events.find((e) => e.type === "user_input_request")).toBeTruthy();
+
+    await m.interrupt(session.id);
+    await new Promise((r) => setTimeout(r, 20));
+    // After interrupt, answering the (now-cleared) request is stale.
+    const req = events.find((e) => e.type === "user_input_request") as any;
+    expect(m.resolveInput(session.id, req.request_id, "late")).toBe(false);
+  });
+});

--- a/packages/runtime/src/__tests__/event-mapping.test.ts
+++ b/packages/runtime/src/__tests__/event-mapping.test.ts
@@ -3,6 +3,7 @@ import { parseEvent, type AgUiEvent } from "@brainpilot/protocol";
 import { EventBus } from "../event-bus.js";
 import { MasAgent } from "../mas-agent.js";
 import { MockAgentSession } from "../mock-agent.js";
+import { ev } from "../events.js";
 
 /**
  * Event mapping: drive a MasAgent over the MockAgentSession (which emits real
@@ -86,6 +87,21 @@ describe("event mapping (Pi -> AG-UI via parseEvent)", () => {
     expect(types).toContain("TOOL_CALL_RESULT");
     const result = captured.find((e) => e.type === "TOOL_CALL_RESULT") as { content: string };
     expect(result.content).toBe("pong");
+  });
+
+  describe("ev.userInputRequest", () => {
+    it("builds a valid user_input_request event", () => {
+      const e = ev.userInputRequest(
+        { sessionId: "s1", runId: "run_1" },
+        { request_id: "req_1", agent: "principal", question: "Pick one", options: ["a", "b"], allow_free_text: true },
+      );
+      const parsed = parseEvent(e); // throws if invalid against the protocol union
+      expect(parsed.type).toBe("user_input_request");
+      expect((parsed as any).request_id).toBe("req_1");
+      expect((parsed as any).question).toBe("Pick one");
+      expect((parsed as any).options).toEqual(["a", "b"]);
+      expect((parsed as any).session_id).toBe("s1");
+    });
   });
 
   it("maps auto_retry failure to a system_message and error status", async () => {

--- a/packages/runtime/src/__tests__/server.test.ts
+++ b/packages/runtime/src/__tests__/server.test.ts
@@ -137,6 +137,47 @@ describe("HTTP server (RUNTIME_ROUTES)", () => {
     });
     expect(put.status).toBe(404);
   });
+
+  it("POST /messages with user_input_response resolves or reports stale", async () => {
+    const a = app();
+    const created = await a.request("/sessions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "T" }),
+    });
+    const { id } = (await created.json()) as { id: string };
+
+    // No outstanding request → stale, but still 200.
+    const res = await a.request(`/sessions/${id}/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        type: "user_input_response",
+        session_id: id,
+        request_id: "req_missing",
+        answer: "x",
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: "stale" });
+  });
+
+  it("POST /messages still accepts a normal content body", async () => {
+    const a = app();
+    const created = await a.request("/sessions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ title: "T" }),
+    });
+    const { id } = (await created.json()) as { id: string };
+    const res = await a.request(`/sessions/${id}/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ content: "hello" }),
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).accepted).toBe(true);
+  });
 });
 
 describe("workspace file routes", () => {

--- a/packages/runtime/src/__tests__/tool-access.test.ts
+++ b/packages/runtime/src/__tests__/tool-access.test.ts
@@ -16,6 +16,7 @@ function deps(name: string): ToolDeps {
     trace: new GraphOfTrace("s"),
     ensureAgent: async () => {},
     destroyAgent: async () => {},
+    requestUserInput: async () => "stub-answer",
   };
 }
 
@@ -25,6 +26,12 @@ describe("tool access control (§9)", () => {
     expect(names).toEqual(expect.arrayContaining(["send_message", "create_agent", "destroy_agent", "record_trace"]));
     expect(names).not.toContain("create_trace_node");
     expect(names).not.toContain("get_trace_graph");
+  });
+
+  it("principal can ask_user; experts and trace cannot", () => {
+    expect(systemToolNamesForRole("principal", "principal")).toContain("ask_user");
+    expect(systemToolNamesForRole("expert", "librarian")).not.toContain("ask_user");
+    expect(systemToolNamesForRole("trace", "trace")).not.toContain("ask_user");
   });
 
   it("trace agent gets ONLY graph tools", () => {

--- a/packages/runtime/src/events.ts
+++ b/packages/runtime/src/events.ts
@@ -136,6 +136,20 @@ export const ev = {
     }
     return e as AgUiEvent;
   },
+  userInputRequest(
+    ctx: Ctx,
+    req: { request_id: string; agent: string; question: string; options?: string[]; allow_free_text?: boolean },
+  ): AgUiEvent {
+    return {
+      type: "user_input_request",
+      ...envelope(ctx),
+      request_id: req.request_id,
+      agent: req.agent,
+      question: req.question,
+      options: req.options,
+      allow_free_text: req.allow_free_text,
+    } as AgUiEvent;
+  },
   systemMessage(
     sessionId: string,
     level: "info" | "warning" | "error" | "fatal",

--- a/packages/runtime/src/server.ts
+++ b/packages/runtime/src/server.ts
@@ -76,8 +76,18 @@ export function createServer(opts: SessionManagerOptions & { manager?: SessionMa
     const parsed = SendMessageRequestSchema.safeParse(body);
     if (!parsed.success) return c.json({ error: "invalid body" }, 400);
     if (!manager.getSession(id)) return c.json({ error: "not found" }, 404);
-    const res = await manager.sendMessage(id, parsed.data.content, parsed.data.agent ?? "principal", {
-      uuid: parsed.data.data?.uuid,
+
+    // ask_user reply branch: resolve the outstanding request.
+    const data = parsed.data;
+    if ("type" in data && data.type === "user_input_response") {
+      const okResolved = manager.resolveInput(id, data.request_id, data.answer);
+      return c.json({ status: okResolved ? "ok" : "stale" });
+    }
+
+    // Normal message branch.
+    if (!("content" in data)) return c.json({ error: "invalid body" }, 400);
+    const res = await manager.sendMessage(id, data.content, data.agent ?? "principal", {
+      uuid: data.data?.uuid,
     });
     return c.json(res);
   });

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -26,6 +26,22 @@ import { resolveSessionProvider, type SessionProviderRef } from "./provider-conf
 import { MemWatchdog, parseMemLimitMb } from "./mem-watchdog.js";
 import type { AgentRole, AgentSessionFactory, EventListener, SystemTool } from "./types.js";
 
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: Error) => void;
+}
+
+function makeDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: Error) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 interface SessionEntry {
   id: string;
   title: string;
@@ -40,6 +56,8 @@ interface SessionEntry {
   tasks: Map<string, string>;
   runActive: boolean;
   activeRunId: string | null;
+  /** Outstanding ask_user requests, keyed by request_id (§ ask_user). */
+  pendingInputs: Map<string, Deferred<string>>;
   /** This session's chosen provider/model (resolved against providers.json). */
   providerRef: SessionProviderRef;
 }
@@ -395,6 +413,7 @@ export class SessionManager {
       tasks: new Map(),
       runActive: false,
       activeRunId: null,
+      pendingInputs: new Map(),
       providerRef,
     };
     this.sessions.set(id, entry);
@@ -465,6 +484,10 @@ export class SessionManager {
     await e.mailbox.flush();
     await e.trace.flush();
     e.bus.clear();
+    for (const [id2, d] of e.pendingInputs) {
+      d.reject(new Error("evicted"));
+      e.pendingInputs.delete(id2);
+    }
     this.sessions.delete(id);
     return { evicted: true, agentsKilled: killed };
   }
@@ -530,6 +553,44 @@ export class SessionManager {
     return { accepted: true, runId };
   }
 
+  /**
+   * Ask the terminal user a question on behalf of `agent`. Emits a
+   * `user_input_request` event and returns a promise that resolves when
+   * `resolveInput` is called with the matching request_id, or rejects if the
+   * session is interrupted/evicted. Blocks the calling tool's turn.
+   */
+  private requestUserInput(
+    entry: SessionEntry,
+    agent: string,
+    req: { question: string; options?: string[]; allow_free_text?: boolean },
+  ): Promise<string> {
+    const requestId = `req_${randomUUID()}`;
+    const deferred = makeDeferred<string>();
+    entry.pendingInputs.set(requestId, deferred);
+    entry.bus.emit(
+      ev.userInputRequest(
+        { sessionId: entry.id, runId: entry.activeRunId ?? undefined },
+        { request_id: requestId, agent, question: req.question, options: req.options, allow_free_text: req.allow_free_text },
+      ),
+    );
+    return deferred.promise;
+  }
+
+  /**
+   * Resolve an outstanding ask_user request. Returns false when the session or
+   * request_id is unknown/already consumed (stale answer). Pure lookup; never
+   * throws — the server handles 404 for unknown sessions before calling.
+   */
+  resolveInput(sessionId: string, requestId: string, answer: string): boolean {
+    const entry = this.sessions.get(sessionId);
+    const deferred = entry?.pendingInputs.get(requestId);
+    if (!entry || !deferred) return false;
+    entry.pendingInputs.delete(requestId);
+    deferred.resolve(answer);
+    this.touch(entry);
+    return true;
+  }
+
   /** Interrupt a session (or a specific agent). */
   async interrupt(sessionId: string, agentName?: string): Promise<boolean> {
     const entry = this.sessions.get(sessionId);
@@ -538,6 +599,10 @@ export class SessionManager {
     for (const a of targets) await a!.abort();
     entry.runActive = false;
     entry.activeRunId = null;
+    for (const [id, d] of entry.pendingInputs) {
+      d.reject(new Error("interrupted"));
+      entry.pendingInputs.delete(id);
+    }
     return targets.length > 0;
   }
 
@@ -562,6 +627,7 @@ export class SessionManager {
       destroyAgent: async (target) => {
         await this.destroyAgent(sessionId, target);
       },
+      requestUserInput: (req) => this.requestUserInput(entry, name, req),
     };
     const systemTools = systemToolsForRole(role, name, deps);
     // External MCP tools go to non-trace agents (trace agent is graph-only, §9).

--- a/packages/runtime/src/tools/system-tools.ts
+++ b/packages/runtime/src/tools/system-tools.ts
@@ -20,6 +20,12 @@ export interface ToolDeps {
   ensureAgent: (name: string) => Promise<void>;
   /** Destroy an agent (memory only; history kept). */
   destroyAgent: (name: string) => Promise<void>;
+  /** Ask the terminal user a question; resolves with their answer. Blocks the turn. */
+  requestUserInput: (req: {
+    question: string;
+    options?: string[];
+    allow_free_text?: boolean;
+  }) => Promise<string>;
 }
 
 function ok(text: string): { content: [{ type: "text"; text: string }] } {
@@ -53,6 +59,39 @@ export function createSendMessageTool(deps: ToolDeps): SystemTool {
 function deriveMsgType(from: string, to: string): MsgType {
   if (to === "principal") return "result_deliver";
   return "task_delegate";
+}
+
+export function createAskUserTool(deps: ToolDeps): SystemTool {
+  return {
+    name: "ask_user",
+    description:
+      "Ask the human user a question and wait for their answer. Use when you need a decision or information only the user can provide. Returns the user's answer as text.",
+    parameters: {
+      type: "object",
+      properties: {
+        question: { type: "string", description: "The question to show the user" },
+        options: {
+          type: "array",
+          items: { type: "string" },
+          description: "Optional choices to offer the user",
+        },
+        allow_free_text: {
+          type: "boolean",
+          description: "Whether the user may type a free-text answer (default true)",
+        },
+      },
+      required: ["question"],
+    },
+    execute: async (params: Record<string, unknown>) => {
+      const answer = await deps.requestUserInput({
+        question: String(params.question ?? ""),
+        options: Array.isArray(params.options) ? (params.options as string[]) : undefined,
+        allow_free_text:
+          typeof params.allow_free_text === "boolean" ? params.allow_free_text : undefined,
+      });
+      return ok(answer);
+    },
+  };
 }
 
 export function createCreateAgentTool(deps: ToolDeps): SystemTool {
@@ -212,6 +251,7 @@ export function createGetTraceGraphTool(deps: ToolDeps): SystemTool {
 export function allSystemTools(deps: ToolDeps): Map<string, SystemTool> {
   const tools = [
     createSendMessageTool(deps),
+    createAskUserTool(deps),
     createCreateAgentTool(deps),
     createDestroyAgentTool(deps),
     createRecordTraceTool(deps),
@@ -229,7 +269,7 @@ export function allSystemTools(deps: ToolDeps): Map<string, SystemTool> {
  * tools (read/bash/grep/...) are controlled separately via `builtinToolsForRole`.
  */
 export const AGENT_TOOL_CONFIG: Record<string, string[]> = {
-  principal: ["send_message", "create_agent", "destroy_agent", "record_trace"],
+  principal: ["send_message", "create_agent", "destroy_agent", "record_trace", "ask_user"],
   trace: ["create_trace_node", "update_trace_node", "add_trace_relation", "get_trace_graph"],
   expert: ["send_message", "record_trace"],
   // Default for any other expert-like agent.


### PR DESCRIPTION
## Summary

Completes the half-built **ask_user** feature: the `principal` agent can now ask the terminal user a question mid-turn, block until they answer, then resume the same turn. The protocol events and the frontend `AskUserCard`/`respondToInput` were already in place — this PR wires up the missing runtime piece plus one protocol schema widening. **No web code changes were required.**

## How it works

1. `principal` calls the new `ask_user` system tool (principal-only via `AGENT_TOOL_CONFIG`).
2. The tool's `execute` blocks on a deferred promise stored in `SessionEntry.pendingInputs`, reached through a new `ToolDeps.requestUserInput` callback (mirrors the existing `ensureAgent` delegation).
3. It emits a `user_input_request` AG-UI event, consumed by the already-built frontend `AskUserCard`.
4. The user's answer POSTs to the existing `/sessions/:id/messages` endpoint; `SendMessageRequestSchema` is widened to a union accepting a `user_input_response` body.
5. The server routes that body to `manager.resolveInput(...)`, which resolves the deferred so the turn continues.
6. `interrupt` / `evictSession` reject any pending inputs (the blocked tool throws, per Pi's tool-failure convention).

## Design decisions (from the spec)

- Only `principal` can ask; experts and the trace agent cannot.
- Session `status` stays `running` while waiting — no new status enum.
- No timeout timer (the `timeout_sec` field is retained in the event schema but not enforced); `interrupt` is the cancellation path.
- Reuses the existing `/messages` endpoint — no new route.
- Stale/unknown `request_id` returns `{ status: "stale" }` (HTTP 200), not an error.

## Tasks (TDD, one commit each)

1. `feat(protocol)` — widen `SendMessageRequestSchema` to a union
2. `feat(runtime)` — `ev.userInputRequest` event builder
3. `feat(runtime)` — `ask_user` system tool, principal-only
4. `feat(runtime)` — `pendingInputs` registry + `requestUserInput`/`resolveInput`, reject-on-interrupt/evict
5. `feat(runtime)` — route `user_input_response` to `resolveInput` on `/messages`

## Verification

- `npm test` → **377/377** pass
- web tests → **48/48** pass
- `npm run typecheck` → clean
- `npm run build` → succeeds
- `bash scripts/smoke-e2e.sh` → **SMOKE PASS**

Spec: `docs/superpowers/specs/2026-06-18-ask-user-design.md` · Plan: `docs/superpowers/plans/2026-06-18-ask-user.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
