### PR TITLE
fix(runtime): truncate oversized tool results to prevent context overflow (closes #80)

### DIFF
--- a/packages/runtime/src/__tests__/tool-truncation.test.ts
+++ b/packages/runtime/src/__tests__/tool-truncation.test.ts
@@ -1,0 +1,381 @@
+/**
+ * Tool result truncation tests (issue #80).
+ *
+ * Verifies that SystemTool results exceeding a configurable token budget are
+ * truncated, with full content saved to the session workspace and a warning
+ * surfaced to the frontend.
+ */
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtemp, mkdir, readFile, readdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgUiEvent } from "@brainpilot/protocol";
+import { SessionManager, estimateTokens } from "../session-manager.js";
+import { mockAgentFactory } from "../agent-factory.js";
+import type { McpBridge, McpServersConfig, SystemTool } from "../mcp-bridge.js";
+import type { SystemToolResult } from "../types.js";
+
+/* ------------------------------------------------------------------ *
+ * Helpers
+ * ------------------------------------------------------------------ */
+
+/** Build a fake MCP bridge that returns `tools` on connectAll. */
+function fakeMcpBridge(tools: SystemTool[]): McpBridge {
+  return {
+    tools,
+    connectAll: async (_cfg: McpServersConfig) => tools,
+    close: async () => {},
+  } as unknown as McpBridge;
+}
+
+/** A tool that returns `text` repeated `times` times. */
+function largeResultTool(name: string, chunk: string, times: number): SystemTool {
+  return {
+    name,
+    description: "returns a lot of text",
+    parameters: { type: "object", properties: {} },
+    execute: async (_params: Record<string, unknown>): Promise<SystemToolResult> => {
+      return { content: [{ type: "text", text: chunk.repeat(times) }] };
+    },
+  };
+}
+
+/** Write a minimal mcp_servers.json so ensureMcpTools doesn't bail early. */
+async function writeMcpServersConfig(dataDir: string, names: string[]): Promise<void> {
+  const dir = join(dataDir, "bp_template");
+  await mkdir(dir, { recursive: true });
+  const cfg = {
+    mcpServers: Object.fromEntries(names.map((n) => [n, { type: "stdio", command: "echo" }])),
+  };
+  await writeFile(join(dir, "mcp_servers.json"), JSON.stringify(cfg), "utf8");
+}
+
+function waitFor(fn: () => boolean, ms = 2000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const start = Date.now();
+    const check = () => {
+      if (fn()) return resolve();
+      if (Date.now() - start > ms) return reject(new Error("timeout"));
+      setTimeout(check, 20);
+    };
+    check();
+  });
+}
+
+/* ------------------------------------------------------------------ *
+ * Tests
+ * ------------------------------------------------------------------ */
+
+describe("estimateTokens", () => {
+  it("returns 0 for empty string", () => {
+    expect(estimateTokens("")).toBe(0);
+  });
+
+  it("estimates ~1 token per 3.5 chars", () => {
+    expect(estimateTokens("a".repeat(35))).toBe(10);
+  });
+
+  it("rounds up for partial tokens", () => {
+    expect(estimateTokens("a".repeat(10))).toBe(3);
+  });
+});
+
+describe("tool result truncation", () => {
+  let dataDir: string;
+
+  afterEach(async () => {
+    if (dataDir) {
+      try {
+        await rm(dataDir, { recursive: true, force: true });
+      } catch {
+        /* cleanup best-effort */
+      }
+    }
+  });
+
+  /* ------------------------------------------------------------------ *
+   * Small result passes through
+   * ------------------------------------------------------------------ */
+
+  it("passes through small tool results unchanged", async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "bp-trunc-"));
+    const tool = largeResultTool("small_tool", "hello ", 100); // ~600 chars → ~171 tokens
+    await writeMcpServersConfig(dataDir, ["test"]);
+
+    const mgr = new SessionManager({
+      persist: true,
+      dataRoot: dataDir,
+      agentFactory: mockAgentFactory,
+      maxToolResultTokens: 10000,
+      mcpBridge: fakeMcpBridge([tool]),
+    });
+
+    const s = await mgr.createSession({ title: "test" });
+    const events: AgUiEvent[] = [];
+    mgr.subscribe(s.id, (e) => events.push(e));
+
+    await mgr.sendMessage(s.id, "hello [[tool:small_tool]]");
+    await waitFor(() => events.some((e) => e.type === "RUN_FINISHED"));
+
+    const truncWarnings = events.filter(
+      (e) => e.type === "system_message" && "message" in e && typeof e.message === "string" && e.message.includes("已截断"),
+    );
+    expect(truncWarnings.length).toBe(0);
+  });
+
+  /* ------------------------------------------------------------------ *
+   * Large result gets truncated
+   * ------------------------------------------------------------------ */
+
+  it("truncates large tool results and saves full content", async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "bp-trunc-"));
+    // 50000 * 43 chars = 2_150_000 chars → ~614286 tokens (well over 1000 limit)
+    const chunk = "All work and no play makes Jack a dull boy. ";
+    const tool = largeResultTool("big_tool", chunk, 50000);
+    await writeMcpServersConfig(dataDir, ["test"]);
+
+    const mgr = new SessionManager({
+      persist: true,
+      dataRoot: dataDir,
+      agentFactory: mockAgentFactory,
+      maxToolResultTokens: 1000,
+      mcpBridge: fakeMcpBridge([tool]),
+    });
+
+    const s = await mgr.createSession({ title: "test" });
+    const events: AgUiEvent[] = [];
+    mgr.subscribe(s.id, (e) => events.push(e));
+
+    await mgr.sendMessage(s.id, "hello [[tool:big_tool]]");
+    await waitFor(() => events.some((e) => e.type === "RUN_FINISHED"), 5000);
+
+    // 1. Warning system_message emitted.
+    const truncWarnings = events.filter(
+      (e) => e.type === "system_message" && "message" in e && typeof e.message === "string" && e.message.includes("已截断"),
+    );
+    expect(truncWarnings.length).toBeGreaterThanOrEqual(1);
+
+    // 2. Tool result content is truncated.
+    const results = events.filter(
+      (e) => e.type === "TOOL_CALL_RESULT" && "content" in e,
+    );
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    const resultContent = (results[0] as { content: string }).content;
+    expect(resultContent.length).toBeLessThan(20000);
+    expect(resultContent).toContain("[⚠️ 结果已截断");
+
+    // 3. Full content saved to workspace.
+    const truncatedDir = join(dataDir, "workspaces", s.id, ".truncated");
+    const entries = await readdir(truncatedDir);
+    expect(entries.length).toBe(1);
+    expect(entries[0]).toMatch(/^big_tool_.*\.json$/);
+  });
+
+  /* ------------------------------------------------------------------ *
+   * Full content saved to .truncated/ directory
+   * ------------------------------------------------------------------ */
+
+  it("saves full content to workspace/.truncated/ with correct metadata", async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "bp-trunc-"));
+    const uniqueChunk = "UNIQUE_MARKER_";
+    const tool = largeResultTool("save_test", uniqueChunk, 8000); // 112000 chars → ~32000 tokens
+    await writeMcpServersConfig(dataDir, ["test"]);
+
+    const mgr = new SessionManager({
+      persist: true,
+      dataRoot: dataDir,
+      agentFactory: mockAgentFactory,
+      maxToolResultTokens: 500,
+      mcpBridge: fakeMcpBridge([tool]),
+    });
+
+    const s = await mgr.createSession({ title: "test" });
+    const events: AgUiEvent[] = [];
+    mgr.subscribe(s.id, (e) => events.push(e));
+
+    await mgr.sendMessage(s.id, "hello [[tool:save_test]]");
+    await waitFor(() => events.some((e) => e.type === "RUN_FINISHED"), 5000);
+
+    const truncatedDir = join(dataDir, "workspaces", s.id, ".truncated");
+    const entries = await readdir(truncatedDir);
+    expect(entries.length).toBe(1);
+    expect(entries[0]).toMatch(/^save_test_.*\.json$/);
+
+    const saved = JSON.parse(await readFile(join(truncatedDir, entries[0]!), "utf8")) as Record<string, unknown>;
+    expect(saved.tool).toBe("save_test");
+    expect(saved.content as string).toContain("UNIQUE_MARKER_");
+    expect((saved.content as string).length).toBe(uniqueChunk.length * 8000);
+    expect(saved.maxTokens).toBe(500);
+    expect(saved.estimatedTokens as number).toBeGreaterThan(500);
+    expect(typeof saved.truncatedAt).toBe("string");
+  });
+
+  /* ------------------------------------------------------------------ *
+   * Warning event
+   * ------------------------------------------------------------------ */
+
+  it("emits warning with tool name and file path", async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "bp-trunc-"));
+    const tool = largeResultTool("warn_tool", "data ", 10000);
+    await writeMcpServersConfig(dataDir, ["test"]);
+
+    const mgr = new SessionManager({
+      persist: true,
+      dataRoot: dataDir,
+      agentFactory: mockAgentFactory,
+      maxToolResultTokens: 2000,
+      mcpBridge: fakeMcpBridge([tool]),
+    });
+
+    const s = await mgr.createSession({ title: "test" });
+    const events: AgUiEvent[] = [];
+    mgr.subscribe(s.id, (e) => events.push(e));
+
+    await mgr.sendMessage(s.id, "hello [[tool:warn_tool]]");
+    await waitFor(() => events.some((e) => e.type === "RUN_FINISHED"), 5000);
+
+    const warn = events.find(
+      (e) => e.type === "system_message" && "message" in e && typeof e.message === "string" && e.message.includes("已截断"),
+    ) as { level: string; message: string } | undefined;
+    expect(warn).toBeTruthy();
+    expect(warn!.level).toBe("warning");
+    expect(warn!.message).toContain("warn_tool");
+    expect(warn!.message).toContain("workspace/.truncated/");
+  });
+
+  /* ------------------------------------------------------------------ *
+   * Custom maxToolResultTokens is respected
+   * ------------------------------------------------------------------ */
+
+  it("respects custom maxToolResultTokens (high limit → no truncation)", async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "bp-trunc-"));
+    const tool = largeResultTool("custom_test", "x", 5000);
+    await writeMcpServersConfig(dataDir, ["test"]);
+
+    const mgr = new SessionManager({
+      persist: true,
+      dataRoot: dataDir,
+      agentFactory: mockAgentFactory,
+      maxToolResultTokens: 100000,
+      mcpBridge: fakeMcpBridge([tool]),
+    });
+
+    const s = await mgr.createSession({ title: "test" });
+    const events: AgUiEvent[] = [];
+    mgr.subscribe(s.id, (e) => events.push(e));
+
+    await mgr.sendMessage(s.id, "hello [[tool:custom_test]]");
+    await waitFor(() => events.some((e) => e.type === "RUN_FINISHED"), 5000);
+
+    const truncWarnings = events.filter(
+      (e) => e.type === "system_message" && "message" in e && typeof e.message === "string" && e.message.includes("已截断"),
+    );
+    expect(truncWarnings.length).toBe(0);
+  });
+
+  /* ------------------------------------------------------------------ *
+   * maxToolResultTokens = 0 disables truncation
+   * ------------------------------------------------------------------ */
+
+  it("disables truncation when maxToolResultTokens is 0", async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "bp-trunc-"));
+    const tool = largeResultTool("no_trunc", "big ", 50000);
+    await writeMcpServersConfig(dataDir, ["test"]);
+
+    const mgr = new SessionManager({
+      persist: true,
+      dataRoot: dataDir,
+      agentFactory: mockAgentFactory,
+      maxToolResultTokens: 0,
+      mcpBridge: fakeMcpBridge([tool]),
+    });
+
+    const s = await mgr.createSession({ title: "test" });
+    const events: AgUiEvent[] = [];
+    mgr.subscribe(s.id, (e) => events.push(e));
+
+    await mgr.sendMessage(s.id, "hello [[tool:no_trunc]]");
+    await waitFor(() => events.some((e) => e.type === "RUN_FINISHED"), 5000);
+
+    const truncWarnings = events.filter(
+      (e) => e.type === "system_message" && "message" in e && typeof e.message === "string" && e.message.includes("已截断"),
+    );
+    expect(truncWarnings.length).toBe(0);
+  });
+
+  /* ------------------------------------------------------------------ *
+   * Error results are never truncated
+   * ------------------------------------------------------------------ */
+
+  it("never truncates error results", async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "bp-trunc-"));
+    const bigError = "ERROR_".repeat(50000);
+    const tool: SystemTool = {
+      name: "failing_tool",
+      description: "always fails",
+      parameters: { type: "object", properties: {} },
+      execute: async (): Promise<SystemToolResult> => ({
+        content: [{ type: "text", text: bigError }],
+        isError: true,
+      }),
+    };
+    await writeMcpServersConfig(dataDir, ["test"]);
+
+    const mgr = new SessionManager({
+      persist: true,
+      dataRoot: dataDir,
+      agentFactory: mockAgentFactory,
+      maxToolResultTokens: 100,
+      mcpBridge: fakeMcpBridge([tool]),
+    });
+
+    const s = await mgr.createSession({ title: "test" });
+    const events: AgUiEvent[] = [];
+    mgr.subscribe(s.id, (e) => events.push(e));
+
+    await mgr.sendMessage(s.id, "hello [[tool:failing_tool]]");
+    await waitFor(() => events.some((e) => e.type === "RUN_FINISHED"), 5000);
+
+    const truncWarnings = events.filter(
+      (e) => e.type === "system_message" && "message" in e && typeof e.message === "string" && e.message.includes("已截断"),
+    );
+    expect(truncWarnings.length).toBe(0);
+  });
+
+  /* ------------------------------------------------------------------ *
+   * Empty result is not affected
+   * ------------------------------------------------------------------ */
+
+  it("passes through empty tool results", async () => {
+    dataDir = await mkdtemp(join(tmpdir(), "bp-trunc-"));
+    const tool: SystemTool = {
+      name: "empty_tool",
+      description: "returns nothing",
+      parameters: { type: "object", properties: {} },
+      execute: async (): Promise<SystemToolResult> => ({
+        content: [{ type: "text", text: "" }],
+      }),
+    };
+    await writeMcpServersConfig(dataDir, ["test"]);
+
+    const mgr = new SessionManager({
+      persist: true,
+      dataRoot: dataDir,
+      agentFactory: mockAgentFactory,
+      maxToolResultTokens: 1000,
+      mcpBridge: fakeMcpBridge([tool]),
+    });
+
+    const s = await mgr.createSession({ title: "test" });
+    const events: AgUiEvent[] = [];
+    mgr.subscribe(s.id, (e) => events.push(e));
+
+    await mgr.sendMessage(s.id, "hello [[tool:empty_tool]]");
+    await waitFor(() => events.some((e) => e.type === "RUN_FINISHED"));
+
+    const truncWarnings = events.filter(
+      (e) => e.type === "system_message" && "message" in e && typeof e.message === "string" && e.message.includes("已截断"),
+    );
+    expect(truncWarnings.length).toBe(0);
+  });
+});

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -24,7 +24,7 @@ import { personaFor } from "./personas.js";
 import { McpBridge, loadMcpServersConfig } from "./mcp-bridge.js";
 import { resolveSessionProvider, type SessionProviderRef } from "./provider-config.js";
 import { MemWatchdog, parseMemLimitMb } from "./mem-watchdog.js";
-import type { AgentRole, AgentSessionFactory, EventListener, SystemTool } from "./types.js";
+import type { AgentRole, AgentSessionFactory, EventListener, SystemTool, SystemToolResult } from "./types.js";
 
 interface Deferred<T> {
   promise: Promise<T>;
@@ -80,6 +80,15 @@ export interface SessionManagerOptions {
   memLimitBytes?: number | null;
   /** Override the watchdog's RSS reader (tests inject; default reads real RSS). */
   readRss?: () => number;
+  /**
+   * Max estimated tokens per tool result before truncation (issue #80).
+   * When a tool returns content exceeding this threshold, the result is
+   * truncated, the full content is saved to the session workspace, and a
+   * warning is surfaced in the chat. Default: 64000 (~224KB text).
+   * Set to 0 to disable truncation entirely.
+   * Env override: BP_MAX_TOOL_RESULT_TOKENS.
+   */
+  maxToolResultTokens?: number;
 }
 
 /** Roles inferred from agent name. */
@@ -87,6 +96,28 @@ function roleFor(name: string): AgentRole {
   if (name === "principal") return "principal";
   if (name === "trace") return "trace";
   return "expert";
+}
+
+/**
+ * Conservative token estimation from character count (issue #80).
+ * English text averages ~4 chars/token; CJK text ~1-2 chars/token.
+ * 3.5 gives a safety margin — we'd rather truncate slightly early than
+ * overflow the provider's context window. Exported for tests.
+ */
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 3.5);
+}
+
+/** Filesystem-safe form of a tool name (for saving truncated results). */
+function sanitiseFilename(name: string): string {
+  return name.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 64);
+}
+
+/** Human-readable byte size (e.g. "1.2MB"). */
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n}B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)}KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)}MB`;
 }
 
 export class SessionManager {
@@ -105,11 +136,24 @@ export class SessionManager {
   // Opt-in memory watchdog (§R-4 / issue #20). Null when no budget is set.
   private readonly memWatchdog: MemWatchdog | null;
 
+  // Tool result truncation (issue #80). 0 = disabled.
+  private readonly maxToolResultTokens: number;
+
   constructor(opts: SessionManagerOptions = {}) {
     this.dataRoot = opts.dataRoot ?? process.env.BP_DATA_DIR ?? join(process.cwd(), ".bp-data");
     this.agentFactory = opts.agentFactory ?? selectFactory();
     this.persist = opts.persist ?? true;
     this.mcpBridge = opts.mcpBridge ?? null;
+    this.maxToolResultTokens =
+      opts.maxToolResultTokens ??
+      (() => {
+        const env = process.env.BP_MAX_TOOL_RESULT_TOKENS?.trim();
+        if (env !== undefined && env !== "") {
+          const n = Number(env);
+          if (Number.isInteger(n) && n >= 0) return n;
+        }
+        return 64000;
+      })();
 
     const limitBytes = opts.memLimitBytes ?? parseMemLimitMb(process.env);
     this.memWatchdog =
@@ -608,6 +652,100 @@ export class SessionManager {
 
   /* ------------------------------ agents ------------------------------- */
 
+  /**
+   * Wrap a SystemTool so its execute() results are guarded against overflowing
+   * the model's context window (issue #80). When truncation triggers, the full
+   * result is saved to `<workspace>/.truncated/` and a system_message warning
+   * is emitted. No-op when maxToolResultTokens is 0.
+   */
+  private wrapToolWithTruncation(
+    tool: SystemTool,
+    sessionId: string,
+    bus: EventBus,
+  ): SystemTool {
+    if (this.maxToolResultTokens <= 0) return tool;
+    const maxTokens = this.maxToolResultTokens;
+    const saveFullResult = (origResult: SystemToolResult) =>
+      this.truncateToolResult(tool.name, sessionId, bus, origResult, maxTokens);
+    const originalExecute = tool.execute.bind(tool);
+    return {
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.parameters,
+      execute: async (params: Record<string, unknown>): Promise<SystemToolResult> => {
+        const result = await originalExecute(params);
+        if (result.isError) return result; // never truncate error messages
+        return saveFullResult(result);
+      },
+    };
+  }
+
+  /**
+   * Estimate tokens in a tool result, truncate if over budget, save the full
+   * content to the session workspace, and emit a warning event.
+   */
+  private async truncateToolResult(
+    toolName: string,
+    sessionId: string,
+    bus: EventBus,
+    result: SystemToolResult,
+    maxTokens: number,
+  ): Promise<SystemToolResult> {
+    // Concatenate all text blocks to estimate total tokens.
+    const fullText = result.content.map((c) => c.text).join("");
+    const estimated = estimateTokens(fullText);
+    if (estimated <= maxTokens) return result;
+
+    // Truncate at ~maxTokens chars (conservative).
+    const maxChars = maxTokens * 3.5;
+    const truncatedText = fullText.slice(0, Math.floor(maxChars));
+    const now = new Date().toISOString();
+    const ts = now.replace(/[:.]/g, "-");
+    const fname = `${sanitiseFilename(toolName)}_${ts}.json`;
+    const relPath = `.truncated/${fname}`;
+
+    // Save full content to workspace.
+    try {
+      const absDir = join(this.workspaceDir(sessionId), ".truncated");
+      await mkdir(absDir, { recursive: true });
+      const saved: Record<string, unknown> = {
+        tool: toolName,
+        truncatedAt: now,
+        originalBytes: Buffer.byteLength(fullText),
+        truncatedBytes: Buffer.byteLength(truncatedText),
+        estimatedTokens: estimated,
+        maxTokens,
+        content: fullText,
+      };
+      await writeFile(join(absDir, fname), JSON.stringify(saved, null, 2), "utf8");
+    } catch {
+      // Best-effort — never block the agent on file I/O.
+    }
+
+    // Emit warning.
+    bus.emit(
+      ev.systemMessage(
+        sessionId,
+        "warning",
+        `⚠️ 工具 ${toolName} 返回结果过大 ` +
+          `(原始约 ${estimated} tokens / ${formatBytes(Buffer.byteLength(fullText))})，` +
+          `已截断至约 ${estimateTokens(truncatedText)} tokens。` +
+          `完整结果已保存至 workspace/${relPath}`,
+        { recoverable: true },
+      ),
+    );
+
+    const notice =
+      `\n\n---\n` +
+      `[⚠️ 结果已截断: 原始 ${estimated} tokens / ${formatBytes(Buffer.byteLength(fullText))} → ` +
+      `截断后 ${estimateTokens(truncatedText)} tokens。` +
+      `完整内容已保存至 workspace/${relPath} ，可用 read 工具读取]`;
+
+    return {
+      content: [{ type: "text", text: truncatedText + notice }],
+    };
+  }
+
   /** Ensure an agent exists (create or resurrect). */
   async ensureAgent(sessionId: string, name: string): Promise<MasAgent> {
     const entry = this.sessions.get(sessionId);
@@ -632,7 +770,9 @@ export class SessionManager {
     const systemTools = systemToolsForRole(role, name, deps);
     // External MCP tools go to non-trace agents (trace agent is graph-only, §9).
     const mcpTools = role === "trace" ? [] : await this.ensureMcpTools();
-    const agentTools = [...systemTools, ...mcpTools];
+    const rawTools = [...systemTools, ...mcpTools];
+    // #80: guard every tool result against context-window overflow.
+    const agentTools = rawTools.map((t) => this.wrapToolWithTruncation(t, sessionId, entry.bus));
     const builtins = builtinToolNamesForRole(role, name);
     const allowedToolNames = [...builtins, ...agentTools.map((t) => t.name)];
 


### PR DESCRIPTION
## 问题

papersearch MCP 在 `mode=full-paper` 时返回 ~1MB 结果，导致下一次 provider 请求超出 131072 token 输入限制，Agent 崩溃进入 error 状态。

## 修复方案

实现**通用工具结果大小守卫**，对所有工具（系统 + MCP）的返回内容进行 token 估算，超出阈值时截断并保存完整内容到 session workspace。

### 设计要点

- **插入点**：`SessionManager.ensureAgent()` 中工具组装完成后，包裹每个 `SystemTool.execute()`，对 Pi SDK 完全透明
- **Token 估算**：`Math.ceil(text.length / 3.5)`，保守估计（英文 ~4，中文 ~1-2），零依赖
- **默认阈值**：64000 tokens（~224KB），可通过 `BP_MAX_TOOL_RESULT_TOKENS` 环境变量或 `SessionManagerOptions.maxToolResultTokens` 配置，设为 0 禁用
- **截断行为**：超出阈值时截断文本、追加截断提示（含完整文件路径）、保存完整内容至 `workspace/<sid>/.truncated/<tool>_<ts>.json`、发送 system_message warning 到前端
- **错误保护**：`isError=true` 的结果永不截断
- **前端兼容**：复用已有 `SystemMessageBubble` 组件，无需改前端

### 文件变更

| 文件 | 说明 |
|---|---|
| `packages/runtime/src/session-manager.ts` | 添加 `estimateTokens()`、`wrapToolWithTruncation()`、`truncateToolResult()`，在 `ensureAgent()` 中应用包裹 |
| `packages/runtime/src/__tests__/tool-truncation.test.ts` | **新建**，11 个测试用例 |

### 测试结果

```
 ✓ |@brainpilot/runtime| 15 test files passed
 ✓ Tests: 116 passed (116)
```

11 个新增测试 + 零回归。

Closes #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)