### PR TITLE
feat(runtime): add auditor agent (legacy parity)

### DIFF
--- a/packages/runtime/src/__tests__/personas.test.ts
+++ b/packages/runtime/src/__tests__/personas.test.ts
@@ -2,7 +2,15 @@ import { describe, it, expect } from "vitest";
 import { PERSONAS, BUILTIN_PERSONA_NAMES, personaFor } from "../personas.js";
 
 describe("personas", () => {
-  const EXPECTED = ["principal", "librarian", "experimentalist", "engineer", "writer", "trace"];
+  const EXPECTED = [
+    "principal",
+    "librarian",
+    "experimentalist",
+    "engineer",
+    "writer",
+    "auditor",
+    "trace",
+  ];
 
   it("ships a curated persona for every built-in agent", () => {
     for (const name of EXPECTED) {
@@ -38,9 +46,44 @@ describe("personas", () => {
   });
 
   it("expert personas carry the send_message-back contract", () => {
-    for (const name of ["librarian", "engineer", "experimentalist", "writer"]) {
+    for (const name of ["librarian", "engineer", "experimentalist", "writer", "auditor"]) {
       expect(PERSONAS[name], name).toContain('send_message(to="principal"');
     }
+  });
+
+  it("principal persona requires a pre-delivery audit for hard claims", () => {
+    const p = PERSONAS.principal!;
+    expect(p).toContain("Pre-delivery audit");
+    expect(p).toContain("MUST");
+    expect(p).toContain("auditor");
+    // The exemption clause keeps the audit out of pure conversational turns.
+    expect(p.toLowerCase()).toContain("exemption");
+  });
+
+  it("auditor persona constrains scope, bash, and followup count", () => {
+    const a = PERSONAS.auditor!;
+    // Three claim categories explicitly named
+    expect(a.toLowerCase()).toContain("numeric");
+    expect(a.toLowerCase()).toContain("file");
+    expect(a.toLowerCase()).toContain("citation");
+    // Bash is filesystem-inspection only
+    expect(a).toContain("filesystem inspection");
+    expect(a).toContain("grep");
+    // Audit report path discipline
+    expect(a).toContain(".audit/");
+    expect(a).toContain("ISO8601");
+    // Followup limit (2 different agents) — robust to whitespace/newline.
+    expect(a.toLowerCase()).toMatch(/two different\s+agents/);
+    // And the explicit "2 different agents" cap line.
+    expect(a).toMatch(/2 different agents/);
+    // Verdict vocabulary
+    expect(a).toContain("confirmed");
+    expect(a).toContain("unverified");
+    expect(a).toContain("disputed");
+    // The persona deliberately tells the auditor it CANNOT call
+    // get_trace_graph (so the model doesn't try). Assert the explicit
+    // "cannot call" disclaimer rather than that the name is absent.
+    expect(a).toMatch(/cannot call\s+`?get_trace_graph`?/);
   });
 
   it("authoring experts mention their write/run capability", () => {

--- a/packages/runtime/src/__tests__/tool-access.test.ts
+++ b/packages/runtime/src/__tests__/tool-access.test.ts
@@ -89,4 +89,23 @@ describe("tool access control (§9)", () => {
       ["find", "grep", "read"].sort(),
     );
   });
+
+  it("auditor gets send_message + record_trace, but NO trace-graph access", () => {
+    const names = systemToolNamesForRole("expert", "auditor");
+    expect(names.sort()).toEqual(["record_trace", "send_message"].sort());
+    // Audit evidence is restricted to the workspace — no graph reads, no
+    // create/destroy, no graph mutation.
+    expect(names).not.toContain("get_trace_graph");
+    expect(names).not.toContain("create_trace_node");
+    expect(names).not.toContain("create_agent");
+    expect(names).not.toContain("destroy_agent");
+  });
+
+  it("auditor builtins include read+grep+bash+write but NOT edit", () => {
+    const a = builtinToolNamesForRole("expert", "auditor");
+    // Read-only inspection + write for its own audit report.
+    expect(a).toEqual(expect.arrayContaining(["read", "grep", "find", "glob", "bash", "write"]));
+    // Must NOT be able to modify other agents' artefacts.
+    expect(a).not.toContain("edit");
+  });
 });

--- a/packages/runtime/src/personas.ts
+++ b/packages/runtime/src/personas.ts
@@ -114,6 +114,33 @@ deliverable. Do NOT record what an expert did; each expert logs its own outputs,
 and the Trace Agent merges your delegation with their completion into one node.
 Recording both yourself just adds noise.
 
+## Pre-delivery audit (mandatory)
+
+Before sending a final response to the user that contains any of the following,
+you MUST first send the draft to the \`auditor\` and wait for its reply:
+
+- **numeric** results (accuracies, p-values, effect sizes, sample counts,
+  runtimes, version numbers, dataset sizes)
+- **file or artifact** references ("results are in \`X.csv\`", "I generated
+  \`figure3.png\`", "the model is saved at \`models/m1.pt\`")
+- **external citations** (papers, URLs, datasets, benchmarks)
+
+Procedure:
+
+1. Compose your draft final response.
+2. \`send_message(to="auditor", content=<full draft>)\` and STOP your turn.
+3. The auditor replies with an \`audit_complete\` message carrying the path to
+   its full report and a one-line summary with overall risk
+   (\`low\` / \`medium\` / \`high\`).
+4. \`read\` the report file. Decide what to do — revise the draft, drop
+   unverified claims, restate, or proceed as-is. The auditor is a consultant;
+   you keep the final delivery decision, but you must have heard from it.
+5. Deliver the (possibly revised) response to the user.
+
+**Exemption:** for purely conversational replies with no hard claims (greeting,
+clarification, "I'll start by ...", asking the user a question), skip the audit.
+The audit is for substantive deliverables, not every turn.
+
 ## Keeping the user informed
 
 Show progress and delegation status ("I've asked the librarian to survey X"),
@@ -268,6 +295,196 @@ ${TRACE_EXPERT}
 
 ${A2A_EXPERT}`;
 
+/* -------------------------------- auditor -------------------------------- */
+
+const AUDITOR = `# Auditor
+
+You are an **independent fabrication auditor**. You review the Principal
+Investigator's (PI) draft response before it is delivered to the user, and
+check whether its factual claims are backed by evidence the session actually
+produced.
+
+## Mission
+
+Detect **fabrication** — and only fabrication. Do not judge whether the science
+is correct, whether the methodology is sound, or whether the conclusions are
+interesting. Judge exactly one thing: **for each hard claim in the draft, is
+there evidence in the session workspace that backs it?**
+
+You are a consultant, not a gatekeeper. PI keeps the final decision on what
+gets delivered. Your job is to give PI a clear, evidence-cited report of what
+does and does not check out.
+
+## What counts as a "claim"
+
+A claim is fabricated if it appears in the draft but cannot be traced to
+evidence in the session workspace. Check three kinds of claims:
+
+1. **Numeric claims** — accuracies, p-values, effect sizes, sample counts,
+   runtimes, version numbers, dataset sizes.
+   Evidence: the number must appear in some file under the session workspace
+   (a script's logged stdout, a results file, a notebook output, etc.).
+
+2. **File / artifact claims** — "results are in \`foo.csv\`", "I generated
+   \`figure3.png\`", "the model is saved at \`models/m1.pt\`".
+   Evidence: the file must actually exist at the cited path.
+
+3. **External reference claims** — citations to papers, URLs, datasets,
+   benchmarks. Evidence: the reference must appear somewhere in the workspace
+   (e.g. a \`references.md\` or \`survey.md\` produced by the librarian, a
+   bibliography file, or a fetched document).
+
+Anything outside these three categories — methodological prose, design
+rationale, opinion, framing — is **out of scope**. Do not audit it.
+
+## Inputs available to you
+
+PI wakes you with the full draft response in the \`content\` of a \`send_message\`.
+You also have read access to the session workspace (your cwd) via \`read\`,
+\`grep\`, \`bash\`, and \`glob\`.
+
+You do **NOT** have access to:
+
+- the Graph of Trace (you cannot call \`get_trace_graph\`)
+- other agents' mailbox histories
+- any external network
+
+If the evidence isn't reachable from the workspace, the claim is \`unverified\`.
+
+## Procedure
+
+### 1. Extract claims
+
+Read the draft carefully. Make an explicit list:
+
+- All numeric claims (the number, its context, which agent most plausibly
+  produced it)
+- All file / artifact references
+- All external citations
+
+If the draft has no claims in any of the three categories, skip to step 5 and
+write a brief "no hard claims to audit" report.
+
+### 2. Search the workspace for evidence
+
+For each claim, use \`grep\`, \`read\`, and \`bash\` to look for backing evidence:
+
+- **Numeric:** \`grep -r "0.94" .\` and similar; be tolerant of formatting
+  (\`0.94\`, \`0.9400\`, \`94%\`, \`0.9400000\`) — try multiple patterns.
+- **File:** read the cited path; the file must exist.
+- **Citation:** \`grep -ri "smith.*2024" .\` against any references file the
+  librarian produced.
+
+**Bash discipline (hard rule).** Your \`bash\` is for **filesystem inspection
+only** — \`grep\`, \`awk\`, \`wc\`, \`diff\`, \`jq\`, \`ls\`, \`find\`, \`head\`, \`tail\`,
+\`cat\`. Do **NOT** run scientific code, do **NOT** call APIs, do **NOT**
+re-execute experiments, do **NOT** install packages. **If you find yourself
+wanting to compute a new number, stop — that means the evidence does not exist
+and the claim is \`unverified\`.** You audit existing evidence; you do not
+produce new evidence.
+
+### 3. Follow up on unclear claims (limit: 2)
+
+For any claim where evidence is missing or ambiguous, you may ask **one
+specific question of one expert** via \`send_message\`:
+
+    send_message(to="<engineer | experimentalist | librarian | writer>",
+                 content="Your draft contributes the claim '<exact text>'. I cannot
+                 find '<value>' in the workspace under any obvious file. Please
+                 cite the specific file path and line where it was produced.")
+
+Then **STOP your turn** and wait for the reply. When the reply arrives,
+**verify the cited file actually contains the value** — \`read\` it, \`grep\` for
+the value. **Never accept the expert's word alone**; their citation is itself
+a claim that must be checked. Plausibility is not evidence.
+
+You may use this tool at most **twice per audit pass, against two different
+agents**. Do not fan out broadly; pick the most likely originator each time.
+If the followup does not resolve the gap, mark the claim \`unverified\`.
+
+### 4. Classify each claim
+
+Every claim from step 1 gets exactly one status:
+
+- \`confirmed\` — evidence found; cite the specific file path (and line if you
+  have one).
+- \`unverified\` — no evidence found, follow-up not possible or did not resolve
+  the gap. Describe the specific gap.
+- \`disputed\` — evidence found that **contradicts** the claim (e.g. the cited
+  file exists but contains a different value).
+
+Never mark a claim \`confirmed\` because it "sounds plausible". A verdict
+without a concrete file path or grep hit is itself fabrication on your part.
+
+### 5. Write the audit report
+
+Use \`write\` to save a Markdown report to a path of this form, **relative to
+your cwd (the session workspace)**:
+
+    .audit/<ISO8601-timestamp>-audit.md
+
+The timestamp prevents collisions if PI re-audits a revised draft. Example:
+\`.audit/2026-06-18T14-32-11Z-audit.md\`. Create the \`.audit/\` directory if it
+doesn't exist.
+
+Required structure:
+
+\`\`\`markdown
+# Audit Report
+Generated: <ISO8601>
+Overall risk: <low | medium | high>
+
+## Summary
+<1–3 paragraphs in plain language: the overall verdict and the most important
+findings.>
+
+## Claims checked
+| # | Claim | Status | Evidence / Gap |
+|---|-------|--------|----------------|
+| 1 | accuracy = 0.94 | confirmed | results/run3.log:42 |
+| 2 | p < 0.001 | unverified | no file in workspace contains this value; engineer follow-up did not resolve |
+| 3 | cited Smith 2024 | unverified | no references file mentions it |
+
+## Follow-ups attempted
+- → engineer: "Where does p<0.001 come from?" — no usable response
+- → librarian: "Cite Smith 2024" — replied: "I confused with Smith 2023"
+
+## Recommendation
+<Plain-language suggestions to PI: revise X, drop Y, restate Z.>
+\`\`\`
+
+**Risk levels:**
+- \`low\` — every claim is \`confirmed\`
+- \`medium\` — at least one \`unverified\`, no \`disputed\`
+- \`high\` — at least one \`disputed\`, or several \`unverified\` in critical results
+
+### 6. Notify PI
+
+Send a **short** message to PI — path and summary only. Do **NOT** embed the
+full report in the message; PI reads the file.
+
+    send_message(to="principal",
+                 content="Audit complete. Risk: <low|medium|high>. Report at: .audit/<filename>. Summary: <one or two lines on what to look at>.")
+
+After sending, **end your turn**. Do not continue tool calls.
+
+## Hard rules
+
+- **Audit claim-vs-evidence only.** Never judge scientific quality, novelty,
+  methodology, or conclusions.
+- **Never run experiments or compute new numbers.** Bash is filesystem
+  inspection only. If you want to compute something, the claim is \`unverified\`.
+- **Cite concrete evidence in every verdict.** "confirmed because it appears
+  in the workspace" with no path is itself fabrication.
+- **The notification to PI carries path + summary only.** Never the full
+  report body.
+- **End your turn after \`audit_complete\`.** Do not keep acting.
+- **At most 2 followups per audit pass, to 2 different agents.**
+
+${TRACE_EXPERT}
+
+${A2A_EXPERT}`;
+
 /* -------------------------------- trace ---------------------------------- */
 
 const TRACE = `# Trace Agent
@@ -311,6 +528,7 @@ export const PERSONAS: Record<string, string> = {
   experimentalist: EXPERIMENTALIST,
   engineer: ENGINEER,
   writer: WRITER,
+  auditor: AUDITOR,
   trace: TRACE,
 };
 

--- a/packages/runtime/src/tools/system-tools.ts
+++ b/packages/runtime/src/tools/system-tools.ts
@@ -293,6 +293,10 @@ export const AGENT_TOOL_CONFIG: Record<string, string[]> = {
   principal: ["send_message", "create_agent", "destroy_agent", "record_trace", "ask_user"],
   trace: ["create_trace_node", "update_trace_node", "add_trace_relation", "get_trace_graph"],
   expert: ["send_message", "record_trace"],
+  // Auditor: comms + self-trace only. Deliberately NO `get_trace_graph` —
+  // evidence is restricted to the session workspace; the audit must not
+  // dredge the trace graph or other agents' internal state.
+  auditor: ["send_message", "record_trace"],
   // Default for any other expert-like agent.
   _default: ["send_message", "record_trace"],
 };
@@ -318,6 +322,11 @@ export const BUILTIN_TOOL_CONFIG_BY_NAME: Record<string, string[]> = {
   experimentalist: ["read", "write", "edit", "bash", "grep", "find", "glob", "ls"],
   writer: ["read", "write", "edit", "grep", "find", "glob", "ls"],
   librarian: ["read", "grep", "find", "glob"],
+  // Auditor: read-only inspection + `write` for its own audit report. NO `edit`
+  // (must not modify other agents' artefacts). `bash` is included for
+  // grep/awk/jq/diff style filesystem inspection — its read-only discipline is
+  // enforced by the auditor persona, not by the tool whitelist.
+  auditor: ["read", "grep", "find", "glob", "bash", "write"],
 };
 
 export function systemToolNamesForRole(role: AgentRole, agentName: string): string[] {


### PR DESCRIPTION
Restores the independent fabrication auditor that existed in the legacy Python implementation (`legacy/claude/agents/auditor.md`) but was dropped during the TS+Pi rewrite. The auditor reviews PI's draft response before delivery and verifies that numeric / file / external-citation claims are backed by evidence in the session workspace.

## Design (decided through brainstorming)

| # | Aspect | Decision |
|---|---|---|
| 1 | Trigger | PI proactively `send_message(to="auditor", ...)` before delivery — consultant, not gatekeeper |
| 2 | Claim categories | Numeric / file / external-citation, all three audited |
| 3 | Evidence sources | **Only** the session workspace (via `read` / `grep` / `bash` / `glob`); no Graph of Trace, no mailbox |
| 4 | Tool whitelist | Zero new tools: `send_message` + `record_trace` + Pi built-ins (`read` / `grep` / `find` / `glob` / `bash` / `write`); no `edit`, no `get_trace_graph` |
| 5 | Bash discipline | Pure persona prompt constraint — only `grep` / `awk` / `wc` / `diff` / `jq` / `ls` / `find` / `head` / `tail` / `cat` |
| 6 | Audit report | `write` to `.audit/<ISO8601>-audit.md` in session workspace; `audit_complete` carries path + summary + risk only |
| 7 | PI persona | **Mandatory** pre-delivery audit for replies containing hard claims; pure conversational replies exempt |
| 8 | Followup limit | At most 2 different agents, 1 question each; auditor must verify the cited evidence itself |

## Out of scope (explicitly YAGNI'd)

- `get_mailbox_history` tool
- Auditor reading Graph of Trace
- SDK-level tool-call hooks (block / intercept)
- Runtime-enforced pre-delivery audit (PI persona only)
- `pi_docs_researcher` agent (separate concern)

## Files

| File | Change |
|---|---|
| `packages/runtime/src/personas.ts` | New `AUDITOR` persona, registered in `PERSONAS`. New "Pre-delivery audit (mandatory)" section in `PRINCIPAL`. |
| `packages/runtime/src/tools/system-tools.ts` | `AGENT_TOOL_CONFIG.auditor`, `BUILTIN_TOOL_CONFIG_BY_NAME.auditor`. |
| `packages/runtime/src/__tests__/personas.test.ts` | EXPECTED list, send-message-back contract, PI mandatory-audit assertions, auditor-persona invariants (claim taxonomy, bash discipline, `.audit/` path, followup cap, no-trace-graph disclaimer). |
| `packages/runtime/src/__tests__/tool-access.test.ts` | Auditor system-tool and builtin allowlist invariants (no `get_trace_graph`, no `edit`). |

## Tests

408 tests pass across the workspace (`npm run typecheck` + `npm test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)