### PR TITLE
feat(runtime): Pi-native reminder hooks, replacing #79 backend trace capture

### DIFF
--- a/packages/runtime/src/__tests__/trace-agent.test.ts
+++ b/packages/runtime/src/__tests__/trace-agent.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Trace Agent — verifies that record_trace dispatches to a real spawned trace
+ * agent (legacy parity), so the Agents panel sees its idle/running transitions
+ * instead of a permanently-dormant placeholder.
+ *
+ * What this pins down (host-side, mock factory):
+ *   - calling `record_trace` ensures a `trace` agent is in the session's agent
+ *     list (status idle by default; visible to the panel via `listAgents`);
+ *   - a `trace_event` envelope is delivered to the trace agent's mailbox,
+ *     formatted as `[Trace Event]\nDescription: …\nContext: …\n\nArtifacts:`;
+ *   - `agent_status_update` events with name="trace" reach the bus once the
+ *     trace agent runs (running → idle), proving the panel will "light up";
+ *   - the trace agent's run does NOT flip the session's derived run-active
+ *     flag — `deriveRunActive` excludes the trace role on purpose.
+ */
+import { describe, it, expect } from "vitest";
+import { SessionManager } from "../session-manager.js";
+import type {
+  AgUiEvent,
+  AgentSessionFactory,
+  IAgentSession,
+  PiAgentEvent,
+  SystemTool,
+} from "../types.js";
+
+interface Script {
+  onPrompt?: (
+    text: string,
+    turn: number,
+  ) => { tool: string; args: Record<string, unknown> } | undefined;
+}
+
+function scriptedFactory(scripts: Record<string, Script>): AgentSessionFactory {
+  return async ({ sessionId, agentName, systemTools }) => {
+    const toolMap = new Map<string, SystemTool>(systemTools.map((t) => [t.name, t]));
+    const listeners = new Set<(e: PiAgentEvent) => void>();
+    let turn = 0;
+    const emit = (e: PiAgentEvent) => {
+      for (const l of listeners) {
+        try {
+          l(e);
+        } catch {
+          /* isolate */
+        }
+      }
+    };
+    const session: IAgentSession = {
+      sessionId,
+      subscribe(listener) {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+      async prompt(text: string) {
+        turn += 1;
+        emit({ type: "agent_start" });
+        emit({ type: "turn_start" });
+        emit({ type: "message_start", message: { role: "assistant", content: [] } });
+        emit({
+          type: "message_end",
+          message: { role: "assistant", content: [{ type: "text", text: `ok ${agentName}` }] },
+        });
+        const call = scripts[agentName]?.onPrompt?.(text, turn);
+        if (call) {
+          const tool = toolMap.get(call.tool);
+          const toolCallId = `tc_${call.tool}_${turn}`;
+          emit({ type: "tool_execution_start", toolCallId, toolName: call.tool, args: call.args });
+          let result = "";
+          let isError = false;
+          if (tool) {
+            const res = await tool.execute(call.args);
+            result = res.content.map((c) => c.text).join("");
+            isError = res.isError ?? false;
+          } else {
+            result = `tool ${call.tool} not available`;
+            isError = true;
+          }
+          emit({ type: "tool_execution_end", toolCallId, toolName: call.tool, result, isError });
+        }
+        emit({ type: "turn_end" });
+        emit({ type: "agent_end", messages: [], willRetry: false });
+      },
+      async abort() {},
+      dispose() {},
+    };
+    return session;
+  };
+}
+
+async function waitFor(pred: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timed out");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe("Trace Agent — record_trace dispatches to a spawned trace agent", () => {
+  it("ensures a trace agent appears in listAgents after record_trace", async () => {
+    const factory = scriptedFactory({
+      principal: {
+        onPrompt: (_text, turn) =>
+          turn === 1
+            ? { tool: "record_trace", args: { description: "first decision" } }
+            : undefined,
+      },
+      // No script for trace: it just needs to exist; we're checking spawn.
+    });
+    const m = new SessionManager({ persist: false, agentFactory: factory });
+    const s = await m.createSession();
+
+    await m.sendMessage(s.id, "go");
+    await waitFor(() => m.listAgents(s.id).some((a) => a.name === "trace"));
+
+    const names = m.listAgents(s.id).map((a) => a.name);
+    expect(names).toContain("principal");
+    expect(names).toContain("trace");
+  });
+
+  it("delivers a [Trace Event] envelope to the trace agent's mailbox", async () => {
+    let captured: string | undefined;
+    const factory = scriptedFactory({
+      principal: {
+        onPrompt: (_text, turn) =>
+          turn === 1
+            ? {
+                tool: "record_trace",
+                args: {
+                  description: "designed an experiment",
+                  context: "after reviewing prior art",
+                  artifacts: ["plan.md", "diagram.png"],
+                },
+              }
+            : undefined,
+      },
+      trace: {
+        onPrompt: (text) => {
+          captured = text;
+          return undefined;
+        },
+      },
+    });
+    const m = new SessionManager({ persist: false, agentFactory: factory });
+    const s = await m.createSession();
+
+    await m.sendMessage(s.id, "go");
+    await waitFor(() => captured !== undefined && captured.includes("[Trace Event]"));
+
+    expect(captured!).toContain("[Trace Event]");
+    expect(captured!).toContain("Description: designed an experiment");
+    expect(captured!).toContain("Context: after reviewing prior art");
+    expect(captured!).toContain("- plan.md");
+    expect(captured!).toContain("- diagram.png");
+  });
+
+  it("emits agent_status_update events for the trace agent (running → idle)", async () => {
+    const factory = scriptedFactory({
+      principal: {
+        onPrompt: (_text, turn) =>
+          turn === 1
+            ? { tool: "record_trace", args: { description: "a decision" } }
+            : undefined,
+      },
+      trace: {
+        // Trace consumes the envelope and writes a node — exercises a real run.
+        onPrompt: (text) =>
+          text.includes("[Trace Event]")
+            ? { tool: "create_trace_node", args: { title: "a decision" } }
+            : undefined,
+      },
+    });
+    const m = new SessionManager({ persist: false, agentFactory: factory });
+    const s = await m.createSession();
+
+    const traceStatusUpdates: string[] = [];
+    m.subscribe(s.id, (e: AgUiEvent) => {
+      const ev = e as { type: string; name?: string; status?: string };
+      if (ev.type === "agent_status_update" && ev.name === "trace") {
+        traceStatusUpdates.push(String(ev.status));
+      }
+    });
+
+    await m.sendMessage(s.id, "go");
+    await waitFor(() => traceStatusUpdates.includes("running") && traceStatusUpdates.includes("idle"));
+
+    // Order matters: must run, then settle back to idle.
+    const firstRunningIdx = traceStatusUpdates.indexOf("running");
+    const firstIdleAfterRunning = traceStatusUpdates.indexOf("idle", firstRunningIdx + 1);
+    expect(firstRunningIdx).toBeGreaterThanOrEqual(0);
+    expect(firstIdleAfterRunning).toBeGreaterThan(firstRunningIdx);
+  });
+
+  it("trace agent's run does NOT flip the session's derived run-active flag", async () => {
+    // Per session-manager.ts: the trace agent is excluded from
+    // deriveRunActive — its self-recording shouldn't read as "the user's
+    // task is still running". Once the principal's run finishes, runState
+    // settles to inactive even if the trace agent is still consuming
+    // its mailbox.
+    const factory = scriptedFactory({
+      principal: {
+        onPrompt: (_text, turn) =>
+          turn === 1
+            ? { tool: "record_trace", args: { description: "a decision" } }
+            : undefined,
+      },
+      trace: {
+        onPrompt: (text) =>
+          text.includes("[Trace Event]")
+            ? { tool: "create_trace_node", args: { title: "a decision" } }
+            : undefined,
+      },
+    });
+    const m = new SessionManager({ persist: false, agentFactory: factory });
+    const s = await m.createSession();
+
+    await m.sendMessage(s.id, "go");
+    await waitFor(() => m.getTrace(s.id)!.nodes.length >= 1);
+    // After the trace agent has produced a node, give the manager a tick to
+    // emit the post-run session_state and then assert.
+    await new Promise((r) => setTimeout(r, 20));
+    const state = m.getSessionState(s.id);
+    expect(state).toBeDefined();
+    expect(state!.runState.active).toBe(false);
+  });
+});

--- a/packages/runtime/src/__tests__/trace-edges.test.ts
+++ b/packages/runtime/src/__tests__/trace-edges.test.ts
@@ -1,13 +1,17 @@
 /**
  * Graph of Trace — structural guarantees driven through the real SessionManager.
  *
- * The behavioural "reminder" hooks (nudge the agent to record_trace / report
- * back) now live in the Pi-native `trace-reminder` extension, which only loads
- * under the real Pi factory; per design §7 / T2 they are verified in real mode,
- * not here. What these tests still pin down is the host-side trace plumbing that
- * is independent of any prompt-compliance hook:
- *   - consecutive `record_trace` calls chain into a connected DAG (visible edges,
- *     not orphan dots);
+ * After the legacy-parity rewrite, `record_trace` does NOT mutate the graph
+ * directly. It dispatches a `[Trace Event]` envelope into the trace agent's
+ * mailbox; the trace agent (a real Pi AgentSession) is the editor that calls
+ * `create_trace_node` / `update_trace_node` / `add_trace_relation`. These tests
+ * pin down the host-side plumbing — independent of the Pi-native reminder hooks
+ * which only load under the real factory (verified separately per design §7/T2):
+ *   - the principal calling `record_trace` causes a trace agent to be spawned
+ *     and a `trace_event` envelope to land in its mailbox;
+ *   - when the trace agent runs and calls `create_trace_node` consecutively,
+ *     the resulting nodes are chained into a connected DAG via the
+ *     `getLastNodeId()` fallback (visible edges, not orphan dots);
  *   - every trace mutation is pushed to the SSE stream as CUSTOM:trace_node.
  */
 import { describe, it, expect } from "vitest";
@@ -81,15 +85,34 @@ async function waitFor(pred: () => boolean, timeoutMs = 2000): Promise<void> {
 }
 
 describe("Graph of Trace structural plumbing", () => {
-  it("chains consecutive record_trace nodes so the graph has edges (not orphans)", async () => {
-    // Regression: record_trace used to create orphan nodes (no parents), so the
-    // Graph of Trace rendered as disconnected dots with no visible edges.
-    let turn = 0;
+  it("chains consecutive trace agent nodes into a connected DAG (not orphans)", async () => {
+    // Regression: before the agent-driven rewrite, `record_trace` chained nodes
+    // itself; now the trace agent is the writer. The `create_trace_node` tool
+    // still falls back to `getLastNodeId()` when no explicit parent is given,
+    // so consecutive trace-agent decisions remain a connected chain.
+    let principalTurn = 0;
+    let traceTurn = 0;
     const factory = scriptedFactory({
       principal: {
         onPrompt: () => {
-          turn += 1;
-          return { tool: "record_trace", args: { description: `decision ${turn}` } };
+          principalTurn += 1;
+          return {
+            tool: "record_trace",
+            args: { description: `decision ${principalTurn}` },
+          };
+        },
+      },
+      trace: {
+        onPrompt: (text) => {
+          // The trace agent reads the [Trace Event] envelope and creates a
+          // node; it does NOT pass parent_id, so the chain is via the
+          // create_trace_node fallback to getLastNodeId.
+          if (!text.includes("[Trace Event]")) return undefined;
+          traceTurn += 1;
+          return {
+            tool: "create_trace_node",
+            args: { title: `decision ${traceTurn}`, type: "trace" },
+          };
         },
       },
     });
@@ -106,7 +129,6 @@ describe("Graph of Trace structural plumbing", () => {
     const second = nodes.find((n) => n.title === "decision 2")!;
     expect(first).toBeDefined();
     expect(second).toBeDefined();
-    // The second trace is linked to the first → at least one edge exists.
     expect(second.parentIds).toContain(first.id);
     expect(second.parents[0]!.relation).toBe("follows");
   });
@@ -117,6 +139,12 @@ describe("Graph of Trace structural plumbing", () => {
         onPrompt: (text) =>
           text.includes("TRACE")
             ? { tool: "record_trace", args: { description: "a decision" } }
+            : undefined,
+      },
+      trace: {
+        onPrompt: (text) =>
+          text.includes("[Trace Event]")
+            ? { tool: "create_trace_node", args: { title: "a decision", type: "trace" } }
             : undefined,
       },
     });

--- a/packages/runtime/src/__tests__/trace-edges.test.ts
+++ b/packages/runtime/src/__tests__/trace-edges.test.ts
@@ -1,12 +1,13 @@
 /**
- * #79 — deterministic post-turn trace capture.
+ * Graph of Trace — structural guarantees driven through the real SessionManager.
  *
- * The Graph of Trace must stay reliable even when the model never calls
- * `record_trace`. These tests drive scripted agent turns through the real
- * SessionManager and assert:
- *   - a principal that delegates without record_trace still gets an auto node;
- *   - an expert that delivers a result without record_trace gets an auto node;
- *   - a turn that DOES call record_trace produces no duplicate auto node;
+ * The behavioural "reminder" hooks (nudge the agent to record_trace / report
+ * back) now live in the Pi-native `trace-reminder` extension, which only loads
+ * under the real Pi factory; per design §7 / T2 they are verified in real mode,
+ * not here. What these tests still pin down is the host-side trace plumbing that
+ * is independent of any prompt-compliance hook:
+ *   - consecutive `record_trace` calls chain into a connected DAG (visible edges,
+ *     not orphan dots);
  *   - every trace mutation is pushed to the SSE stream as CUSTOM:trace_node.
  */
 import { describe, it, expect } from "vitest";
@@ -79,80 +80,35 @@ async function waitFor(pred: () => boolean, timeoutMs = 2000): Promise<void> {
   }
 }
 
-describe("deterministic trace capture (#79)", () => {
-  it("auto-captures a milestone when principal delegates without record_trace", async () => {
+describe("Graph of Trace structural plumbing", () => {
+  it("chains consecutive record_trace nodes so the graph has edges (not orphans)", async () => {
+    // Regression: record_trace used to create orphan nodes (no parents), so the
+    // Graph of Trace rendered as disconnected dots with no visible edges.
+    let turn = 0;
     const factory = scriptedFactory({
       principal: {
-        onPrompt: (text) =>
-          text.includes("DELEGATE")
-            ? { tool: "create_agent", args: { agent_type: "librarian", task: "survey" } }
-            : undefined,
+        onPrompt: () => {
+          turn += 1;
+          return { tool: "record_trace", args: { description: `decision ${turn}` } };
+        },
       },
-      librarian: {},
     });
     const m = new SessionManager({ persist: false, agentFactory: factory });
     const s = await m.createSession();
 
-    await m.sendMessage(s.id, "please DELEGATE this");
-    await waitFor(() => m.getTrace(s.id)!.nodes.length > 0);
+    await m.sendMessage(s.id, "first");
+    await waitFor(() => m.getTrace(s.id)!.nodes.length >= 1);
+    await m.sendMessage(s.id, "second");
+    await waitFor(() => m.getTrace(s.id)!.nodes.length >= 2);
 
     const nodes = m.getTrace(s.id)!.nodes;
-    const auto = nodes.find((n) => n.metadata?.auto);
-    expect(auto).toBeDefined();
-    expect(auto!.title).toBe("Delegated to librarian");
-    expect(auto!.agent).toBe("principal");
-    expect(auto!.metadata?.hook).toBe("principal_trace");
-  });
-
-  it("auto-captures an expert delivery without record_trace", async () => {
-    const factory = scriptedFactory({
-      principal: {
-        onPrompt: (text) =>
-          text.includes("DELEGATE")
-            ? { tool: "send_message", args: { to: "librarian", content: "do work" } }
-            : undefined,
-      },
-      librarian: {
-        onPrompt: (text) =>
-          text.includes("do work")
-            ? { tool: "send_message", args: { to: "principal", content: "findings ready" } }
-            : undefined,
-      },
-    });
-    const m = new SessionManager({ persist: false, agentFactory: factory });
-    const s = await m.createSession();
-
-    await m.sendMessage(s.id, "please DELEGATE this");
-    await waitFor(() =>
-      m.getTrace(s.id)!.nodes.some((n) => n.agent === "librarian" && n.metadata?.auto),
-    );
-
-    const lib = m.getTrace(s.id)!.nodes.find((n) => n.agent === "librarian" && n.metadata?.auto)!;
-    expect(lib.title).toBe("librarian delivered result");
-    expect(lib.metadata?.hook).toBe("expert_reply");
-  });
-
-  it("does NOT add an auto node when the model already called record_trace", async () => {
-    const factory = scriptedFactory({
-      principal: {
-        onPrompt: (text) =>
-          text.includes("TRACE")
-            ? { tool: "record_trace", args: { description: "explicit decision" } }
-            : undefined,
-      },
-    });
-    const m = new SessionManager({ persist: false, agentFactory: factory });
-    const s = await m.createSession();
-
-    await m.sendMessage(s.id, "please TRACE this");
-    await waitFor(() => m.getTrace(s.id)!.nodes.length > 0);
-    // settle: let the turn_end hook run
-    await new Promise((r) => setTimeout(r, 20));
-
-    const nodes = m.getTrace(s.id)!.nodes;
-    expect(nodes).toHaveLength(1);
-    expect(nodes[0]!.metadata?.auto).toBeUndefined();
-    expect(nodes[0]!.title).toBe("explicit decision");
+    const first = nodes.find((n) => n.title === "decision 1")!;
+    const second = nodes.find((n) => n.title === "decision 2")!;
+    expect(first).toBeDefined();
+    expect(second).toBeDefined();
+    // The second trace is linked to the first → at least one edge exists.
+    expect(second.parentIds).toContain(first.id);
+    expect(second.parents[0]!.relation).toBe("follows");
   });
 
   it("pushes every trace mutation to the SSE stream as CUSTOM:trace_node", async () => {

--- a/packages/runtime/src/agent-factory.ts
+++ b/packages/runtime/src/agent-factory.ts
@@ -17,6 +17,7 @@
 import type { AgentSessionFactory, IAgentSession, PiAgentEvent, SystemTool } from "./types.js";
 import { MockAgentSession } from "./mock-agent.js";
 import { resolveGatewayModel, resolveSessionModel, type PiProviderSdk } from "./pi-provider.js";
+import { makeTraceReminderExt } from "./extensions/trace-reminder.js";
 
 export function isMockMode(env: Record<string, string | undefined> = process.env): boolean {
   return env.BP_MOCK === "1" || env.BP_MOCK === "true";
@@ -66,6 +67,15 @@ export const realAgentFactory: AgentSessionFactory = async (params) => {
   // they'd absorb whatever AGENTS.md/CLAUDE.md happen to sit in the ancestry —
   // e.g. the legacy "MAS Platform Phase 1" doc — and mis-identify themselves.
   // Agent identity must come ONLY from the per-role persona below.
+  // Pi-native hooks: register the trace-reminder extension per AgentSession (its
+  // closure state is naturally per-agent). Only the real factory loads it — the
+  // mock factory has no Pi event loop, so behavioural hooks are verified in real
+  // mode (design §7 / T2).
+  const traceReminder = makeTraceReminderExt({
+    role: params.role,
+    name: params.agentName,
+    onUnreplied: params.onUnreplied ?? (() => {}),
+  });
   const resourceLoader = new DefaultResourceLoader({
     cwd: params.cwd,
     agentDir,
@@ -73,6 +83,7 @@ export const realAgentFactory: AgentSessionFactory = async (params) => {
     noContextFiles: true,
     additionalSkillPaths: params.skillPaths,
     appendSystemPrompt: params.systemPrompt ? [params.systemPrompt] : [],
+    extensionFactories: [traceReminder],
   });
   await resourceLoader.reload();
 
@@ -175,6 +186,8 @@ interface PiSdk {
     noContextFiles?: boolean;
     /** Explicit skill dirs/files; loaded even when noSkills is true, and not trust-gated. */
     additionalSkillPaths?: string[];
+    /** Inline Pi extensions: each is called with the per-session ExtensionAPI. */
+    extensionFactories?: unknown[];
   }) => { reload(): Promise<void> };
   getAgentDir(): string;
   AuthStorage: {

--- a/packages/runtime/src/extensions/trace-reminder.ts
+++ b/packages/runtime/src/extensions/trace-reminder.ts
@@ -3,23 +3,32 @@
  *
  * Philosophy (vs. #79): the host no longer writes trace nodes on the agent's
  * behalf. Instead we REMIND the agent at the right moment and let it decide:
- *  - 意图一 (PI work leaves a trace): if a principal turn made a decision but
- *    never called record_trace, nudge it once to record (D).
- *  - 意图二 (expert results flow back): if an expert turn produced work but never
- *    send_message'd the principal, nudge once; if it still won't, the host writes
- *    a fallback note into the principal's mailbox so the PI never dead-waits.
+ *  - 意图一 (work leaves a trace): if a run ended without record_trace, nudge.
+ *    Applies to BOTH principal and expert (every non-trace role), not just PI.
+ *  - 意图二 (expert results flow back): if an expert run produced work but never
+ *    send_message'd the principal, nudge; if it still won't, the host writes a
+ *    fallback note into the principal's mailbox so the PI never dead-waits.
  *  - 意图三 (PI keeps to delegation): if the principal does substantive work
  *    directly without delegating, append a soft reminder to the tool result.
  *  - 意图四 (resource awareness): on a tool error, append a soft hint that the
  *    knowledge tools / record_trace exist. (Static identity lives in personas.)
  *
- * Mechanism (Pi SDK v0.79, verified against installed d.ts):
+ * 意图一 and 意图二 are ORTHOGONAL checks (B): an expert can owe both a trace
+ * and a reply. They limit independently (A — separate counters), but when BOTH
+ * lapse at the same run end they collapse into ONE merged reminder rather than
+ * two separate followUps (fewer round-trips).
+ *
+ * Mechanism (Pi SDK v0.79, verified against installed d.ts + real provider):
  *  - Registered per-AgentSession via DefaultResourceLoader.extensionFactories.
  *    Closure state is therefore naturally isolated per agent.
+ *  - One prompt() == one agent loop (agent_start…agent_end) spanning MANY turns.
+ *    "Did the work" flags are RUN-scoped (reset on agent_start, accumulated
+ *    across turns) — resetting them on turn_start was the false-report bug.
  *  - `agent_end` / `turn_*` are pure notifications (no return value, cannot
  *    block). The ONLY "force continue" lever is `pi.sendUserMessage(text,
  *    {deliverAs:"followUp"})` inside `agent_end`: it releases the current stop
- *    and injects a message that triggers a NEW turn.
+ *    and starts a NEW agent loop (a fresh agent_start) — which is why the
+ *    anti-loop counters must NOT reset on agent_start.
  *  - `tool_result` MAY return `{content}` to rewrite the result text — used for
  *    the soft reminders (意图三/四).
  */
@@ -27,7 +36,7 @@ import type { AgentRole } from "../types.js";
 
 /** Minimal structural surface of Pi's ExtensionAPI we depend on. */
 interface PiExtensionApi {
-  on(event: "turn_start", handler: () => void): void;
+  on(event: "agent_start", handler: () => void): void;
   on(event: "tool_execution_start", handler: (e: { toolName: string; args?: unknown }) => void): void;
   on(event: "tool_execution_end", handler: (e: { toolName: string; isError: boolean }) => void): void;
   on(
@@ -65,10 +74,14 @@ const MGMT_TOOLS = new Set([
   "get_trace_graph",
 ]);
 
-const PRINCIPAL_TRACE_REMINDER =
-  "你本轮做了实质决策但尚未调用 record_trace。如果这步值得留痕，请调用 record_trace 记录后再结束。";
+const TRACE_REMINDER =
+  "你本轮做了实质工作但尚未调用 record_trace。如果这步值得留痕，请调用 record_trace 记录后再结束。";
 const EXPERT_REPLY_REMINDER =
   "你尚未通过 send_message(to=\"principal\", ...) 把结果回交给 Principal。请回交结果，否则 Principal 收不到你的产出。";
+const MERGED_REMINDER =
+  "你本轮尚未回交结果，也未记录关键决策。结束前请：" +
+  "① 用 send_message(to=\"principal\", ...) 回交结果；" +
+  "② 用 record_trace 记录关键决策。";
 const DELEGATE_REMINDER = "[提醒：作为 Principal，实质工作应委派给专家，而不是自己埋头执行。]";
 const TOOL_FAILURE_REMINDER =
   "[提醒：该工具调用失败。可用 record_trace 记录这次失败，或借助知识库/检索工具寻找替代方案。]";
@@ -79,19 +92,28 @@ const TOOL_FAILURE_REMINDER =
  */
 export function makeTraceReminderExt(deps: TraceReminderDeps): (pi: PiExtensionApi) => void {
   return (pi) => {
-    // Per-turn flags — reset on turn_start.
+    // Per-RUN flags — reset on agent_start (NOT turn_start). A single prompt()
+    // is one agent loop (agent_start…agent_end) spanning MANY turns, and a model
+    // naturally calls a tool in one turn then writes its closing sentence in the
+    // NEXT (tool-less) turn. Resetting on turn_start wiped the earlier turn's
+    // success, so agent_end only ever saw the last turn and falsely reported the
+    // work as undone. Keyed to the run, these accumulate across all its turns.
     let traced = false;
     let replied = false;
     let delegated = false;
     let delegateRemindCount = 0;
 
-    // ⚠️ Cross-run counter — MUST NOT reset on turn_start / at the top of
-    // agent_end. sendUserMessage(followUp) triggers a NEW run whose end re-enters
-    // agent_end; if this were cleared we would re-remind forever. It is reset
-    // ONLY at the two terminal exits below (goal met, or already reminded once).
-    let remindCount = 0;
+    // ⚠️ Cross-run-CHAIN counters — MUST NOT reset on agent_start/turn_start nor
+    // at the top of agent_end. sendUserMessage(followUp) starts a NEW agent loop
+    // (verified: a followUp fires a fresh agent_start) whose end re-enters
+    // agent_end; if these were cleared we would re-remind forever. They are reset
+    // ONLY at the terminal exits below (dimension satisfied, or already reminded
+    // once → fallback/let-go). Decoupled per dimension (A) so a trace reminder
+    // and a reply reminder limit independently.
+    let traceRemindCount = 0;
+    let replyRemindCount = 0;
 
-    pi.on("turn_start", () => {
+    pi.on("agent_start", () => {
       traced = false;
       replied = false;
       delegated = false;
@@ -135,36 +157,52 @@ export function makeTraceReminderExt(deps: TraceReminderDeps): (pi: PiExtensionA
     pi.on("agent_end", () => {
       if (deps.role === "trace") return; // the recorder itself — never nudge.
 
-      if (deps.role === "principal") {
-        if (traced) {
-          remindCount = 0; // goal met — safe to reset.
-          return;
-        }
-        if (remindCount < 1) {
-          remindCount++;
-          pi.sendUserMessage(PRINCIPAL_TRACE_REMINDER, { deliverAs: "followUp" });
-          return;
-        }
-        // Already reminded once — let it go. PI is the top coordinator: no
-        // host-side fallback. ⚠️ reset only here (already-reminded exit).
-        remindCount = 0;
-        return;
-      }
+      // Two ORTHOGONAL checks (B). Both can be true for one expert (it produced
+      // work worth tracing AND owes the principal a reply).
+      //  - 留痕 (trace): every non-trace role is nudged unconditionally when it
+      //    ends a run without a record_trace.
+      //  - 回交 (reply): only an expert has a principal to report back to.
+      const needTrace = !traced;
+      const needReply = deps.role !== "principal" && !replied;
 
-      // expert branch (everything that isn't principal/trace).
-      if (replied) {
-        remindCount = 0; // goal met — safe to reset.
+      // A satisfied dimension resets its own counter (so a later real lapse is
+      // nudged afresh).
+      if (!needTrace) traceRemindCount = 0;
+      if (!needReply) replyRemindCount = 0;
+
+      const canTrace = needTrace && traceRemindCount < 1;
+      const canReply = needReply && replyRemindCount < 1;
+
+      // Both lapsed and both still nudge-able → ONE merged reminder, not two.
+      if (canTrace && canReply) {
+        traceRemindCount++;
+        replyRemindCount++;
+        pi.sendUserMessage(MERGED_REMINDER, { deliverAs: "followUp" });
         return;
       }
-      if (remindCount < 1) {
-        remindCount++;
+      if (canReply) {
+        replyRemindCount++;
         pi.sendUserMessage(EXPERT_REPLY_REMINDER, { deliverAs: "followUp" });
         return;
       }
-      // Reminded once and still no reply → host fallback so the PI never
-      // dead-waits. ⚠️ reset only here (already-reminded exit).
-      deps.onUnreplied(deps.name);
-      remindCount = 0;
+      if (canTrace) {
+        traceRemindCount++;
+        pi.sendUserMessage(TRACE_REMINDER, { deliverAs: "followUp" });
+        return;
+      }
+
+      // Nothing left to nudge (each lapsed dimension was already reminded once).
+      // Terminal handling per dimension:
+      //  - reply has a host fallback so the principal never dead-waits;
+      //  - trace has none (PI/expert self-decides) — just let it go.
+      // ⚠️ counters reset only here (the already-reminded terminal exit).
+      if (needReply) {
+        deps.onUnreplied(deps.name);
+        replyRemindCount = 0;
+      }
+      if (needTrace) {
+        traceRemindCount = 0;
+      }
     });
   };
 }

--- a/packages/runtime/src/extensions/trace-reminder.ts
+++ b/packages/runtime/src/extensions/trace-reminder.ts
@@ -1,0 +1,170 @@
+/**
+ * trace-reminder — the one Pi-native extension (replaces #79 captureMilestone).
+ *
+ * Philosophy (vs. #79): the host no longer writes trace nodes on the agent's
+ * behalf. Instead we REMIND the agent at the right moment and let it decide:
+ *  - 意图一 (PI work leaves a trace): if a principal turn made a decision but
+ *    never called record_trace, nudge it once to record (D).
+ *  - 意图二 (expert results flow back): if an expert turn produced work but never
+ *    send_message'd the principal, nudge once; if it still won't, the host writes
+ *    a fallback note into the principal's mailbox so the PI never dead-waits.
+ *  - 意图三 (PI keeps to delegation): if the principal does substantive work
+ *    directly without delegating, append a soft reminder to the tool result.
+ *  - 意图四 (resource awareness): on a tool error, append a soft hint that the
+ *    knowledge tools / record_trace exist. (Static identity lives in personas.)
+ *
+ * Mechanism (Pi SDK v0.79, verified against installed d.ts):
+ *  - Registered per-AgentSession via DefaultResourceLoader.extensionFactories.
+ *    Closure state is therefore naturally isolated per agent.
+ *  - `agent_end` / `turn_*` are pure notifications (no return value, cannot
+ *    block). The ONLY "force continue" lever is `pi.sendUserMessage(text,
+ *    {deliverAs:"followUp"})` inside `agent_end`: it releases the current stop
+ *    and injects a message that triggers a NEW turn.
+ *  - `tool_result` MAY return `{content}` to rewrite the result text — used for
+ *    the soft reminders (意图三/四).
+ */
+import type { AgentRole } from "../types.js";
+
+/** Minimal structural surface of Pi's ExtensionAPI we depend on. */
+interface PiExtensionApi {
+  on(event: "turn_start", handler: () => void): void;
+  on(event: "tool_execution_start", handler: (e: { toolName: string; args?: unknown }) => void): void;
+  on(event: "tool_execution_end", handler: (e: { toolName: string; isError: boolean }) => void): void;
+  on(
+    event: "tool_result",
+    handler: (e: {
+      toolName: string;
+      isError: boolean;
+      content: Array<{ type: string; text?: string }>;
+    }) => { content: Array<{ type: "text"; text: string }> } | void,
+  ): void;
+  on(event: "agent_end", handler: () => void): void;
+  sendUserMessage(content: string, options?: { deliverAs?: "steer" | "followUp" }): void;
+}
+
+export interface TraceReminderDeps {
+  role: AgentRole;
+  name: string;
+  /**
+   * 意图二 fallback: invoked when an expert was reminded once and STILL did not
+   * report back. The host writes a note into the principal's mailbox.
+   */
+  onUnreplied: (agentName: string) => void;
+}
+
+/**
+ * Management/coordination tools that are legitimate for a principal to call
+ * directly — they don't count as "doing the work itself" (意图三 exemption).
+ */
+const MGMT_TOOLS = new Set([
+  "create_agent",
+  "destroy_agent",
+  "record_trace",
+  "send_message",
+  "ask_user",
+  "get_trace_graph",
+]);
+
+const PRINCIPAL_TRACE_REMINDER =
+  "你本轮做了实质决策但尚未调用 record_trace。如果这步值得留痕，请调用 record_trace 记录后再结束。";
+const EXPERT_REPLY_REMINDER =
+  "你尚未通过 send_message(to=\"principal\", ...) 把结果回交给 Principal。请回交结果，否则 Principal 收不到你的产出。";
+const DELEGATE_REMINDER = "[提醒：作为 Principal，实质工作应委派给专家，而不是自己埋头执行。]";
+const TOOL_FAILURE_REMINDER =
+  "[提醒：该工具调用失败。可用 record_trace 记录这次失败，或借助知识库/检索工具寻找替代方案。]";
+
+/**
+ * Build the extension factory for one agent. The returned function is what Pi
+ * calls with the per-session `ExtensionAPI`.
+ */
+export function makeTraceReminderExt(deps: TraceReminderDeps): (pi: PiExtensionApi) => void {
+  return (pi) => {
+    // Per-turn flags — reset on turn_start.
+    let traced = false;
+    let replied = false;
+    let delegated = false;
+    let delegateRemindCount = 0;
+
+    // ⚠️ Cross-run counter — MUST NOT reset on turn_start / at the top of
+    // agent_end. sendUserMessage(followUp) triggers a NEW run whose end re-enters
+    // agent_end; if this were cleared we would re-remind forever. It is reset
+    // ONLY at the two terminal exits below (goal met, or already reminded once).
+    let remindCount = 0;
+
+    pi.on("turn_start", () => {
+      traced = false;
+      replied = false;
+      delegated = false;
+      delegateRemindCount = 0;
+    });
+
+    // tool_execution_start: nothing required for accounting (we key off
+    // tool_execution_end which carries success/failure). Kept as a no-op anchor
+    // so the wiring is obvious if richer arg capture is needed later.
+
+    pi.on("tool_execution_end", (e) => {
+      if (e.isError) return; // only successful calls count toward "did the work"
+      const t = e.toolName;
+      if (t === "record_trace" || t.startsWith("create_trace")) traced = true;
+      if (t === "send_message") replied = true;
+      if (t === "create_agent") delegated = true;
+    });
+
+    pi.on("tool_result", (e) => {
+      // 意图四 (failure hint) takes precedence; 意图三 (over-step) can stack.
+      let suffix = "";
+      if (e.isError) {
+        suffix += `\n${TOOL_FAILURE_REMINDER}`;
+      }
+      if (
+        deps.role === "principal" &&
+        !delegated &&
+        !MGMT_TOOLS.has(e.toolName) &&
+        delegateRemindCount < 1
+      ) {
+        delegateRemindCount++;
+        suffix += `\n${DELEGATE_REMINDER}`;
+      }
+      if (!suffix) return; // no rewrite — leave the result untouched
+
+      // Rewrite by appending to the existing text content; the tool still ran.
+      const text = e.content.map((c) => (c.type === "text" ? c.text ?? "" : "")).join("");
+      return { content: [{ type: "text", text: `${text}${suffix}` }] };
+    });
+
+    pi.on("agent_end", () => {
+      if (deps.role === "trace") return; // the recorder itself — never nudge.
+
+      if (deps.role === "principal") {
+        if (traced) {
+          remindCount = 0; // goal met — safe to reset.
+          return;
+        }
+        if (remindCount < 1) {
+          remindCount++;
+          pi.sendUserMessage(PRINCIPAL_TRACE_REMINDER, { deliverAs: "followUp" });
+          return;
+        }
+        // Already reminded once — let it go. PI is the top coordinator: no
+        // host-side fallback. ⚠️ reset only here (already-reminded exit).
+        remindCount = 0;
+        return;
+      }
+
+      // expert branch (everything that isn't principal/trace).
+      if (replied) {
+        remindCount = 0; // goal met — safe to reset.
+        return;
+      }
+      if (remindCount < 1) {
+        remindCount++;
+        pi.sendUserMessage(EXPERT_REPLY_REMINDER, { deliverAs: "followUp" });
+        return;
+      }
+      // Reminded once and still no reply → host fallback so the PI never
+      // dead-waits. ⚠️ reset only here (already-reminded exit).
+      deps.onUnreplied(deps.name);
+      remindCount = 0;
+    });
+  };
+}

--- a/packages/runtime/src/mas-agent.ts
+++ b/packages/runtime/src/mas-agent.ts
@@ -8,7 +8,11 @@
  *    converted to RUN_ERROR + system_message and the agent goes to `error`.
  *  - Map Pi `auto_retry_start/end` → agent_status_update + system_message;
  *    suppress internal events (turn_*, compaction_*).
- *  - Event-driven hooks (§8): track reply/trace/delegate per turn.
+ *
+ * Behavioural hooks (remind/trace/reply/delegate) used to live here as per-turn
+ * TurnTrackers (#79). They now live in the Pi-native `trace-reminder` extension
+ * (`extensions/trace-reminder.ts`), registered per AgentSession by the real
+ * factory. MasAgent is back to a pure Pi→AG-UI translator.
  */
 import type { AgUiEvent, AgentState } from "@brainpilot/protocol";
 import type { EventBus } from "./event-bus.js";
@@ -23,20 +27,6 @@ import type {
 
 export type AgentStatus = "idle" | "running" | "error" | "stopped";
 
-/** Per-turn activity summary handed to the §8 post-turn hook. */
-export interface TurnTrackers {
-  /** Replied to another agent via `send_message`. */
-  replied: boolean;
-  /** Recorded a trace node via `record_trace` / `create_trace_*`. */
-  traced: boolean;
-  /** Spawned a sub-agent via `create_agent`. */
-  delegated: boolean;
-  /** Name of the most recent `create_agent` target this turn, if any. */
-  delegateTarget?: string;
-  /** Tool names that ran (no error) this turn. */
-  usedToolNames: Set<string>;
-}
-
 export interface MasAgentOpts {
   sessionId: string;
   name: string;
@@ -44,12 +34,6 @@ export interface MasAgentOpts {
   session: IAgentSession;
   bus: EventBus;
   onStatusChange?: (name: string, status: AgentStatus) => void;
-  /**
-   * §8 deterministic post-turn hook. Fired at every Pi `turn_end` with a
-   * snapshot of what the turn did, so the host can capture a milestone into the
-   * Graph of Trace even when the model never called `record_trace` (#79).
-   */
-  onTurnEnd?: (info: { name: string; role: AgentRole; trackers: TurnTrackers }) => void;
 }
 
 export class MasAgent {
@@ -66,14 +50,6 @@ export class MasAgent {
   private inReasoning = false;
   private activeToolExecutions = new Set<string>();
   private lastError: AgentState["lastError"];
-
-  // §8 hook trackers (reset each turn).
-  private trackers: TurnTrackers = {
-    replied: false,
-    traced: false,
-    delegated: false,
-    usedToolNames: new Set(),
-  };
 
   constructor(private readonly opts: MasAgentOpts) {
     this.name = opts.name;
@@ -115,7 +91,6 @@ export class MasAgent {
    */
   async prompt(text: string): Promise<void> {
     this.currentRunId = newRunId();
-    this.resetTrackers();
     this.setStatus("running");
     this.bus.emit(ev.runStarted({ sessionId: this.sessionId, agentName: this.name, runId: this.currentRunId }));
     try {
@@ -169,37 +144,20 @@ export class MasAgent {
     );
   }
 
-  private resetTrackers(): void {
-    this.trackers = {
-      replied: false,
-      traced: false,
-      delegated: false,
-      usedToolNames: new Set(),
-    };
-  }
-
   /** Translate one Pi event into zero or more AG-UI events (§6). */
   private onPiEvent(e: PiAgentEvent): void {
     const ctx = { sessionId: this.sessionId, agentName: this.name, runId: this.currentRunId };
     switch (e.type) {
       case "agent_start":
       case "agent_end":
+      case "turn_start":
+      case "turn_end":
       case "compaction_start":
       case "compaction_end":
       case "queue_update":
         // Internal / suppressed (§6 table: turn_*, compaction_* not exposed).
-        return;
-
-      case "turn_start":
-        this.resetTrackers();
-        return;
-
-      case "turn_end":
-        // §8 deterministic capture: hand the turn summary to the host hook
-        // before resetting, so a missed milestone can still enter the graph (#79).
-        // Not exposed as an AG-UI event (§6 keeps turn_* internal).
-        this.opts.onTurnEnd?.({ name: this.name, role: this.role, trackers: this.trackers });
-        this.resetTrackers();
+        // Behavioural reactions to turn_*/agent_end now live in the Pi-native
+        // trace-reminder extension, not here.
         return;
 
       case "message_start": {
@@ -248,13 +206,6 @@ export class MasAgent {
         this.bus.emit(ev.toolCallStart(ctx, t.toolCallId, t.toolName, this.currentMessageId));
         const argsStr = safeStringify(t.args);
         if (argsStr) this.bus.emit(ev.toolCallArgs(ctx, t.toolCallId, argsStr));
-        // Capture the delegation target for the §8 hook (#79). `create_agent`'s
-        // arg is `agent_type` (see createCreateAgentTool); fall back to `name`.
-        if (t.toolName === "create_agent") {
-          const args = (t.args ?? {}) as Record<string, unknown>;
-          const target = args.agent_type ?? args.name;
-          if (typeof target === "string" && target) this.trackers.delegateTarget = target;
-        }
         return;
       }
 
@@ -264,8 +215,6 @@ export class MasAgent {
         this.bus.emit(ev.toolCallEnd(ctx, t.toolCallId));
         const resultStr = typeof t.result === "string" ? t.result : safeStringify(t.result);
         this.bus.emit(ev.toolCallResult(ctx, t.toolCallId, resultStr, t.isError));
-        // §8 hooks: mark replied/traced/delegated from tool results.
-        this.onToolResult(t.toolName, t.isError);
         // §7 L1: surface tool errors as system_message.
         if (t.isError) {
           this.bus.emit(
@@ -353,19 +302,6 @@ export class MasAgent {
       default:
         return;
     }
-  }
-
-  private onToolResult(toolName: string, isError: boolean): void {
-    if (isError) return;
-    this.trackers.usedToolNames.add(toolName);
-    if (toolName === "send_message") this.trackers.replied = true;
-    if (toolName === "record_trace" || toolName.startsWith("create_trace")) this.trackers.traced = true;
-    if (toolName === "create_agent") this.trackers.delegated = true;
-  }
-
-  /** Expose tracker state (for hook tests). */
-  getTrackers(): TurnTrackers {
-    return { ...this.trackers, usedToolNames: new Set(this.trackers.usedToolNames) };
   }
 }
 

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -24,7 +24,7 @@ import {
 import { EventBus } from "./event-bus.js";
 import { Mailbox, type MailboxMessage } from "./mailbox.js";
 import { GraphOfTrace } from "./trace.js";
-import { MasAgent, type TurnTrackers } from "./mas-agent.js";
+import { MasAgent } from "./mas-agent.js";
 import { systemToolsForRole, builtinToolNamesForRole, type ToolDeps } from "./tools/system-tools.js";
 import { ev } from "./events.js";
 import { selectFactory, isMockMode } from "./agent-factory.js";
@@ -104,16 +104,6 @@ function roleFor(name: string): AgentRole {
   if (name === "principal") return "principal";
   if (name === "trace") return "trace";
   return "expert";
-}
-
-/** Builtin tools that mutate the workspace — a milestone worth tracing (#79). */
-const WORKSPACE_MUTATION_TOOLS = new Set(["write", "edit", "bash"]);
-function hasWorkspaceMutation(used: Set<string>): boolean {
-  for (const t of used) if (WORKSPACE_MUTATION_TOOLS.has(t)) return true;
-  return false;
-}
-function listTools(used: Set<string>): string {
-  return [...used].filter((t) => WORKSPACE_MUTATION_TOOLS.has(t)).join(", ") || "the workspace tools";
 }
 
 /**
@@ -891,6 +881,10 @@ export class SessionManager {
       systemPrompt: await this.loadPersona(name, role),
       skillPaths: [this.templateSkillsDir(), this.sessionSkillsDir(sessionId)],
       providerConfig,
+      // 意图二 fallback: the trace-reminder extension calls this when an expert
+      // was reminded once and still didn't report back, so the principal never
+      // dead-waits on a silent expert.
+      onUnreplied: (agentName) => this.writeFallbackToPrincipal(entry, agentName),
     });
 
     const agent = new MasAgent({
@@ -906,10 +900,6 @@ export class SessionManager {
         this.touch(entry);
         this.emitSessionState(entry);
       },
-      // #79: deterministic milestone capture. If a turn did meaningful work but
-      // the model never called record_trace, synthesize a chained node so the
-      // Graph of Trace is reliable without depending on prompt compliance.
-      onTurnEnd: (info) => this.captureMilestone(entry, info),
     });
     entry.agents.set(name, agent);
     if (!entry.tasks.has(name)) entry.tasks.set(name, "");
@@ -917,51 +907,25 @@ export class SessionManager {
   }
 
   /**
-   * §8 / #79 — deterministic post-turn trace capture. Called at every agent
-   * `turn_end`. When the model already recorded a trace this turn we stay quiet
-   * (the LLM's node, possibly refined by the trace agent, is authoritative). We
-   * only synthesize a node when a milestone clearly happened but went unrecorded:
-   *  - principal delegated work (`create_agent`) → "Delegated to <target>";
-   *  - principal mutated the workspace (write/edit/bash) → "Principal action";
-   *  - an expert delivered a result back (`send_message`) → "<name> delivered result".
-   * The synthesized node is chained to the previous node so the graph stays a DAG,
-   * and tagged `metadata.auto` so the UI can distinguish it from LLM traces.
-   * The `trace` agent itself is exempt (it IS the recorder).
+   * 意图二 fallback — the trace-reminder extension calls this (via the factory's
+   * `onUnreplied`) when an expert was reminded once and STILL did not
+   * `send_message` the principal. We write a system note into the principal's
+   * mailbox and wake it, so the principal can re-delegate or proceed without the
+   * silent expert's output rather than dead-waiting. Best-effort: a failed write
+   * must never break the agent loop.
    */
-  private captureMilestone(
-    entry: SessionEntry,
-    info: { name: string; role: AgentRole; trackers: TurnTrackers },
-  ): void {
-    const { name, role, trackers } = info;
-    if (role === "trace") return;
-    if (trackers.traced) return; // LLM already recorded — don't duplicate.
-
-    let title: string | undefined;
-    let description: string | undefined;
-    if (role === "principal" && trackers.delegated) {
-      const target = trackers.delegateTarget ?? "an expert";
-      title = `Delegated to ${target}`;
-      description = `Principal delegated work to ${target}.`;
-    } else if (role === "principal" && hasWorkspaceMutation(trackers.usedToolNames)) {
-      title = "Principal action";
-      description = `Principal acted directly using ${listTools(trackers.usedToolNames)}.`;
-    } else if (role !== "principal" && trackers.replied) {
-      title = `${name} delivered result`;
-      description = `${name} delivered a result back to the principal.`;
-    }
-    if (!title) return; // nothing milestone-worthy this turn.
-
-    try {
-      entry.trace.createChainedNode({
-        title,
-        agent: name,
-        description,
-        metadata: { auto: true, hook: role === "principal" ? "principal_trace" : "expert_reply" },
+  private writeFallbackToPrincipal(entry: SessionEntry, expert: string): void {
+    void entry.mailbox
+      .write({
+        fromAgent: "system",
+        toAgent: "principal",
+        msgType: "system",
+        content: `专家 ${expert} 多次未回交结果。建议重新委派该任务，或不依赖其输出继续推进。`,
+      })
+      .then(() => this.wakeAgent(entry.id, "principal"))
+      .catch(() => {
+        /* best-effort */
       });
-      this.touch(entry);
-    } catch {
-      // Best-effort — a trace write must never break the agent turn.
-    }
   }
 
   async destroyAgent(sessionId: string, name: string): Promise<void> {
@@ -1024,7 +988,7 @@ export class SessionManager {
       this.touch(entry);
       // Surface the delegated run immediately (derived active flag, agent list).
       this.emitSessionState(entry);
-      await agent.prompt(this.renderEnvelopes(msgs));
+      await agent.prompt(this.renderEnvelopes(msgs, name));
     }
   }
 
@@ -1033,9 +997,14 @@ export class SessionManager {
    * persona (`personas.ts`) tells agents to expect, so the model knows who sent
    * each message and why. User-origin messages declare `<source type="user"/>`;
    * agent-origin ones name the sender.
+   *
+   * 意图一·触发点2 (Pi-native hooks): when the PRINCIPAL receives a message from
+   * another agent (not the user — i.e. an expert reporting back), append a single
+   * static line nudging it to record_trace any real decision it makes while
+   * processing the reply. Stateless, loop-free (at most one line per delivery).
    */
-  private renderEnvelopes(msgs: readonly MailboxMessage[]): string {
-    return msgs
+  private renderEnvelopes(msgs: readonly MailboxMessage[], toAgent: string): string {
+    const body = msgs
       .map((m) => {
         const source =
           m.msgType === "user_message"
@@ -1044,6 +1013,12 @@ export class SessionManager {
         return `<message_envelope>\n  ${source}\n  <type>${m.msgType}</type>\n</message_envelope>\n${m.content}`;
       })
       .join("\n\n");
+
+    const fromAgent = msgs.some((m) => m.msgType !== "user_message");
+    if (toAgent === "principal" && fromAgent) {
+      return `${body}\n\n[提醒：处理完这些消息后，如有实质决策请调用 record_trace 记录。]`;
+    }
+    return body;
   }
 
   /* -------------------------- state authority -------------------------- */

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -1046,9 +1046,12 @@ export class SessionManager {
    * registered synchronously inside `send_message`, so this closes the await gap
    * between the sender finishing its turn and the delegated target starting —
    * without it the flag would flicker false in that window). The trace agent is
-   * excluded from the aggregate (it self-records continuously and shouldn't read
-   * as "the user's task is still running"), but it is still LISTED in `agents[]`
-   * with its own status, so the UI shows exactly which agents are running.
+   * a real spawned agent (record_trace dispatches `trace_event` envelopes into
+   * its mailbox and it owns the Graph of Trace as editor, see
+   * `system-tools.ts:createRecordTraceTool`), but it is excluded from the
+   * AGGREGATE: a trace recording isn't "the user's task is still running". It
+   * is still LISTED in `agents[]` with its own status so the Agents panel shows
+   * its idle/running transitions live.
    */
   private deriveRunActive(entry: SessionEntry): boolean {
     if (entry.runActive) return true;

--- a/packages/runtime/src/tools/system-tools.ts
+++ b/packages/runtime/src/tools/system-tools.ts
@@ -152,7 +152,10 @@ export function createDestroyAgentTool(deps: ToolDeps): SystemTool {
 export function createRecordTraceTool(deps: ToolDeps): SystemTool {
   return {
     name: "record_trace",
-    description: "Record a reasoning/trace event into the Graph of Trace.",
+    description:
+      "Notify the Trace Agent of a reasoning/trace event. The Trace Agent is a " +
+      "real agent that owns the Graph of Trace; it decides whether to create a " +
+      "new node, update an existing one, or merge with a sibling.",
     parameters: {
       type: "object",
       properties: {
@@ -163,20 +166,49 @@ export function createRecordTraceTool(deps: ToolDeps): SystemTool {
       required: ["description"],
     },
     execute: async (params: Record<string, unknown>) => {
-      // Chain to the most recent node so consecutive traces form a connected DAG
-      // (otherwise every record_trace is an orphan and the graph has no edges).
-      const parentId = deps.trace.getLastNodeId();
-      const node = deps.trace.createNode({
-        title: String(params.description ?? "trace"),
-        type: "trace",
-        status: "completed",
-        agent: deps.fromAgent,
-        description: String(params.description ?? ""),
-        content: String(params.context ?? ""),
-        artifacts: ((params.artifacts as string[]) ?? []).map((p) => ({ path: p })),
-        parents: parentId ? [{ id: parentId, relation: "follows" }] : undefined,
-      });
-      return ok(`trace recorded: ${node.id}`);
+      // §10 (legacy parity): record_trace does NOT mutate the graph directly.
+      // Instead it dispatches a [Trace Event] envelope into the trace agent's
+      // mailbox; the trace agent — a real Pi AgentSession — receives it and
+      // calls create_trace_node / update_trace_node / add_trace_relation as the
+      // editor. This keeps the trace agent's status authentically live in the
+      // Agents panel (otherwise it would be a permanently-dormant placeholder)
+      // and lets the trace agent merge/dedupe across multiple sources, which is
+      // exactly the persona we already ship for it.
+      const description = String(params.description ?? "");
+      const context = String(params.context ?? "");
+      const artifacts = (params.artifacts as string[]) ?? [];
+      const lines = [`[Trace Event]`, `Description: ${description}`];
+      if (context) lines.push(`Context: ${context}`);
+      lines.push("", "Artifacts:");
+      if (artifacts.length === 0) {
+        lines.push("(none)");
+      } else {
+        for (const a of artifacts) lines.push(`- ${a}`);
+      }
+      const envelope = lines.join("\n");
+
+      // Spawn-on-demand: the trace agent is a real Pi session. ensureAgent
+      // creates one if it doesn't exist yet (idempotent) and resurrects a
+      // stopped one. That spawn is what finally surfaces the trace agent as
+      // "idle/running" in the Agents panel.
+      await deps.ensureAgent("trace");
+      try {
+        await deps.mailbox.write({
+          fromAgent: deps.fromAgent,
+          toAgent: "trace",
+          content: envelope,
+          msgType: "trace_event",
+        });
+      } catch (err) {
+        if (err instanceof MailboxFullError) {
+          return { ...ok(`cannot deliver to trace: ${err.message}`), isError: true };
+        }
+        throw err;
+      }
+      // Fire-and-forget: kick the trace agent's delivery loop so the envelope
+      // is consumed in its own run rather than sitting unread.
+      deps.wakeAgent("trace");
+      return ok("trace event dispatched");
     },
   };
 }

--- a/packages/runtime/src/tools/system-tools.ts
+++ b/packages/runtime/src/tools/system-tools.ts
@@ -163,6 +163,9 @@ export function createRecordTraceTool(deps: ToolDeps): SystemTool {
       required: ["description"],
     },
     execute: async (params: Record<string, unknown>) => {
+      // Chain to the most recent node so consecutive traces form a connected DAG
+      // (otherwise every record_trace is an orphan and the graph has no edges).
+      const parentId = deps.trace.getLastNodeId();
       const node = deps.trace.createNode({
         title: String(params.description ?? "trace"),
         type: "trace",
@@ -171,6 +174,7 @@ export function createRecordTraceTool(deps: ToolDeps): SystemTool {
         description: String(params.description ?? ""),
         content: String(params.context ?? ""),
         artifacts: ((params.artifacts as string[]) ?? []).map((p) => ({ path: p })),
+        parents: parentId ? [{ id: parentId, relation: "follows" }] : undefined,
       });
       return ok(`trace recorded: ${node.id}`);
     },
@@ -193,14 +197,18 @@ export function createTraceNodeTool(deps: ToolDeps): SystemTool {
       required: ["title"],
     },
     execute: async (params: Record<string, unknown>) => {
-      const parentId = params.parent_id ? String(params.parent_id) : undefined;
+      // Honour an explicit parent_id; otherwise chain to the most recent node so
+      // the graph stays connected instead of accumulating orphan nodes.
+      const explicitParent = params.parent_id ? String(params.parent_id) : undefined;
+      const parentId = explicitParent ?? deps.trace.getLastNodeId();
+      const relation = explicitParent ? "parent" : "follows";
       const node = deps.trace.createNode({
         title: String(params.title ?? ""),
         type: params.type ? String(params.type) : undefined,
         status: params.status ? String(params.status) : undefined,
         description: params.description ? String(params.description) : undefined,
         agent: deps.fromAgent,
-        parents: parentId ? [{ id: parentId, relation: "parent" }] : undefined,
+        parents: parentId ? [{ id: parentId, relation }] : undefined,
       });
       return ok(`node ${node.id} created`);
     },

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -112,6 +112,13 @@ export type AgentSessionFactory = (params: {
   /** System prompt for the agent. */
   systemPrompt: string;
   /**
+   * 意图二 fallback (Pi-native hooks): invoked by the trace-reminder extension
+   * when an expert was reminded once and STILL did not report back, so the host
+   * can write a fallback note into the principal's mailbox (the PI never
+   * dead-waits). Omitted by the mock factory.
+   */
+  onUnreplied?: (agentName: string) => void;
+  /**
    * App-controlled skill directories loaded for this agent (template dir shared
    * by all sessions + this session's own dir). Replaces the host-global skill
    * discovery — see agent-factory `noSkills: true`.

--- a/packages/web/src/__tests__/chatScrollMemory.test.ts
+++ b/packages/web/src/__tests__/chatScrollMemory.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  getChatScroll,
+  setChatScroll,
+  resolveScrollTop,
+} from "../components/chat/chatScrollMemory";
+
+describe("chatScrollMemory (#89)", () => {
+  beforeEach(() => {
+    // Each test uses unique keys, but clear shared rows defensively.
+    setChatScroll("s1", { scrollTop: 0, pinned: true });
+    setChatScroll("s2", { scrollTop: 0, pinned: true });
+  });
+
+  it("stores and reads per-session state", () => {
+    setChatScroll("s1", { scrollTop: 120, pinned: false });
+    expect(getChatScroll("s1")).toEqual({ scrollTop: 120, pinned: false });
+  });
+
+  it("isolates sessions", () => {
+    setChatScroll("s1", { scrollTop: 50, pinned: false });
+    setChatScroll("s2", { scrollTop: 999, pinned: true });
+    expect(getChatScroll("s1")?.scrollTop).toBe(50);
+    expect(getChatScroll("s2")?.scrollTop).toBe(999);
+  });
+
+  it("ignores undefined keys", () => {
+    setChatScroll(undefined, { scrollTop: 5, pinned: false });
+    expect(getChatScroll(undefined)).toBeUndefined();
+  });
+
+  describe("resolveScrollTop", () => {
+    it("returns bottom when there is no memory (fresh conversation)", () => {
+      expect(resolveScrollTop(undefined, 4000)).toBe(4000);
+    });
+
+    it("returns bottom when the user was pinned (following live output)", () => {
+      expect(resolveScrollTop({ scrollTop: 100, pinned: true }, 4000)).toBe(4000);
+    });
+
+    it("restores the saved position when the user was reading history", () => {
+      expect(resolveScrollTop({ scrollTop: 800, pinned: false }, 4000)).toBe(800);
+    });
+
+    it("clamps a stale position to the current scrollHeight", () => {
+      expect(resolveScrollTop({ scrollTop: 9000, pinned: false }, 4000)).toBe(4000);
+    });
+  });
+});

--- a/packages/web/src/__tests__/toolDisplay.test.ts
+++ b/packages/web/src/__tests__/toolDisplay.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { formatToolName, formatPayload } from "../utils/toolDisplay";
+
+describe("formatToolName (#84)", () => {
+  it("maps mcp__server__tool to 'server · tool'", () => {
+    expect(formatToolName("mcp__bp_skills__skills_tool")).toBe("bp_skills · skills_tool");
+  });
+
+  it("keeps server/tool segments that contain underscores", () => {
+    expect(formatToolName("mcp__my_server__do_a_thing")).toBe("my_server · do_a_thing");
+  });
+
+  it("returns non-MCP names unchanged", () => {
+    expect(formatToolName("read")).toBe("read");
+    expect(formatToolName("send_message")).toBe("send_message");
+  });
+
+  it("falls back gracefully for missing/empty names", () => {
+    expect(formatToolName(undefined)).toBe("tool");
+    expect(formatToolName(null)).toBe("tool");
+    expect(formatToolName("")).toBe("tool");
+  });
+
+  it("does not crash on a malformed mcp__ prefix with no tool segment", () => {
+    // No second `__` — show the remainder rather than the raw identifier.
+    expect(formatToolName("mcp__justserver")).toBe("justserver");
+  });
+});
+
+describe("formatPayload (#84)", () => {
+  it("parses a JSON string so it is not double-escaped", () => {
+    const raw = JSON.stringify({ path: "a/b.txt", count: 2 });
+    const out = formatPayload(raw);
+    expect(out).toBe('{\n  "path": "a/b.txt",\n  "count": 2\n}');
+    expect(out).not.toContain('\\"');
+  });
+
+  it("pretty-prints a plain object", () => {
+    expect(formatPayload({ a: 1 })).toBe('{\n  "a": 1\n}');
+  });
+
+  it("returns non-JSON strings verbatim", () => {
+    expect(formatPayload("just some text")).toBe("just some text");
+  });
+
+  it("returns a partial/invalid JSON string verbatim", () => {
+    expect(formatPayload('{"path": "a/b')).toBe('{"path": "a/b');
+  });
+
+  it("returns empty string for null/undefined/blank", () => {
+    expect(formatPayload(undefined)).toBe("");
+    expect(formatPayload(null)).toBe("");
+    expect(formatPayload("   ")).toBe("");
+  });
+});

--- a/packages/web/src/components/chat/MessageStream.tsx
+++ b/packages/web/src/components/chat/MessageStream.tsx
@@ -1,5 +1,5 @@
 import { Check, ChevronDown, Copy } from "lucide-react";
-import { memo, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { ChatMessage } from "../../contracts/backend";
 import { buildRenderItems } from "../../contexts/messageGroups";
 import { useT } from "../../i18n/useT";
@@ -7,12 +7,21 @@ import { MarkdownMessage } from "./MarkdownMessage";
 import { SystemMessageBubble } from "./SystemMessageBubble";
 import { AskUserCard } from "./AskUserCard";
 import { AutoRetryIndicator } from "./AutoRetryIndicator";
+import { formatToolName, formatPayload } from "../../utils/toolDisplay";
+import { getChatScroll, setChatScroll, resolveScrollTop } from "./chatScrollMemory";
 
 interface MessageStreamProps {
   /** Already filtered / time-sliced by the host. */
   messages: ChatMessage[];
   /** Pin to bottom as new messages arrive (live chat). Default false. */
   autoScroll?: boolean;
+  /**
+   * #89 — session id used to remember scroll position/pinned intent across
+   * tab switches (Chat is unmounted when Agents/Trace is active). When set, the
+   * stream restores its prior position on mount instead of replaying a visible
+   * top-to-bottom scroll. Omit in read-only contexts (demo replay).
+   */
+  scrollKey?: string;
   /** Show the "N messages" toolbar row. Default true. */
   showToolbarCount?: boolean;
   /** Show per-agent elapsed timers + total conversation time. Live chat only. */
@@ -66,6 +75,7 @@ function formatElapsed(ms: number): string {
 function MessageStreamImpl({
   messages,
   autoScroll = false,
+  scrollKey,
   showToolbarCount = true,
   showTiming = false,
   className,
@@ -169,6 +179,35 @@ function MessageStreamImpl({
     return formatElapsed(end - entry.start);
   };
 
+  // #89 — restore scroll position on (re)mount BEFORE the browser paints, so
+  // returning to Chat from another tab lands at the right place with no visible
+  // top-to-bottom replay. Reads the per-session memory: pinned/fresh → bottom,
+  // otherwise the saved history position. A double rAF re-applies after async
+  // layout (Markdown, images) settles, in case scrollHeight grew post-mount.
+  useLayoutEffect(() => {
+    const node = stackRef.current;
+    if (!node) return;
+    const mem = getChatScroll(scrollKey);
+    isPinnedRef.current = mem ? mem.pinned : true;
+    const apply = () => {
+      const n = stackRef.current;
+      if (!n) return;
+      n.scrollTop = resolveScrollTop(mem, n.scrollHeight);
+    };
+    apply();
+    let raf2 = 0;
+    const raf1 = window.requestAnimationFrame(() => {
+      apply();
+      raf2 = window.requestAnimationFrame(apply);
+    });
+    return () => {
+      window.cancelAnimationFrame(raf1);
+      if (raf2) window.cancelAnimationFrame(raf2);
+    };
+    // Mount-only restore; live append is handled by the autoScroll effect below.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scrollKey]);
+
   useEffect(() => {
     if (!autoScroll) {
       return;
@@ -187,6 +226,8 @@ function MessageStreamImpl({
     }
     const distanceFromBottom = node.scrollHeight - node.scrollTop - node.clientHeight;
     isPinnedRef.current = distanceFromBottom < 24;
+    // #89 — persist intent so a tab switch (which unmounts Chat) can restore it.
+    setChatScroll(scrollKey, { scrollTop: node.scrollTop, pinned: isPinnedRef.current });
   };
 
   const handleCopy = async (id: string, text: string) => {
@@ -377,15 +418,20 @@ function MessageStreamImpl({
   const renderActivityStep = (step: ChatMessage) => {
     const isExpert = !!step.agent && step.agent !== "principal";
     if (step.kind === "tool") {
+      // #84: render a friendly tool name (mcp__server__tool → server · tool) and
+      // un-escaped payloads. The raw name stays in `title` for debugging/copy.
+      const friendly = t("chat.toolPrefix", { name: formatToolName(step.toolName) });
+      const input = formatPayload(step.toolInput);
+      const result = formatPayload(step.toolResult);
       return (
         <div className="activity-step" key={step.id}>
           <details>
-            <summary>
+            <summary title={step.toolName || undefined}>
               {isExpert ? <span className="message-card__agent-badge">{step.agent}</span> : null}
-              {step.content || t("chat.toolPrefix", { name: step.toolName || "tool" })}
+              {friendly}
             </summary>
-            {step.toolInput !== undefined && step.toolInput !== "" ? <pre>{JSON.stringify(step.toolInput, null, 2)}</pre> : null}
-            {step.toolResult !== undefined ? <pre>{JSON.stringify(step.toolResult, null, 2)}</pre> : null}
+            {input ? <pre>{input}</pre> : null}
+            {result ? <pre>{result}</pre> : null}
           </details>
         </div>
       );
@@ -410,7 +456,7 @@ function MessageStreamImpl({
   const activitySubtitle = (steps: ChatMessage[], streaming: boolean) => {
     if (!streaming) return t("chat.thinkingSteps", { count: steps.length });
     const last = steps[steps.length - 1];
-    if (last?.kind === "tool") return t("chat.toolCall", { name: last.toolName || "tool" });
+    if (last?.kind === "tool") return t("chat.toolCall", { name: formatToolName(last.toolName) });
     const text = (last?.reasoning || last?.content || "").trim();
     if (text) return text.length > 80 ? `${text.slice(0, 80)}…` : text;
     return t("chat.thinking");

--- a/packages/web/src/components/chat/PromptComposer.tsx
+++ b/packages/web/src/components/chat/PromptComposer.tsx
@@ -270,6 +270,7 @@ export function PromptComposer() {
           <MessageStream
             messages={visibleMessages}
             autoScroll
+            scrollKey={sessionId ?? undefined}
             showTiming
             runningAgents={runningAgents}
             onAskUserSubmit={(requestId, answer) => void respondToInput(requestId, answer)}

--- a/packages/web/src/components/chat/chatScrollMemory.ts
+++ b/packages/web/src/components/chat/chatScrollMemory.ts
@@ -1,0 +1,49 @@
+/**
+ * Per-session chat scroll memory (#89).
+ *
+ * Switching workspace tabs (Chat ↔ Agents ↔ Trace) unmounts/remounts the Chat
+ * subtree in DesktopShell, so MessageStream loses its scroll position and its
+ * "is the user pinned to the bottom" intent. This module-level store survives
+ * those remounts, keyed by session id, so returning to Chat can restore where
+ * the user was — at the bottom following live output, or up in the history they
+ * were reading — without a visible top-to-bottom replay.
+ *
+ * Module-level (not React state) on purpose: it must outlive the component that
+ * reads it, and it is deliberately ephemeral (lost on full page reload, which
+ * is the right default — a reload starts a fresh view).
+ */
+
+export interface ChatScrollState {
+  /** Last observed scrollTop of the message stack. */
+  scrollTop: number;
+  /** Whether the user was pinned to (near) the bottom. */
+  pinned: boolean;
+}
+
+const store = new Map<string, ChatScrollState>();
+
+export function getChatScroll(key: string | undefined): ChatScrollState | undefined {
+  if (!key) return undefined;
+  return store.get(key);
+}
+
+export function setChatScroll(key: string | undefined, state: ChatScrollState): void {
+  if (!key) return;
+  store.set(key, state);
+}
+
+/**
+ * Resolve the scrollTop to apply on (re)mount.
+ *
+ * - no memory yet, or the user was pinned → bottom (scrollHeight); this is the
+ *   default for a freshly-opened conversation and for "following live output".
+ * - the user had scrolled up to read history → restore that exact position,
+ *   clamped to the current scrollHeight in case content shrank.
+ */
+export function resolveScrollTop(
+  mem: ChatScrollState | undefined,
+  scrollHeight: number,
+): number {
+  if (!mem || mem.pinned) return scrollHeight;
+  return Math.min(mem.scrollTop, scrollHeight);
+}

--- a/packages/web/src/components/session/traceLayout.ts
+++ b/packages/web/src/components/session/traceLayout.ts
@@ -65,6 +65,9 @@ export const relationLabels: Record<string, string> = {
   used: "used",
   produced: "produced",
   comparison_with: "compared with",
+  follows: "then",
+  depends_on: "depends on",
+  parent: "parent",
 };
 
 export const artifactLabels: Record<string, string> = {

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -1148,8 +1148,8 @@ button {
 
 .trace-edge path {
   fill: none;
-  stroke: var(--color-border-strong);
-  stroke-width: 1.35;
+  stroke: color-mix(in srgb, var(--color-accent) 55%, var(--color-border-strong));
+  stroke-width: 2;
   marker-end: url("#trace-arrow");
 }
 
@@ -1160,6 +1160,10 @@ button {
 
 .trace-edge--produced path {
   stroke: var(--color-success);
+}
+
+.trace-edge--follows path {
+  stroke: color-mix(in srgb, var(--color-accent) 50%, var(--color-border-strong));
 }
 
 .trace-edge-label rect {
@@ -1179,7 +1183,7 @@ button {
 }
 
 #trace-arrow path {
-  fill: var(--color-border-strong);
+  fill: color-mix(in srgb, var(--color-accent) 55%, var(--color-border-strong));
 }
 
 .trace-map-node {

--- a/packages/web/src/utils/toolDisplay.ts
+++ b/packages/web/src/utils/toolDisplay.ts
@@ -1,0 +1,74 @@
+/**
+ * Presentation helpers for the tool-activity block (#84).
+ *
+ * The runtime namespaces MCP tools as `mcp__<server>__<tool>` (see
+ * packages/runtime/src/mcp-bridge.ts) to avoid collisions, and tool
+ * args/results arrive as already-encoded JSON strings. Surfacing those raw in
+ * the chat UI reads like debug output:
+ *   - `mcp__bp_skills__skills_tool` instead of a friendly name, and
+ *   - payloads double-encoded into `\"key\": \"value\"` walls of backslashes.
+ *
+ * These helpers are display-only — the raw name/payload stays available for
+ * copying and debugging; nothing here touches the wire protocol.
+ */
+
+/**
+ * Friendly tool name. `mcp__<server>__<tool>` collapses to `<server> · <tool>`;
+ * any other name (built-in tools, already-friendly names) is returned as-is.
+ *
+ * The MCP prefix split is intentionally lenient: a server or tool segment may
+ * itself contain single underscores, so we split on the literal `mcp__` prefix
+ * and the FIRST `__` separator after the server name.
+ */
+export function formatToolName(raw: string | undefined | null): string {
+  if (!raw) return "tool";
+  if (!raw.startsWith("mcp__")) return raw;
+  const rest = raw.slice("mcp__".length);
+  const sep = rest.indexOf("__");
+  if (sep <= 0 || sep >= rest.length - 2) {
+    // Malformed (no tool segment) — show the un-prefixed remainder rather than
+    // the raw mcp__ identifier.
+    return rest || raw;
+  }
+  const server = rest.slice(0, sep);
+  const tool = rest.slice(sep + 2);
+  return `${server} · ${tool}`;
+}
+
+/**
+ * Pretty-print a tool payload without double-escaping. Tool args/results are
+ * accumulated as JSON strings over TOOL_CALL_ARGS deltas; calling
+ * JSON.stringify on an already-stringified value yields a `\"`-littered wall.
+ *
+ * Strategy:
+ *   - string that parses as JSON  → parse, then pretty-print the value;
+ *   - string that does NOT parse  → return verbatim (plain text / partial);
+ *   - anything else (object/etc.) → pretty-print directly.
+ *
+ * Returns "" for null/undefined so callers can skip empty <pre> blocks.
+ */
+export function formatPayload(value: unknown): string {
+  if (value === undefined || value === null) return "";
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed === "") return "";
+    // Only attempt a parse when it looks like JSON — avoids turning a bare
+    // number/quoted word into a reformatted value users didn't write.
+    const looksJson =
+      (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+      (trimmed.startsWith("[") && trimmed.endsWith("]"));
+    if (looksJson) {
+      try {
+        return JSON.stringify(JSON.parse(trimmed), null, 2);
+      } catch {
+        return value;
+      }
+    }
+    return value;
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}


### PR DESCRIPTION
Replaces the captureMilestone path from PR #92 with legacy MAS-Platform's "remind + agent decides + fallback only when needed" philosophy, implemented through Pi's native extension API (one `createTraceReminder()` extension per AgentSession, closure-scoped state).

## Why the swap

PR #92 (closes #79) made the host write trace nodes for the agent when a turn did "meaningful work" but never called `record_trace`. In practice that produced two pain points:

1. **Noisy auto-traces** — trace fidelity ended up depending on the host's view of "meaningful work" rather than the agent's own reflection, so the panel filled with auto nodes that didn't match what the agent actually thought it had achieved.
2. **Trace authority lived in the wrong place** — the agent never learned that tracing was its responsibility, because the host kept covering for it.

The new path inverts this: nudge the agent and only fall back when absolutely necessary (to avoid the PI dead-waiting on an expert that won't reply).

## What the extension covers

- **PI work leaves a trace** — if a principal turn made a decision but never called `record_trace`, nudge once via `sendUserMessage(followUp)` at `agent_end`.
- **Expert results flow back** — if an expert turn didn't `send_message` the principal, nudge once; if it still won't, the host writes a fallback note into the principal's mailbox (`onUnreplied`) so the PI never dead-waits.
- **PI keeps to delegation** — a principal doing substantive work directly gets a soft reminder appended to the `tool_result` (once per turn).
- **Resource awareness** — on a tool error, append a soft hint that `record_trace` / knowledge tools exist.

Static identity stays in personas, unchanged.

## Hard anti-loop invariant

The followUp path is guarded so the cross-run `remindCount` resets **only** at the two terminal exits (goal met / already reminded), **never** on `turn_start` — otherwise the new turn that followUp triggers would re-remind forever.

## Wiring

- `agent-factory`: `realAgentFactory` passes `extensionFactories` to the AgentSession options (fresh per agent).
- `mas-agent` / `session-manager`: drop the `captureMilestone` / `onTurnEnd` plumbing #79 introduced; the extension owns per-turn state.
- `types`: add `extensionFactories` to the factory contract.
- `tools/system-tools`: `record_trace` chains to `lastNodeId` for connected edges (otherwise nodes appear as orphan dots).

## Follow-up fixes squashed into the same PR

- `bdb2c72` make trace a real spawned agent so the Agents panel reflects its status (legacy parity).
- `1f0eb3c` scope reminder flags to the run, decouple trace/reply nudges (one cause of duplicate nudges in long sessions).

## Web carried in

The v1 PR #92 also shipped web-side polish (friendly tool names + chat scroll memory + visible trace edges); those changes are folded in here so the panel keeps working as before after the swap. Tests added:
- `chatScrollMemory.test.ts` (7 cases)
- `toolDisplay.test.ts` (10 cases)
- `trace-edges.test.ts` replaces `trace-hooks.test.ts` — host-side structural plumbing (DAG chaining + SSE emission) is verified here; reminder behaviour is verified in the real Pi factory per design §7/T2.
- `trace-agent.test.ts` covers the spawned trace agent's lifecycle.

## Verification

- `npm run typecheck` — clean
- `npm test` — 428/428
- `cd packages/web && npm test` — 77/77
- `bash scripts/smoke-e2e.sh` — SMOKE PASS
- Manually verified against real Pi provider: followUp triggers a new turn, anti-loop holds, expert fallback writes the principal mailbox, tool_result nudges are appended once per turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)