### PR TITLE
fix: restore sessions and chat history on boot

### DIFF
--- a/packages/backend-core/src/app.ts
+++ b/packages/backend-core/src/app.ts
@@ -122,6 +122,10 @@ export function createApp(options: CreateAppOptions): Hono {
   api.delete("/sessions/:id", forward("deleteSession", { idParam: "id" }));
   api.get("/sessions/:id/state", forward("getSessionState", { idParam: "id" }));
   api.get("/sessions/:id/trace", forward("getTrace", { idParam: "id" }));
+  // Persisted event tail for chat rehydrate after a restart. SSE replays only
+  // the in-memory ring; this endpoint reads events.jsonl on disk. Carries the
+  // ?limit query verbatim.
+  api.get("/sessions/:id/history", forward("getSessionHistory", { idParam: "id", withQuery: true }));
   api.post("/sessions/:id/messages", forward("sendMessage", { idParam: "id", withBody: true }));
   api.post("/sessions/:id/interrupt", forward("interrupt", { idParam: "id", withBody: true }));
   api.get("/sessions/:id/agents", forward("listAgents", { idParam: "id" }));

--- a/packages/backend-core/test/app.test.ts
+++ b/packages/backend-core/test/app.test.ts
@@ -122,6 +122,39 @@ describe("Hono app — REST forwarding", () => {
     expect(fetchFn).toHaveBeenCalledTimes(1);
   });
 
+  it("GET /api/sessions/:id/history forwards to the runtime (preserving ?limit)", async () => {
+    // Same class as the /trace regression: chat rehydrate after a runtime
+    // restart depends on this proxy. When it was missing, the SPA's
+    // api.sessions.getHistory call hit the static SPA fallback, returned 200
+    // text/html, and the SessionContext silently treated it as zero events —
+    // so restored sessions opened with an empty chat.
+    const body =
+      '{"events":[{"type":"TEXT_MESSAGE_START","messageId":"m1","role":"assistant"}],"total":1,"truncated":false}';
+    const fetchFn = vi.fn(async (url: string) => {
+      expect(url).toBe("http://runtime.test/sessions/abc/history?limit=3");
+      return new Response(body, {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const root = await mkdtemp(path.join(tmpdir(), "bp-web-history-"));
+    await writeFile(path.join(root, "index.html"), "<!doctype html><title>BP</title>");
+    const app = createApp({
+      orchestrator: fakeOrchestrator(),
+      fetchFn: fetchFn as never,
+      webRoot: root,
+    });
+    const res = await app.request("/api/sessions/abc/history?limit=3");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    expect(await res.json()).toEqual({
+      events: [{ type: "TEXT_MESSAGE_START", messageId: "m1", role: "assistant" }],
+      total: 1,
+      truncated: false,
+    });
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+  });
+
   // #29: session rename. The SPA PUTs /api/sessions/:id {title}; this must
   // proxy to the runtime's updateSession route (PUT /sessions/:id) with the
   // body intact — not the old forwardRename hack that PUT the GET path.

--- a/packages/protocol/src/http.ts
+++ b/packages/protocol/src/http.ts
@@ -247,6 +247,14 @@ export const RUNTIME_ROUTES = {
   sessionEvents: { method: "GET", path: "/sse/:id" },
   /** Alias path some callers use; same AgUiEvent payload as `sessionEvents`. */
   sessionEventsAlias: { method: "GET", path: "/sessions/:id/events" },
+  /**
+   * Persisted AG-UI event history from `events.jsonl`. The SPA calls this on
+   * session activation to rehydrate chat after a runtime restart (the SSE
+   * stream only replays the in-memory ring buffer). Query: `?limit=N`
+   * (default 1000, capped at 5000); returns the most recent N events when
+   * the file is longer.
+   */
+  getSessionHistory: { method: "GET", path: "/sessions/:id/history" },
   interrupt: { method: "POST", path: "/sessions/:id/interrupt" },
   listAgents: { method: "GET", path: "/sessions/:id/agents" },
   evictSession: { method: "POST", path: "/sessions/:id/evict" },

--- a/packages/runtime/src/__tests__/history-endpoint.test.ts
+++ b/packages/runtime/src/__tests__/history-endpoint.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Persisted history endpoint — used by the web to rehydrate chat after a
+ * runtime restart (the SSE ring buffer only carries the last ~500 live events).
+ *
+ * Covers SessionManager.readEventHistory + GET /sessions/:id/history end-to-end.
+ */
+import { describe, it, expect } from "vitest";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer } from "../server.js";
+import { SessionManager } from "../session-manager.js";
+import { mockAgentFactory } from "../agent-factory.js";
+
+async function seed(dataRoot: string, sid: string, lines: string[]): Promise<void> {
+  const dir = join(dataRoot, ".bp", sid);
+  await mkdir(dir, { recursive: true });
+  await writeFile(
+    join(dir, "meta.json"),
+    JSON.stringify({
+      id: sid,
+      title: "seeded",
+      createdAt: "2026-06-01T00:00:00.000Z",
+      updatedAt: "2026-06-01T00:00:00.000Z",
+      lastActivityAt: 1780000000000,
+    }),
+    "utf8",
+  );
+  await writeFile(join(dir, "events.jsonl"), lines.join("\n") + "\n", "utf8");
+}
+
+function mkEvent(i: number): string {
+  return JSON.stringify({
+    type: "TEXT_MESSAGE_CHUNK",
+    session_id: "s",
+    delta: `msg-${i}`,
+    message_id: `m-${i}`,
+  });
+}
+
+async function appWithRestored(sid: string, lines: string[]) {
+  const dataRoot = await mkdtemp(join(tmpdir(), "bp-history-"));
+  await seed(dataRoot, sid, lines);
+  const manager = new SessionManager({ dataRoot, persist: true, agentFactory: mockAgentFactory });
+  await manager.restoreFromDisk();
+  const app = createServer({ manager }).app;
+  return { app, manager, dataRoot };
+}
+
+describe("GET /sessions/:id/history", () => {
+  it("returns all events when count <= default limit", async () => {
+    const lines = Array.from({ length: 5 }, (_, i) => mkEvent(i));
+    const { app } = await appWithRestored("11111111-1111-1111-1111-111111111111", lines);
+    const res = await app.request("/sessions/11111111-1111-1111-1111-111111111111/history");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { events: Array<{ delta: string }>; total: number; truncated: boolean };
+    expect(body.total).toBe(5);
+    expect(body.truncated).toBe(false);
+    expect(body.events.map((e) => e.delta)).toEqual(["msg-0", "msg-1", "msg-2", "msg-3", "msg-4"]);
+  });
+
+  it("returns the tail N events when total > limit", async () => {
+    const lines = Array.from({ length: 15 }, (_, i) => mkEvent(i));
+    const { app } = await appWithRestored("22222222-2222-2222-2222-222222222222", lines);
+    const res = await app.request("/sessions/22222222-2222-2222-2222-222222222222/history?limit=10");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { events: Array<{ delta: string }>; total: number; truncated: boolean };
+    expect(body.total).toBe(15);
+    expect(body.truncated).toBe(true);
+    expect(body.events).toHaveLength(10);
+    // tail: msg-5..msg-14
+    expect(body.events[0]!.delta).toBe("msg-5");
+    expect(body.events[9]!.delta).toBe("msg-14");
+  });
+
+  it("clamps an absurd limit down to 5000", async () => {
+    const lines = Array.from({ length: 3 }, (_, i) => mkEvent(i));
+    const { app, manager } = await appWithRestored("33333333-3333-3333-3333-333333333333", lines);
+    // verify clamping at the SessionManager layer too
+    const got = await manager.readEventHistory("33333333-3333-3333-3333-333333333333", { limit: 999999 });
+    expect(got?.events).toHaveLength(3);
+    const res = await app.request("/sessions/33333333-3333-3333-3333-333333333333/history?limit=999999");
+    expect(res.status).toBe(200);
+  });
+
+  it("skips malformed lines without breaking the rest", async () => {
+    const lines = [mkEvent(0), "{not json", mkEvent(1), "", mkEvent(2)];
+    const { app } = await appWithRestored("44444444-4444-4444-4444-444444444444", lines);
+    const res = await app.request("/sessions/44444444-4444-4444-4444-444444444444/history");
+    const body = (await res.json()) as { events: Array<{ delta: string }>; total: number };
+    expect(body.total).toBe(3);
+    expect(body.events.map((e) => e.delta)).toEqual(["msg-0", "msg-1", "msg-2"]);
+  });
+
+  it("returns empty result when events.jsonl is missing", async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), "bp-history-"));
+    const sid = "55555555-5555-5555-5555-555555555555";
+    const dir = join(dataRoot, ".bp", sid);
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, "meta.json"),
+      JSON.stringify({
+        id: sid,
+        title: "empty",
+        createdAt: "2026-06-01T00:00:00.000Z",
+        updatedAt: "2026-06-01T00:00:00.000Z",
+        lastActivityAt: 1780000000000,
+      }),
+      "utf8",
+    );
+    const manager = new SessionManager({ dataRoot, persist: true, agentFactory: mockAgentFactory });
+    await manager.restoreFromDisk();
+    const app = createServer({ manager }).app;
+    const res = await app.request(`/sessions/${sid}/history`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ events: [], total: 0, truncated: false });
+  });
+
+  it("404s when the session is unknown", async () => {
+    const manager = new SessionManager({ persist: false, agentFactory: mockAgentFactory });
+    const app = createServer({ manager }).app;
+    const res = await app.request("/sessions/does-not-exist/history");
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/runtime/src/__tests__/restore.test.ts
+++ b/packages/runtime/src/__tests__/restore.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Boot-time session restore. `SessionManager.restoreFromDisk` scans
+ * `<dataRoot>/.bp/<id>/meta.json` for every persisted session id and rebuilds
+ * the in-memory session list with the persisted timestamps intact (the
+ * restore path skips `writeMeta` so the canonical file is not clobbered with
+ * boot-time values).
+ *
+ * The `startServer` integration test in server.test.ts asserts the same
+ * behavior end-to-end via `GET /sessions` after boot.
+ */
+import { describe, it, expect } from "vitest";
+import { mkdtemp, mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SessionManager } from "../session-manager.js";
+import { mockAgentFactory } from "../agent-factory.js";
+
+async function writeMeta(
+  dataRoot: string,
+  id: string,
+  meta: Record<string, unknown>,
+): Promise<string> {
+  const dir = join(dataRoot, ".bp", id);
+  await mkdir(dir, { recursive: true });
+  const path = join(dir, "meta.json");
+  await writeFile(path, JSON.stringify(meta, null, 2), "utf8");
+  return path;
+}
+
+describe("SessionManager.restoreFromDisk", () => {
+  it("rehydrates sessions preserving on-disk timestamps", async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), "bp-restore-"));
+    await writeMeta(dataRoot, "11111111-1111-1111-1111-111111111111", {
+      id: "11111111-1111-1111-1111-111111111111",
+      title: "Old session A",
+      createdAt: "2026-06-01T10:00:00.000Z",
+      updatedAt: "2026-06-02T11:00:00.000Z",
+      lastActivityAt: 1780000000000,
+    });
+    await writeMeta(dataRoot, "22222222-2222-2222-2222-222222222222", {
+      id: "22222222-2222-2222-2222-222222222222",
+      title: "Old session B",
+      createdAt: "2026-05-20T09:00:00.000Z",
+      updatedAt: "2026-05-21T12:30:00.000Z",
+      lastActivityAt: 1779000000000,
+    });
+
+    const m = new SessionManager({
+      dataRoot,
+      persist: true,
+      agentFactory: mockAgentFactory,
+    });
+    const restored = await m.restoreFromDisk();
+    expect(restored.sort()).toEqual([
+      "11111111-1111-1111-1111-111111111111",
+      "22222222-2222-2222-2222-222222222222",
+    ]);
+
+    const sessions = m.listSessions();
+    expect(sessions).toHaveLength(2);
+    const a = sessions.find((s) => s.id === "11111111-1111-1111-1111-111111111111")!;
+    expect(a.title).toBe("Old session A");
+    expect(a.createdAt).toBe("2026-06-01T10:00:00.000Z");
+    expect(a.updatedAt).toBe("2026-06-02T11:00:00.000Z");
+    const b = sessions.find((s) => s.id === "22222222-2222-2222-2222-222222222222")!;
+    expect(b.createdAt).toBe("2026-05-20T09:00:00.000Z");
+    expect(b.updatedAt).toBe("2026-05-21T12:30:00.000Z");
+  });
+
+  it("does NOT rewrite meta.json on restore", async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), "bp-restore-"));
+    const metaPath = await writeMeta(dataRoot, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", {
+      id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      title: "Untouched",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-02T00:00:00.000Z",
+      lastActivityAt: 1770000000000,
+    });
+    const before = await readFile(metaPath, "utf8");
+    const beforeMtime = (await stat(metaPath)).mtimeMs;
+
+    // tiny sleep so any rewrite would change mtimeMs at filesystem resolution
+    await new Promise((r) => setTimeout(r, 50));
+
+    const m = new SessionManager({
+      dataRoot,
+      persist: true,
+      agentFactory: mockAgentFactory,
+    });
+    await m.restoreFromDisk();
+
+    const after = await readFile(metaPath, "utf8");
+    const afterMtime = (await stat(metaPath)).mtimeMs;
+    expect(after).toBe(before);
+    expect(afterMtime).toBe(beforeMtime);
+  });
+
+  it("is idempotent — second call is a no-op", async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), "bp-restore-"));
+    await writeMeta(dataRoot, "cccccccc-cccc-cccc-cccc-cccccccccccc", {
+      id: "cccccccc-cccc-cccc-cccc-cccccccccccc",
+      title: "Once",
+      createdAt: "2026-03-01T00:00:00.000Z",
+      updatedAt: "2026-03-02T00:00:00.000Z",
+      lastActivityAt: 1771000000000,
+    });
+    const m = new SessionManager({
+      dataRoot,
+      persist: true,
+      agentFactory: mockAgentFactory,
+    });
+    const first = await m.restoreFromDisk();
+    expect(first).toHaveLength(1);
+    const second = await m.restoreFromDisk();
+    expect(second).toEqual([]);
+    expect(m.listSessions()).toHaveLength(1);
+    // Timestamps still original after the second pass
+    expect(m.listSessions()[0]!.createdAt).toBe("2026-03-01T00:00:00.000Z");
+  });
+
+  it("returns empty when .bp/ does not exist", async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), "bp-restore-"));
+    const m = new SessionManager({
+      dataRoot,
+      persist: true,
+      agentFactory: mockAgentFactory,
+    });
+    await expect(m.restoreFromDisk()).resolves.toEqual([]);
+  });
+
+  it("skips entries with missing or malformed meta.json", async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), "bp-restore-"));
+    // no meta.json
+    await mkdir(join(dataRoot, ".bp", "no-meta"), { recursive: true });
+    // malformed json
+    const broken = join(dataRoot, ".bp", "broken");
+    await mkdir(broken, { recursive: true });
+    await writeFile(join(broken, "meta.json"), "{not valid json", "utf8");
+    // valid
+    await writeMeta(dataRoot, "dddddddd-dddd-dddd-dddd-dddddddddddd", {
+      id: "dddddddd-dddd-dddd-dddd-dddddddddddd",
+      title: "Good",
+      createdAt: "2026-02-01T00:00:00.000Z",
+      updatedAt: "2026-02-02T00:00:00.000Z",
+      lastActivityAt: 1772000000000,
+    });
+
+    const m = new SessionManager({
+      dataRoot,
+      persist: true,
+      agentFactory: mockAgentFactory,
+    });
+    const restored = await m.restoreFromDisk();
+    expect(restored).toEqual(["dddddddd-dddd-dddd-dddd-dddddddddddd"]);
+  });
+
+  it("backfills missing timestamp fields without crashing", async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), "bp-restore-"));
+    await writeMeta(dataRoot, "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee", {
+      id: "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+      title: "Legacy meta missing fields",
+    });
+    const m = new SessionManager({
+      dataRoot,
+      persist: true,
+      agentFactory: mockAgentFactory,
+    });
+    await m.restoreFromDisk();
+    const s = m.listSessions()[0]!;
+    expect(s.id).toBe("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
+    expect(typeof s.createdAt).toBe("string");
+    expect(typeof s.updatedAt).toBe("string");
+  });
+});

--- a/packages/runtime/src/__tests__/server.test.ts
+++ b/packages/runtime/src/__tests__/server.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { mkdtemp, mkdir, writeFile, readFile, readdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createServer } from "../server.js";
+import { createServer, startServer } from "../server.js";
 import { SessionManager } from "../session-manager.js";
 import { mockAgentFactory } from "../agent-factory.js";
 
@@ -314,3 +314,52 @@ async function waitFor(pred: () => boolean | Promise<boolean>, timeoutMs = 2000)
     await new Promise((r) => setTimeout(r, 5));
   }
 }
+
+describe("startServer boot-time restore", () => {
+  it("rehydrates persisted sessions before serving the first request", async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), "bp-boot-"));
+    // Seed two persisted session dirs the way the runtime writes them.
+    for (const seed of [
+      {
+        id: "11111111-1111-1111-1111-111111111111",
+        title: "Persisted A",
+        createdAt: "2026-06-01T00:00:00.000Z",
+        updatedAt: "2026-06-02T00:00:00.000Z",
+        lastActivityAt: 1780000000000,
+      },
+      {
+        id: "22222222-2222-2222-2222-222222222222",
+        title: "Persisted B",
+        createdAt: "2026-06-03T00:00:00.000Z",
+        updatedAt: "2026-06-04T00:00:00.000Z",
+        lastActivityAt: 1780100000000,
+      },
+    ]) {
+      const dir = join(dataRoot, ".bp", seed.id);
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, "meta.json"), JSON.stringify(seed), "utf8");
+    }
+
+    // port: 0 → kernel-assigned; never collides with anything else
+    const handle = await startServer({
+      port: 0,
+      dataRoot,
+      persist: true,
+      agentFactory: mockAgentFactory,
+    });
+    try {
+      const res = await fetch(`http://127.0.0.1:${handle.port}/sessions`);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { sessions: Array<{ id: string; createdAt: string }> };
+      const ids = body.sessions.map((s) => s.id).sort();
+      expect(ids).toEqual([
+        "11111111-1111-1111-1111-111111111111",
+        "22222222-2222-2222-2222-222222222222",
+      ]);
+      const a = body.sessions.find((s) => s.id === "11111111-1111-1111-1111-111111111111")!;
+      expect(a.createdAt).toBe("2026-06-01T00:00:00.000Z");
+    } finally {
+      await handle.close();
+    }
+  });
+});

--- a/packages/runtime/src/server.ts
+++ b/packages/runtime/src/server.ts
@@ -70,6 +70,20 @@ export function createServer(opts: SessionManagerOptions & { manager?: SessionMa
     return graph ? c.json(graph) : c.json({ error: "not found" }, 404);
   });
 
+  // Persisted event history (events.jsonl) — see RUNTIME_ROUTES.getSessionHistory.
+  // Used by the web to rehydrate chat after a runtime restart; SSE only replays
+  // the in-memory ring buffer.
+  app.get("/sessions/:id/history", async (c) => {
+    const id = c.req.param("id");
+    const limitQ = c.req.query("limit");
+    const limit = limitQ !== undefined ? Number(limitQ) : undefined;
+    const result = await manager.readEventHistory(id, {
+      limit: Number.isFinite(limit) ? (limit as number) : undefined,
+    });
+    if (!result) return c.json({ error: "not found" }, 404);
+    return c.json(result);
+  });
+
   app.post("/sessions/:id/messages", async (c) => {
     const id = c.req.param("id");
     const body = await safeBody(c);
@@ -223,19 +237,46 @@ export interface StartServerOptions extends SessionManagerOptions {
   manager?: SessionManager;
 }
 
-export function startServer(opts: StartServerOptions = {}): {
+export async function startServer(opts: StartServerOptions = {}): Promise<{
   manager: SessionManager;
   port: number;
   close: () => Promise<void>;
-} {
+}> {
   const { app, manager } = createServer(opts);
+
+  // Restore sessions persisted under `<dataRoot>/.bp/*/meta.json` before we
+  // accept the first HTTP request, so `GET /sessions` reflects history on
+  // boot instead of an empty list. Persist defaults to true on the manager
+  // (see SessionManagerOptions); we only skip restore when the caller
+  // explicitly disabled persistence.
+  if (opts.persist !== false) {
+    try {
+      const restored = await manager.restoreFromDisk();
+      if (restored.length) {
+        // eslint-disable-next-line no-console
+        console.log(`[runtime] restored ${restored.length} session(s) from disk`);
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn("[runtime] session restore failed:", err);
+    }
+  }
+
   const port =
     opts.port ??
     (process.env.PORT ? Number(process.env.PORT) : undefined) ??
     (process.env.BP_RUNTIME_PORT ? Number(process.env.BP_RUNTIME_PORT) : undefined) ??
     8081;
 
-  const server = serve({ fetch: app.fetch, port });
+  // Wait for the socket to be bound so callers (and tests using `port: 0`)
+  // can talk to the server / read the kernel-assigned port immediately.
+  let boundPort = port;
+  const server = await new Promise<ReturnType<typeof serve>>((resolve) => {
+    const s = serve({ fetch: app.fetch, port }, (info) => {
+      boundPort = info.port;
+      resolve(s);
+    });
+  });
 
   // §R-4: surface the opt-in memory budget at boot (only when active).
   const memLimitMb = process.env.BP_MEM_LIMIT_MB;
@@ -259,7 +300,7 @@ export function startServer(opts: StartServerOptions = {}): {
 
   return {
     manager,
-    port,
+    port: boundPort,
     close: () =>
       new Promise<void>((resolve) => {
         manager.shutdown();
@@ -270,7 +311,8 @@ export function startServer(opts: StartServerOptions = {}): {
 
 // Allow `node dist/server.js` to boot directly.
 if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
-  const { port } = startServer();
-  // eslint-disable-next-line no-console
-  console.log(`[runtime] listening on :${port} (mock=${process.env.BP_MOCK ?? "0"})`);
+  void startServer().then(({ port }) => {
+    // eslint-disable-next-line no-console
+    console.log(`[runtime] listening on :${port} (mock=${process.env.BP_MOCK ?? "0"})`);
+  });
 }

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -436,13 +436,22 @@ export class SessionManager {
 
   async createSession(
     input: { id?: string; title?: string; providerId?: string; modelId?: string } = {},
+    /**
+     * Internal restore path (see `restoreFromDisk`): when provided, the entry
+     * inherits the on-disk meta.json timestamps verbatim instead of stamping
+     * fresh ones, and `writeMeta` is skipped so the canonical file is not
+     * clobbered with boot-time values. Public callers should not pass this.
+     */
+    _restore?: { createdAt: string; updatedAt: string; lastActivityAt: number },
   ): Promise<Session> {
     if (this.memWatchdog?.isOverSoftLimit()) {
       throw new Error("memory budget exceeded: refusing new session");
     }
     const id = input.id ?? randomUUID();
     if (this.sessions.has(id)) return this.toSession(this.sessions.get(id)!);
-    const nowIso = new Date().toISOString();
+    const nowIso = _restore ? _restore.updatedAt : new Date().toISOString();
+    const createdAt = _restore ? _restore.createdAt : nowIso;
+    const lastActivityAt = _restore ? _restore.lastActivityAt : Date.now();
     const persistBase = this.persist ? this.bpDir(id) : undefined;
 
     // Provider ref: explicit input wins; otherwise reuse an existing on-disk ref
@@ -470,9 +479,9 @@ export class SessionManager {
     const entry: SessionEntry = {
       id,
       title: input.title ?? "Untitled session",
-      createdAt: nowIso,
+      createdAt,
       updatedAt: nowIso,
-      lastActivityAt: Date.now(),
+      lastActivityAt,
       bus,
       mailbox,
       trace,
@@ -484,13 +493,15 @@ export class SessionManager {
       providerRef,
     };
     this.sessions.set(id, entry);
-    this.touch(entry);
+    if (!_restore) this.touch(entry);
+    else this.lastActivityAt = entry.lastActivityAt;
 
     if (this.persist) {
       await mkdir(join(this.bpDir(id), "history"), { recursive: true });
       await mkdir(this.sessionSkillsDir(id), { recursive: true });
       await mkdir(this.workspaceDir(id), { recursive: true });
-      await this.writeMeta(entry);
+      // On restore, meta.json on disk is the authority — do not write it back.
+      if (!_restore) await this.writeMeta(entry);
       // Only (re)write the ref when the caller chose one — restore must not
       // clobber an existing ref with an empty object.
       if (explicitRef) await this.writeProviderRef(entry);
@@ -1106,6 +1117,54 @@ export class SessionManager {
     return entry?.trace.getGraph();
   }
 
+  /**
+   * Read persisted AG-UI events for a session from `.bp/<sid>/events.jsonl`.
+   * Used by the web to rehydrate chat history after a runtime restart (the
+   * in-memory bus ring buffer only carries `recent()` for live SSE replay).
+   *
+   * The file is read line-by-line and unparseable lines are skipped so a
+   * single corrupt record doesn't poison the whole history.
+   *
+   * `limit` caps the returned array; when total > limit we return the **tail**
+   * (most recent events) since that's what users actually want for chat
+   * resume. Default 1000, capped at 5000.
+   *
+   * Returns `undefined` if the session id isn't in memory — this method is
+   * only useful for known sessions (call `restoreFromDisk` first if needed).
+   */
+  async readEventHistory(
+    sessionId: string,
+    opts: { limit?: number } = {},
+  ): Promise<{ events: AgUiEvent[]; total: number; truncated: boolean } | undefined> {
+    if (!this.sessions.has(sessionId)) return undefined;
+    const limit = Math.max(1, Math.min(opts.limit ?? 1000, 5000));
+    const path = join(this.bpDir(sessionId), "events.jsonl");
+    let raw: string;
+    try {
+      raw = await readFile(path, "utf8");
+    } catch {
+      // No events file yet — empty history is valid (newly created session).
+      return { events: [], total: 0, truncated: false };
+    }
+    const lines = raw.split("\n");
+    const events: AgUiEvent[] = [];
+    let total = 0;
+    for (const line of lines) {
+      if (!line) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        continue; // skip malformed line
+      }
+      total++;
+      events.push(parsed as AgUiEvent);
+    }
+    const truncated = events.length > limit;
+    const out = truncated ? events.slice(events.length - limit) : events;
+    return { events: out, total, truncated };
+  }
+
   metrics(): {
     activeSessions: number;
     runningAgents: number;
@@ -1233,7 +1292,18 @@ export class SessionManager {
     }
   }
 
-  /** Restore session list from disk (§10 策略A: agents start idle, lazily revived). */
+  /**
+   * Restore session list from disk. Reads `<dataRoot>/.bp/<id>/meta.json` for
+   * every directory and recreates the session entry with its original
+   * timestamps preserved (provider ref, mailbox, trace also rehydrate via the
+   * normal `createSession` restore path). §10 策略A: agents start idle and
+   * are lazily revived when the user actually sends a message.
+   *
+   * Idempotent — sessions already in memory are skipped, not reset.
+   *
+   * Returns the ids that were restored this call (i.e. excluding ones that
+   * were already loaded or whose meta.json was missing / malformed).
+   */
   async restoreFromDisk(): Promise<string[]> {
     const restored: string[] = [];
     const root = join(this.dataRoot, ".bp");
@@ -1241,18 +1311,41 @@ export class SessionManager {
     try {
       ids = await readdir(root);
     } catch {
-      return restored;
+      return restored; // .bp/ doesn't exist yet — fresh install
     }
     for (const id of ids) {
+      if (this.sessions.has(id)) continue;
+      const metaPath = join(root, id, "meta.json");
+      let raw: string;
       try {
-        const raw = await readFile(join(root, id, "meta.json"), "utf8");
-        const meta = JSON.parse(raw) as { id: string; title?: string };
-        if (!this.sessions.has(meta.id)) {
-          await this.createSession({ id: meta.id, title: meta.title });
-          restored.push(meta.id);
-        }
+        raw = await readFile(metaPath, "utf8");
       } catch {
-        /* skip non-session dirs */
+        continue; // not a session dir (no meta.json) — silent skip
+      }
+      try {
+        const meta = JSON.parse(raw) as {
+          id?: string;
+          title?: string;
+          createdAt?: string;
+          updatedAt?: string;
+          lastActivityAt?: number;
+        };
+        const sid = meta.id ?? id;
+        if (this.sessions.has(sid)) continue;
+        const now = new Date().toISOString();
+        await this.createSession(
+          { id: sid, title: meta.title },
+          {
+            createdAt: meta.createdAt ?? now,
+            updatedAt: meta.updatedAt ?? now,
+            lastActivityAt:
+              typeof meta.lastActivityAt === "number" ? meta.lastActivityAt : Date.now(),
+          },
+        );
+        restored.push(sid);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn(`[runtime] skipping ${id}: ${(err as Error).message}`);
       }
     }
     return restored;

--- a/packages/web/src/__tests__/api.test.ts
+++ b/packages/web/src/__tests__/api.test.ts
@@ -102,6 +102,42 @@ describe("api.sessions.getEvents — tolerates SSE / non-JSON responses", () => 
   });
 });
 
+describe("api.sessions.getHistory — persisted events.jsonl rehydration", () => {
+  it("returns the envelope shape from a JSON response", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({
+        contentType: "application/json",
+        json: { events: [{ type: "TEXT_MESSAGE_CHUNK", delta: "hi" }], total: 1, truncated: false },
+      }),
+    );
+    const out = await api.sessions.getHistory("s1");
+    expect(out.events).toHaveLength(1);
+    expect(out.total).toBe(1);
+    expect(out.truncated).toBe(false);
+  });
+
+  it("forwards the limit query string", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({ contentType: "application/json", json: { events: [], total: 0, truncated: false } }),
+    );
+    await api.sessions.getHistory("s1", { limit: 42 });
+    const url = String(fetchMock.mock.calls[0]![0]);
+    expect(url).toContain("/sessions/s1/history?limit=42");
+  });
+
+  it("returns the empty envelope on a non-ok response", async () => {
+    fetchMock.mockResolvedValueOnce(makeResponse({ ok: false, status: 404 }));
+    const out = await api.sessions.getHistory("s1");
+    expect(out).toEqual({ events: [], total: 0, truncated: false });
+  });
+
+  it("returns the empty envelope when the body is null", async () => {
+    fetchMock.mockResolvedValueOnce(makeResponse({ contentType: "application/json", json: null }));
+    const out = await api.sessions.getHistory("s1");
+    expect(out).toEqual({ events: [], total: 0, truncated: false });
+  });
+});
+
 describe("api.sessions.interrupt — hits the interrupt route, not /messages (#90)", () => {
   it("POSTs to /sessions/:id/interrupt and returns { interrupted }", async () => {
     fetchMock.mockResolvedValueOnce(

--- a/packages/web/src/components/demo/demoBundle.ts
+++ b/packages/web/src/components/demo/demoBundle.ts
@@ -157,11 +157,16 @@ export async function buildDemoBundle(opts: BuildDemoOptions): Promise<DemoBundl
 
   onProgress?.("reading conversation timeline…");
   let timeline: DemoBundle["timeline"] = "timestamped";
-  let events = await api.sessions.getEvents(session.id);
+  // Pull the persisted event timeline from the new history endpoint (the
+  // legacy `/sessions/:id/events` path is an SSE alias and returns no JSON).
+  // Cap at 5000 — the endpoint enforces the same cap, but stating it here
+  // documents the bundle's max footprint.
+  const historyEnvelope = await api.sessions.getHistory(session.id, { limit: 5000 });
+  let events: typeof historyEnvelope.events | undefined = historyEnvelope.events;
   let messages: ChatMessage[] | undefined;
   if (!events || events.length === 0) {
     timeline = "ordered";
-    events = undefined as never;
+    events = undefined;
     messages = fallbackMessages ?? [];
   }
 

--- a/packages/web/src/contexts/SessionContext.tsx
+++ b/packages/web/src/contexts/SessionContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 // TODO(dead-code): SessionEventEntry removed with pre-AG-UI polling protocol.
-import { AgentStatus, ChatMessage, MessageFilterRule, Session, TraceGraph, /* SessionEventEntry, */ SessionMessageEntry } from "../contracts/backend";
+import { AgentStatus, ChatMessage, MessageFilterRule, Session, TraceGraph, normalizeWebSocketEvent, /* SessionEventEntry, */ SessionMessageEntry } from "../contracts/backend";
 import { api } from "../utils/api";
 import { tg } from "../i18n/translate";
 import { useAuth } from "./AuthContext";
@@ -142,23 +142,87 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     void refreshSessions();
   }, [refreshSessions]);
 
+  // Sessions whose persisted history has already been pulled this page-load.
+  // Guards against re-hydrating on every tab switch — once SSE is attached we
+  // own the up-to-date state and don't want to refetch the .jsonl tail.
+  const hydratedSessionsRef = useRef<Set<string>>(new Set());
+
   useEffect(() => {
     if (!currentSessionId) {
       return;
     }
     const sessionId = currentSessionId;
-    let cancelled = false;
-    async function loadMessages() {
-      setIsRefreshingMessages(true);
-      if (!cancelled) {
-        setMessagesBySession((current) => ({ ...current, [sessionId]: current[sessionId] ?? [] }));
-      }
-      setIsRefreshingMessages(false);
+    if (hydratedSessionsRef.current.has(sessionId)) {
+      return;
     }
-    void loadMessages();
-    return () => {
-      cancelled = true;
-    };
+    let cancelled = false;
+
+    async function loadHistory() {
+      setIsRefreshingMessages(true);
+      try {
+        const { events } = await api.sessions.getHistory(sessionId);
+        if (cancelled) return;
+
+        // Replay the persisted event stream through the same reducers SSE uses
+        // (messageReducer / traceReducer / agents seed via session_state). The
+        // SSE ring buffer that arrives next is deduped by messageId/toolCallId
+        // inside the reducer, so any overlap is a no-op.
+        let nextMessages: ChatMessage[] = [];
+        let nextTrace: TraceGraph | null = null;
+        let lastAgents: AgentStatus[] | null = null;
+
+        for (const raw of events) {
+          const ev = normalizeWebSocketEvent(raw);
+          if (!ev) continue;
+          nextMessages = reduceMessagesForEvent(nextMessages, ev);
+          nextTrace = reduceTraceForEvent(nextTrace, ev, sessionId);
+          if (ev.type === "CUSTOM" && ev.name === "session_state") {
+            const v = (ev.value ?? {}) as Record<string, unknown>;
+            if (Array.isArray(v.agents)) {
+              lastAgents = (v.agents as Array<Record<string, unknown>>).map((agent) => ({
+                name: String(agent.name ?? ""),
+                status: String(agent.status ?? "idle"),
+                task: String(agent.task ?? ""),
+                updatedAt:
+                  typeof agent.updatedAt === "string"
+                    ? agent.updatedAt
+                    : new Date().toISOString(),
+                alive: typeof agent.alive === "boolean" ? agent.alive : undefined,
+              }));
+            }
+          }
+        }
+
+        if (cancelled) return;
+        hydratedSessionsRef.current.add(sessionId);
+
+        // Only seed the message list if the user hasn't already started typing
+        // / receiving live SSE for this session in the brief window before
+        // history arrived (otherwise we'd clobber their in-flight messages).
+        setMessagesBySession((current) => {
+          if ((current[sessionId]?.length ?? 0) > 0) return current;
+          return { ...current, [sessionId]: nextMessages };
+        });
+        if (nextTrace) {
+          setTraceBySession((current) =>
+            current[sessionId] ? current : { ...current, [sessionId]: nextTrace! },
+          );
+        }
+        // Only seed agents when the current panel is empty — live SSE may have
+        // already pushed an authoritative session_state since selection.
+        if (lastAgents && lastAgents.length > 0) {
+          setAgents((current) => (current.length === 0 ? lastAgents! : current));
+        }
+      } catch (err) {
+        // Best-effort. SSE will eventually drive the panel; we shouldn't surface
+        // a banner just because the history file was unreachable for a moment.
+        console.warn(`[SessionContext] history rehydrate failed for ${sessionId}:`, err);
+      } finally {
+        if (!cancelled) setIsRefreshingMessages(false);
+      }
+    }
+
+    void loadHistory();
     return () => {
       cancelled = true;
     };
@@ -213,6 +277,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
       // Drop any unsent draft so re-creating a session with the same id (rare,
       // but possible) doesn't resurrect stale text.
       draftStore.delete(sessionId);
+      hydratedSessionsRef.current.delete(sessionId);
     } catch (err) {
       setError(err instanceof Error ? err.message : tg("ctx.session.deleteFailed"));
       throw err;

--- a/packages/web/src/utils/api.ts
+++ b/packages/web/src/utils/api.ts
@@ -452,6 +452,39 @@ export const api = {
       return Array.isArray(raw.events) ? (raw.events as RawAgUiEvent[]) : [];
     },
 
+    /**
+     * Persisted AG-UI event history from `events.jsonl` — used to rehydrate
+     * the chat list (and trace/agents seed) when a session is activated after
+     * a runtime restart. SSE only replays the in-memory ring buffer; this
+     * endpoint walks the on-disk log and returns the tail when long.
+     *
+     * Tolerates any non-200 / non-JSON response by returning an empty
+     * envelope, so callers can fall through to whatever live data the SSE
+     * stream eventually delivers.
+     */
+    async getHistory(
+      sessionId: string,
+      opts: { limit?: number } = {},
+    ): Promise<{ events: RawAgUiEvent[]; total: number; truncated: boolean }> {
+      if (runtimeConfig.useMockBackend) {
+        return { events: [], total: 0, truncated: false };
+      }
+      const qs = opts.limit !== undefined ? `?limit=${encodeURIComponent(opts.limit)}` : "";
+      const res = await apiFetch(
+        `${API_BASE}/sessions/${sessionId}/history${qs}`,
+        { headers: authHeaders() },
+      );
+      if (!res.ok) return { events: [], total: 0, truncated: false };
+      const raw = (await res.json().catch(() => null)) as
+        | { events?: unknown[]; total?: number; truncated?: boolean }
+        | null;
+      return {
+        events: Array.isArray(raw?.events) ? (raw!.events as RawAgUiEvent[]) : [],
+        total: typeof raw?.total === "number" ? raw!.total : 0,
+        truncated: Boolean(raw?.truncated),
+      };
+    },
+
     async state(sessionId: string): Promise<SessionStateSnapshot> {
       if (runtimeConfig.useMockBackend) {
         return mockBackend.state();


### PR DESCRIPTION
After running `brainpilot up`, the session list was empty even though `.bp/<id>/` directories existed on disk, and clicking a restored session showed an empty chat pane.

Two layers were broken; both fixed in this PR.

## Phase 1 — session list rehydrate

The runtime persists every session to `<dataRoot>/.bp/<id>/{meta.json, events.jsonl, trace.json, mailbox/, history/, skills/, provider.json}`, and `SessionManager.restoreFromDisk()` already existed — but **had zero callers**, so a fresh process always started with an empty in-memory map.

- `session-manager.ts` — `createSession` gains an internal `_restore` arg so a restored entry inherits the on-disk timestamps verbatim (instead of stamping fresh ones) and skips `writeMeta` (so the canonical file isn't clobbered with boot-time values).
- `session-manager.ts` — `restoreFromDisk()` rewritten to read full `meta.json` and call `createSession` with `_restore`. Skips missing/malformed meta gracefully; backfills missing fields.
- `server.ts` — `startServer` is now `async` and `await`s restore before binding the port. Also fixes a latent bug: it now uses `serve()`'s `listeningListener` callback to capture the kernel-assigned port (matters for `port: 0` test setups), instead of returning the literal config value before bind completes.

## Phase 2 — chat history rehydrate

Even with sessions restored, the chat pane stayed empty: SSE only replays the in-memory ring buffer (~500 events), which is empty on a fresh process.

- `session-manager.ts` — new `readEventHistory()` reads `events.jsonl` line-by-line with a tail-N truncation (default 1000, cap 5000) and a malformed-line skip.
- `protocol/src/http.ts` — registered `getSessionHistory` in `RUNTIME_ROUTES` as the new wire contract.
- `runtime/src/server.ts` — new `GET /sessions/:id/history` endpoint.
- `web/src/utils/api.ts` — `api.sessions.getHistory()` client method.
- `web/src/contexts/SessionContext.tsx` — on session activation, fetch history once (`hydratedSessionsRef` gate so tab switches don't refetch), run each event through the same reducers SSE uses (`reduceMessagesForEvent` / `reduceTraceForEvent`, agents seeded from `session_state`). Only seeds state when current is empty, so live SSE doesn't get clobbered.
- `web/src/components/demo/demoBundle.ts` — switched off the deprecated `getEvents` (SSE alias, always returned `[]` against the real backend) onto `getHistory`.

## Phase 3 — backend-core proxy (was the user-facing symptom on top of Phase 2)

The runtime endpoint and the web client were wired, but `backend-core`'s `/api/*` table never registered a forward for `/sessions/:id/history` — so the SPA's request fell through to the static SPA fallback, returned `index.html` (200 text/html), and the web silently treated it as zero events. Same regression class as the earlier `/trace` one.

- `backend-core/src/app.ts` — added the missing forward with `withQuery: true` so `?limit=N` is preserved.

## Tests

- `restore.test.ts` (new, 6 cases) — rehydrate preserves timestamps, doesn't rewrite `meta.json` (verified via `stat` mtimeMs), idempotent, empty `.bp/` returns `[]`, skips missing/malformed meta, backfills missing fields.
- `server.test.ts` (+1 case) — `startServer` boot-time restore through a real HTTP round-trip on a `port: 0` listener.
- `history-endpoint.test.ts` (new, 6 cases) — full event tail returned when ≤ limit; tail-N truncation when > limit; clamp at 5000; skips malformed lines; empty result when `events.jsonl` missing; 404 for unknown session.
- `api.test.ts` (+4 cases) — envelope shape parse, limit query forwarded, non-ok returns empty, null body returns empty.
- `app.test.ts` (+1 case) — backend-core forwards `/api/sessions/:id/history?limit=N` to the runtime preserving the query.

## Verification

- `npm run typecheck` — clean
- `npm test` — **442/442**
- `cd packages/web && npm test` — **81/81**
- `cd packages/web && npm run build` — clean
- `bash scripts/smoke-e2e.sh` — SMOKE PASS
- Manual: `BP_MOCK=1 BP_DATA_DIR=<real-brainpilot-data> node packages/runtime/dist/server.js` printed `[runtime] restored N session(s) from disk` against an actual `.bp/` directory; `GET /sessions` returned the full list; `GET /sessions/:id/history?limit=10` returned the persisted events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)