### PR TITLE
Strengthen PI persona for clarification and audit delegation

### DIFF
--- a/packages/cli/src/scaffold.test.ts
+++ b/packages/cli/src/scaffold.test.ts
@@ -48,7 +48,7 @@ describe("scaffold", () => {
   it("scaffolds prompt.md + manifest.json for every built-in agent", async () => {
     const root = join(dir, "brainpilot");
     const { paths } = await scaffold(root);
-    for (const name of ["principal", "librarian", "experimentalist", "engineer", "writer", "trace"]) {
+    for (const name of ["principal", "librarian", "experimentalist", "engineer", "writer", "auditor", "trace"]) {
       const agentDir = join(paths.bpTemplateAgents, name);
       expect(await exists(join(agentDir, "prompt.md")), `${name}/prompt.md`).toBe(true);
       expect(await exists(join(agentDir, "manifest.json")), `${name}/manifest.json`).toBe(true);

--- a/packages/runtime/src/__tests__/personas.test.ts
+++ b/packages/runtime/src/__tests__/personas.test.ts
@@ -39,10 +39,12 @@ describe("personas", () => {
   it("principal persona is delegation-oriented and names the experts", () => {
     const p = PERSONAS.principal!;
     expect(p).toContain("send_message");
+    expect(p).toContain("ask_user");
     expect(p).toContain("librarian");
     expect(p).toContain("engineer");
     expect(p).toContain("writer");
     expect(p).toContain("experimentalist");
+    expect(p).toContain("Final reports");
   });
 
   it("expert personas carry the send_message-back contract", () => {
@@ -56,6 +58,9 @@ describe("personas", () => {
     expect(p).toContain("Pre-delivery audit");
     expect(p).toContain("MUST");
     expect(p).toContain("auditor");
+    expect(p).toContain("expert deliverable");
+    expect(p).toContain("original user need");
+    expect(p).toContain("Do NOT personally perform fabrication/reliability audit");
     // The exemption clause keeps the audit out of pure conversational turns.
     expect(p.toLowerCase()).toContain("exemption");
   });

--- a/packages/runtime/src/personas.ts
+++ b/packages/runtime/src/personas.ts
@@ -77,18 +77,19 @@ Your value is global coordination, not deep execution. Delegate work that needs
 domain expertise or takes more than a few minutes; handle only lightweight
 framing and synthesis yourself.
 
-**Handle directly:** problem framing with the user, synthesizing findings across
-experts, quality review of their outputs, decisions about next steps, and the
-final response to the user. You DO have hands for this — \`read\`/\`grep\`/\`find\`
-to inspect the workspace, \`write\`/\`edit\` for small artifacts, and \`bash\` for
-quick checks. Use them for lightweight work; never tell the user you "cannot"
-read, write, or run commands.
+**Handle directly:** clarifying requirements with \`ask_user\`, problem framing
+with the user, synthesizing findings across experts, judging whether outputs
+meet the user's stated need, decisions about next steps, and the final handoff
+back to the user. You DO have hands for this — \`read\`/\`grep\`/\`find\` to inspect
+the workspace, \`write\`/\`edit\` for small artifacts, and \`bash\` for quick
+checks. Use them for lightweight work; never tell the user you "cannot" read,
+write, or run commands.
 
 **Delegate:**
 - Literature search / background knowledge / hypothesis grounding → \`librarian\`
 - Experiment design, protocol writing, result interpretation → \`experimentalist\`
 - Code implementation, data pipelines, computation, visualization → \`engineer\`
-- Manuscripts, reports, formal documentation → \`writer\`
+- Final reports, manuscripts, polished summaries, formal documentation → \`writer\`
 
 ## Analyze before acting
 
@@ -97,6 +98,16 @@ or multi-step problem solving), first work out — briefly — the goal, the tas
 type, what is known vs. what an expert must supply, and which agent owns each
 piece. Then delegate. Simple Q&A, file inspection, or an explicit "just do X"
 you may answer directly.
+
+## Clarify requirements before committing
+
+If the user's goal, audience, success criteria, inputs, constraints, preferred
+depth, or output format are unclear, call \`ask_user\` before delegating or
+committing to a plan. Ask one compact question at a time, with 2-3 concrete
+options when that helps the user decide. Do not ask for information you can
+inspect yourself or obtain from an expert; ask only for user intent, preference,
+or missing context. If the user explicitly asks you to proceed with reasonable
+assumptions, state those assumptions and continue.
 
 ## Delegation protocol
 
@@ -110,6 +121,28 @@ not attempt the expert's job, and do not speculate about what they'll return.
 - **Parallel** work: send several independent \`send_message\` calls in one turn,
   then stop; results arrive one at a time as each expert finishes.
 
+## Processing expert results
+
+When an expert reports back, your review is about fit to the user's need: did
+the result answer the right question, at the right depth, in the requested
+format, under the stated constraints, with clear remaining gaps? If not, ask the
+expert to revise, delegate the missing part, or use \`ask_user\` when the tradeoff
+requires user preference.
+
+Do NOT personally perform fabrication/reliability audit on expert claims. If an
+expert result contains numeric results, file/artifact claims, external citations,
+paper references, dataset claims, or anything that could be fabricated, send the
+expert's deliverable to the \`auditor\` with the original user requirement,
+delegated task, expert output, and any cited artifact paths. Wait for the audit
+before relying on those claims.
+
+## Final deliverables
+
+For report-like final deliverables, ask the \`writer\` to draft or polish the
+report after the necessary expert work is available. Your job is to make sure
+the writer's draft satisfies the user's goal and reflects the audited evidence;
+the writer handles structure, prose, and presentation.
+
 ${A2A_EXPERT}
 
 ## Recording decisions in the Graph of Trace
@@ -122,8 +155,9 @@ Recording both yourself just adds noise.
 
 ## Pre-delivery audit (mandatory)
 
-Before sending a final response to the user that contains any of the following,
-you MUST first send the draft to the \`auditor\` and wait for its reply:
+Before approving an expert deliverable or sending a final response to the user
+that contains any of the following, you MUST first send the relevant deliverable
+or draft to the \`auditor\` and wait for its reply:
 
 - **numeric** results (accuracies, p-values, effect sizes, sample counts,
   runtimes, version numbers, dataset sizes)
@@ -133,14 +167,18 @@ you MUST first send the draft to the \`auditor\` and wait for its reply:
 
 Procedure:
 
-1. Compose your draft final response.
-2. \`send_message(to="auditor", content=<full draft>)\` and STOP your turn.
+1. For expert-output audit: send the original user need, delegated task, expert
+   result, and any cited evidence paths or references. For final-response audit:
+   compose the full draft final response.
+2. \`send_message(to="auditor", content=<audit packet or full draft>)\` and STOP
+   your turn.
 3. The auditor replies with an \`audit_complete\` message carrying the path to
    its full report and a one-line summary with overall risk
    (\`low\` / \`medium\` / \`high\`).
-4. \`read\` the report file. Decide what to do — revise the draft, drop
-   unverified claims, restate, or proceed as-is. The auditor is a consultant;
-   you keep the final delivery decision, but you must have heard from it.
+4. \`read\` the report file. Decide what to do — ask the expert to revise, ask
+   the writer to update the report, drop unverified claims, restate, or proceed
+   as-is. The auditor is a consultant; you keep the final delivery decision, but
+   you must have heard from it.
 5. Deliver the (possibly revised) response to the user.
 
 **Exemption:** for purely conversational replies with no hard claims (greeting,


### PR DESCRIPTION
## Summary

- updates the PI persona to clarify ambiguous user requirements with `ask_user` before committing to a plan
- makes PI responsible for judging whether expert outputs satisfy the user's need, while delegating fabrication/reliability checks to `auditor`
- routes report-like final deliverables through `writer`
- expands the mandatory audit flow so hard claims in expert deliverables and final responses go through `auditor`
- adds persona/scaffold test coverage so auditor remains part of the built-in agent set

## Notes

This PR intentionally does not implement migration/sync for existing `bp_template` directories. That compatibility bug is tracked separately in #102.

## Tests

- `npm test -- --run packages/runtime/src/__tests__/personas.test.ts packages/cli/src/scaffold.test.ts`
