### PR TITLE
fix(web): session auto-title stays stale in sidebar/header until reload (#96)

### DIFF
--- a/packages/web/src/__tests__/api.test.ts
+++ b/packages/web/src/__tests__/api.test.ts
@@ -78,6 +78,36 @@ describe("api.sessions.list — unwraps { sessions } and tolerates shape", () =>
   });
 });
 
+describe("api.sessions.create — unwraps the { id, session } envelope (#96)", () => {
+  it("reads the real title from the runtime's { id, session } envelope", async () => {
+    // The runtime's POST /sessions returns `{ id, session }` (server.ts), unlike
+    // the GET routes which return the bare session. Before the fix the whole
+    // envelope was handed to normalizeSession, so `raw.title` was undefined and
+    // the sidebar/header fell back to `Session <id8>` until a reload.
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({
+        contentType: "application/json",
+        json: { id: "f8f35032", session: { id: "f8f35032", title: "请用两句话介绍 BrainPilot" } },
+      }),
+    );
+    const out = await api.sessions.create("请用两句话介绍 BrainPilot");
+    expect(out.id).toBe("f8f35032");
+    expect(out.title).toBe("请用两句话介绍 BrainPilot");
+  });
+
+  it("tolerates a bare session object (no envelope)", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({
+        contentType: "application/json",
+        json: { id: "abc", title: "bare title" },
+      }),
+    );
+    const out = await api.sessions.create("bare title");
+    expect(out.id).toBe("abc");
+    expect(out.title).toBe("bare title");
+  });
+});
+
 describe("api.sessions.getEvents — tolerates SSE / non-JSON responses", () => {
   it("returns the events array for a JSON { events } body", async () => {
     fetchMock.mockResolvedValueOnce(

--- a/packages/web/src/utils/api.ts
+++ b/packages/web/src/utils/api.ts
@@ -323,7 +323,16 @@ export const api = {
           }),
         }),
       );
-      return normalizeSession(raw as Parameters<typeof normalizeSession>[0]);
+      // The runtime's POST /sessions returns the envelope `{ id, session }`
+      // (server.ts), unlike GET /sessions[/:id] which return the bare session.
+      // Unwrap `session` if present so normalizeSession reads the real `title`
+      // instead of falling back to `Session <id8>` (#96). Tolerate a bare
+      // object too (mock / future shape change).
+      const envelope = raw as { session?: unknown } | null;
+      const sessionRaw = envelope && typeof envelope === "object" && "session" in envelope
+        ? envelope.session
+        : raw;
+      return normalizeSession(sessionRaw as Parameters<typeof normalizeSession>[0]);
     },
 
     async update(sessionId: string, title: string): Promise<Session> {


### PR DESCRIPTION
## Summary

Fixes #96 — after sending the first message in a fresh session, the visible title surfaces (sidebar, workspace header, Live Demo picker) kept showing the generated short-id label (`Session f8f35032`) until a full page reload, even though `GET /api/sessions` already returned the real title.

## Root cause

The runtime's `POST /sessions` returns the envelope `{ id, session }` (`server.ts`), unlike `GET /sessions[/:id]` which return the **bare** session. `api.sessions.create` handed the whole envelope to `normalizeSession`, so `raw.title` was `undefined` and the title fell back to `Session <id8>` (`contracts/backend.ts`). A reload re-fetched via `GET /sessions` (list shape is correct), which is why the title appeared only after reload.

This slipped through because the mock backend returns a **bare** session, so the shape mismatch never surfaced in tests.

There is no server-side auto-title derivation at all — the title is simply the first message truncated to 48 chars, set at creation time.

## Changes

- `packages/web/src/utils/api.ts` — `create()` unwraps `session` from the envelope when present, tolerating a bare object (mock / future shapes).
- `packages/web/src/__tests__/api.test.ts` — regression coverage for both the `{ id, session }` envelope and the bare-object shape.

## Verification

- web tests: **83 passed** (incl. 2 new)
- web build: ✓
- `npm run typecheck` + `npm test` (non-web): **442 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)