### PR TITLE
fix(runtime): enforce chronological direction for trace depends_on edges (#110)

### DIFF
--- a/packages/runtime/src/__tests__/trace.test.ts
+++ b/packages/runtime/src/__tests__/trace.test.ts
@@ -46,6 +46,81 @@ describe("GraphOfTrace onChange (#79)", () => {
     expect(g.getLastNodeId()).toBe(b.id);
   });
 
+  it("keeps a depends_on edge prerequisite→dependent when given correctly", () => {
+    const g = new GraphOfTrace("s");
+    const survey: TraceNode = {
+      id: "survey", title: "survey", type: "task", status: "completed",
+      parents: [], artifacts: [], parentIds: [], childIds: [],
+      createdAt: "2026-01-01T11:20:18.000Z", updatedAt: "2026-01-01T11:20:18.000Z",
+      toolCalls: [],
+    };
+    const synthesis: TraceNode = { ...survey, id: "synthesis", title: "synthesis", createdAt: "2026-01-01T11:24:55.000Z", updatedAt: "2026-01-01T11:24:55.000Z" };
+    g.load({ meta: { sessionId: "s" }, nodes: [survey, synthesis] });
+
+    // Correct direction: survey (earlier) is prerequisite of synthesis (later).
+    expect(g.addRelation("survey", "synthesis", "synthesis builds on the survey")).toBe(true);
+    // synthesis depends_on survey: survey recorded as synthesis's parent.
+    expect(g.getNode("synthesis")!.parentIds).toContain("survey");
+    expect(g.getNode("survey")!.childIds).toContain("synthesis");
+  });
+
+  it("auto-corrects a reversed depends_on edge to follow chronology (#110)", () => {
+    const g = new GraphOfTrace("s");
+    // Chain: survey -> synthesis -> audit, each created later than the last.
+    const mk = (id: string, ts: string): TraceNode => ({
+      id, title: id, type: "task", status: "completed",
+      parents: [], artifacts: [], parentIds: [], childIds: [],
+      createdAt: ts, updatedAt: ts, toolCalls: [],
+    });
+    g.load({
+      meta: { sessionId: "s" },
+      nodes: [
+        mk("survey", "2026-01-01T11:20:18.000Z"),
+        mk("synthesis", "2026-01-01T11:24:55.000Z"),
+        mk("audit", "2026-01-01T11:31:22.000Z"),
+      ],
+    });
+
+    // Reversed args: caller says from=synthesis (later) -> to=survey (earlier).
+    // The guard must swap so the edge still points survey -> synthesis.
+    expect(g.addRelation("synthesis", "survey", "synthesis depends on survey")).toBe(true);
+    expect(g.getNode("synthesis")!.parentIds).toContain("survey");
+    expect(g.getNode("synthesis")!.parentIds).not.toContain("synthesis");
+    expect(g.getNode("survey")!.childIds).toContain("synthesis");
+    expect(g.getNode("survey")!.parentIds).not.toContain("synthesis");
+
+    // Reversed again: from=audit (latest) -> to=synthesis. Swap → synthesis -> audit.
+    expect(g.addRelation("audit", "synthesis", "audit depends on synthesis")).toBe(true);
+    expect(g.getNode("audit")!.parentIds).toContain("synthesis");
+    expect(g.getNode("synthesis")!.childIds).toContain("audit");
+
+    // Every depends_on edge now points earlier → later (no time reversal).
+    for (const node of g.getGraph().nodes) {
+      for (const p of node.parents) {
+        if (p.relation !== "depends_on") continue;
+        const parent = g.getNode(p.id)!;
+        expect(parent.createdAt! <= node.createdAt!).toBe(true);
+      }
+    }
+  });
+
+  it("does not reorder non-depends_on relations (parent/follows left intact)", () => {
+    const g = new GraphOfTrace("s");
+    const mk = (id: string, ts: string): TraceNode => ({
+      id, title: id, type: "task", status: "completed",
+      parents: [], artifacts: [], parentIds: [], childIds: [],
+      createdAt: ts, updatedAt: ts, toolCalls: [],
+    });
+    g.load({
+      meta: { sessionId: "s" },
+      nodes: [mk("early", "2026-01-01T00:00:00.000Z"), mk("late", "2026-01-02T00:00:00.000Z")],
+    });
+    // A 'parent' edge from the later node is a legitimate hierarchy link; the
+    // chronology guard only applies to depends_on and must leave this as-is.
+    expect(g.addRelation("late", "early", "hierarchy", "parent")).toBe(true);
+    expect(g.getNode("early")!.parentIds).toContain("late");
+  });
+
   it("load() resumes chaining from the latest node", () => {
     const g = new GraphOfTrace("s");
     const older: TraceNode = {

--- a/packages/runtime/src/personas.ts
+++ b/packages/runtime/src/personas.ts
@@ -561,7 +561,25 @@ camera operator and the editor: you decide what makes the final cut.
 5. Deduplicate redundant records and infer relations between nodes from context.
 
 Use \`get_trace_graph\` to see current state before deciding whether an incoming
-event is new, a duplicate to merge, or a refinement of an existing node.`;
+event is new, a duplicate to merge, or a refinement of an existing node.
+
+## Dependency edge direction (read carefully)
+
+When you call \`add_trace_relation(from_id, to_id)\`, the edge means
+"**to_id depends_on from_id**" and is drawn \`from_id ──▶ to_id\`:
+
+- \`from_id\` = the **prerequisite** / earlier source work that must exist first.
+- \`to_id\` = the **dependent** / later downstream work that relies on it.
+
+Because later work depends on earlier work, the prerequisite (\`from_id\`) is
+almost always the node that was **created earlier**. If you are about to point an
+edge from a later node back to an earlier one, you have the arguments reversed.
+
+Example chain (each later step depends on the previous deliverable):
+\`survey ──▶ synthesis ──▶ audit ──▶ cleanup ──▶ final verification\`
+recorded as \`add_trace_relation(from_id=survey, to_id=synthesis)\`,
+\`add_trace_relation(from_id=synthesis, to_id=audit)\`, and so on — never the
+reverse.`;
 
 /* ------------------------------- registry -------------------------------- */
 

--- a/packages/runtime/src/tools/system-tools.ts
+++ b/packages/runtime/src/tools/system-tools.ts
@@ -276,12 +276,21 @@ export function createUpdateTraceNodeTool(deps: ToolDeps): SystemTool {
 export function createAddTraceRelationTool(deps: ToolDeps): SystemTool {
   return {
     name: "add_trace_relation",
-    description: "Add a relation (edge) between two trace nodes.",
+    description:
+      "Add a directed dependency edge between two trace nodes. DIRECTION MATTERS: " +
+      "`from_id` is the PREREQUISITE (the earlier source work that must exist first), " +
+      "`to_id` is the DEPENDENT (the later downstream work that relies on it). The " +
+      "edge points from_id ──▶ to_id, read as \"to_id depends_on from_id\". " +
+      "Example: a librarian survey is the prerequisite of an experimentalist synthesis, " +
+      "so call add_trace_relation(from_id=<survey>, to_id=<synthesis>) — NOT the reverse. " +
+      "Rule of thumb: the prerequisite (from_id) is almost always the node that was " +
+      "created earlier; if you find yourself pointing from a later node to an earlier " +
+      "one, you have the arguments backwards.",
     parameters: {
       type: "object",
       properties: {
-        from_id: { type: "string" },
-        to_id: { type: "string" },
+        from_id: { type: "string", description: "Prerequisite / earlier source node." },
+        to_id: { type: "string", description: "Dependent / later downstream node." },
         explanation: { type: "string" },
       },
       required: ["from_id", "to_id", "explanation"],

--- a/packages/runtime/src/trace.ts
+++ b/packages/runtime/src/trace.ts
@@ -119,9 +119,25 @@ export class GraphOfTrace {
   }
 
   addRelation(fromId: string, toId: string, explanation: string, relation = "depends_on"): boolean {
-    const from = this.nodes.get(fromId);
-    const to = this.nodes.get(toId);
+    let from = this.nodes.get(fromId);
+    let to = this.nodes.get(toId);
     if (!from || !to) return false;
+    // Chronology guard (#110): a `depends_on` edge must point prerequisite → dependent,
+    // i.e. the source (`from`) is created no later than the dependent (`to`). The Trace
+    // agent (an LLM) sometimes passes the arguments reversed ("synthesis depends_on
+    // survey" written as from=synthesis,to=survey), producing edges that point backward
+    // in time. Time is a hard fact, so when a depends_on edge would run later→earlier we
+    // swap the endpoints to restore the semantic direction. Other relation kinds
+    // (parent/follows/produced/…) are left untouched.
+    if (
+      relation === "depends_on" &&
+      from.createdAt &&
+      to.createdAt &&
+      from.createdAt > to.createdAt
+    ) {
+      [from, to] = [to, from];
+      [fromId, toId] = [toId, fromId];
+    }
     if (!to.parents.some((p) => p.id === fromId)) {
       to.parents.push({ id: fromId, relation, explanation });
       to.parentIds.push(fromId);


### PR DESCRIPTION
## Problem

In a real multi-agent session the Trace graph produced `depends_on` edges that point **backward in time** — downstream verification/cleanup nodes appeared as prerequisites of the earlier work they actually depend on (#110).

Root cause: `add_trace_relation(from_id, to_id)` gave the Trace agent (an LLM) **no direction semantics**. The data layer treats `from` as the prerequisite (parent of `to`), but nothing told the model that, so it frequently passed the arguments reversed — writing "synthesis depends_on survey" as `from=synthesis, to=survey`.

## Fix — three layers of defense

1. **Tool description** (`system-tools.ts`): spell out that `from_id` is the prerequisite/earlier source and `to_id` the dependent/later downstream; the edge reads "to_id depends_on from_id" and points `from ──▶ to`. Includes a worked example and a rule-of-thumb (pointing at an earlier node = args reversed). Both params get descriptions.
2. **Persona** (`personas.ts` TRACE): new "Dependency edge direction" section with the canonical `survey ──▶ synthesis ──▶ audit ──▶ cleanup ──▶ final` chain.
3. **Runtime guard** (`trace.ts` `addRelation`): for `depends_on` edges, if `from` was created later than `to`, swap the endpoints so the edge always points earlier→later. Time is a hard fact, so the graph stays chronologically sound even if the LLM still passes reversed args. Other relations (`parent`/`follows`/…) are untouched.

## Tests

New regression tests in `trace.test.ts`:
- correct direction is preserved;
- a reversed `depends_on` edge is auto-corrected, driven through the issue's original `survey→synthesis→audit` chain, with a whole-graph no-time-reversal invariant;
- non-`depends_on` relations are left intact.

`npm run typecheck` passes; full runtime suite **164 tests** green.

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)