### PR TITLE
fix(web): hide Sandbox control in local mode; document data dir (closes #100)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,35 @@ brainpilot logs      # tail backend log; add --runtime for runtime log
 brainpilot down      # stop the detached backend
 ```
 
+### Where your files live
+
+`brainpilot up` resolves a single **data directory** and keeps everything under
+it. Precedence: `--dir <path>` > `BP_DATA_DIR` env > `./brainpilot` under the
+current working directory. So a plain `brainpilot up` uses `./brainpilot/`.
+
+```
+brainpilot/                       # data root (default: ./brainpilot)
+├── workspaces/<sessionId>/       # the agent's working directory (cwd) — one per
+│                                 #   session; every file an agent reads/writes
+│                                 #   or generates lands here
+├── bp_template/                  # configuration (written by `brainpilot init`)
+│   ├── providers.json            #   API key / base URL / model (providers)
+│   ├── settings.json             #   runtime settings
+│   ├── mcp_servers.json          #   MCP server connections
+│   ├── agents/                   #   custom agent personas
+│   └── skills/                   #   custom skills
+├── .bp/<sessionId>/              # per-session state (metadata, trace graph)
+├── brainpilot.config.json        # local top-level config
+├── .env                          # environment variables
+└── .runtime/                     # process state: logs/, pid files, server.json
+```
+
+> **Trust boundary.** In local (non-Docker) mode there is **no container
+> isolation** — agents read and write directly on your machine, under
+> `brainpilot/workspaces/<sessionId>/`. The UI hides the *Sandbox* control in
+> this mode because there is no Docker sandbox to attach. If you need isolation,
+> use the Docker deployment below, which runs agents inside a sandbox container.
+
 ## 💻 Run from source (contributors)
 
 From a local BrainPilot checkout:

--- a/packages/web/src/components/shell/DesktopShell.tsx
+++ b/packages/web/src/components/shell/DesktopShell.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "../../contexts/AuthContext";
 import { useSandbox } from "../../contexts/SandboxContext";
 import { useSessions } from "../../contexts/SessionContext";
 import { useT } from "../../i18n/useT";
+import { runtimeConfig } from "../../config";
 import { PromptComposer } from "../chat/PromptComposer";
 import { DemoView } from "../demo/DemoView";
 import { FileSidebar } from "../files/FileSidebar";
@@ -201,7 +202,12 @@ export function DesktopShell() {
                 <RefreshCw size={14} />
               </IconButton>
             ) : null}
-            <SandboxStatus />
+            {/* #100: in local single-user mode there is no Docker sandbox to
+                inspect — the runtime IS the workspace, so the Sandbox status
+                popover would only show empty container metrics and read like a
+                fault. Hide it here; downstream multi-user Docker builds set
+                VITE_LOCAL_MODE=0 and keep the real container UI. */}
+            {runtimeConfig.localMode ? null : <SandboxStatus />}
             <IconButton
               aria-pressed={isFilesOpen}
               className={isFilesOpen ? "is-active" : ""}


### PR DESCRIPTION
## Problem (#100)

In local (non-Docker) single-user mode the runtime IS the workspace — there is no container lifecycle. But the UI:
- showed a **Sandbox** popover full of empty container metrics (name/port/memory/cpu all `-`), which reads like a fault;
- never made clear whether agents run in a Docker sandbox or directly on the host filesystem, nor where generated files land.

That ambiguity is part of the self-hosted trust model.

## Fix

- **DesktopShell** — gate `<SandboxStatus/>` behind `runtimeConfig.localMode`. This repo (npm + default Docker images) builds with `localMode=true`; only downstream multi-user Docker builds set `VITE_LOCAL_MODE=0` and keep the real container UI, so the control still appears where a sandbox actually exists. *(Verified: no Dockerfile/compose in this repo sets `VITE_LOCAL_MODE=0`, and the local path already routes through `LocalSandboxProvider` / skips `/api/sandbox/*`.)*
- **README** — add a "Where your files live" section: data-dir resolution (`--dir` > `BP_DATA_DIR` > `./brainpilot`) and the on-disk layout (`workspaces/<sessionId>` = agent cwd, `bp_template` = config, `.bp` = session state, `.runtime` = logs/pids), plus an explicit **trust-boundary** note that local mode has no container isolation and agents act directly under `brainpilot/workspaces/<sessionId>/`.

## Tests

Web suite: **86 passing**; typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)