### PR TITLE
chore: gitignore TemplateRevise.md local working note

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ legacy/
 # Local agent guidance (user-specific, not part of the open-source tree)
 AGENTS.md
 CLAUDE.md
+TemplateRevise.md
 
 # System
 .DS_Store


### PR DESCRIPTION
Add \`TemplateRevise.md\` to the existing "Local agent guidance" section of \`.gitignore\` alongside \`AGENTS.md\` and \`CLAUDE.md\`.

\`TemplateRevise.md\` is a user-local working note for tracking template revisions (per project convention captured in CLAUDE.md). It never ships with the open-source tree — same rationale as the two existing entries in that section.

One-line ignore-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)