### PR TITLE
fix(runtime): concise provider errors + language-follow directive (#97)

### DIFF
--- a/packages/runtime/src/__tests__/agent-error.test.ts
+++ b/packages/runtime/src/__tests__/agent-error.test.ts
@@ -12,35 +12,78 @@ describe("normalizeAgentError (#45)", () => {
 
   it("replaces the no-key SDK error with a Settings → Providers message", () => {
     const out = normalizeAgentError(noKeyRaw);
-    expect(out).toContain("设置 → Providers");
+    expect(out.message).toContain("设置 → Providers");
   });
 
   it("never leaks /login or node_modules paths for the no-key case", () => {
     const out = normalizeAgentError(noKeyRaw);
-    expect(out).not.toMatch(/\/login/i);
-    expect(out).not.toMatch(/node_modules/);
+    expect(out.message).not.toMatch(/\/login/i);
+    expect(out.message).not.toMatch(/node_modules/);
+    expect(out.details).toBeUndefined();
   });
 
   it("does not mention the BP_MOCK test switch", () => {
     const out = normalizeAgentError(noKeyRaw);
-    expect(out).not.toMatch(/BP_MOCK/i);
+    expect(out.message).not.toMatch(/BP_MOCK/i);
   });
 
   it("redacts paths/login from other errors while keeping the message", () => {
     const raw =
       "Tool failed: cannot read config.\nUse /login first.\n/srv/app/node_modules/pkg/docs/x.md";
     const out = normalizeAgentError(raw);
-    expect(out).toContain("Tool failed: cannot read config.");
-    expect(out).not.toMatch(/\/login/i);
-    expect(out).not.toMatch(/node_modules/);
+    expect(out.message).toContain("Tool failed: cannot read config.");
+    expect(out.message).not.toMatch(/\/login/i);
+    expect(out.message).not.toMatch(/node_modules/);
   });
 
   it("leaves a clean error untouched", () => {
     const raw = "Rate limit exceeded, retry in 30s.";
-    expect(normalizeAgentError(raw)).toBe(raw);
+    expect(normalizeAgentError(raw).message).toBe(raw);
   });
 
   it("handles empty input", () => {
-    expect(normalizeAgentError("")).toBe("");
+    expect(normalizeAgentError("").message).toBe("");
+  });
+});
+
+describe("normalizeAgentError — provider HTTP errors (#97)", () => {
+  const raw401 =
+    '401 {"error":{"message":"invalid api key (request id: req_abc123)","type":"authentication_error"}}';
+
+  it("produces a concise localized headline, not the raw blob", () => {
+    const out = normalizeAgentError(raw401);
+    expect(out.message).toContain("401");
+    expect(out.message).toContain("invalid api key");
+    // The primary message must not be the full escaped JSON dump.
+    expect(out.message).not.toContain('{"error"');
+  });
+
+  it("keeps the full raw error (incl. request id) in details", () => {
+    const out = normalizeAgentError(raw401);
+    expect(out.details).toBe(raw401);
+    expect(out.details).toContain("request id: req_abc123");
+  });
+
+  it("falls back to a code-only headline when no message is extractable", () => {
+    const raw = "429 {}";
+    const out = normalizeAgentError(raw);
+    expect(out.message).toContain("429");
+    expect(out.details).toBe(raw);
+  });
+
+  it("handles a 5xx with a string error field", () => {
+    const raw = '503 {"error":"service unavailable"}';
+    const out = normalizeAgentError(raw);
+    expect(out.message).toContain("503");
+    expect(out.message).toContain("service unavailable");
+    expect(out.details).toBe(raw);
+  });
+
+  it("does not echo a JSON-shaped extracted message into the headline", () => {
+    // Nested/odd shape where the naive pick would still contain braces.
+    const raw = '400 {"error":{"detail":{"x":1}}}';
+    const out = normalizeAgentError(raw);
+    expect(out.message).not.toMatch(/[{}]/);
+    expect(out.message).toContain("400");
   });
 });

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -137,7 +137,10 @@ describe("SessionManager (mock mode)", () => {
     await sm.sendMessage(s.id, "hi");
     await waitFor(() => seen.length > 0);
 
-    expect(seen[0]).toBe("# Custom PI\nDo it my way.");
+    // The on-disk persona is used verbatim as the base, with the language
+    // directive appended at load time (#97) so it reaches pre-existing scaffolds.
+    expect(seen[0]).toContain("# Custom PI\nDo it my way.");
+    expect(seen[0]).toContain("## Response language");
     await rm(root, { recursive: true, force: true });
   });
 });

--- a/packages/runtime/src/agent-error.ts
+++ b/packages/runtime/src/agent-error.ts
@@ -1,18 +1,33 @@
 /**
  * agent-error.ts — normalize raw agent/SDK error messages before they reach
- * the user-facing event stream and events.jsonl (issue #45).
+ * the user-facing event stream and events.jsonl (issues #45, #97).
  *
- * Two jobs:
+ * Three jobs:
  *  1. Recognize the "no provider / no API key" case and replace the raw Pi SDK
  *     guidance (which points at `/login` and absolute node_modules doc paths)
  *     with a product-level message that points at BrainPilot's own Settings →
  *     Providers flow.
- *  2. Redact local filesystem leakage (absolute node_modules paths, `/login`
+ *  2. Recognize a provider HTTP error (e.g. `401 {"error":{...}}`) and split it
+ *     into a concise, localized headline (`message`) and the full raw blob
+ *     (`details`), so the chat bubble shows a short line and tucks the provider
+ *     internals / request id behind an expandable section instead of dumping
+ *     escaped JSON into the primary transcript (#97).
+ *  3. Redact local filesystem leakage (absolute node_modules paths, `/login`
  *     hints) from any other error, so we never persist or display internal
  *     install paths.
  *
- * Language follows the existing runtime system_message convention (Chinese).
+ * Language follows the existing runtime system_message convention (Chinese) for
+ * the BrainPilot-authored shell; the provider's own error text is preserved
+ * verbatim (we don't translate third-party messages — that loses fidelity).
  */
+
+/** Normalized error: a short headline plus optional expandable raw detail. */
+export interface NormalizedAgentError {
+  /** Concise, user-facing headline (chat bubble body). */
+  message: string;
+  /** Full raw error for the expandable "details" section, when worth keeping. */
+  details?: string;
+}
 
 /** Product-level recovery message for a missing provider/key. */
 const NO_PROVIDER_MESSAGE =
@@ -23,6 +38,71 @@ function isNoProviderError(raw: string): boolean {
   return /no api key|no provider|api key found|api key for the selected model/i.test(
     raw,
   );
+}
+
+/**
+ * Detect a provider HTTP error and build a concise headline + raw details.
+ *
+ * Real shape (observed in #97):
+ *   `401 {"error":{"message":"invalid api key (request id: ...)", ...}}`
+ * i.e. a leading HTTP status code followed by a JSON body. We extract the
+ * status code and, when possible, the provider's own `error.message`, and keep
+ * the entire original blob as `details` so the request id stays available
+ * behind the expandable section.
+ *
+ * Returns undefined when the string doesn't look like a provider HTTP error,
+ * so the caller falls through to plain redaction.
+ */
+function parseProviderError(raw: string): NormalizedAgentError | undefined {
+  // Observed shape is always `<status> {json}` — require BOTH a 4xx/5xx code
+  // and a JSON body, so a plain message that happens to contain a 3-digit
+  // number ("retry in 500ms") is NOT misclassified as a provider error.
+  if (!raw.includes("{")) return undefined;
+  const m = raw.match(/\b(4\d{2}|5\d{2})\b/);
+  if (!m) return undefined;
+  const status = m[1];
+
+  let providerMsg = extractProviderMessage(raw);
+  // Guard against echoing the whole blob back as the "message" — if the
+  // extracted text still looks like a JSON dump, drop it and keep only the code.
+  if (providerMsg && /[{}]/.test(providerMsg)) providerMsg = undefined;
+
+  const headline = providerMsg
+    ? `provider 拒绝请求 (${status}): ${providerMsg}`
+    : `provider 拒绝请求 (HTTP ${status})。详情见下方展开。`;
+
+  return { message: headline, details: raw.trim() };
+}
+
+/**
+ * Best-effort pull of the provider's own human-readable message out of an
+ * error blob. Tries to JSON.parse a `{...}` substring and read common shapes
+ * (`error.message`, `message`, `error` as string); falls back to undefined.
+ */
+function extractProviderMessage(raw: string): string | undefined {
+  const start = raw.indexOf("{");
+  const end = raw.lastIndexOf("}");
+  if (start === -1 || end === -1 || end <= start) return undefined;
+  try {
+    const obj = JSON.parse(raw.slice(start, end + 1)) as unknown;
+    const msg = pickMessage(obj);
+    return msg?.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function pickMessage(obj: unknown): string | undefined {
+  if (!obj || typeof obj !== "object") return undefined;
+  const o = obj as Record<string, unknown>;
+  if (typeof o.message === "string") return o.message;
+  const err = o.error;
+  if (typeof err === "string") return err;
+  if (err && typeof err === "object") {
+    const e = err as Record<string, unknown>;
+    if (typeof e.message === "string") return e.message;
+  }
+  return undefined;
 }
 
 /**
@@ -53,10 +133,13 @@ function redact(raw: string): string {
 /**
  * Normalize a raw agent error message for user display + persistence.
  * - No-provider/no-key errors → a product-level Settings → Providers message.
+ * - Provider HTTP errors (`401 {...}`) → concise headline + raw blob in details.
  * - Everything else → the original message with local paths / `/login` redacted.
  */
-export function normalizeAgentError(raw: string): string {
-  if (!raw) return raw;
-  if (isNoProviderError(raw)) return NO_PROVIDER_MESSAGE;
-  return redact(raw);
+export function normalizeAgentError(raw: string): NormalizedAgentError {
+  if (!raw) return { message: raw };
+  if (isNoProviderError(raw)) return { message: NO_PROVIDER_MESSAGE };
+  const provider = parseProviderError(raw);
+  if (provider) return provider;
+  return { message: redact(raw) };
 }

--- a/packages/runtime/src/mas-agent.ts
+++ b/packages/runtime/src/mas-agent.ts
@@ -121,8 +121,8 @@ export class MasAgent {
       // issue #45: never surface raw SDK guidance (/login, node_modules paths)
       // — normalize to a product message / redact local paths before it hits
       // the event stream, events.jsonl, and lastError.
-      const message = normalizeAgentError(raw);
-      this.recordError(message);
+      const { message, details } = normalizeAgentError(raw);
+      this.recordError(message, details);
       this.bus.emit(
         ev.runError({ sessionId: this.sessionId, agentName: this.name, runId: this.currentRunId }, message),
       );
@@ -219,8 +219,8 @@ export class MasAgent {
         const msg = end.message as { stopReason?: string; errorMessage?: string } | undefined;
         if (msg?.stopReason === "error") {
           const raw = msg.errorMessage || "provider request failed";
-          const message = normalizeAgentError(raw);
-          this.recordError(message);
+          const { message, details } = normalizeAgentError(raw);
+          this.recordError(message, details);
           this.setStatus("error");
         }
         if (this.currentMessageId) {
@@ -280,7 +280,8 @@ export class MasAgent {
       case "auto_retry_end": {
         const r = e as Extract<PiAgentEvent, { type: "auto_retry_end" }>;
         if (!r.success) {
-          this.recordError(r.finalError ?? "retry exhausted");
+          const { message, details } = normalizeAgentError(r.finalError ?? "retry exhausted");
+          this.recordError(message, details);
           this.setStatus("error");
         }
         return;
@@ -329,7 +330,8 @@ export class MasAgent {
           (typeof err.error === "string" ? err.error : undefined) ??
           err.reason ??
           "provider request failed";
-        this.recordError(normalizeAgentError(raw));
+        const { message, details } = normalizeAgentError(raw);
+        this.recordError(message, details);
         this.setStatus("error");
         return;
       }

--- a/packages/runtime/src/personas.ts
+++ b/packages/runtime/src/personas.ts
@@ -26,6 +26,32 @@
 
 /* ----------------------------- shared blocks ----------------------------- */
 
+/**
+ * Language-following directive (#97). Appended to EVERY agent persona at load
+ * time (see SessionManager.loadPersona) — kept out of the per-role persona text
+ * and the user-editable on-disk `prompt.md` copies so it also reaches users who
+ * scaffolded before this existed. Authored in English (all personas are), but it
+ * instructs the agent to mirror the USER's language, and to switch on request —
+ * a follow rule, not a fixed lock, so a mid-conversation "switch to English"
+ * is honored. Experts inherit this naturally: the Principal's delegated task
+ * text is in the user's language, so the expert answers in kind.
+ */
+export const LANGUAGE_DIRECTIVE = `## Response language
+
+Respond in the same language the user is currently writing in. This applies to
+all user-visible output, including progress updates and status messages. If the
+user explicitly asks you to switch languages, comply immediately and keep using
+the requested language until they change it again. Do not lock to one language —
+follow the user.`;
+
+/**
+ * Append the language-following directive to a resolved persona (#97). Used at
+ * persona load time so both built-in and on-disk personas get it.
+ */
+export function withLanguageDirective(persona: string): string {
+  return `${persona}\n\n${LANGUAGE_DIRECTIVE}`;
+}
+
 /** A2A messaging contract — identical mechanics for every non-trace agent. */
 const A2A_EXPERT = `## Communicating back to the Principal
 

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -28,7 +28,7 @@ import { MasAgent } from "./mas-agent.js";
 import { systemToolsForRole, builtinToolNamesForRole, type ToolDeps } from "./tools/system-tools.js";
 import { ev } from "./events.js";
 import { selectFactory, isMockMode } from "./agent-factory.js";
-import { personaFor } from "./personas.js";
+import { personaFor, withLanguageDirective } from "./personas.js";
 import { McpBridge, loadMcpServersConfig } from "./mcp-bridge.js";
 import { resolveSessionProvider, type SessionProviderRef } from "./provider-config.js";
 import { MemWatchdog, parseMemLimitMb } from "./mem-watchdog.js";
@@ -423,13 +423,17 @@ export class SessionManager {
    * file is present or it's empty.
    */
   private async loadPersona(name: string, role: AgentRole): Promise<string> {
+    let base: string | undefined;
     try {
       const raw = (await readFile(this.agentPromptPath(name), "utf8")).trim();
-      if (raw) return raw;
+      if (raw) base = raw;
     } catch {
       // No on-disk override — fall through to the built-in persona.
     }
-    return personaFor(name, role);
+    // #97: append the language-following directive here (not in the persona text
+    // / on-disk prompt.md) so it also reaches users who scaffolded earlier, and
+    // applies whether the persona came from disk or the built-in constant.
+    return withLanguageDirective(base ?? personaFor(name, role));
   }
 
   /* ---------------------------- session CRUD ---------------------------- */


### PR DESCRIPTION
Two user-facing fixes from real-provider testing (BPCASE-0041). This is a
**partial** fix for #97 — it covers the display/UX half (A + D below). The
correctness half (B + C: surfacing an expert failure back to the Principal so
it doesn't claim a result it never got, and labeling answer reliability) is
tracked separately and will land in a follow-up. **This PR does not close #97.**

## A — provider errors no longer dump escaped JSON into the transcript

A provider 401 surfaced as `Agent librarian 遇到错误: 401 {\"error\":{...invalid api key (request id: ...)...}}` — escaped JSON, provider internals, and a request id, right in the primary chat bubble.

`normalizeAgentError` now returns `{ message, details? }`. A provider HTTP error (`<4xx/5xx> {json}` — requiring **both** a status code and a JSON body, so a clean `retry in 500ms` is not misclassified) is split into:
- **`message`**: concise localized headline, e.g. `provider 拒绝请求 (401): invalid api key (request id: ...)`;
- **`details`**: the full raw blob (incl. request id).

`mas-agent`'s four error sites pass `details` through to `recordError`, which already feeds `SystemMessageBubble`'s existing `<details>` section — so the raw error is one expand away, not in the primary transcript. **No frontend change needed.** The BrainPilot-authored shell is localized; the provider's own message is preserved verbatim (we don't translate third-party text). The retry-exhausted site, previously un-normalized, now goes through too.

## D — delegated experts follow the user's language

Personas carried no language guidance, so a librarian sometimes replied in English inside a Chinese conversation. Add a `LANGUAGE_DIRECTIVE` appended in `SessionManager.loadPersona` — **not** in the persona text or the on-disk `bp_template/agents/<name>/prompt.md` copies — so it also reaches users who scaffolded before this existed, and applies whether the persona came from disk or the built-in constant. It is a *follow* rule (mirror the user's current language; switch on explicit request), not a fixed lock, so a mid-conversation language switch is honored. Authored in English per persona convention.

## Test plan

- `agent-error.test.ts`: adds 401/429/503/nested-JSON cases (11 pass)
- `session-manager.test.ts`: asserts the on-disk persona is the base + directive appended
- Full runtime suite: **172 pass**; `npm run typecheck` clean

Note: D is a soft (model-followed) directive — not asserted by unit tests and not exercised in BP_MOCK mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)