### PR TITLE
fix(web): faithful multi-agent transcript in Live Demo (closes #98)

### DIFF
--- a/packages/web/src/__tests__/demoConversation.test.ts
+++ b/packages/web/src/__tests__/demoConversation.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import type { ChatMessage } from "../contracts/backend";
+import { isDemoConversational } from "../components/demo/DemoView";
+
+function msg(overrides: Partial<ChatMessage>): ChatMessage {
+  return {
+    id: overrides.id ?? "m1",
+    role: overrides.role ?? "assistant",
+    content: overrides.content ?? "",
+    createdAt: "2026-06-18T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("isDemoConversational (#98 multi-agent transcript)", () => {
+  it("keeps non-empty user prompts", () => {
+    expect(isDemoConversational(msg({ role: "user", content: "hello" }))).toBe(true);
+    expect(isDemoConversational(msg({ role: "user", content: "  " }))).toBe(false);
+  });
+
+  it("keeps the principal's substantive text replies", () => {
+    expect(
+      isDemoConversational(msg({ role: "assistant", agent: "principal", kind: "text", content: "done" })),
+    ).toBe(true);
+  });
+
+  it("keeps EXPERT agent text replies (the core #98 regression)", () => {
+    // librarian / engineer / experimentalist replies must survive — the live
+    // Chat shows them, so the demo must too.
+    expect(
+      isDemoConversational(msg({ role: "assistant", agent: "librarian", kind: "text", content: "searching…" })),
+    ).toBe(true);
+    expect(
+      isDemoConversational(msg({ role: "assistant", agent: "engineer", kind: undefined, content: "built it" })),
+    ).toBe(true);
+  });
+
+  it("treats a missing agent as conversational (older bundles)", () => {
+    expect(isDemoConversational(msg({ role: "assistant", kind: "text", content: "hi" }))).toBe(true);
+  });
+
+  it("keeps error bubbles with content", () => {
+    expect(isDemoConversational(msg({ role: "system", kind: "error", content: "librarian failed" }))).toBe(true);
+    expect(isDemoConversational(msg({ role: "system", kind: "error", content: "" }))).toBe(false);
+  });
+
+  it("keeps system_message bubbles that carry a payload", () => {
+    expect(
+      isDemoConversational(
+        msg({
+          role: "system",
+          kind: "system_message",
+          content: "",
+          systemMessage: { level: "error", message: "librarian error", recoverable: true },
+        }),
+      ),
+    ).toBe(true);
+    // No payload → nothing to render.
+    expect(isDemoConversational(msg({ role: "system", kind: "system_message", content: "" }))).toBe(false);
+  });
+
+  it("drops reasoning, tool calls/results, hooks and interactive cards", () => {
+    expect(isDemoConversational(msg({ kind: "thinking", content: "let me think" }))).toBe(false);
+    expect(isDemoConversational(msg({ kind: "tool", content: "Tool: read" }))).toBe(false);
+    expect(isDemoConversational(msg({ role: "system", kind: "hook", content: "reset" }))).toBe(false);
+    expect(isDemoConversational(msg({ kind: "ask_user", content: "pick one" }))).toBe(false);
+    expect(isDemoConversational(msg({ kind: "auto_retry", content: "retrying" }))).toBe(false);
+  });
+
+  it("drops empty text placeholders", () => {
+    expect(isDemoConversational(msg({ role: "assistant", kind: "text", content: "   " }))).toBe(false);
+  });
+});

--- a/packages/web/src/components/demo/DemoView.tsx
+++ b/packages/web/src/components/demo/DemoView.tsx
@@ -4,6 +4,7 @@ import { FileUp, MessageSquare, Pause, Play, RotateCcw, SkipBack, SkipForward, U
 import type { ChatMessage, TraceNode, WebSocketEvent } from "../../contracts/backend";
 import { normalizeWebSocketEvent } from "../../contracts/backend";
 import { DemoBundle, DemoFile } from "../../contracts/demoBundle";
+import { applyMessageFilters, defaultFilterRules } from "../../contexts/messageFilters";
 import { reduceMessagesForEvent } from "../../contexts/messageReducer";
 import { useSandbox } from "../../contexts/SandboxContext";
 import { useSessions } from "../../contexts/SessionContext";
@@ -41,32 +42,40 @@ function basename(path: string): string {
 }
 
 /**
- * Keep only the user-facing dialogue backbone for the demo's left panel.
+ * Keep the user-facing dialogue backbone for the demo's left panel.
  *
- * This is a multi-agent system: the live EventRouter
- * (agent_runtime/event_router.py) forwards only the principal (PI) agent's
- * messages to the frontend, while worker agents (engineer / trace /
- * experimentalist) run internally. The demo bundle, however, captures *all*
- * raw events, so a naive "any assistant text" filter floods the panel with
- * internal worker narration ("Recorded as T001…", engineer step notes).
+ * This is a multi-agent system. The demo bundle captures *all* raw events, and
+ * the live Chat (PromptComposer) does NOT collapse the transcript to the
+ * principal — it renders every agent's substantive replies, plus error and
+ * system_message bubbles, with per-agent attribution. The demo must mirror that
+ * so the replay faithfully represents what the user saw: a librarian's progress
+ * reply or an expert's error alert is first-class conversation, not internal
+ * noise (issue #98).
  *
- * Mirror the live behavior: keep the user's prompts and the principal's
- * substantive text replies — the seed prompt, the key exchanges, and the final
- * result — and drop everything else (worker narration, reasoning, tool
- * calls/results, hook diagnostics, NO-RENDER placeholders, empties). The
- * reasoning graph on the right tells the internal story.
+ * Keep: user prompts; assistant/system plain-text replies from ANY agent;
+ * error and system_message bubbles (the agent-attributed warnings/alerts the
+ * live Chat shows). Drop: reasoning, tool calls/results, hook diagnostics, and
+ * the interactive ask_user / auto_retry cards (the reasoning graph on the right
+ * tells the internal story, and the cards have no meaning in a read-only
+ * replay), plus NO-RENDER placeholders and empties.
  */
-function isConversationalMessage(m: ChatMessage): boolean {
+export function isDemoConversational(m: ChatMessage): boolean {
   if (m.role === "user") {
     return !!m.content?.trim();
   }
-  const isPlainText = m.kind === "text" || m.kind === undefined;
-  if (!isPlainText || !m.content?.trim()) {
-    return false;
+  // Agent-attributed warnings/errors the live Chat surfaces as standalone
+  // bubbles. system_message carries its own payload; error carries content.
+  if (m.kind === "system_message") {
+    return !!m.systemMessage;
   }
-  // Only the principal agent is user-facing. Missing agent → treat as principal
-  // for resilience against older bundles where attribution was not recorded.
-  return m.agent === undefined || m.agent === "principal";
+  if (m.kind === "error") {
+    return !!m.content?.trim();
+  }
+  // Substantive text replies from ANY agent (principal or expert). MessageStream
+  // attributes each row by `agent`, so non-principal messages render with their
+  // own avatar/name. Missing agent → treated as principal downstream.
+  const isPlainText = m.kind === "text" || m.kind === undefined;
+  return isPlainText && !!m.content?.trim();
 }
 
 const REPORT_NAME = /report|summary|总结|conclusion|readme/i;
@@ -245,15 +254,19 @@ export function DemoView() {
     return timeline.ordered.slice(0, count);
   }, [bundle, timeline, cursor]);
 
-  // The left panel shows the conversation backbone — the actual dialogue: the
-  // seed prompt and every substantive text reply. Reasoning, tool calls, tool
-  // results, hook notes and empty placeholders are dropped (the reasoning graph
-  // on the right tells that story). This is deliberately a content predicate,
-  // not a pin-to-two-messages filter: the latter relied on exact id-matching
-  // across two independent event folds and silently emptied the panel whenever a
-  // MESSAGES_SNAPSHOT reshuffled ids or no clean seed/summary message existed.
+  // The left panel shows the conversation backbone — the actual dialogue across
+  // every agent: the seed prompt, each agent's substantive text replies, and the
+  // error/system_message bubbles the live Chat surfaces. Reasoning, tool calls,
+  // tool results, hook notes and empty placeholders are dropped (the reasoning
+  // graph on the right tells that story). `applyMessageFilters` mirrors the live
+  // Chat's default rules (e.g. hiding spurious single-dot messages) so the
+  // replay matches what the user actually saw. This is deliberately a content
+  // predicate, not a pin-to-two-messages filter: the latter relied on exact
+  // id-matching across two independent event folds and silently emptied the
+  // panel whenever a MESSAGES_SNAPSHOT reshuffled ids or no clean seed/summary
+  // message existed.
   const condensedMessages = useMemo<ChatMessage[]>(
-    () => revealedMessages.filter(isConversationalMessage),
+    () => applyMessageFilters(revealedMessages.filter(isDemoConversational), defaultFilterRules),
     [revealedMessages],
   );
 
@@ -530,12 +543,19 @@ export function DemoView() {
   }
 
   // ----- Player -----
+  // Prefer the authoritative title from the live session list (it tracks
+  // backend `session_title` updates) over the snapshot captured into the bundle
+  // at pack time, which can be stale (e.g. "Session f8f35032" before a reload).
+  // Falls back to the bundle title for imported bundles whose source session is
+  // not in this client's list.
+  const liveSession = sessions.find((s) => s.id === bundle.session.id);
+  const displayTitle = liveSession?.title || bundle.session.title;
   return (
     <main className="demo-view" aria-label={t("demo.title")}>
       <header className="demo-header">
         <div className="demo-header__title">
           <span className="workspace-panel__eyebrow">{t("demo.eyebrow")}</span>
-          <h1>{bundle.session.title}</h1>
+          <h1>{displayTitle}</h1>
           <span className="demo-header__meta">
             {t("demo.meta.exported", { time: new Date(bundle.exportedAt).toLocaleString() })}
           </span>
@@ -602,6 +622,12 @@ export function DemoView() {
                 onZoomChange={setZoom}
                 fitToken={revealedNodes.length}
                 formatKind={formatNodeKind}
+                zoomLabels={{
+                  controls: t("trace.aria.zoomControls"),
+                  zoomIn: t("trace.aria.zoomIn"),
+                  zoomOut: t("trace.aria.zoomOut"),
+                  reset: t("trace.aria.resetZoom"),
+                }}
               />
             </div>
             <div className="demo-transport">


### PR DESCRIPTION
## Problem

The Live Demo conversation panel filtered the transcript down to the **principal agent only**, citing a now-stale "mirror the live EventRouter" rationale. But the live Chat (`PromptComposer`) does **not** collapse to the principal — it renders every agent's replies plus error/`system_message` bubbles with per-agent attribution.

So a session involving librarian / engineer / experimentalist agents exported a demo that looked like only PI talked, dropping expert progress messages and error alerts (issue reports 29 source messages → a much smaller preview). The issue also flagged a stale title and unlabeled zoom controls.

## Changes (`packages/web`, frontend only)

- **Multi-agent transcript** (`DemoView.tsx`): `isConversationalMessage` → `isDemoConversational` (exported). Now keeps assistant/system plain-text replies from **any** agent and the agent-attributed `error` / `system_message` bubbles; still drops reasoning, tool calls/results, hooks, and the interactive `ask_user`/`auto_retry` cards (no meaning in a read-only replay). Applies the live Chat's `defaultFilterRules` for parity.
- **Stale title**: the header now prefers the authoritative title from the live session list (tracks backend `session_title` updates), falling back to the bundle's pack-time snapshot for imported bundles. Fixes the "Session f8f35032" before reload.
- **Accessibility**: pass `zoomLabels` to the demo's `TraceGraphView` so the zoom controls have accessible names (reuses existing `trace.aria.*` keys).

No backend or bundle-format changes — older bundles already persist non-principal events, so they replay faithfully too.

## Testing

- New `demoConversation.test.ts` — 8 cases (expert text / error / system_message kept; reasoning / tool / hook / cards dropped). All pass.
- Full web suite: 96 passed. The 5 failures in `traceReducer.test.ts` are **pre-existing on `development`** (a `CUSTOM_EVENT` export gap), unrelated to this change.
- `tsc -b --force` clean; `vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)