### PR TITLE
feat(runtime): inject live team-status into the principal each turn (#97)

### DIFF
--- a/packages/runtime/src/__tests__/agent-status.test.ts
+++ b/packages/runtime/src/__tests__/agent-status.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from "vitest";
+import {
+  renderAgentStatusBlock,
+  collectAgentStatusLines,
+  makeAgentStatusExt,
+  type AgentStatusLine,
+  type StatusAgentLike,
+} from "../extensions/agent-status.js";
+
+/* ----------------------- pure renderer (#97 option B) ---------------------- */
+
+describe("renderAgentStatusBlock", () => {
+  it("returns empty string when there are no agents", () => {
+    expect(renderAgentStatusBlock([])).toBe("");
+  });
+
+  it("renders a natural-language line per agent with status + unread count", () => {
+    const lines: AgentStatusLine[] = [
+      { name: "principal", status: "running", unread: 1 },
+      { name: "librarian", status: "idle", unread: 0 },
+      { name: "engineer", status: "error", unread: 2 },
+    ];
+    const out = renderAgentStatusBlock(lines);
+    expect(out).toContain("<agent_status>");
+    expect(out).toContain("</agent_status>");
+    expect(out).toContain("- principal: running, 1 unread message");
+    expect(out).toContain("- librarian: idle, 0 unread messages");
+    expect(out).toContain("- engineer: error, 2 unread messages");
+  });
+
+  it("uses the singular form for exactly one unread message", () => {
+    const out = renderAgentStatusBlock([{ name: "x", status: "idle", unread: 1 }]);
+    expect(out).toContain("1 unread message");
+    expect(out).not.toContain("1 unread messages");
+  });
+
+  it("uses the plural form for zero and many", () => {
+    const out = renderAgentStatusBlock([
+      { name: "a", status: "idle", unread: 0 },
+      { name: "b", status: "idle", unread: 3 },
+    ]);
+    expect(out).toContain("0 unread messages");
+    expect(out).toContain("3 unread messages");
+  });
+});
+
+/* --------------------------- line collection ------------------------------ */
+
+describe("collectAgentStatusLines", () => {
+  const unread = (counts: Record<string, number>) => (name: string) => counts[name] ?? 0;
+
+  it("includes the principal itself", () => {
+    const agents: StatusAgentLike[] = [
+      { name: "principal", role: "principal", status: "running" },
+      { name: "engineer", role: "expert", status: "idle" },
+    ];
+    const lines = collectAgentStatusLines(agents, unread({ principal: 1, engineer: 0 }));
+    expect(lines.map((l) => l.name)).toEqual(["principal", "engineer"]);
+    expect(lines.find((l) => l.name === "principal")?.unread).toBe(1);
+  });
+
+  it("excludes the trace agent", () => {
+    const agents: StatusAgentLike[] = [
+      { name: "principal", role: "principal", status: "idle" },
+      { name: "trace", role: "trace", status: "running" },
+    ];
+    const lines = collectAgentStatusLines(agents, unread({}));
+    expect(lines.map((l) => l.name)).toEqual(["principal"]);
+  });
+
+  it("excludes stopped agents", () => {
+    const agents: StatusAgentLike[] = [
+      { name: "principal", role: "principal", status: "idle" },
+      { name: "engineer", role: "expert", status: "stopped" },
+    ];
+    const lines = collectAgentStatusLines(agents, unread({}));
+    expect(lines.map((l) => l.name)).toEqual(["principal"]);
+  });
+
+  it("carries the unread count from the inbox", () => {
+    const agents: StatusAgentLike[] = [
+      { name: "engineer", role: "expert", status: "error" },
+    ];
+    const lines = collectAgentStatusLines(agents, unread({ engineer: 3 }));
+    expect(lines[0]).toEqual({ name: "engineer", status: "error", unread: 3 });
+  });
+});
+
+/* ------------------------- context-hook behaviour -------------------------- */
+
+interface FakeMsg {
+  role: string;
+  content: Array<{ type: string; text?: string }>;
+}
+
+/** Minimal fake `pi` that captures the single `context` handler. */
+function fakePi() {
+  let handler:
+    | ((e: { messages: FakeMsg[] }) => { messages: FakeMsg[] } | void)
+    | undefined;
+  const pi = {
+    on(_event: "context", h: (e: { messages: FakeMsg[] }) => { messages: FakeMsg[] } | void) {
+      handler = h;
+    },
+  };
+  return {
+    pi,
+    fire(messages: FakeMsg[]) {
+      if (!handler) throw new Error("no context handler registered");
+      return handler({ messages });
+    },
+  };
+}
+
+const userMsg = (text: string): FakeMsg => ({ role: "user", content: [{ type: "text", text }] });
+
+describe("makeAgentStatusExt — context hook", () => {
+  it("appends a fresh status block before the LLM call", () => {
+    const block = "<agent_status>\nfresh\n</agent_status>";
+    const { pi, fire } = fakePi();
+    makeAgentStatusExt({ renderStatus: () => block })(pi as never);
+
+    const res = fire([userMsg("hello")]);
+    expect(res).toBeDefined();
+    const msgs = (res as { messages: FakeMsg[] }).messages;
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0]).toEqual(userMsg("hello"));
+    expect(msgs[1].content[0].text).toBe(block);
+  });
+
+  it("strips a stale block from a previous turn and injects only the latest", () => {
+    const stale = "<agent_status>\nold\n</agent_status>";
+    const fresh = "<agent_status>\nnew\n</agent_status>";
+    const { pi, fire } = fakePi();
+    makeAgentStatusExt({ renderStatus: () => fresh })(pi as never);
+
+    const res = fire([userMsg("hello"), userMsg(stale)]);
+    const msgs = (res as { messages: FakeMsg[] }).messages;
+    // exactly one status block, and it is the fresh one
+    const blocks = msgs.filter((m) => (m.content[0].text ?? "").startsWith("<agent_status>"));
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].content[0].text).toBe(fresh);
+    // the real user message survives
+    expect(msgs.some((m) => m.content[0].text === "hello")).toBe(true);
+  });
+
+  it("strips a stale block and injects nothing when there is nothing to report", () => {
+    const stale = "<agent_status>\nold\n</agent_status>";
+    const { pi, fire } = fakePi();
+    makeAgentStatusExt({ renderStatus: () => "" })(pi as never);
+
+    const res = fire([userMsg("hello"), userMsg(stale)]);
+    const msgs = (res as { messages: FakeMsg[] }).messages;
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].content[0].text).toBe("hello");
+  });
+
+  it("leaves messages untouched (no rewrite) when nothing to report and no stale block", () => {
+    const { pi, fire } = fakePi();
+    makeAgentStatusExt({ renderStatus: () => "" })(pi as never);
+
+    const res = fire([userMsg("hello")]);
+    expect(res).toBeUndefined();
+  });
+});

--- a/packages/runtime/src/agent-factory.ts
+++ b/packages/runtime/src/agent-factory.ts
@@ -18,6 +18,7 @@ import type { AgentSessionFactory, IAgentSession, PiAgentEvent, SystemTool } fro
 import { MockAgentSession } from "./mock-agent.js";
 import { resolveGatewayModel, resolveSessionModel, type PiProviderSdk } from "./pi-provider.js";
 import { makeTraceReminderExt } from "./extensions/trace-reminder.js";
+import { makeAgentStatusExt } from "./extensions/agent-status.js";
 
 export function isMockMode(env: Record<string, string | undefined> = process.env): boolean {
   return env.BP_MOCK === "1" || env.BP_MOCK === "true";
@@ -76,6 +77,13 @@ export const realAgentFactory: AgentSessionFactory = async (params) => {
     name: params.agentName,
     onUnreplied: params.onUnreplied ?? (() => {}),
   });
+  // #97: inject a fresh team-status block at the top of every turn, but only for
+  // the agent the host supplied a renderer for (the principal). The `context`
+  // hook recomputes per turn and the rewrite is ephemeral (never persisted).
+  const extensionFactories: unknown[] = [traceReminder];
+  if (params.renderAgentStatus) {
+    extensionFactories.push(makeAgentStatusExt({ renderStatus: params.renderAgentStatus }));
+  }
   const resourceLoader = new DefaultResourceLoader({
     cwd: params.cwd,
     agentDir,
@@ -83,7 +91,7 @@ export const realAgentFactory: AgentSessionFactory = async (params) => {
     noContextFiles: true,
     additionalSkillPaths: params.skillPaths,
     appendSystemPrompt: params.systemPrompt ? [params.systemPrompt] : [],
-    extensionFactories: [traceReminder],
+    extensionFactories,
   });
   await resourceLoader.reload();
 

--- a/packages/runtime/src/extensions/agent-status.ts
+++ b/packages/runtime/src/extensions/agent-status.ts
@@ -1,0 +1,152 @@
+/**
+ * agent-status — a Pi-native extension that injects a fresh team-status block
+ * at the top of EVERY turn for the agent it is registered on (#97).
+ *
+ * Why an extension / the `context` hook (not the system prompt):
+ *  - The per-role persona is injected via `appendSystemPrompt`, which Pi
+ *    evaluates ONCE at session creation. A team-status snapshot put there would
+ *    be frozen at "session start" and go stale immediately.
+ *  - Pi's `context` hook fires before EACH LLM call (every turn within a run)
+ *    and lets an extension non-destructively rewrite the `messages` array that
+ *    is sent to the model. That rewrite is per-turn EPHEMERAL — it is applied to
+ *    a local copy and is NOT persisted to the session history (events.jsonl).
+ *    So a status block injected here is recomputed and current on every turn,
+ *    and never accumulates stale snapshots on disk.
+ *
+ * Mechanism (Pi SDK, verified against the docs corpus):
+ *  - Registered per-AgentSession via DefaultResourceLoader.extensionFactories,
+ *    same as trace-reminder. Closure state is naturally per-agent.
+ *  - `context` handler receives `{ messages }` (a safe-to-mutate copy) and may
+ *    return `{ messages }` to replace what the model sees this turn.
+ *  - Because the host appends a NEW block each turn, we first STRIP any block we
+ *    injected on a previous turn (identified by the `<agent_status>` opener) so
+ *    the model only ever sees the latest snapshot, not a pile of old ones.
+ *
+ * Only the real factory loads this — the mock has no Pi event loop, so the
+ * behavioural injection is verified in real mode. The pure block renderer
+ * (`renderAgentStatusBlock`) and the strip/inject logic are unit-tested here via
+ * a fake `pi`.
+ */
+
+/** One agent's live state, as seen by the status block. */
+export interface AgentStatusLine {
+  name: string;
+  /** Authoritative status: idle | running | error | stopped. */
+  status: string;
+  /** Inbound messages still queued unread in this agent's inbox. */
+  unread: number;
+}
+
+/** Opening tag — also the marker used to recognise a block we injected before. */
+const TAG_OPEN = "<agent_status>";
+const TAG_CLOSE = "</agent_status>";
+
+/**
+ * Build the team-status block as a natural-language list (#97, option B). The
+ * wording is self-explanatory so the model needs no schema knowledge: each line
+ * names an agent, its status, and how many messages are still waiting unread in
+ * its inbox. Returns "" when there is nothing to report (caller skips injection).
+ *
+ * `lines` should already be filtered by the caller (trace agent excluded,
+ * stopped agents excluded). Order is preserved.
+ */
+export function renderAgentStatusBlock(lines: readonly AgentStatusLine[]): string {
+  if (lines.length === 0) return "";
+  const body = lines
+    .map((l) => {
+      const n = l.unread;
+      const msg = `${n} unread message${n === 1 ? "" : "s"}`;
+      return `- ${l.name}: ${l.status}, ${msg}`;
+    })
+    .join("\n");
+  return (
+    `${TAG_OPEN}\n` +
+    `Current agents (status, and how many messages are still waiting unread in each inbox):\n` +
+    `${body}\n` +
+    `${TAG_CLOSE}`
+  );
+}
+
+/** Minimal structural surface of an agent the collector reads. */
+export interface StatusAgentLike {
+  name: string;
+  role: string;
+  status: string;
+}
+
+/**
+ * Collect the status lines for a team snapshot from the live agents (#97).
+ * Includes every agent — INCLUDING the principal, so it sees its own backlog —
+ * except the trace agent (an internal recorder) and any stopped agent
+ * (destroyed; irrelevant to coordination). `unreadOf` returns the number of
+ * messages still queued unread in that agent's inbox. Order follows iteration.
+ */
+export function collectAgentStatusLines(
+  agents: Iterable<StatusAgentLike>,
+  unreadOf: (name: string) => number,
+): AgentStatusLine[] {
+  const lines: AgentStatusLine[] = [];
+  for (const a of agents) {
+    if (a.role === "trace") continue;
+    if (a.status === "stopped") continue;
+    lines.push({ name: a.name, status: a.status, unread: unreadOf(a.name) });
+  }
+  return lines;
+}
+
+/** Minimal structural surface of Pi's ExtensionAPI we depend on. */
+interface PiContextMessage {
+  role: string;
+  content: Array<{ type: string; text?: string }>;
+  timestamp?: number;
+}
+interface PiExtensionApi {
+  on(
+    event: "context",
+    handler: (e: {
+      messages: PiContextMessage[];
+    }) => { messages: PiContextMessage[] } | void,
+  ): void;
+}
+
+export interface AgentStatusDeps {
+  /**
+   * Compute the current status block. Called once per turn. Returns "" when
+   * there is nothing to inject (the handler then only strips any stale block).
+   */
+  renderStatus: () => string;
+}
+
+/** True for a `user` message whose text is a status block we injected earlier. */
+function isStatusMessage(m: PiContextMessage): boolean {
+  return (
+    m.role === "user" &&
+    m.content.some((c) => c.type === "text" && (c.text ?? "").startsWith(TAG_OPEN))
+  );
+}
+
+/**
+ * Build the extension factory for one agent. The returned function is what Pi
+ * calls with the per-session `ExtensionAPI`.
+ */
+export function makeAgentStatusExt(deps: AgentStatusDeps): (pi: PiExtensionApi) => void {
+  return (pi) => {
+    pi.on("context", (e) => {
+      const block = deps.renderStatus();
+      // Strip any block we injected on a previous turn so only the latest
+      // snapshot survives (the context copy is ephemeral — this never touches
+      // persisted history).
+      const stripped = e.messages.filter((m) => !isStatusMessage(m));
+      const removedSome = stripped.length !== e.messages.length;
+
+      if (!block) {
+        // Nothing to report this turn. Only return a rewrite if we actually
+        // removed a stale block; otherwise leave the messages untouched.
+        return removedSome ? { messages: stripped } : undefined;
+      }
+
+      stripped.push({ role: "user", content: [{ type: "text", text: block }] });
+      return { messages: stripped };
+    });
+  };
+}

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -29,6 +29,7 @@ import { systemToolsForRole, builtinToolNamesForRole, type ToolDeps } from "./to
 import { ev } from "./events.js";
 import { selectFactory, isMockMode } from "./agent-factory.js";
 import { personaFor, withLanguageDirective } from "./personas.js";
+import { renderAgentStatusBlock, collectAgentStatusLines } from "./extensions/agent-status.js";
 import { McpBridge, loadMcpServersConfig } from "./mcp-bridge.js";
 import { resolveSessionProvider, type SessionProviderRef } from "./provider-config.js";
 import { MemWatchdog, parseMemLimitMb } from "./mem-watchdog.js";
@@ -906,6 +907,10 @@ export class SessionManager {
       // was reminded once and still didn't report back, so the principal never
       // dead-waits on a silent expert.
       onUnreplied: (agentName) => this.writeFallbackToPrincipal(entry, agentName),
+      // #97: only the principal gets the live team-status block injected each
+      // turn (it is the coordinator). Other roles run without it.
+      renderAgentStatus:
+        name === "principal" ? () => this.renderAgentStatus(entry) : undefined,
     });
 
     const agent = new MasAgent({
@@ -949,6 +954,23 @@ export class SessionManager {
       .catch(() => {
         /* best-effort */
       });
+  }
+
+  /**
+   * #97: snapshot the live team status for injection into the principal's turn
+   * (via the agent-status extension's Pi `context` hook). Lists every agent —
+   * INCLUDING the principal itself, so it sees its own inbox backlog — with its
+   * authoritative status and the number of messages still queued unread in its
+   * inbox (`mailbox.count`). Excludes the trace agent (an internal recorder) and
+   * any stopped agent (destroyed; irrelevant to current coordination). Returns
+   * "" when nothing is worth reporting so the extension injects nothing.
+   */
+  private renderAgentStatus(entry: SessionEntry): string {
+    const lines = collectAgentStatusLines(
+      entry.agents.values(),
+      (name) => entry.mailbox.count(name),
+    );
+    return renderAgentStatusBlock(lines);
   }
 
   async destroyAgent(sessionId: string, name: string): Promise<void> {

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -125,6 +125,14 @@ export type AgentSessionFactory = (params: {
    */
   onUnreplied?: (agentName: string) => void;
   /**
+   * #97: compute a fresh "team status" block to inject at the top of every turn
+   * (via the agent-status extension's Pi `context` hook). Called once per turn;
+   * returns "" when there is nothing to inject. Supplied only for the principal
+   * (the coordinator that benefits from the whole-team view); omitted for other
+   * roles and by the mock factory.
+   */
+  renderAgentStatus?: () => string;
+  /**
    * App-controlled skill directories loaded for this agent (template dir shared
    * by all sessions + this session's own dir). Replaces the host-global skill
    * discovery — see agent-factory `noSkills: true`.


### PR DESCRIPTION
## What

Give the principal a **live view of the team** at the top of every turn: each agent's status and how many messages are still waiting unread in its inbox.

```
<agent_status>
Current agents (status, and how many messages are still waiting unread in each inbox):
- principal: running, 1 unread message
- librarian: idle, 0 unread messages
- engineer: error, 2 unread messages
</agent_status>
```

## Why a Pi `context` hook, not the system prompt

The per-role persona is injected via `appendSystemPrompt`, which Pi evaluates **once** at session creation — a status snapshot there would freeze at "session start". Pi's `context` hook fires **before every LLM call (every turn)** and lets an extension non-destructively rewrite the messages sent to the model. That rewrite is **per-turn ephemeral** and is **never persisted to `events.jsonl`**, so the block is recomputed and current on every turn and never accumulates stale snapshots on disk. (Confirmed via the Pi docs corpus.)

## How

- **`extensions/agent-status.ts`** — three pure, unit-tested pieces:
  - `renderAgentStatusBlock` — natural-language block (self-explanatory; no schema for the model to learn).
  - `collectAgentStatusLines` — includes the principal itself (sees its own backlog), excludes the trace agent and any stopped agent; unread count from the mailbox.
  - `makeAgentStatusExt` — the `context` hook: strips the block injected on a previous turn (only the latest survives), then appends the fresh one; injects nothing when there's nothing to report.
- **`agent-factory.ts`** — register the extension only when the host supplies a renderer (i.e. for the principal).
- **`session-manager.ts`** — `renderAgentStatus(entry)` feeds live agents + mailbox counts; wired into `ensureAgent` for the principal only.
- **`types.ts`** — new optional `renderAgentStatus` factory param.

## Injection timing / frequency

Once per **turn** (every LLM call), not once per user message. A multi-turn coordination run injects on each turn, always with the current snapshot; the previous turn's block is stripped first, so history holds at most one block at a time. Maximum-freshness strategy by design.

## Scope

Part of #97. **Does not close it** — the error-path relay (silence vs. error split) and delegator-targeted routing remain deferred to follow-ups.

## Test

`npm run typecheck` ✅ · `npm test` ✅ (492 passed, +12). Like `trace-reminder`, the `context` hook only runs under the real factory (the mock has no Pi loop); the pure logic (renderer, collector filters, strip/inject behaviour) is covered here via a fake `pi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)