### PR TITLE
fix(web): sidebar Live Demo re-click returns to session selection (closes #111)

### DIFF
--- a/packages/web/src/__tests__/demoReset.test.ts
+++ b/packages/web/src/__tests__/demoReset.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { shouldResetDemo } from "../components/demo/demoReset";
+
+describe("shouldResetDemo (#111 sidebar re-click returns to landing)", () => {
+  it("does not reset on the initial mount (same value)", () => {
+    // prev === next on first render — packing/importing a bundle must survive.
+    expect(shouldResetDemo(0, 0)).toBe(false);
+    expect(shouldResetDemo(3, 3)).toBe(false);
+  });
+
+  it("resets when the signal advances (sidebar clicked again)", () => {
+    expect(shouldResetDemo(0, 1)).toBe(true);
+    expect(shouldResetDemo(1, 2)).toBe(true);
+  });
+
+  it("treats an undefined signal (standalone mount) as no reset", () => {
+    // DemoView mounted without the prop: prev and next are both undefined.
+    expect(shouldResetDemo(undefined, undefined)).toBe(false);
+  });
+
+  it("resets when transitioning from undefined to a number", () => {
+    expect(shouldResetDemo(undefined, 1)).toBe(true);
+  });
+});

--- a/packages/web/src/components/demo/DemoView.tsx
+++ b/packages/web/src/components/demo/DemoView.tsx
@@ -18,6 +18,7 @@ import { TraceGraphView } from "../session/TraceGraphView";
 import { getNodeKindLabelKey } from "../session/traceLayout";
 import { buildDemoBundle, parseDemoBundle } from "./demoBundle";
 import { getCachedBundle, setCachedBundle } from "./demoCache";
+import { shouldResetDemo } from "./demoReset";
 import { DemoFileTree } from "./DemoFileTree";
 import { TraceNodeModal } from "./TraceNodeModal";
 
@@ -99,7 +100,19 @@ function pickDefaultFile(files: DemoFile[]): string | null {
 }
 
 
-export function DemoView() {
+export interface DemoViewProps {
+  /**
+   * Monotonic counter bumped by the shell each time the sidebar "Live Demo"
+   * entry is clicked. A *change* (not the initial value) returns the player to
+   * the session-selection / import landing — the same effect as the header
+   * "Reselect" button — so re-clicking the nav item while a demo is already
+   * open isn't a dead no-op (issue #111). Optional so standalone/test mounts
+   * work without it.
+   */
+  resetSignal?: number;
+}
+
+export function DemoView({ resetSignal }: DemoViewProps = {}) {
   const t = useT();
   const { sessions, currentSession, messages } = useSessions();
   const { currentSandbox } = useSandbox();
@@ -202,6 +215,21 @@ export function DemoView() {
     const nodeMs = nodes.map((_, j) => (nodes.length <= 1 ? 0 : (j / (nodes.length - 1)) * t1));
     return { t0: 0, t1, sorted: [], nodeMs, ordered };
   }, [bundle, nodes]);
+
+  // Return to the landing when the shell signals a sidebar "Live Demo" re-click
+  // (issue #111). Fires only on a *change* of resetSignal, never on the initial
+  // mount, so importing/packing a bundle isn't immediately undone. Clearing the
+  // bundle is enough — the "reset transport on new bundle" effect below re-inits
+  // cursor/zoom/etc. the next time a bundle is selected. The module-level
+  // demoCache keeps re-opening the same session instant.
+  const prevResetSignal = useRef(resetSignal);
+  useEffect(() => {
+    if (shouldResetDemo(prevResetSignal.current, resetSignal)) {
+      prevResetSignal.current = resetSignal;
+      setBundle(null);
+      setError(null);
+    }
+  }, [resetSignal]);
 
   // Reset transport on new bundle (start fully revealed, paused, default file).
   useEffect(() => {

--- a/packages/web/src/components/demo/demoReset.ts
+++ b/packages/web/src/components/demo/demoReset.ts
@@ -1,0 +1,16 @@
+/**
+ * Pure reset-signal logic for the Live Demo player (issue #111).
+ *
+ * The shell bumps a monotonic `resetSignal` every time the sidebar "Live Demo"
+ * entry is clicked. DemoView must return to its session-selection landing on a
+ * *change* of that signal — but NOT on the initial mount, or importing/packing
+ * a freshly-selected bundle would be undone immediately. Extracted as a pure
+ * function so this guard is unit-testable without rendering the component (the
+ * monorepo has no jsdom/@testing-library).
+ */
+export function shouldResetDemo(
+  previous: number | undefined,
+  next: number | undefined,
+): boolean {
+  return next !== previous;
+}

--- a/packages/web/src/components/shell/DesktopShell.tsx
+++ b/packages/web/src/components/shell/DesktopShell.tsx
@@ -28,6 +28,9 @@ export function DesktopShell() {
   const t = useT();
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
   const [activePage, setActivePage] = useState<"workspace" | "demo">("workspace");
+  // Bumped on every sidebar "Live Demo" click so DemoView returns to its
+  // session-selection landing even when the demo page is already open (#111).
+  const [demoResetSignal, setDemoResetSignal] = useState(0);
   const [sidebarWidth, setSidebarWidth] = useState(268);
   const [isSidebarResizing, setIsSidebarResizing] = useState(false);
   const [isSearchOpen, setIsSearchOpen] = useState(false);
@@ -110,7 +113,10 @@ export function DesktopShell() {
       <Sidebar
         isCollapsed={isSidebarCollapsed}
         activePage={activePage}
-        onOpenDemo={() => setActivePage("demo")}
+        onOpenDemo={() => {
+          setActivePage("demo");
+          setDemoResetSignal((n) => n + 1);
+        }}
         onGoWorkspace={() => setActivePage("workspace")}
         onOpenSettings={() => setIsSettingsOpen(true)}
         onOpenSearch={() => setIsSearchOpen(true)}
@@ -126,7 +132,7 @@ export function DesktopShell() {
       />
 
       {activePage === "demo" ? (
-        <DemoView />
+        <DemoView resetSignal={demoResetSignal} />
       ) : (
       <main
         className={`workspace ${isFilesOpen ? "workspace--files-open" : ""} ${


### PR DESCRIPTION
## Problem

Clicking the sidebar **Live Demo** entry while a demo was already open was a dead no-op. `onOpenDemo` only set `activePage` to `"demo"` (already the case), and the selected `bundle` lives in `DemoView`'s local state — reset only by the header **Reselect** button. So the nav item gave no feedback and no way back to the session-selection / import landing.

## Fix (`packages/web`, frontend only)

- `DesktopShell` bumps a monotonic `demoResetSignal` on every sidebar Live Demo click and passes it to `DemoView`.
- `DemoView` returns to the landing (clears `bundle` + `error`, equivalent to Reselect) when the signal **changes** — never on the initial mount, so packing/importing a freshly-selected bundle isn't immediately undone.
- The change-vs-mount guard is extracted as the pure `shouldResetDemo(prev, next)` so it's unit-testable without rendering (the monorepo has no jsdom/@testing-library; existing tests follow the same pure-helper pattern).
- The module-level `demoCache` keeps re-opening the same session instant after a reset.

## Testing

- New `demoReset.test.ts` — 4 cases (no reset on initial/equal value or undefined↔undefined; resets when the signal advances or goes undefined→number).
- Full web suite: **105 passed**.
- `tsc -b` clean; `vite build` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)