### PR TITLE
fix(runtime): self-retry then escalate a failed expert delegation (#97)

### DIFF
--- a/packages/runtime/src/__tests__/agent-error.test.ts
+++ b/packages/runtime/src/__tests__/agent-error.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { normalizeAgentError } from "../agent-error.js";
+import { normalizeAgentError, classifyAgentError } from "../agent-error.js";
 
 describe("normalizeAgentError (#45)", () => {
   const noKeyRaw = [
@@ -85,5 +85,35 @@ describe("normalizeAgentError — provider HTTP errors (#97)", () => {
     const out = normalizeAgentError(raw);
     expect(out.message).not.toMatch(/[{}]/);
     expect(out.message).toContain("400");
+  });
+});
+
+describe("classifyAgentError (#97)", () => {
+  it("classifies auth/401/403 as fatal", () => {
+    expect(classifyAgentError('401 {"error":{"message":"invalid api key"}}')).toBe("fatal");
+    expect(classifyAgentError("403 forbidden")).toBe("fatal");
+    expect(classifyAgentError("No API key found for the selected model.")).toBe("fatal");
+    expect(classifyAgentError("authentication failed")).toBe("fatal");
+    expect(classifyAgentError("permission denied")).toBe("fatal");
+  });
+
+  it("classifies rate-limit / 5xx / timeout / network as retryable", () => {
+    expect(classifyAgentError("429 too many requests")).toBe("retryable");
+    expect(classifyAgentError('503 {"error":"service unavailable"}')).toBe("retryable");
+    expect(classifyAgentError("request timed out")).toBe("retryable");
+    expect(classifyAgentError("model is overloaded")).toBe("retryable");
+    expect(classifyAgentError("ECONNRESET")).toBe("retryable");
+    expect(classifyAgentError("fetch failed")).toBe("retryable");
+  });
+
+  it("treats fatal patterns as fatal even when a retryable word co-occurs", () => {
+    // A 401 blob that also mentions a rate limit must stay fatal (no point
+    // retrying a bad key).
+    expect(classifyAgentError("401 unauthorized — also rate limited")).toBe("fatal");
+  });
+
+  it("defaults unknown and empty errors to retryable", () => {
+    expect(classifyAgentError("something weird happened")).toBe("retryable");
+    expect(classifyAgentError("")).toBe("retryable");
   });
 });

--- a/packages/runtime/src/__tests__/delivery-error.test.ts
+++ b/packages/runtime/src/__tests__/delivery-error.test.ts
@@ -1,0 +1,248 @@
+/**
+ * #97 error path — a delegated expert run that ends in error must NOT leave the
+ * principal dead-waiting (and must not be mislabeled as "silence").
+ *
+ * Policy under test (runDeliveryLoop + handleDeliveryError):
+ *   - a `retryable` error (rate limit / 5xx / network) self-retries the SAME
+ *     expert up to MAX_DELIVERY_RETRIES (3), emitting a `warning` each time and
+ *     re-waking it via a neutral note in its own inbox;
+ *   - the 3rd consecutive failure escalates: a neutral, error-flavored `system`
+ *     note is written to the principal's mailbox (waking it) and an `error`
+ *     system_message is surfaced;
+ *   - a `fatal` error (auth/401) escalates on the FIRST failure, no retry;
+ *   - a run that later succeeds resets the streak.
+ *
+ * These drive the path through a scripted factory whose expert can emit an
+ * errored message_end (the shape Pi uses for provider failures — it does NOT
+ * throw, so MasAgent stays error-isolated).
+ */
+import { describe, it, expect } from "vitest";
+import { SessionManager } from "../session-manager.js";
+import type { AgentSessionFactory, IAgentSession, PiAgentEvent, SystemTool } from "../types.js";
+
+interface SystemMsg {
+  level: string;
+  text: string;
+  agent?: string;
+}
+
+/** Per-agent script: decide each prompt's outcome (ok / error with a raw blob). */
+interface ExpertPlan {
+  /** Called with the prompt count (1-based); return an error blob to fail, or null to succeed. */
+  outcome: (promptCount: number, text: string) => string | null;
+  /** When succeeding, optionally report back to the principal. */
+  reply?: (text: string) => { to: string; content: string } | undefined;
+}
+
+function factoryWith(
+  expertPlans: Record<string, ExpertPlan>,
+  observe: { prompts: Array<{ agent: string; text: string }> },
+): AgentSessionFactory {
+  const counts = new Map<string, number>();
+  return async ({ sessionId, agentName, systemTools }) => {
+    const toolMap = new Map<string, SystemTool>(systemTools.map((t) => [t.name, t]));
+    const listeners = new Set<(e: PiAgentEvent) => void>();
+    const emit = (e: PiAgentEvent) => {
+      for (const l of listeners) {
+        try {
+          l(e);
+        } catch {
+          /* isolate */
+        }
+      }
+    };
+    const session: IAgentSession = {
+      sessionId,
+      subscribe(listener) {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+      async prompt(text: string) {
+        observe.prompts.push({ agent: agentName, text });
+        emit({ type: "agent_start" });
+        emit({ type: "turn_start" });
+        emit({ type: "message_start", message: { role: "assistant", content: [] } });
+
+        const plan = expertPlans[agentName];
+        const n = (counts.get(agentName) ?? 0) + 1;
+        counts.set(agentName, n);
+        const errBlob = plan?.outcome(n, text) ?? null;
+
+        if (errBlob) {
+          // Pi encodes a provider failure as a finalized assistant message with
+          // stopReason "error" (it does not throw). MasAgent routes this to
+          // error status + lastErrorKind.
+          emit({
+            type: "message_end",
+            message: { role: "assistant", content: [], stopReason: "error", errorMessage: errBlob },
+          });
+          emit({ type: "agent_end", messages: [{ role: "assistant", stopReason: "error" }] });
+          return;
+        }
+
+        emit({
+          type: "message_end",
+          message: { role: "assistant", content: [{ type: "text", text: `ok ${agentName}` }] },
+        });
+        const r = plan?.reply?.(text);
+        if (r) {
+          const tool = toolMap.get("send_message");
+          const toolCallId = "tc_send";
+          emit({ type: "tool_execution_start", toolCallId, toolName: "send_message", args: r });
+          let isError = false;
+          if (tool) {
+            const res = await tool.execute({ to: r.to, content: r.content });
+            isError = res.isError ?? false;
+          }
+          emit({ type: "tool_execution_end", toolCallId, toolName: "send_message", result: "", isError });
+        }
+        emit({ type: "turn_end" });
+        emit({ type: "agent_end", messages: [{ role: "assistant", stopReason: "stop" }] });
+      },
+      async abort() {},
+      dispose() {},
+    };
+    return session;
+  };
+}
+
+async function waitFor(pred: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timed out");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+/**
+ * Enqueue a task into an expert's inbox (as the principal would via send_message)
+ * and wake the delivery loop. Reaching into the private mailbox/wakeAgent keeps
+ * the test focused on the loop's error policy without scripting a full principal
+ * delegation turn.
+ */
+async function delegateToExpert(m: SessionManager, sid: string, expert: string): Promise<void> {
+  const entry = (m as unknown as { sessions: Map<string, { mailbox: { write: (msg: unknown) => Promise<unknown> } }> }).sessions.get(sid)!;
+  await entry.mailbox.write({
+    fromAgent: "principal",
+    toAgent: expert,
+    msgType: "task_delegate",
+    content: "survey X",
+  });
+  (m as unknown as { wakeAgent: (sid: string, name: string) => void }).wakeAgent(sid, expert);
+}
+
+describe("delivery error path (#97)", () => {
+  it("escalates to the principal after 3 consecutive retryable failures", async () => {
+    const observe = { prompts: [] as Array<{ agent: string; text: string }> };
+    // librarian fails every time with a retryable (429) error.
+    const factory = factoryWith(
+      { librarian: { outcome: () => "429 too many requests" } },
+      observe,
+    );
+    const m = new SessionManager({ persist: false, agentFactory: factory });
+    const s = await m.createSession();
+
+    const sys: SystemMsg[] = [];
+    m.subscribe(s.id, (e) => {
+      if (e.type === "system_message") {
+        const v = e as { level?: string; message?: string; agent?: string };
+        sys.push({ level: v.level ?? "", text: v.message ?? "", agent: v.agent });
+      }
+    });
+
+    // Kick the librarian via the mailbox (agent→agent path) so the delivery loop
+    // owns the run.
+    await delegateToExpert(m, s.id, "librarian");
+
+    // It should retry twice (warning 1/3, 2/3) then escalate (error) on the 3rd.
+    // (MasAgent also emits its own raw-provider-error bubble per attempt — the
+    // #97-A behavior; we match OUR lifecycle messages specifically.)
+    await waitFor(() => sys.some((x) => x.level === "error" && x.text.includes("已通知主管")));
+
+    const warnings = sys.filter((x) => x.level === "warning" && x.text.includes("正在自动重试"));
+    expect(warnings.length).toBe(2); // 1/3 and 2/3
+    expect(warnings[0]!.text).toContain("(1/3)");
+    expect(warnings[1]!.text).toContain("(2/3)");
+
+    const error = sys.find((x) => x.level === "error" && x.text.includes("已通知主管"));
+    expect(error!.text).toContain("连续");
+    expect(error!.text).toContain("librarian");
+
+    // librarian was prompted 3 times (initial + 2 self-retries).
+    const libPrompts = observe.prompts.filter((p) => p.agent === "librarian");
+    expect(libPrompts.length).toBe(3);
+    // The 2nd and 3rd prompts carry the neutral self-retry note.
+    expect(libPrompts[1]!.text).toContain("请重试");
+
+    // The principal received an error-flavored note in its inbox (escalation).
+    await waitFor(() => observe.prompts.some((p) => p.agent === "principal" && p.text.includes("发生错误")));
+    const escalation = observe.prompts.find(
+      (p) => p.agent === "principal" && p.text.includes("发生错误"),
+    );
+    expect(escalation!.text).toContain("librarian");
+  });
+
+  it("escalates a fatal (auth) error on the first failure, no retry", async () => {
+    const observe = { prompts: [] as Array<{ agent: string; text: string }> };
+    const factory = factoryWith(
+      { librarian: { outcome: () => '401 {"error":{"message":"invalid api key"}}' } },
+      observe,
+    );
+    const m = new SessionManager({ persist: false, agentFactory: factory });
+    const s = await m.createSession();
+
+    const sys: SystemMsg[] = [];
+    m.subscribe(s.id, (e) => {
+      if (e.type === "system_message") {
+        const v = e as { level?: string; message?: string };
+        sys.push({ level: v.level ?? "", text: v.message ?? "" });
+      }
+    });
+
+    await delegateToExpert(m, s.id, "librarian");
+
+    await waitFor(() => sys.some((x) => x.level === "error" && x.text.includes("已通知主管")));
+
+    // No retry warnings — fatal escalates immediately.
+    expect(sys.filter((x) => x.level === "warning" && x.text.includes("正在自动重试")).length).toBe(0);
+    const error = sys.find((x) => x.level === "error" && x.text.includes("已通知主管"));
+    expect(error!.text).toContain("无法自动恢复");
+
+    // librarian prompted exactly once (no self-retry).
+    expect(observe.prompts.filter((p) => p.agent === "librarian").length).toBe(1);
+    // Principal got the escalation note.
+    await waitFor(() => observe.prompts.some((p) => p.agent === "principal" && p.text.includes("发生错误")));
+  });
+
+  it("recovers and does NOT escalate when a retry succeeds", async () => {
+    const observe = { prompts: [] as Array<{ agent: string; text: string }> };
+    // Fail once (retryable), then succeed on the self-retry.
+    const factory = factoryWith(
+      { librarian: { outcome: (n) => (n === 1 ? "503 service unavailable" : null) } },
+      observe,
+    );
+    const m = new SessionManager({ persist: false, agentFactory: factory });
+    const s = await m.createSession();
+
+    const sys: SystemMsg[] = [];
+    m.subscribe(s.id, (e) => {
+      if (e.type === "system_message") {
+        const v = e as { level?: string; message?: string };
+        sys.push({ level: v.level ?? "", text: v.message ?? "" });
+      }
+    });
+
+    await delegateToExpert(m, s.id, "librarian");
+
+    // One retry warning, then it succeeds — no error escalation ever.
+    await waitFor(() => observe.prompts.filter((p) => p.agent === "librarian").length >= 2);
+    await waitFor(() => m.getSessionState(s.id)?.runState.active === false);
+
+    expect(sys.filter((x) => x.level === "warning" && x.text.includes("正在自动重试")).length).toBe(1);
+    // No escalation lifecycle error (MasAgent's own per-attempt raw bubble may
+    // exist, but OUR "已通知主管" escalation must not).
+    expect(sys.some((x) => x.level === "error" && x.text.includes("已通知主管"))).toBe(false);
+    // No escalation note to the principal.
+    expect(observe.prompts.some((p) => p.agent === "principal" && p.text.includes("发生错误"))).toBe(false);
+  });
+});

--- a/packages/runtime/src/agent-error.ts
+++ b/packages/runtime/src/agent-error.ts
@@ -29,6 +29,42 @@ export interface NormalizedAgentError {
   details?: string;
 }
 
+/**
+ * #97 error path — coarse recoverability class for an agent/provider error.
+ *  - `retryable`: transient (rate limit, 5xx, timeout, network reset). Re-running
+ *    the same prompt may succeed, so the delivery loop self-retries the expert.
+ *  - `fatal`: re-running is pointless (auth/401/403, missing key/provider,
+ *    permission denied). Escalate to the principal immediately, no retry.
+ */
+export type AgentErrorKind = "retryable" | "fatal";
+
+/**
+ * Auth / configuration failures where a retry cannot help: a wrong or missing
+ * key, a forbidden/unauthorized response, or no provider configured. Matched
+ * BEFORE the retryable set so a "401 ... rate limit ..." blob is fatal.
+ */
+const FATAL_RE =
+  /\b(401|403)\b|invalid api key|no api key|api key (?:found|for)|no provider|unauthor|forbidden|authentication|permission denied/i;
+
+/**
+ * Transient failures worth a retry: explicit 408/429/5xx status codes, timeouts,
+ * overload, and the common Node socket/network error codes.
+ */
+const RETRYABLE_RE =
+  /\b(408|429|5\d{2})\b|timeout|timed out|temporar|overloaded|rate.?limit|econnreset|etimedout|enotfound|econnrefused|network|fetch failed|socket hang up|connection/i;
+
+/**
+ * Classify a raw agent/SDK error string for the delivery-loop error path (#97).
+ * Defaults to `retryable` for the unknown case so a transient failure we didn't
+ * pattern-match still gets the benefit of a retry before escalation.
+ */
+export function classifyAgentError(raw: string): AgentErrorKind {
+  if (!raw) return "retryable";
+  if (FATAL_RE.test(raw)) return "fatal";
+  if (RETRYABLE_RE.test(raw)) return "retryable";
+  return "retryable";
+}
+
 /** Product-level recovery message for a missing provider/key. */
 const NO_PROVIDER_MESSAGE =
   "未配置任何 provider。请打开 设置 → Providers 添加一个 provider。";

--- a/packages/runtime/src/extensions/trace-reminder.ts
+++ b/packages/runtime/src/extensions/trace-reminder.ts
@@ -47,8 +47,33 @@ interface PiExtensionApi {
       content: Array<{ type: string; text?: string }>;
     }) => { content: Array<{ type: "text"; text: string }> } | void,
   ): void;
-  on(event: "agent_end", handler: () => void): void;
+  on(event: "agent_end", handler: (e: AgentEndLike) => void): void;
   sendUserMessage(content: string, options?: { deliverAs?: "steer" | "followUp" }): void;
+}
+
+/**
+ * Structural slice of Pi's `AgentEndEvent` we read: the run's message list, used
+ * only to detect whether the run ENDED IN AN ERROR (last assistant message's
+ * `stopReason`). A provider failure (401, retry exhausted, mid-stream error) is
+ * encoded by Pi as a final AssistantMessage with `stopReason: "error" |
+ * "aborted"` — it does NOT throw. When that's the case the host owns recovery
+ * (#97 self-retry / escalation), so this extension must NOT also nudge/followUp.
+ */
+interface AgentEndLike {
+  messages?: Array<{ role?: string; stopReason?: string }>;
+}
+
+/** True when the run's last assistant message ended in an error/abort. */
+function endedInError(e: AgentEndLike): boolean {
+  const msgs = e.messages;
+  if (!Array.isArray(msgs)) return false;
+  for (let i = msgs.length - 1; i >= 0; i--) {
+    const m = msgs[i];
+    if (m?.role === "assistant") {
+      return m.stopReason === "error" || m.stopReason === "aborted";
+    }
+  }
+  return false;
 }
 
 export interface TraceReminderDeps {
@@ -154,8 +179,14 @@ export function makeTraceReminderExt(deps: TraceReminderDeps): (pi: PiExtensionA
       return { content: [{ type: "text", text: `${text}${suffix}` }] };
     });
 
-    pi.on("agent_end", () => {
+    pi.on("agent_end", (e) => {
       if (deps.role === "trace") return; // the recorder itself — never nudge.
+
+      // #97: if THIS run ended in an error (provider 401 / retry exhausted /
+      // mid-stream failure), bail entirely. A followUp here would just re-hit the
+      // broken provider, and onUnreplied would mislabel an error as silence. The
+      // host's delivery-loop error path owns recovery (self-retry / escalation).
+      if (endedInError(e)) return;
 
       // Two ORTHOGONAL checks (B). Both can be true for one expert (it produced
       // work worth tracing AND owes the principal a reply).

--- a/packages/runtime/src/mas-agent.ts
+++ b/packages/runtime/src/mas-agent.ts
@@ -17,7 +17,7 @@
 import type { AgUiEvent, AgentState } from "@brainpilot/protocol";
 import type { EventBus } from "./event-bus.js";
 import { ev, newMessageId, newRunId } from "./events.js";
-import { normalizeAgentError } from "./agent-error.js";
+import { normalizeAgentError, classifyAgentError, type AgentErrorKind } from "./agent-error.js";
 import type {
   AgentRole,
   IAgentSession,
@@ -51,6 +51,13 @@ export class MasAgent {
   private activeToolExecutions = new Set<string>();
   private lastError: AgentState["lastError"];
   /**
+   * #97 error path: recoverability class of the most recent error, or undefined
+   * when the last run did not error. The delivery loop reads this after a run to
+   * decide self-retry (retryable) vs immediate escalation to the principal
+   * (fatal). Reset to undefined whenever a run completes without error.
+   */
+  private _lastErrorKind: AgentErrorKind | undefined;
+  /**
    * The in-flight `prompt()` promise (its try/catch/finally inclusive), or
    * undefined when idle. `abort()` awaits this so a caller can fence the old
    * run — guaranteeing RUN_FINISHED is emitted and `status` has settled —
@@ -69,6 +76,15 @@ export class MasAgent {
 
   get status(): AgentStatus {
     return this._status;
+  }
+
+  /**
+   * #97: the recoverability class of the last error (`retryable`/`fatal`), or
+   * undefined if the last run did not error. Read by the delivery loop to choose
+   * self-retry vs escalation. The headline of that error is in `lastError`.
+   */
+  get lastErrorKind(): AgentErrorKind | undefined {
+    return this._lastErrorKind;
   }
 
   /** §10 authoritative state snapshot. */
@@ -115,14 +131,21 @@ export class MasAgent {
       this.bus.emit(
         ev.runFinished({ sessionId: this.sessionId, agentName: this.name, runId: this.currentRunId }),
       );
-      if (this._status !== "error") this.setStatus("idle");
+      // A run that reached here without an in-stream error (message_end /
+      // auto_retry_end / delta error all flip status to "error") completed
+      // cleanly — clear the error class so the delivery loop's retry counter
+      // resets on the next success.
+      if (this._status !== "error") {
+        this._lastErrorKind = undefined;
+        this.setStatus("idle");
+      }
     } catch (err) {
       const raw = (err as Error)?.message ?? String(err);
       // issue #45: never surface raw SDK guidance (/login, node_modules paths)
       // — normalize to a product message / redact local paths before it hits
       // the event stream, events.jsonl, and lastError.
       const { message, details } = normalizeAgentError(raw);
-      this.recordError(message, details);
+      this.recordError(message, details, raw);
       this.bus.emit(
         ev.runError({ sessionId: this.sessionId, agentName: this.name, runId: this.currentRunId }, message),
       );
@@ -166,9 +189,13 @@ export class MasAgent {
     this.setStatus("stopped");
   }
 
-  private recordError(message: string, details?: string): void {
+  private recordError(message: string, details?: string, raw?: string): void {
     const prev = this.lastError?.consecutiveCount ?? 0;
     this.lastError = { message, timestamp: new Date().toISOString(), consecutiveCount: prev + 1 };
+    // #97: classify from the rawest signal we have (raw provider blob when the
+    // caller has it, else the normalized headline) so the delivery loop can pick
+    // self-retry vs escalation.
+    this._lastErrorKind = classifyAgentError(raw ?? message);
     this.bus.emit(
       ev.systemMessage(this.sessionId, "error", `⚠️ Agent ${this.name} 遇到错误: ${message}`, {
         agent: this.name,
@@ -220,7 +247,7 @@ export class MasAgent {
         if (msg?.stopReason === "error") {
           const raw = msg.errorMessage || "provider request failed";
           const { message, details } = normalizeAgentError(raw);
-          this.recordError(message, details);
+          this.recordError(message, details, raw);
           this.setStatus("error");
         }
         if (this.currentMessageId) {
@@ -280,8 +307,9 @@ export class MasAgent {
       case "auto_retry_end": {
         const r = e as Extract<PiAgentEvent, { type: "auto_retry_end" }>;
         if (!r.success) {
-          const { message, details } = normalizeAgentError(r.finalError ?? "retry exhausted");
-          this.recordError(message, details);
+          const raw = r.finalError ?? "retry exhausted";
+          const { message, details } = normalizeAgentError(raw);
+          this.recordError(message, details, raw);
           this.setStatus("error");
         }
         return;
@@ -331,7 +359,7 @@ export class MasAgent {
           err.reason ??
           "provider request failed";
         const { message, details } = normalizeAgentError(raw);
-        this.recordError(message, details);
+        this.recordError(message, details, raw);
         this.setStatus("error");
         return;
       }

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -63,6 +63,12 @@ interface SessionEntry {
   agents: Map<string, MasAgent>;
   /** agent name → task description (for AgentStatus.task). */
   tasks: Map<string, string>;
+  /**
+   * #97 error path: per-agent count of CONSECUTIVE failed delivery runs. Bumped
+   * when a delegated run ends in `error`, reset to 0 on any successful (non-error)
+   * delivery run. Drives self-retry vs escalation in `runDeliveryLoop`.
+   */
+  deliveryErrors: Map<string, number>;
   runActive: boolean;
   activeRunId: string | null;
   /** Outstanding ask_user requests, keyed by request_id (§ ask_user). */
@@ -218,6 +224,13 @@ export class SessionManager {
    * workspace right before the agent runs (see drainLocalUploads).
    */
   private static readonly UPLOAD_STAGING_SID = "local";
+  /**
+   * #97: max CONSECUTIVE failed delivery runs for one expert before the failure
+   * is escalated to the principal instead of self-retried. Matches the legacy
+   * circuit-breaker threshold (3). Only `retryable` errors consume retries;
+   * a `fatal` error escalates on the first failure regardless of this cap.
+   */
+  private static readonly MAX_DELIVERY_RETRIES = 3;
   private historyPath(sid: string, agent: string): string {
     return join(this.bpDir(sid), "history", `${agent}.jsonl`);
   }
@@ -492,6 +505,7 @@ export class SessionManager {
       trace,
       agents: new Map(),
       tasks: new Map(),
+      deliveryErrors: new Map(),
       runActive: false,
       activeRunId: null,
       pendingInputs: new Map(),
@@ -1034,7 +1048,103 @@ export class SessionManager {
       // Surface the delegated run immediately (derived active flag, agent list).
       this.emitSessionState(entry);
       await agent.prompt(this.renderEnvelopes(msgs, name));
+
+      // #97 error path. A delegated run that ended in `error` is handled here
+      // (the trace-reminder extension bails on an errored run, leaving the host
+      // the sole owner of error recovery). Transient errors self-retry up to a
+      // cap; fatal errors (auth/config) and the exhausted cap escalate to the
+      // principal. A clean run resets the agent's consecutive-error count.
+      if (agent.status === "error" && agent.role === "expert") {
+        if (this.handleDeliveryError(entry, agent)) continue; // self-retry queued
+        return; // escalated — nothing more to drain for this agent
+      }
+      entry.deliveryErrors.delete(name); // clean run → reset the streak
     }
+  }
+
+  /**
+   * #97: react to a failed delegated expert run. Returns true when a self-retry
+   * was queued (the loop should continue and re-drain the agent's own inbox),
+   * false when the failure was escalated to the principal (the loop should stop).
+   *
+   * Policy:
+   *  - `retryable` (rate limit / 5xx / network) AND under the retry cap →
+   *    re-wake the SAME expert with a neutral system nudge in its own inbox, and
+   *    surface a `warning` to the user ("retrying n/N"). Re-running may succeed.
+   *  - `fatal` (auth / missing key / forbidden), OR the cap is reached →
+   *    escalate: write a NEUTRAL error note to the principal's mailbox + wake it,
+   *    surface an `error` to the user, and reset the streak so a future task to
+   *    this expert starts fresh.
+   */
+  private handleDeliveryError(entry: SessionEntry, agent: MasAgent): boolean {
+    const name = agent.name;
+    const count = (entry.deliveryErrors.get(name) ?? 0) + 1;
+    entry.deliveryErrors.set(name, count);
+    const kind = agent.lastErrorKind ?? "retryable";
+    const headline = agent.state().lastError?.message ?? "未知错误";
+
+    if (kind === "retryable" && count < SessionManager.MAX_DELIVERY_RETRIES) {
+      entry.bus.emit(
+        ev.systemMessage(
+          entry.id,
+          "warning",
+          `专家 "${name}" 执行任务时出错，正在自动重试 (${count}/${SessionManager.MAX_DELIVERY_RETRIES})…`,
+          { agent: name, recoverable: true },
+        ),
+      );
+      // Re-wake the SAME expert via its own inbox: a neutral, directive-free
+      // nudge. The expert retains its prior conversation context, so it knows
+      // what it was attempting; we only signal "the last attempt failed, try
+      // again". Returning true lets the loop re-drain this note immediately.
+      void entry.mailbox
+        .write({
+          fromAgent: "system",
+          toAgent: name,
+          msgType: "system",
+          content: `[系统通知] 上一次任务执行出错（${headline}）。请重试。`,
+        })
+        .catch(() => {
+          /* best-effort */
+        });
+      return true;
+    }
+
+    // Fatal, or retries exhausted → escalate to the principal and stop.
+    entry.bus.emit(
+      ev.systemMessage(
+        entry.id,
+        "error",
+        kind === "fatal"
+          ? `专家 "${name}" 发生无法自动恢复的错误，已通知主管。`
+          : `专家 "${name}" 连续 ${count} 次执行失败，已通知主管。`,
+        { agent: name, recoverable: true },
+      ),
+    );
+    this.writeErrorToPrincipal(entry, name, headline);
+    entry.deliveryErrors.delete(name); // reset streak for a future task
+    return false;
+  }
+
+  /**
+   * #97 error escalation: write a NEUTRAL, error-flavored system note into the
+   * principal's mailbox and wake it, so the PI learns an expert failed rather
+   * than dead-waiting. Distinct from `writeFallbackToPrincipal` (the "silence"
+   * path): this one states an ERROR occurred and carries the error headline as
+   * context, but — like the silence note — gives NO directive ("re-delegate" /
+   * "proceed"): the principal decides. Best-effort; never breaks the loop.
+   */
+  private writeErrorToPrincipal(entry: SessionEntry, expert: string, headline: string): void {
+    void entry.mailbox
+      .write({
+        fromAgent: "system",
+        toAgent: "principal",
+        msgType: "system",
+        content: `[系统通知] 专家 "${expert}" 在执行任务时发生错误，未能产出结果。错误：${headline}`,
+      })
+      .then(() => this.wakeAgent(entry.id, "principal"))
+      .catch(() => {
+        /* best-effort */
+      });
   }
 
   /**


### PR DESCRIPTION
## What & why

Part of #97 (the deferred **error path**). A delegated expert run that ends in a provider error (401 / retry exhausted / mid-stream failure) used to leave the **principal dead-waiting**: Pi does not throw on provider failure — it finalizes the assistant message with `stopReason: "error"` — so `MasAgent` settled to `error` *without the expert ever `send_message`-ing back*. The existing 意图二 fallback then **mislabeled the error as "silence"** and wasted a `followUp` re-hitting the broken provider.

This splits **silence vs error** into separate paths, mirroring the legacy "retry self, then escalate to PI" design.

## Behavior

When a delegated expert run ends in error:

1. **trace-reminder extension bails** — reads `agent_end`'s last assistant `stopReason`; on `error`/`aborted` it returns early (no trace nudge, no reply `followUp`, no `onUnreplied`). The host's delivery loop now solely owns error recovery.
2. **host (`runDeliveryLoop`)**:
   - **retryable** (429/5xx/timeout/network) & under cap → self-retry the **same** expert (neutral, directive-free note in its own inbox), surfacing a `warning` "正在自动重试 (n/3)"; immediate re-wake, no delay.
   - **fatal** (auth/401/403/missing key) → escalate on the **first** failure (no wasted retry).
   - 3rd consecutive retryable failure → escalate.
   - **escalate** = neutral, error-flavored `system` note to the principal's mailbox (`writeErrorToPrincipal`, distinct from the silence-path `writeFallbackToPrincipal`) + wake; frontend `error` "已通知主管".
   - clean run → reset the consecutive-error streak.

The raw provider-error bubble still reaches the frontend per attempt (the #97-A behavior); the new warning/error messages are the retry/escalation **lifecycle** layer on top.

## Files

- `agent-error.ts` — `classifyAgentError()` + `AgentErrorKind` (fatal matched first; default retryable)
- `mas-agent.ts` — record/expose `lastErrorKind`; cleared on a clean run
- `session-manager.ts` — `SessionEntry.deliveryErrors`, `MAX_DELIVERY_RETRIES=3`, `handleDeliveryError`, `writeErrorToPrincipal`
- `extensions/trace-reminder.ts` — `agent_end` bails on an errored run
- tests — `agent-error.test.ts` (+4 classify); new `delivery-error.test.ts` (+3: 3 retryable → escalate, fatal → escalate first, retry succeeds → no escalate)

## Verification

`npm run typecheck` ✅ · `npm test` ✅ **499 tests pass** (was 492).

## Still deferred under #97

- **Delegator-targeting**: route the escalation to the *real* delegator (chains like auditor→engineer) instead of the hardcoded `principal`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)