### PR TITLE
fix(runtime): route expert failure/silence escalation to the real delegator (#97)

### DIFF
--- a/packages/runtime/src/__tests__/delivery-error.test.ts
+++ b/packages/runtime/src/__tests__/delivery-error.test.ts
@@ -120,10 +120,15 @@ async function waitFor(pred: () => boolean, timeoutMs = 2000): Promise<void> {
  * the test focused on the loop's error policy without scripting a full principal
  * delegation turn.
  */
-async function delegateToExpert(m: SessionManager, sid: string, expert: string): Promise<void> {
+async function delegateToExpert(
+  m: SessionManager,
+  sid: string,
+  expert: string,
+  from = "principal",
+): Promise<void> {
   const entry = (m as unknown as { sessions: Map<string, { mailbox: { write: (msg: unknown) => Promise<unknown> } }> }).sessions.get(sid)!;
   await entry.mailbox.write({
-    fromAgent: "principal",
+    fromAgent: from,
     toAgent: expert,
     msgType: "task_delegate",
     content: "survey X",
@@ -157,14 +162,14 @@ describe("delivery error path (#97)", () => {
     // It should retry twice (warning 1/3, 2/3) then escalate (error) on the 3rd.
     // (MasAgent also emits its own raw-provider-error bubble per attempt — the
     // #97-A behavior; we match OUR lifecycle messages specifically.)
-    await waitFor(() => sys.some((x) => x.level === "error" && x.text.includes("已通知主管")));
+    await waitFor(() => sys.some((x) => x.level === "error" && x.text.includes("已上报主管")));
 
     const warnings = sys.filter((x) => x.level === "warning" && x.text.includes("正在自动重试"));
     expect(warnings.length).toBe(2); // 1/3 and 2/3
     expect(warnings[0]!.text).toContain("(1/3)");
     expect(warnings[1]!.text).toContain("(2/3)");
 
-    const error = sys.find((x) => x.level === "error" && x.text.includes("已通知主管"));
+    const error = sys.find((x) => x.level === "error" && x.text.includes("已上报主管"));
     expect(error!.text).toContain("连续");
     expect(error!.text).toContain("librarian");
 
@@ -201,17 +206,81 @@ describe("delivery error path (#97)", () => {
 
     await delegateToExpert(m, s.id, "librarian");
 
-    await waitFor(() => sys.some((x) => x.level === "error" && x.text.includes("已通知主管")));
+    await waitFor(() => sys.some((x) => x.level === "error" && x.text.includes("已上报主管")));
 
     // No retry warnings — fatal escalates immediately.
     expect(sys.filter((x) => x.level === "warning" && x.text.includes("正在自动重试")).length).toBe(0);
-    const error = sys.find((x) => x.level === "error" && x.text.includes("已通知主管"));
+    const error = sys.find((x) => x.level === "error" && x.text.includes("已上报主管"));
     expect(error!.text).toContain("无法自动恢复");
 
     // librarian prompted exactly once (no self-retry).
     expect(observe.prompts.filter((p) => p.agent === "librarian").length).toBe(1);
     // Principal got the escalation note.
     await waitFor(() => observe.prompts.some((p) => p.agent === "principal" && p.text.includes("发生错误")));
+  });
+
+  it("escalates to the REAL delegator, not the principal, in a chain", async () => {
+    // auditor delegated to engineer; engineer fails fatally. The escalation note
+    // must go to the auditor (the real delegator), not the hardcoded principal.
+    const observe = { prompts: [] as Array<{ agent: string; text: string }> };
+    const factory = factoryWith(
+      { engineer: { outcome: () => "401 invalid api key" } },
+      observe,
+    );
+    const m = new SessionManager({ persist: false, agentFactory: factory });
+    const s = await m.createSession();
+
+    const sys: SystemMsg[] = [];
+    m.subscribe(s.id, (e) => {
+      if (e.type === "system_message") {
+        const v = e as { level?: string; message?: string };
+        sys.push({ level: v.level ?? "", text: v.message ?? "" });
+      }
+    });
+
+    // The auditor must be a LIVE agent for the escalation to target it (a
+    // destroyed delegator falls back to the principal).
+    await m.ensureAgent(s.id, "auditor");
+    await delegateToExpert(m, s.id, "engineer", "auditor");
+
+    await waitFor(() => sys.some((x) => x.level === "error" && x.text.includes("已上报")));
+
+    // The user-facing escalation names the auditor, not the principal.
+    const error = sys.find((x) => x.level === "error" && x.text.includes("已上报"));
+    expect(error!.text).toContain('委派方 "auditor"');
+    expect(error!.text).not.toContain("主管");
+
+    // The auditor (not the principal) received the error note.
+    await waitFor(() => observe.prompts.some((p) => p.agent === "auditor" && p.text.includes("发生错误")));
+    expect(observe.prompts.some((p) => p.agent === "principal")).toBe(false);
+  });
+
+  it("falls back to the principal when the delegator was destroyed", async () => {
+    // engineer was delegated by a transient auditor that no longer exists; the
+    // escalation must fall back to the principal rather than resurrect it.
+    const observe = { prompts: [] as Array<{ agent: string; text: string }> };
+    const factory = factoryWith(
+      { engineer: { outcome: () => "401 invalid api key" } },
+      observe,
+    );
+    const m = new SessionManager({ persist: false, agentFactory: factory });
+    const s = await m.createSession();
+
+    const sys: SystemMsg[] = [];
+    m.subscribe(s.id, (e) => {
+      if (e.type === "system_message") {
+        const v = e as { level?: string; message?: string };
+        sys.push({ level: v.level ?? "", text: v.message ?? "" });
+      }
+    });
+
+    // Note: "ghost" is never created as a live agent.
+    await delegateToExpert(m, s.id, "engineer", "ghost");
+
+    await waitFor(() => sys.some((x) => x.level === "error" && x.text.includes("已上报主管")));
+    // Principal got the escalation (fallback); ghost was never woken.
+    await waitFor(() => observe.prompts.some((p) => p.agent === "principal" && p.text.includes("发生错误")));
+    expect(observe.prompts.some((p) => p.agent === "ghost")).toBe(false);
   });
 
   it("recovers and does NOT escalate when a retry succeeds", async () => {
@@ -240,8 +309,8 @@ describe("delivery error path (#97)", () => {
 
     expect(sys.filter((x) => x.level === "warning" && x.text.includes("正在自动重试")).length).toBe(1);
     // No escalation lifecycle error (MasAgent's own per-attempt raw bubble may
-    // exist, but OUR "已通知主管" escalation must not).
-    expect(sys.some((x) => x.level === "error" && x.text.includes("已通知主管"))).toBe(false);
+    // exist, but OUR "已上报主管" escalation must not).
+    expect(sys.some((x) => x.level === "error" && x.text.includes("已上报主管"))).toBe(false);
     // No escalation note to the principal.
     expect(observe.prompts.some((p) => p.agent === "principal" && p.text.includes("发生错误"))).toBe(false);
   });

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -69,6 +69,15 @@ interface SessionEntry {
    * delivery run. Drives self-retry vs escalation in `runDeliveryLoop`.
    */
   deliveryErrors: Map<string, number>;
+  /**
+   * #97 directed escalation: per-agent record of who LAST delegated a task to it
+   * (the `fromAgent` of the most recent `task_delegate` it drained). When a
+   * delegated run fails or ends silently, the escalation note is routed to this
+   * real delegator (supporting chains like auditor→engineer) instead of always
+   * the principal. Cleared on a clean delivery so a stale delegator never targets
+   * an unrelated later run; falls back to `principal` when absent/unreachable.
+   */
+  delegators: Map<string, string>;
   runActive: boolean;
   activeRunId: string | null;
   /** Outstanding ask_user requests, keyed by request_id (§ ask_user). */
@@ -506,6 +515,7 @@ export class SessionManager {
       agents: new Map(),
       tasks: new Map(),
       deliveryErrors: new Map(),
+      delegators: new Map(),
       runActive: false,
       activeRunId: null,
       pendingInputs: new Map(),
@@ -920,7 +930,7 @@ export class SessionManager {
       // 意图二 fallback: the trace-reminder extension calls this when an expert
       // was reminded once and still didn't report back, so the principal never
       // dead-waits on a silent expert.
-      onUnreplied: (agentName) => this.writeFallbackToPrincipal(entry, agentName),
+      onUnreplied: (agentName) => this.writeFallbackToDelegator(entry, agentName),
       // #97: only the principal gets the live team-status block injected each
       // turn (it is the coordinator). Other roles run without it.
       renderAgentStatus:
@@ -949,22 +959,27 @@ export class SessionManager {
   /**
    * 意图二 fallback — the trace-reminder extension calls this (via the factory's
    * `onUnreplied`) when an expert was reminded once and STILL did not
-   * `send_message` the principal (the "silence" path; a hard *error* run is
-   * handled separately). We write a NEUTRAL system note into the principal's
-   * mailbox and wake it so it never dead-waits. The note only states the fact —
-   * the expert ended without delivering a result — and deliberately gives NO
-   * directive ("re-delegate", "proceed without it"): the principal decides what
-   * to do. Best-effort: a failed write must never break the agent loop.
+   * `send_message` its delegator (the "silence" path; a hard *error* run is
+   * handled separately). We write a NEUTRAL system note into the REAL delegator's
+   * mailbox and wake it so it never dead-waits. The delegator is whoever last
+   * delegated to this expert (#97 directed escalation), falling back to the
+   * principal. This fires during the expert's run (before the clean-run cleanup
+   * in `runDeliveryLoop`), so the delegator record is still present. The note
+   * only states the fact — the expert ended without delivering a result — and
+   * deliberately gives NO directive ("re-delegate", "proceed without it"): the
+   * delegator decides what to do. Best-effort: a failed write must never break
+   * the agent loop.
    */
-  private writeFallbackToPrincipal(entry: SessionEntry, expert: string): void {
+  private writeFallbackToDelegator(entry: SessionEntry, expert: string): void {
+    const to = this.delegatorFor(entry, expert);
     void entry.mailbox
       .write({
         fromAgent: "system",
-        toAgent: "principal",
+        toAgent: to,
         msgType: "system",
         content: `[系统通知] 专家 "${expert}" 结束了本次任务但未回交结果。`,
       })
-      .then(() => this.wakeAgent(entry.id, "principal"))
+      .then(() => this.wakeAgent(entry.id, to))
       .catch(() => {
         /* best-effort */
       });
@@ -1044,6 +1059,11 @@ export class SessionManager {
       if (msgs.length === 0) return;
       const agent = await this.ensureAgent(sessionId, name);
       if (agent.status === "stopped") return;
+      // #97 directed escalation: remember who delegated this work (the last
+      // task_delegate in the batch). Self-retry nudges are msgType "system", so
+      // they never overwrite a real delegator recorded on the original task.
+      const delegated = [...msgs].reverse().find((m) => m.msgType === "task_delegate");
+      if (delegated) entry.delegators.set(name, delegated.fromAgent);
       this.touch(entry);
       // Surface the delegated run immediately (derived active flag, agent list).
       this.emitSessionState(entry);
@@ -1059,6 +1079,7 @@ export class SessionManager {
         return; // escalated — nothing more to drain for this agent
       }
       entry.deliveryErrors.delete(name); // clean run → reset the streak
+      entry.delegators.delete(name); // and forget the delegator (task done)
     }
   }
 
@@ -1109,39 +1130,61 @@ export class SessionManager {
       return true;
     }
 
-    // Fatal, or retries exhausted → escalate to the principal and stop.
+    // Fatal, or retries exhausted → escalate to the real delegator and stop.
+    const delegator = this.delegatorFor(entry, name);
+    const target = delegator === "principal" ? "主管" : `委派方 "${delegator}"`;
     entry.bus.emit(
       ev.systemMessage(
         entry.id,
         "error",
         kind === "fatal"
-          ? `专家 "${name}" 发生无法自动恢复的错误，已通知主管。`
-          : `专家 "${name}" 连续 ${count} 次执行失败，已通知主管。`,
+          ? `专家 "${name}" 发生无法自动恢复的错误，已上报${target}。`
+          : `专家 "${name}" 连续 ${count} 次执行失败，已上报${target}。`,
         { agent: name, recoverable: true },
       ),
     );
-    this.writeErrorToPrincipal(entry, name, headline);
+    this.writeErrorToDelegator(entry, name, headline);
     entry.deliveryErrors.delete(name); // reset streak for a future task
+    entry.delegators.delete(name); // delegator notified; forget it
     return false;
   }
 
   /**
-   * #97 error escalation: write a NEUTRAL, error-flavored system note into the
-   * principal's mailbox and wake it, so the PI learns an expert failed rather
-   * than dead-waiting. Distinct from `writeFallbackToPrincipal` (the "silence"
-   * path): this one states an ERROR occurred and carries the error headline as
-   * context, but — like the silence note — gives NO directive ("re-delegate" /
-   * "proceed"): the principal decides. Best-effort; never breaks the loop.
+   * #97 directed escalation: resolve who an expert's failure/silence should be
+   * reported to. Returns the recorded delegator ONLY when it is a still-live,
+   * non-trace agent other than the expert itself (a destroyed/stopped delegator
+   * would be wrongly resurrected by the wake, and a self/system target is
+   * nonsensical). Otherwise falls back to `principal`, the root coordinator,
+   * which always exists and owns un-rooted work.
    */
-  private writeErrorToPrincipal(entry: SessionEntry, expert: string, headline: string): void {
+  private delegatorFor(entry: SessionEntry, expert: string): string {
+    const d = entry.delegators.get(expert);
+    if (!d || d === expert || d === "system" || d === "principal") return "principal";
+    const agent = entry.agents.get(d);
+    if (!agent || agent.status === "stopped" || agent.role === "trace") return "principal";
+    return d;
+  }
+
+  /**
+   * #97 error escalation: write a NEUTRAL, error-flavored system note into the
+   * REAL delegator's mailbox and wake it, so whoever delegated the work (the
+   * principal, or another agent in a chain like auditor→engineer) learns the
+   * expert failed rather than dead-waiting. Distinct from
+   * `writeFallbackToDelegator` (the "silence" path): this one states an ERROR
+   * occurred and carries the error headline as context, but — like the silence
+   * note — gives NO directive ("re-delegate" / "proceed"): the delegator decides.
+   * Best-effort; never breaks the loop.
+   */
+  private writeErrorToDelegator(entry: SessionEntry, expert: string, headline: string): void {
+    const to = this.delegatorFor(entry, expert);
     void entry.mailbox
       .write({
         fromAgent: "system",
-        toAgent: "principal",
+        toAgent: to,
         msgType: "system",
         content: `[系统通知] 专家 "${expert}" 在执行任务时发生错误，未能产出结果。错误：${headline}`,
       })
-      .then(() => this.wakeAgent(entry.id, "principal"))
+      .then(() => this.wakeAgent(entry.id, to))
       .catch(() => {
         /* best-effort */
       });


### PR DESCRIPTION
## What & why

The #97 error and silence escalation paths both hardcoded `principal` as the
target. In a delegation chain (e.g. `auditor→engineer`) a failed or silent
engineer notified the **principal** — not the **auditor** that actually
delegated the work, leaving the auditor dead-waiting. This is the last
remaining deferred item from #97.

## Change

Track the real delegator per expert (the `fromAgent` of the most recent
`task_delegate` it drains, stored in `SessionEntry.delegators`) and route both
escalation paths to it:

- `writeErrorToPrincipal` → `writeErrorToDelegator`
- `writeFallbackToPrincipal` → `writeFallbackToDelegator`
- `delegatorFor()` resolves the recorded delegator, but only when it is a
  still-live, non-trace agent other than the expert itself; otherwise it falls
  back to `principal` (so a destroyed/stopped delegator is never resurrected by
  the wake, and un-rooted work still reaches the coordinator).

Self-retry nudges are `msgType: "system"`, so they never overwrite the real
delegator recorded on the original `task_delegate`. The record is cleared on a
clean delivery and after escalation. The user-facing escalation message now
names the actual target (`已上报委派方 "auditor"` vs `已上报主管`).

## Tests

- New: chain escalation targets the delegator (not principal)
- New: destroyed delegator falls back to principal (ghost never woken)
- Updated: 3 existing wording assertions (`已通知主管` → `已上报主管`)
- **501 pass**, `npm run typecheck` clean

Relates to #97 (stays open until this merges).