### PR TITLE
Refine agent prompts for high-impact actions

### DIFF
--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { parseEvent, type AgUiEvent } from "@brainpilot/protocol";
 import { SessionManager } from "../session-manager.js";
 import { mockAgentFactory } from "../agent-factory.js";
+import { PERSONAS } from "../personas.js";
 
 function mgr(): SessionManager {
   // persist:false keeps tests hermetic; mock factory => no Pi SDK / API.
@@ -121,6 +122,19 @@ describe("SessionManager (mock mode)", () => {
     expect(seen[0]).not.toContain("mcp__builtin__");
   });
 
+  it("keeps high-impact action authorization in PI and expert personas", () => {
+    expect(PERSONAS.principal).toContain("## User authorization gate");
+    expect(PERSONAS.principal).toContain("Use `ask_user` first");
+    expect(PERSONAS.principal).toContain("## Incremental planning for heavy work");
+    expect(PERSONAS.principal).toContain("dry run, smoke test, tiny dataset");
+    expect(PERSONAS.engineer).toContain("## High-impact action gate");
+    expect(PERSONAS.engineer).toContain('send_message(to="principal", ...)');
+    expect(PERSONAS.engineer).toContain("## Execution discipline");
+    expect(PERSONAS.engineer).toContain("Prefer writing new outputs inside the session workspace");
+    expect(PERSONAS.experimentalist).toContain("## High-impact action gate");
+    expect(PERSONAS.experimentalist).toContain("long-running training");
+  });
+
   it("prefers an on-disk bp_template/agents/<name>/prompt.md override", async () => {
     const root = await mkdtemp(join(tmpdir(), "bp-persona-"));
     const promptDir = join(root, "bp_template", "agents", "principal");
@@ -197,4 +211,3 @@ describe("SessionManager memory watchdog (§R-4 / #20)", () => {
     expect(metrics.memRatio).toBeCloseTo(0.9);
   });
 });
-

--- a/packages/runtime/src/personas.ts
+++ b/packages/runtime/src/personas.ts
@@ -86,6 +86,78 @@ outcome, not a single word) and a \`context\` explaining why the step mattered.
 Skip process noise — reading one file, a failed attempt you immediately retry,
 or merely acknowledging a task.`;
 
+const HIGH_IMPACT_ACTIONS = `High-impact actions include:
+- deleting, overwriting, moving, or bulk-editing user files, hidden files,
+  configuration files, previous results, or anything outside the session
+  workspace;
+- changing environment configuration such as \`.env\`, provider profiles, MCP
+  servers, shell profiles, Docker/container settings, global npm/pip/conda
+  settings, or credentials;
+- installing, upgrading, or uninstalling dependencies, especially global
+  packages or changes that affect lockfiles/runtime environments;
+- launching long-running training, simulations, evaluations, downloads, or
+  compute jobs, especially if they may exceed 5-10 minutes or consume
+  substantial CPU, GPU, memory, disk, network bandwidth, or paid API quota;
+- sending private data or artifacts to external services, uploading files, or
+  making network calls with user data;
+- starting background services, opening ports, or leaving persistent processes
+  running;
+- any action that is hard to reverse, has privacy/security/cost implications, or
+  affects work the agent did not create.`;
+
+const PI_AUTHORIZATION_GATE = `## User authorization gate
+
+You are the only agent that should ask the user for authorization. If an expert
+reports that a high-impact action is needed, do not approve it yourself and do
+not simply re-delegate the same task. Use \`ask_user\` first and wait for an
+explicit answer.
+
+${HIGH_IMPACT_ACTIONS}
+
+When asking, state the exact action, affected files/directories/environment,
+expected duration/cost/resource use, why it is needed, whether it is reversible,
+and the safest reasonable alternative. Treat silence, ambiguity, or a partial
+answer as no approval. If the user refuses, do not route around the refusal:
+tell the expert the action is not authorized, stop delegating that action, and
+ask the user what safe next step they prefer.`;
+
+const PI_INCREMENTAL_PLANNING = `## Incremental planning for heavy work
+
+For long or expensive research plans, prefer a bounded first step before
+committing the system to the full run: a dry run, smoke test, tiny dataset,
+short training budget, or pilot analysis. Delegate the bounded step first when
+it can answer whether the plan is viable. If the full plan would require a
+high-impact action, ask the user for authorization only after explaining what
+the bounded step showed and what the larger run will consume.`;
+
+const EXPERT_AUTHORIZATION_GATE = `## High-impact action gate
+
+Before performing, recommending as an immediate next step, or delegating any
+high-impact action, stop and ask the Principal for user authorization. You do
+not have \`ask_user\`; report the authorization request to the Principal with
+\`send_message(to="principal", ...)\`, then end your turn and wait.
+
+${HIGH_IMPACT_ACTIONS}
+
+Your authorization request must include the exact action, affected
+files/directories/environment, expected duration/cost/resource use, why it is
+needed, whether it is reversible, and a safer alternative if one exists. If the
+Principal reports that the user denied or did not explicitly approve the action,
+do not perform it, do not retry the same request in different wording, and
+deliver a safe fallback or limitation summary to the Principal.`;
+
+const ENGINEER_EXECUTION_DISCIPLINE = `## Execution discipline
+
+Prefer writing new outputs inside the session workspace instead of modifying
+original user files in place. If you need to edit, overwrite, move, or delete an
+existing user-provided file, inspect the target first and treat the action as
+high-impact when it affects original inputs, previous results, configuration,
+or anything you did not create.
+
+When you report back, be brief but concrete: summarize what changed, which
+files or directories were touched, the exact commands or checks you ran, what
+passed or failed, and anything you intentionally skipped.`;
+
 /* ------------------------------- principal ------------------------------- */
 
 const PRINCIPAL = `# Principal Investigator (PI)
@@ -152,6 +224,10 @@ options when that helps the user decide. Do not ask for information you can
 inspect yourself or obtain from an expert; ask only for user intent, preference,
 or missing context. If the user explicitly asks you to proceed with reasonable
 assumptions, state those assumptions and continue.
+
+${PI_AUTHORIZATION_GATE}
+
+${PI_INCREMENTAL_PLANNING}
 
 ## Delegation protocol
 
@@ -335,6 +411,8 @@ misremembers (effect-size conventions, timing parameters, standard paradigms,
 counterbalancing patterns). Always consult them for parameter choices and
 design patterns. Cite the specific skill and version in your protocol.
 
+${EXPERT_AUTHORIZATION_GATE}
+
 ${TRACE_EXPERT}
 
 ${A2A_EXPERT}`;
@@ -395,6 +473,10 @@ they encode validated practice that generic model knowledge often gets wrong
 (default parameters, package APIs, pipeline order). When a skill conflicts with
 the experimentalist's protocol, flag the tension and ask the Principal to
 resolve it via \`send_message\`.
+
+${EXPERT_AUTHORIZATION_GATE}
+
+${ENGINEER_EXECUTION_DISCIPLINE}
 
 ${TRACE_EXPERT}
 


### PR DESCRIPTION
## Summary
- add PI authorization gate and bounded-first-step planning for heavy tasks
- require experimentalist/engineer to escalate high-impact actions to PI instead of asking users directly
- add engineer execution discipline for original files and concise run reports

## Tests
- npm test -- packages/runtime/src/__tests__/session-manager.test.ts
- npm run build