### PR TITLE
Route expert outputs through writer drafts before audit

### DIFF
--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -135,6 +135,20 @@ describe("SessionManager (mock mode)", () => {
     expect(PERSONAS.experimentalist).toContain("long-running training");
   });
 
+  it("routes expert outputs through writer drafts before audit", () => {
+    expect(PERSONAS.principal).toContain("do NOT send raw expert output directly to the `auditor`");
+    expect(PERSONAS.principal).toContain("first form an auditable draft");
+    expect(PERSONAS.principal).toContain("`writer` to write or polish a report");
+    expect(PERSONAS.principal).toContain("Do not audit raw expert output.");
+    expect(PERSONAS.librarian).toContain("## Writer handoff packet");
+    expect(PERSONAS.experimentalist).toContain("## Writer handoff packet");
+    expect(PERSONAS.engineer).toContain("## Writer handoff packet");
+    expect(PERSONAS.writer).not.toContain("## Writer handoff packet");
+    expect(PERSONAS.auditor).toContain("If PI gives you only raw expert output");
+    expect(PERSONAS.auditor).not.toContain("## Writer handoff packet");
+    expect(PERSONAS.trace).not.toContain("## Writer handoff packet");
+  });
+
   it("prefers an on-disk bp_template/agents/<name>/prompt.md override", async () => {
     const root = await mkdtemp(join(tmpdir(), "bp-persona-"));
     const promptDir = join(root, "bp_template", "agents", "principal");

--- a/packages/runtime/src/personas.ts
+++ b/packages/runtime/src/personas.ts
@@ -158,6 +158,17 @@ When you report back, be brief but concrete: summarize what changed, which
 files or directories were touched, the exact commands or checks you ran, what
 passed or failed, and anything you intentionally skipped.`;
 
+const WRITER_HANDOFF_PACKET = `## Writer handoff packet
+
+When you finish substantive work for the Principal, structure your result so the
+\`writer\` can draft a report without guessing. Include a concise result summary,
+key claims that may appear in a report, evidence pointers (file paths, command
+outputs, search result names, citation details, or other places the writer and
+auditor can inspect), important caveats or uncertainties, and the report angle
+you recommend. Do not ask the auditor to review raw expert output; the Principal
+will route your handoff to the writer first when a report-like deliverable is
+needed.`;
+
 /* ------------------------------- principal ------------------------------- */
 
 const PRINCIPAL = `# Principal Investigator (PI)
@@ -249,19 +260,25 @@ format, under the stated constraints, with clear remaining gaps? If not, ask the
 expert to revise, delegate the missing part, or use \`ask_user\` when the tradeoff
 requires user preference.
 
-Do NOT personally perform fabrication/reliability audit on expert claims. If an
-expert result contains numeric results, file/artifact claims, external citations,
-paper references, dataset claims, or anything that could be fabricated, send the
-expert's deliverable to the \`auditor\` with the original user requirement,
-delegated task, expert output, and any cited artifact paths. Wait for the audit
-before relying on those claims.
+Do NOT personally perform fabrication/reliability audit on expert claims. Also
+do NOT send raw expert output directly to the \`auditor\`. If a result from
+\`librarian\`, \`experimentalist\`, or \`engineer\` contains numeric results,
+file/artifact claims, external citations, paper references, dataset claims, or
+anything that could be fabricated, first form an auditable draft: ask the
+\`writer\` to write or polish a report from the expert handoff packet, or write a
+short draft yourself for very small answers. Then send that draft/report to the
+\`auditor\` with the original user requirement, delegated task, expert handoff
+packet, and any cited evidence paths. Wait for the audit before relying on those
+claims.
 
 ## Final deliverables
 
 For report-like final deliverables, ask the \`writer\` to draft or polish the
-report after the necessary expert work is available. Your job is to make sure
-the writer's draft satisfies the user's goal and reflects the audited evidence;
-the writer handles structure, prose, and presentation.
+report after the necessary expert handoff packets are available. Your job is to
+make sure the writer's draft satisfies the user's goal and uses the evidence
+pointers supplied by the experts; the writer handles structure, prose, and
+presentation. After the draft/report exists, send it to the \`auditor\` when it
+contains hard claims that require verification.
 
 ${A2A_EXPERT}
 
@@ -287,11 +304,12 @@ or draft to the \`auditor\` and wait for its reply:
 
 Procedure:
 
-1. For expert-output audit: send the original user need, delegated task, expert
-   result, and any cited evidence paths or references. For final-response audit:
-   compose the full draft final response.
-2. \`send_message(to="auditor", content=<audit packet or full draft>)\` and STOP
-   your turn.
+1. Ensure there is an auditable object: a writer-produced report/draft, a report
+   file path, or a short PI-authored final draft. Do not audit raw expert output.
+2. Send the auditor the original user need, delegated task(s), the draft/report
+   or report path, the expert handoff packet(s), and any cited evidence paths or
+   references. \`send_message(to="auditor", content=<audit packet with draft/report>)\`
+   and STOP your turn.
 3. The auditor replies with an \`audit_complete\` message carrying the path to
    its full report and a one-line summary with overall risk
    (\`low\` / \`medium\` / \`high\`).
@@ -347,6 +365,8 @@ Read local or cached files with \`read\`/\`grep\`. For live URL fetching beyond
 your tools, ask the \`engineer\` via \`send_message\`. You do not write files or
 run shell commands; if a deliverable must be saved, hand the content to the
 \`engineer\` or return it to the Principal.
+
+${WRITER_HANDOFF_PACKET}
 
 ${TRACE_EXPERT}
 
@@ -413,6 +433,8 @@ design patterns. Cite the specific skill and version in your protocol.
 
 ${EXPERT_AUTHORIZATION_GATE}
 
+${WRITER_HANDOFF_PACKET}
+
 ${TRACE_EXPERT}
 
 ${A2A_EXPERT}`;
@@ -477,6 +499,8 @@ resolve it via \`send_message\`.
 ${EXPERT_AUTHORIZATION_GATE}
 
 ${ENGINEER_EXECUTION_DISCIPLINE}
+
+${WRITER_HANDOFF_PACKET}
 
 ${TRACE_EXPERT}
 
@@ -619,6 +643,10 @@ You do **NOT** have access to:
 - any external network
 
 If the evidence isn't reachable from the workspace, the claim is \`unverified\`.
+If PI gives you only raw expert output without a draft/report or report path,
+do not construct the report yourself and do not audit the raw output as the
+deliverable. Send PI a concise message asking for an auditable draft/report
+first, then end your turn.
 
 ## Procedure
 


### PR DESCRIPTION
## Summary
- require librarian, experimentalist, and engineer to provide writer handoff packets for substantive results
- route hard-claim expert outputs through writer or PI drafts before auditor review
- make auditor request an auditable draft/report when only raw expert output is provided

## Tests
- npm test -- packages/runtime/src/__tests__/session-manager.test.ts
- npm run build