### PR TITLE
fix(web): stop inline code pills overlapping when they wrap across lines

### DIFF
--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -2796,7 +2796,13 @@ button {
   background: var(--color-surface-soft);
   border: 1px solid var(--color-border);
   border-radius: 4px;
-  padding: 1px 4px;
+  /* em-based padding scales with the (0.92em) code font; box-decoration-break
+     keeps the border/radius/background intact on every fragment when an inline
+     code span wraps across lines, instead of slicing into vertically-overflowing
+     boxes that overlap adjacent lines (#130). */
+  padding: 0.1em 0.35em;
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
 }
 
 .message-card__content pre {


### PR DESCRIPTION
## Summary

Fixes the rendering bug from #130 where inline Markdown/code in the chat stream rendered as floating gray "pills" that overlap surrounding text.

## Root cause

This is a pure CSS issue (not a streaming/parser bug — the issue title's "streaming" is a red herring; it reproduces on static render too).

`.message-card__content code` gives inline `<code>` vertical padding + a border. With the default `box-decoration-break: slice`, a code span that **wraps across lines** (e.g. `<!-- SECTION2 -->`) is split into separate boxes. Per the CSS inline box model, an inline element's vertical padding/border does **not** expand the line box, so those fragment boxes overflow vertically and overlap the adjacent lines — the "floating overlapping pills".

Reproduced in a browser with the exact text from the issue; confirmed the fix resolves it.

## Fix

One CSS rule in `packages/web/src/styles/global.css`:

- `box-decoration-break: clone` (with `-webkit-` prefix) so each wrapped fragment keeps its own intact border / radius / background and hugs its own line instead of overflowing.
- em-based padding (`0.1em 0.35em`) that scales with the 0.92em code font.

No changes to the react-markdown / remark-gfm / rehype-highlight pipeline. Block `pre code` is unaffected (it already resets border/background).

## Verification

- `npm run build` (web) ✅
- web vitest: 105/105 ✅

Fixes #130