### PR TITLE
feat(skills): add skill_search Pi-native tool as second skill-loading path

### DIFF
--- a/packages/runtime/src/__tests__/materialize-skills.test.ts
+++ b/packages/runtime/src/__tests__/materialize-skills.test.ts
@@ -1,11 +1,24 @@
 import { describe, it, expect } from "vitest";
-import { mkdtemp, mkdir, writeFile, readFile, readdir } from "node:fs/promises";
+import { mkdtemp, mkdir, writeFile, readFile, readdir, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { materializeSkills, resolveBundledSkillsDir } from "../materialize-skills.js";
+import {
+  ALWAYS_ON_CATEGORY,
+  materializeSkills,
+  resolveBundledSkillsDir,
+} from "../materialize-skills.js";
 
 async function freshRoot(): Promise<string> {
   return mkdtemp(join(tmpdir(), "bp-skills-"));
+}
+
+async function exists(p: string): Promise<boolean> {
+  try {
+    await stat(p);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 describe("resolveBundledSkillsDir", () => {
@@ -16,46 +29,86 @@ describe("resolveBundledSkillsDir", () => {
   });
 });
 
-describe("materializeSkills", () => {
-  it("copies the bundled skills into <dataRoot>/bp_template/skills", async () => {
+describe("materializeSkills (split: always-on vs router)", () => {
+  it("places Meta-Skills in always-on and every other category in the router", async () => {
     const root = await freshRoot();
     const res = await materializeSkills(root);
 
     expect(res.dest).toBe(join(root, "bp_template", "skills"));
+    expect(res.routerDest).toBe(join(root, "bp_template", "skills-router"));
     expect(res.source).not.toBeNull();
-    expect(res.copied).toBeGreaterThan(0);
 
-    // At least one category dir with a SKILL.md landed.
-    const cats = await readdir(res.dest, { withFileTypes: true });
-    expect(cats.some((d) => d.isDirectory())).toBe(true);
+    // Always-on side: must contain ONLY 01_Meta-Skills (the always-on category).
+    const alwaysOnEntries = await readdir(res.dest, { withFileTypes: true });
+    const alwaysOnDirs = alwaysOnEntries.filter((d) => d.isDirectory()).map((d) => d.name);
+    expect(alwaysOnDirs).toEqual([ALWAYS_ON_CATEGORY]);
+
+    // Router side: must contain at least one OTHER category and NOT 01_Meta-Skills.
+    const routerEntries = await readdir(res.routerDest, { withFileTypes: true });
+    const routerDirs = routerEntries.filter((d) => d.isDirectory()).map((d) => d.name);
+    expect(routerDirs.length).toBeGreaterThan(0);
+    expect(routerDirs).not.toContain(ALWAYS_ON_CATEGORY);
+
+    // Counts must reflect the split (real bundle ships content on both sides).
+    expect(res.copied).toBeGreaterThan(0);
+    expect(res.routerCopied).toBeGreaterThan(0);
+
+    // A representative router skill (one that does NOT live in 01_Meta-Skills)
+    // should land under skills-router, not under skills.
+    const sampleRouterCat = routerDirs[0]!;
+    const sampleSkillName = (
+      await readdir(join(res.routerDest, sampleRouterCat), { withFileTypes: true })
+    ).find((d) => d.isDirectory())?.name;
+    expect(sampleSkillName).toBeTruthy();
+    expect(await exists(join(res.dest, sampleRouterCat, sampleSkillName!, "SKILL.md"))).toBe(false);
+    expect(
+      await exists(join(res.routerDest, sampleRouterCat, sampleSkillName!, "SKILL.md")),
+    ).toBe(true);
   });
 
-  it("is idempotent and never overwrites an existing file (skip-if-exists)", async () => {
+  it("is idempotent and preserves user edits on BOTH sides", async () => {
     const root = await freshRoot();
-    // Pre-create one destination file with sentinel content.
-    const dest = join(root, "bp_template", "skills");
-    const cat = join(dest, "01_Meta-Skills", "verify-skill");
-    await mkdir(cat, { recursive: true });
-    const guarded = join(cat, "SKILL.md");
-    await writeFile(guarded, "USER EDIT — DO NOT TOUCH", "utf8");
+
+    // Pre-create one always-on file (a known meta-skill) with sentinel content.
+    const alwaysOnSkill = join(root, "bp_template", "skills", ALWAYS_ON_CATEGORY, "verify-skill");
+    await mkdir(alwaysOnSkill, { recursive: true });
+    const alwaysOnGuarded = join(alwaysOnSkill, "SKILL.md");
+    await writeFile(alwaysOnGuarded, "USER EDIT — META", "utf8");
+
+    // Pre-create a router-side file under a category we know is shipped (drop in
+    // via a pre-known relative path; a stable category that is NOT 01_Meta-Skills).
+    const routerCustom = join(
+      root,
+      "bp_template",
+      "skills-router",
+      "99_user_added",
+      "my-skill",
+    );
+    await mkdir(routerCustom, { recursive: true });
+    await writeFile(join(routerCustom, "SKILL.md"), "USER ROUTER EDIT", "utf8");
 
     const res = await materializeSkills(root);
 
-    // The pre-existing file must be preserved verbatim.
-    expect(await readFile(guarded, "utf8")).toBe("USER EDIT — DO NOT TOUCH");
-    expect(res.skipped).toBeGreaterThan(0);
+    expect(await readFile(alwaysOnGuarded, "utf8")).toBe("USER EDIT — META");
+    expect(await readFile(join(routerCustom, "SKILL.md"), "utf8")).toBe("USER ROUTER EDIT");
+    expect(res.skipped).toBeGreaterThan(0); // at least the guarded meta file
 
-    // A second run copies nothing new.
+    // A second run copies nothing new on either side.
     const again = await materializeSkills(root);
     expect(again.copied).toBe(0);
+    expect(again.routerCopied).toBe(0);
+
+    // The user-added router category survives (nothing in the bundle clobbers it).
+    expect(await exists(join(routerCustom, "SKILL.md"))).toBe(true);
   });
 
-  it("creates the destination dir even when nothing is copied", async () => {
+  it("creates BOTH destination dirs even when nothing is copied a second time", async () => {
     const root = await freshRoot();
     await materializeSkills(root); // first run populates
     const second = await materializeSkills(root); // nothing new
     expect(second.copied).toBe(0);
-    const entries = await readdir(join(root, "bp_template", "skills"));
-    expect(entries.length).toBeGreaterThan(0);
+    expect(second.routerCopied).toBe(0);
+    expect((await readdir(join(root, "bp_template", "skills"))).length).toBeGreaterThan(0);
+    expect((await readdir(join(root, "bp_template", "skills-router"))).length).toBeGreaterThan(0);
   });
 });

--- a/packages/runtime/src/__tests__/personas.test.ts
+++ b/packages/runtime/src/__tests__/personas.test.ts
@@ -58,6 +58,28 @@ describe("personas", () => {
     expect(personaFor("statistician", "expert")).toContain("Skills-first preflight");
   });
 
+  it("non-trace personas advertise the router (skill_search) library path", () => {
+    // Every non-trace persona must mention the router tool and its name, so the
+    // model knows <available_skills> is NOT the full library.
+    for (const name of [
+      "principal",
+      "librarian",
+      "experimentalist",
+      "engineer",
+      "writer",
+      "auditor",
+    ]) {
+      const p = PERSONAS[name]!;
+      expect(p, name).toContain("skill_search");
+      expect(p, name).toContain("Router skill library");
+    }
+    // Generic fallback expert (no curated persona) inherits the router hint
+    // through SKILLS_FIRST_EXPERT.
+    expect(personaFor("statistician", "expert")).toContain("skill_search");
+    // Trace agent is graph-only and must not be told about skill_search.
+    expect(PERSONAS.trace!).not.toContain("skill_search");
+  });
+
   it("expert personas carry the send_message-back contract", () => {
     for (const name of ["librarian", "engineer", "experimentalist", "writer", "auditor"]) {
       expect(PERSONAS[name], name).toContain('send_message(to="principal"');

--- a/packages/runtime/src/__tests__/skill-search.test.ts
+++ b/packages/runtime/src/__tests__/skill-search.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  collectAllSkills,
+  countKeywordHits,
+  parseFrontmatterDescription,
+  searchSkills,
+  createSkillSearchTool,
+} from "../tools/skill-search.js";
+import { Mailbox } from "../mailbox.js";
+import { GraphOfTrace } from "../trace.js";
+import type { ToolDeps } from "../tools/system-tools.js";
+
+/**
+ * Minimal, self-contained skill router base for the unit tests. Two
+ * categories, one shared skill name across both, one Meta-style stub, and a
+ * file with no description so the parser's empty-string path is exercised.
+ */
+async function makeFixtureBase(): Promise<string> {
+  const base = await mkdtemp(join(tmpdir(), "bp-skill-router-"));
+
+  // 02_Cross-Domain/eeg-paradigm-designer
+  const a = join(base, "02_Cross-Domain", "eeg-paradigm-designer");
+  await mkdir(a, { recursive: true });
+  await writeFile(
+    join(a, "SKILL.md"),
+    `---
+name: eeg-paradigm-designer
+description: "Design oddball, N400, P300 EEG paradigms with stimulus timing tables."
+---
+
+Body content for the EEG paradigm designer.`,
+    "utf8",
+  );
+  await mkdir(join(a, "references"), { recursive: true });
+  await writeFile(join(a, "references", "timings.md"), "timings ref", "utf8");
+
+  // 05_EEG_ERP/eeg-paradigm-designer  → same name, second path
+  const b = join(base, "05_EEG_ERP", "eeg-paradigm-designer");
+  await mkdir(b, { recursive: true });
+  await writeFile(
+    join(b, "SKILL.md"),
+    `---
+description: SHADOW description should NOT replace the first one.
+---
+shadow body`,
+    "utf8",
+  );
+
+  // 13_Visualization/figure-builder
+  const c = join(base, "13_Visualization", "figure-builder");
+  await mkdir(c, { recursive: true });
+  await writeFile(
+    join(c, "SKILL.md"),
+    `---
+description: 'Build publication-grade figures with matplotlib and seaborn.'
+---
+
+Visualization helper.`,
+    "utf8",
+  );
+
+  // 99_misc/no-frontmatter — exercises the empty-description branch
+  const d = join(base, "99_misc", "no-frontmatter");
+  await mkdir(d, { recursive: true });
+  await writeFile(join(d, "SKILL.md"), "no frontmatter at all", "utf8");
+
+  return base;
+}
+
+describe("parseFrontmatterDescription", () => {
+  it("reads double-quoted, single-quoted, and unquoted descriptions", () => {
+    expect(parseFrontmatterDescription(`---\ndescription: "x y"\n---\nbody`)).toBe("x y");
+    expect(parseFrontmatterDescription(`---\ndescription: 'x y'\n---\nbody`)).toBe("x y");
+    expect(parseFrontmatterDescription(`---\ndescription: x y\n---\nbody`)).toBe("x y");
+  });
+  it("returns empty when frontmatter or description is absent", () => {
+    expect(parseFrontmatterDescription("no frontmatter")).toBe("");
+    expect(parseFrontmatterDescription(`---\nname: foo\n---\nbody`)).toBe("");
+  });
+});
+
+describe("countKeywordHits", () => {
+  it("counts case-insensitive substring occurrences across keywords", () => {
+    expect(countKeywordHits("EEG paradigm and EEG timing", ["eeg"])).toBe(2);
+    expect(countKeywordHits("EEG paradigm", ["eeg", "PARADIGM"])).toBe(2);
+    expect(countKeywordHits("foo", ["bar"])).toBe(0);
+    expect(countKeywordHits("foo", [""])).toBe(0); // empty keyword does not match
+  });
+});
+
+describe("collectAllSkills", () => {
+  let base: string;
+  beforeAll(async () => {
+    base = await makeFixtureBase();
+  });
+
+  it("walks <category>/<skill_name>/SKILL.md and dedupes by skill_name", async () => {
+    const skills = await collectAllSkills(base);
+    const names = skills.map((s) => s.name).sort();
+    expect(names).toEqual(["eeg-paradigm-designer", "figure-builder", "no-frontmatter"]);
+
+    const eeg = skills.find((s) => s.name === "eeg-paradigm-designer")!;
+    // First-occurrence wins for description (shadow file does NOT overwrite).
+    expect(eeg.description).toMatch(/oddball/i);
+    // Both paths are recorded.
+    expect(eeg.relative_paths).toHaveLength(2);
+  });
+});
+
+describe("searchSkills — query mode", () => {
+  let base: string;
+  beforeAll(async () => {
+    base = await makeFixtureBase();
+  });
+
+  it("ranks by keyword hits and returns the requested topk", async () => {
+    const out = JSON.parse(
+      await searchSkills(base, { mode: "query", keywords: ["EEG"], topk: 5 }),
+    );
+    expect(out.keywords).toEqual(["EEG"]);
+    expect(out.results[0].name).toBe("eeg-paradigm-designer");
+    expect(out.results[0].keyword_hits).toBeGreaterThan(0);
+    // Other skills with no hits are still returned (lower rank), which is
+    // fine — total_matched only counts hit>0 entries.
+    expect(out.total_matched).toBe(1);
+  });
+
+  it("topk truncates the result list", async () => {
+    const out = JSON.parse(
+      await searchSkills(base, { mode: "query", keywords: ["x"], topk: 1 }),
+    );
+    expect(out.returned).toBe(1);
+    expect(out.results).toHaveLength(1);
+  });
+
+  it("query with skill_name returns the FULL SKILL.md body", async () => {
+    const text = await searchSkills(base, {
+      mode: "query",
+      skill_name: "figure-builder",
+    });
+    expect(text).toContain("Build publication-grade figures");
+    expect(text).toContain("Visualization helper.");
+  });
+
+  it("query with unknown skill_name throws", async () => {
+    await expect(
+      searchSkills(base, { mode: "query", skill_name: "does-not-exist" }),
+    ).rejects.toThrow(/not found in router/);
+  });
+
+  it("query mode requires keywords or skill_name", async () => {
+    await expect(searchSkills(base, { mode: "query" })).rejects.toThrow(/keywords/);
+  });
+});
+
+describe("searchSkills — browse mode", () => {
+  let base: string;
+  beforeAll(async () => {
+    base = await makeFixtureBase();
+  });
+
+  it("lists top-level categories with relative_path='' and '.'", async () => {
+    const out1 = JSON.parse(await searchSkills(base, { mode: "browse", relative_path: "" }));
+    expect(out1.type).toBe("directory");
+    expect(out1.children.map((c: { name: string }) => c.name).sort()).toEqual(
+      ["02_Cross-Domain", "05_EEG_ERP", "13_Visualization", "99_misc"].sort(),
+    );
+
+    const out2 = JSON.parse(await searchSkills(base, { mode: "browse", relative_path: "." }));
+    expect(out2.children.map((c: { name: string }) => c.name).sort()).toEqual(
+      out1.children.map((c: { name: string }) => c.name).sort(),
+    );
+  });
+
+  it("lists a sub-directory when given a category-relative path", async () => {
+    const out = JSON.parse(
+      await searchSkills(base, {
+        mode: "browse",
+        relative_path: "02_Cross-Domain/eeg-paradigm-designer",
+      }),
+    );
+    const names = out.children.map((c: { name: string }) => c.name).sort();
+    expect(names).toEqual(["SKILL.md", "references"].sort());
+  });
+
+  it("returns the file content when given a file path", async () => {
+    const text = await searchSkills(base, {
+      mode: "browse",
+      relative_path: "13_Visualization/figure-builder/SKILL.md",
+    });
+    expect(text).toContain("publication-grade");
+  });
+
+  it("rejects path traversal via '../'", async () => {
+    await expect(
+      searchSkills(base, { mode: "browse", relative_path: "../etc/passwd" }),
+    ).rejects.toThrow(/traversal/);
+  });
+
+  it("rejects absolute paths", async () => {
+    await expect(
+      searchSkills(base, { mode: "browse", relative_path: "/etc/passwd" }),
+    ).rejects.toThrow(/traversal/);
+  });
+
+  it("throws on a missing path", async () => {
+    await expect(
+      searchSkills(base, { mode: "browse", relative_path: "nope/nada" }),
+    ).rejects.toThrow(/does not exist/);
+  });
+});
+
+describe("createSkillSearchTool", () => {
+  it("returns a Pi-shaped SystemTool with mode/keywords/skill_name/relative_path", async () => {
+    const base = await makeFixtureBase();
+    const deps: ToolDeps = {
+      sessionId: "s",
+      fromAgent: "principal",
+      mailbox: new Mailbox("s"),
+      trace: new GraphOfTrace("s"),
+      ensureAgent: async () => {},
+      destroyAgent: async () => {},
+      wakeAgent: () => {},
+      requestUserInput: async () => "",
+      routerSkillsDir: base,
+    };
+    const tool = createSkillSearchTool(deps);
+
+    expect(tool.name).toBe("skill_search");
+    expect(tool.parameters).toMatchObject({ type: "object" });
+    const params = tool.parameters as { properties: Record<string, unknown>; required: string[] };
+    expect(params.properties).toHaveProperty("mode");
+    expect(params.properties).toHaveProperty("keywords");
+    expect(params.properties).toHaveProperty("skill_name");
+    expect(params.properties).toHaveProperty("relative_path");
+    expect(params.required).toContain("mode");
+
+    // Round-trip: invoking execute with {mode:'query', keywords:['EEG']} returns
+    // the JSON payload the model sees.
+    const out = await tool.execute({ mode: "query", keywords: ["EEG"] });
+    const payload = JSON.parse(out.content[0]!.text);
+    expect(payload.results[0].name).toBe("eeg-paradigm-designer");
+  });
+
+  it("propagates errors as thrown exceptions (no isError on AgentToolResult)", async () => {
+    const base = await makeFixtureBase();
+    const deps: ToolDeps = {
+      sessionId: "s",
+      fromAgent: "principal",
+      mailbox: new Mailbox("s"),
+      trace: new GraphOfTrace("s"),
+      ensureAgent: async () => {},
+      destroyAgent: async () => {},
+      wakeAgent: () => {},
+      requestUserInput: async () => "",
+      routerSkillsDir: base,
+    };
+    const tool = createSkillSearchTool(deps);
+    await expect(tool.execute({ mode: "query" })).rejects.toThrow(/keywords/);
+  });
+});

--- a/packages/runtime/src/__tests__/tool-access.test.ts
+++ b/packages/runtime/src/__tests__/tool-access.test.ts
@@ -18,6 +18,7 @@ function deps(name: string): ToolDeps {
     destroyAgent: async () => {},
     wakeAgent: () => {},
     requestUserInput: async () => "stub-answer",
+    routerSkillsDir: "/tmp/bp-test-router",
   };
 }
 
@@ -44,10 +45,20 @@ describe("tool access control (§9)", () => {
     expect(names).not.toContain("create_agent");
   });
 
-  it("expert gets send_message + record_trace only", () => {
+  it("expert gets send_message + record_trace + skill_search", () => {
     const names = systemToolNamesForRole("expert", "librarian");
-    expect(names.sort()).toEqual(["record_trace", "send_message"].sort());
+    expect(names.sort()).toEqual(["record_trace", "send_message", "skill_search"].sort());
     expect(names).not.toContain("create_agent");
+  });
+
+  it("skill_search reaches every non-trace role (router-skill discovery)", () => {
+    expect(systemToolNamesForRole("principal", "principal")).toContain("skill_search");
+    expect(systemToolNamesForRole("expert", "librarian")).toContain("skill_search");
+    expect(systemToolNamesForRole("expert", "writer")).toContain("skill_search");
+    expect(systemToolNamesForRole("expert", "auditor")).toContain("skill_search");
+    expect(systemToolNamesForRole("expert", "statistician")).toContain("skill_search");
+    // Trace is graph-only — no skill discovery surface.
+    expect(systemToolNamesForRole("trace", "trace")).not.toContain("skill_search");
   });
 
   it("resolves the actual SystemTool objects for a role (filtered)", () => {
@@ -94,9 +105,9 @@ describe("tool access control (§9)", () => {
     );
   });
 
-  it("auditor gets send_message + record_trace, but NO trace-graph access", () => {
+  it("auditor gets send_message + record_trace + skill_search, but NO trace-graph access", () => {
     const names = systemToolNamesForRole("expert", "auditor");
-    expect(names.sort()).toEqual(["record_trace", "send_message"].sort());
+    expect(names.sort()).toEqual(["record_trace", "send_message", "skill_search"].sort());
     // Audit evidence is restricted to the workspace — no graph reads, no
     // create/destroy, no graph mutation.
     expect(names).not.toContain("get_trace_graph");

--- a/packages/runtime/src/__tests__/two-skill-paths.test.ts
+++ b/packages/runtime/src/__tests__/two-skill-paths.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Integration test for the two-path skill-loading design:
+ *
+ *   - bp_template/skills/         → Pi-native `additionalSkillPaths` (always-on)
+ *   - bp_template/skills-router/  → `skill_search` Pi-native custom tool
+ *
+ * After materialization, the always-on dir must contain ONLY the Meta-Skills
+ * category, the router dir must contain every other shipped category, and the
+ * SessionManager must hand each path to the right consumer (the agent factory's
+ * `skillPaths` vs the `skill_search` tool's router base).
+ */
+import { describe, it, expect } from "vitest";
+import { mkdtemp, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ALWAYS_ON_CATEGORY, materializeSkills } from "../materialize-skills.js";
+import { SessionManager } from "../session-manager.js";
+import { mockAgentFactory } from "../agent-factory.js";
+import type { AgentSessionFactory } from "../types.js";
+
+async function tmp(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "bp-two-paths-"));
+}
+
+describe("two-path skill loading", () => {
+  it("materialize splits Meta-Skills into always-on and the rest into router", async () => {
+    const root = await tmp();
+    const res = await materializeSkills(root);
+
+    const alwaysOnDirs = (await readdir(res.dest, { withFileTypes: true }))
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name);
+    const routerDirs = (await readdir(res.routerDest, { withFileTypes: true }))
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name);
+
+    expect(alwaysOnDirs).toEqual([ALWAYS_ON_CATEGORY]);
+    expect(routerDirs).not.toContain(ALWAYS_ON_CATEGORY);
+    expect(routerDirs.length).toBeGreaterThan(0);
+  });
+
+  it("SessionManager passes ONLY always-on to the factory's skillPaths", async () => {
+    const root = await tmp();
+    await materializeSkills(root); // populate both sides up-front
+
+    let capturedSkillPaths: string[] | undefined;
+    // Wrap the mock factory so we can observe what the manager handed to it.
+    const wrappedFactory: AgentSessionFactory = async (params) => {
+      capturedSkillPaths = params.skillPaths;
+      return mockAgentFactory(params);
+    };
+
+    const mgr = new SessionManager({
+      dataRoot: root,
+      agentFactory: wrappedFactory,
+      persist: false,
+    });
+    const session = await mgr.createSession({});
+    await mgr.ensureAgent(session.id, "principal");
+
+    // Always-on dir is the only entry; router is NOT in this list.
+    expect(capturedSkillPaths).toEqual([join(root, "bp_template", "skills")]);
+    expect(capturedSkillPaths).not.toContain(join(root, "bp_template", "skills-router"));
+  });
+
+  it("skill_search tool reads from the router dir, not the always-on dir", async () => {
+    const root = await tmp();
+    await materializeSkills(root);
+
+    let capturedRouterDir: string | undefined;
+    let toolNamesSeen: string[] | undefined;
+    const wrappedFactory: AgentSessionFactory = async (params) => {
+      toolNamesSeen = params.systemTools.map((t) => t.name);
+      // The skill_search tool's execute closure captured the router dir;
+      // invoke it with browse('') and confirm it lists router categories.
+      const skillSearch = params.systemTools.find((t) => t.name === "skill_search");
+      if (skillSearch) {
+        const out = await skillSearch.execute({ mode: "browse", relative_path: "" });
+        const payload = JSON.parse(out.content[0]!.text);
+        // The router dir must NOT contain the Meta-Skills category — that one
+        // lives only in the always-on dir.
+        const names = payload.children.map((c: { name: string }) => c.name);
+        expect(names).not.toContain(ALWAYS_ON_CATEGORY);
+        expect(names.length).toBeGreaterThan(0);
+        capturedRouterDir = root; // success signal
+      }
+      return mockAgentFactory(params);
+    };
+
+    const mgr = new SessionManager({
+      dataRoot: root,
+      agentFactory: wrappedFactory,
+      persist: false,
+    });
+    const session = await mgr.createSession({});
+    await mgr.ensureAgent(session.id, "librarian");
+
+    expect(toolNamesSeen).toContain("skill_search");
+    expect(capturedRouterDir).toBe(root);
+  });
+
+  it("trace agent does NOT receive skill_search (graph-only role)", async () => {
+    const root = await tmp();
+    await materializeSkills(root);
+
+    let traceTools: string[] | undefined;
+    const wrappedFactory: AgentSessionFactory = async (params) => {
+      if (params.agentName === "trace") traceTools = params.systemTools.map((t) => t.name);
+      return mockAgentFactory(params);
+    };
+
+    const mgr = new SessionManager({
+      dataRoot: root,
+      agentFactory: wrappedFactory,
+      persist: false,
+    });
+    const session = await mgr.createSession({});
+    await mgr.ensureAgent(session.id, "trace");
+
+    expect(traceTools).toBeDefined();
+    expect(traceTools).not.toContain("skill_search");
+    // Trace also gets no skillPaths (it is skill-less by design).
+  });
+});

--- a/packages/runtime/src/materialize-skills.ts
+++ b/packages/runtime/src/materialize-skills.ts
@@ -1,35 +1,64 @@
 /**
  * materialize-skills.ts — copy the bundled `@brainpilot/skills` content into a
- * data dir's `bp_template/skills/`, so Pi's native skill pipeline can load
- * user-editable skills from there.
+ * data dir, splitting it across TWO physically separate skill libraries:
+ *
+ *   <dataRoot>/bp_template/skills/         (always-on, Pi-native)
+ *     Loaded through Pi's `additionalSkillPaths`. Every SKILL.md's name +
+ *     description appears in the agent's `<available_skills>` block. Reserved
+ *     for high-frequency Meta-Skills so the prompt does not bloat.
+ *
+ *   <dataRoot>/bp_template/skills-router/  (router-only)
+ *     Pi never sees this directory; it is reachable only via the `skill_search`
+ *     custom tool. Holds the long tail of domain skills.
+ *
+ * Distribution rule (purely physical):
+ *   - bundled `01_Meta-Skills/*` → always-on
+ *   - everything else            → router
+ *
+ * Both libraries accept user-added skills with the SAME on-disk format
+ * (`<category>/<skill_name>/SKILL.md` + optional `references/` / `scripts/`),
+ * so the user can drop a directory into either side and it just works.
  *
  * Pipeline (three stages, see issues #139/#140):
  *   - package time: skills ship read-only inside `@brainpilot/skills`.
- *   - deploy time:  this fn copies them into `<dataRoot>/bp_template/skills/`.
- *   - runtime:      Pi loads from `bp_template/skills/` via `additionalSkillPaths`.
+ *   - deploy time:  this fn copies them into the two destinations above.
+ *   - runtime:      Pi loads from `bp_template/skills/` via additionalSkillPaths;
+ *                   `skill_search` reads `bp_template/skills-router/`.
  *
- * Idempotent and edit-preserving: a file that already exists at the destination
- * is NEVER overwritten (so user edits and per-skill customisations survive).
- *
- * Called from BOTH the CLI `scaffold` and the runtime server startup. It lives
- * in `@brainpilot/runtime` (not the CLI) because the dependency direction is
- * cli → runtime; putting it in the CLI would make runtime depend on the CLI.
+ * Idempotent and edit-preserving: a file that already exists at either
+ * destination is NEVER overwritten (so user edits and per-skill customisations
+ * survive). Called from BOTH the CLI `scaffold` and the runtime server startup.
+ * It lives in `@brainpilot/runtime` (not the CLI) because the dependency
+ * direction is cli → runtime.
  */
 import { createRequire } from "node:module";
 import { mkdir, readdir, copyFile, access } from "node:fs/promises";
 import { constants as FS } from "node:fs";
 import { dirname, join } from "node:path";
 
+/**
+ * Source category whose contents go into the always-on library. Anything else
+ * ends up in the router library. Kept as a constant so a test can pin the
+ * distribution rule explicitly.
+ */
+export const ALWAYS_ON_CATEGORY = "01_Meta-Skills";
+
 /** Result of a materialize run. */
 export interface MaterializeSkillsResult {
-  /** Absolute destination dir (`<dataRoot>/bp_template/skills`). */
+  /** Absolute always-on destination dir (`<dataRoot>/bp_template/skills`). */
   dest: string;
+  /** Absolute router destination dir (`<dataRoot>/bp_template/skills-router`). */
+  routerDest: string;
   /** Absolute source dir (the bundled `@brainpilot/skills` skills/). */
   source: string | null;
-  /** Number of files freshly copied (absent before). */
+  /** Files freshly copied into the always-on dir. */
   copied: number;
-  /** Number of files skipped because they already existed. */
+  /** Files skipped (already existed) in the always-on dir. */
   skipped: number;
+  /** Files freshly copied into the router dir. */
+  routerCopied: number;
+  /** Files skipped (already existed) in the router dir. */
+  routerSkipped: number;
 }
 
 /**
@@ -88,23 +117,49 @@ async function copyTreeSkipExisting(
 }
 
 /**
- * Materialize the bundled skills into `<dataRoot>/bp_template/skills/`.
- *
- * Skip-if-exists at the file level: existing files are preserved, missing ones
- * are filled in. Safe to call on every launch. A no-op (copied=0) when the
- * package can't be resolved or the source dir is empty/absent.
+ * Materialize the bundled skills, splitting by source category:
+ * `01_Meta-Skills/*` → always-on dir, every other top-level category → router
+ * dir. Skip-if-exists at the file level on BOTH destinations: existing files
+ * are preserved, missing ones are filled in. Safe to call on every launch. A
+ * no-op (all counts 0) when the package can't be resolved or the source is
+ * empty/absent.
  */
 export async function materializeSkills(dataRoot: string): Promise<MaterializeSkillsResult> {
   const dest = join(dataRoot, "bp_template", "skills");
+  const routerDest = join(dataRoot, "bp_template", "skills-router");
   const source = resolveBundledSkillsDir();
-  const counters = { copied: 0, skipped: 0 };
+  const alwaysOn = { copied: 0, skipped: 0 };
+  const router = { copied: 0, skipped: 0 };
+
+  // Always ensure both destination dirs exist so loaders / the router tool
+  // have a stable path even when the source is missing or empty.
+  await mkdir(dest, { recursive: true });
+  await mkdir(routerDest, { recursive: true });
 
   if (source && (await exists(source))) {
-    await copyTreeSkipExisting(source, dest, counters);
-  } else {
-    // Still ensure the destination dir exists so loaders have a stable path.
-    await mkdir(dest, { recursive: true });
+    const topLevel = await readdir(source, { withFileTypes: true });
+    for (const entry of topLevel) {
+      if (!entry.isDirectory()) continue; // skip stray files at the source root
+      const from = join(source, entry.name);
+      if (entry.name === ALWAYS_ON_CATEGORY) {
+        // Mount the meta-skills directory at the SAME relative path inside the
+        // always-on library so a user-added meta-skill drops in identically.
+        const to = join(dest, entry.name);
+        await copyTreeSkipExisting(from, to, alwaysOn);
+      } else {
+        const to = join(routerDest, entry.name);
+        await copyTreeSkipExisting(from, to, router);
+      }
+    }
   }
 
-  return { dest, source: source && (await exists(source)) ? source : null, ...counters };
+  return {
+    dest,
+    routerDest,
+    source: source && (await exists(source)) ? source : null,
+    copied: alwaysOn.copied,
+    skipped: alwaysOn.skipped,
+    routerCopied: router.copied,
+    routerSkipped: router.skipped,
+  };
 }

--- a/packages/runtime/src/personas.ts
+++ b/packages/runtime/src/personas.ts
@@ -86,21 +86,59 @@ outcome, not a single word) and a \`context\` explaining why the step mattered.
 Skip process noise — reading one file, a failed attempt you immediately retry,
 or merely acknowledging a task.`;
 
+/**
+ * Router skill library — second skill-loading path. The Pi-native
+ * `<available_skills>` list is intentionally narrow (Meta-Skills only); the
+ * domain catalog (~42 skills covering EEG/fMRI/cognition/visualization/writing/
+ * etc.) lives in a parallel directory the agent reaches via the `skill_search`
+ * tool. Every non-trace persona gets this block so the model knows the
+ * <available_skills> list is NOT the full library.
+ */
+const ROUTER_SKILL_LIBRARY = `## Router skill library (skill_search)
+
+Your \`<available_skills>\` block lists ONLY the Meta-Skills (contributing,
+sharing, and verifying skills). The full **domain skill library** —
+neuroscience methodology, paradigm designs, statistical guides, tool manuals,
+visualization patterns, writing templates — is NOT in that block. It is
+reachable through the \`skill_search\` tool:
+
+- \`skill_search(mode="query", keywords=[...])\` — keyword search of the router
+  catalog. Returns the top-ranked skills with name, description, paths, and
+  hit count. Use this whenever you need a domain method, technique, or pattern
+  and \`<available_skills>\` has nothing matching.
+- \`skill_search(mode="query", skill_name="<name>")\` — load a skill's full
+  \`SKILL.md\` body once you've decided which one to apply.
+- \`skill_search(mode="browse", relative_path="...")\` — list a category, walk
+  into a skill's \`references/\`, or read any file under the router root. Use
+  \`""\` or \`"."\` to list top-level categories.
+
+Treat this as your default pre-flight for any non-trivial domain task: if
+nothing in \`<available_skills>\` fits, search the router BEFORE proceeding from
+generic memory. The router is large enough that domain-validated parameters,
+paradigms, or templates almost certainly exist — generic LLM memory of those
+details is often subtly wrong.`;
+
 const SKILLS_FIRST_EXPERT = `## Skills-first preflight
 
-You have a library of built-in skills. Their names and one-line descriptions are
-listed in the \`<available_skills>\` section of your context; each entry has a
-\`location\` (a path to a \`SKILL.md\`).
+You have TWO skill libraries:
+
+1. **Always-on** — the \`<available_skills>\` section of your context lists
+   high-frequency Meta-Skills (contributing, sharing, verifying skills). Each
+   entry has a \`location\` path to a \`SKILL.md\` you can open with \`read\` or
+   force-load with \`/skill:<name>\`.
+2. **Router** — a much larger domain library reachable via the
+   \`skill_search\` tool (see "Router skill library"). It is NOT visible in
+   \`<available_skills>\`; you must call \`skill_search\` to discover it.
 
 For any non-trivial task that involves a domain method, study design, data
 analysis, implementation pipeline, visualization, or written deliverable, your
-first substantive step is to scan that list for a skill whose description matches
-the task. If one fits, **read its \`SKILL.md\` with the \`read\` tool** before
-committing to the approach, and use it as the starting point (it may point to
-further reference files under its folder — read those on demand too). You can
-also force-load a skill by name with \`/skill:<name>\`. If no relevant skill
-exists, proceed from your expertise and briefly note that no matching skill was
-found in your handoff to the Principal.
+first substantive step is to scan \`<available_skills>\` AND query the router
+for a skill whose description matches the task. If one fits, **read its
+\`SKILL.md\`** before committing to the approach, and use it as the starting
+point (it may point to further reference files under its folder — read those
+on demand too). If no relevant skill exists in either library, proceed from
+your expertise and briefly note that no matching skill was found in your
+handoff to the Principal.
 
 Do not stall on skills for greetings, trivial edits, pure status updates, or
 tasks where the Principal already gave you a specific skill name to load.`;
@@ -227,34 +265,45 @@ type, what is known vs. what an expert must supply, and which agent owns each
 piece. Then delegate. Simple Q&A, file inspection, or an explicit "just do X"
 you may answer directly.
 
-## Skills library
+## Skills library (two paths)
 
 You have a curated library of domain-specific methodology guides, tool manuals,
 and best practices (neuroscience, psychology, statistics, visualization,
-writing, etc.). Each skill's name and one-line description appears in the
-\`<available_skills>\` section of your context, with a \`location\` path to its
-\`SKILL.md\`.
+writing, etc.) split across two libraries:
+
+1. **Always-on** — the \`<available_skills>\` section of your context lists
+   high-frequency Meta-Skills (contributing, sharing, verifying skills) with a
+   \`location\` path to each \`SKILL.md\`.
+2. **Router** — the much larger DOMAIN library is NOT in \`<available_skills>\`.
+   Reach it through the \`skill_search\` tool (see "Router skill library"
+   below). Use \`skill_search(mode="query", keywords=[...])\` to discover
+   matches, then \`skill_search(mode="query", skill_name="<name>")\` to load
+   the full body.
 
 - **Skills-first preflight:** for any non-trivial user request, scan
-  \`<available_skills>\` while scoping the task. Skip this only for greetings,
-  pure status replies, or trivial file/text operations.
-- **Use matches immediately:** if a skill's description fits, **read its
-  \`SKILL.md\` with the \`read\` tool** before you commit to a plan or delegate.
+  \`<available_skills>\` AND query the router for relevant skills while scoping
+  the task. Skip this only for greetings, pure status replies, or trivial
+  file/text operations.
+- **Use matches immediately:** if a skill's description fits, load its
+  \`SKILL.md\` (\`read\` for always-on; \`skill_search(mode="query",
+  skill_name=...)\` for router) before committing to a plan or delegating.
   Use it to shape the task split, success criteria, and methodology assumptions.
-- **Point experts to skills:** when you delegate, name the relevant skill in the
-  task description and explicitly tell the expert to load and apply it before
-  doing the work.
-  Example: "Design an EEG paradigm — load the eeg-paradigm-designer skill
-  (read its SKILL.md) before designing."
-- **Read skills yourself** for lightweight methodology checks that don't warrant
-  an expert round-trip — just \`read\` the skill's \`SKILL.md\` (and any
-  reference files under its folder).
+- **Point experts to skills:** when you delegate, name the relevant skill in
+  the task description and explicitly tell the expert to load and apply it
+  before doing the work — they have \`skill_search\` too.
+  Example: "Design an EEG paradigm — call \`skill_search(mode='query',
+  skill_name='eeg-paradigm-designer')\` and apply it before designing."
+- **Read skills yourself** for lightweight methodology checks that don't
+  warrant an expert round-trip.
 - **Check expert skill use:** when an expert reports back on work that clearly
-  had a relevant skill, verify that they used it or explain why it did not apply.
-  If they skipped an important skill, ask them to revise before synthesis.
+  had a relevant skill, verify that they used it or explain why it did not
+  apply. If they skipped an important skill, ask them to revise before
+  synthesis.
 
 Keep skills use mostly invisible to the user. Mention it only when it changes
 the plan, resolves an ambiguity, or improves confidence in the recommendation.
+
+${ROUTER_SKILL_LIBRARY}
 
 ## Clarify requirements before committing
 
@@ -390,11 +439,18 @@ grounded in those gaps, and **References**.
 ## Skills-first knowledge framing
 
 Before a substantial literature survey, hypothesis-grounding task, or
-methodology-sensitive synthesis, scan \`<available_skills>\` for a skill matching
-the domain, method, and evidence type. If a relevant skill exists, **read its
-\`SKILL.md\`** and use it to frame what evidence to look for, what quality signals
-matter, and what caveats to surface. If no relevant skill exists, continue with
-external search and your domain expertise.
+methodology-sensitive synthesis, scan BOTH skill libraries for a skill matching
+the domain, method, and evidence type:
+
+1. \`<available_skills>\` (always-on) — open a match with \`read\`.
+2. The router library — call \`skill_search(mode="query", keywords=[...])\` and
+   \`skill_search(mode="query", skill_name="<name>")\` to discover and load.
+
+If a relevant skill exists in either library, use it to frame what evidence to
+look for, what quality signals matter, and what caveats to surface. If neither
+library has a match, continue with external search and your domain expertise.
+
+${ROUTER_SKILL_LIBRARY}
 
 ## Search tools
 
@@ -448,30 +504,39 @@ interpret the results they return.
 ## Skills-driven design
 
 You have a curated library of paradigm designs, statistical methods, power
-analysis guides, and experimental protocols. Each skill's name and description
-appears in \`<available_skills>\` with a \`location\` path to its \`SKILL.md\`.
-For experimental design work, skills are not an optional polish step — they are
+analysis guides, and experimental protocols across TWO paths: the always-on
+\`<available_skills>\` block (Meta-Skills only) and the much larger ROUTER
+library reached through the \`skill_search\` tool (see "Router skill library").
+The domain skills you'll actually need for design work — paradigm designers,
+power guides, fMRI task templates — almost all live in the router. For
+experimental design work, skills are not an optional polish step — they are
 your first methodology check:
 
 1. **Find relevant skills first:** before proposing a protocol, sample plan,
    statistical test, timing parameter, paradigm, or validation procedure, scan
-   \`<available_skills>\` for a skill matching the domain or paradigm (e.g. an
-   EEG paradigm designer, a power/sample-size guide, an fMRI task-design guide).
-2. **Read the best match before designing:** open its \`SKILL.md\` with the
-   \`read\` tool (or \`/skill:<name>\`). Use its prescriptions —
-   component/timing parameters, design principles, controls, power/sample
-   planning, and analysis plans — as your starting point.
-3. **Explore references for depth:** \`read\` the reference files under the
-   skill's folder (e.g. \`references/\`) for parameter tables, formula guides,
-   classic paradigms, and worked examples.
+   \`<available_skills>\` AND call \`skill_search(mode="query", keywords=[...])\`
+   for a skill matching the domain or paradigm (e.g. an EEG paradigm designer,
+   a power/sample-size guide, an fMRI task-design guide).
+2. **Read the best match before designing:** load its \`SKILL.md\` (\`read\` for
+   always-on; \`skill_search(mode="query", skill_name="<name>")\` for router).
+   Use its prescriptions — component/timing parameters, design principles,
+   controls, power/sample planning, and analysis plans — as your starting
+   point.
+3. **Explore references for depth:** for always-on skills \`read\` the
+   reference files under the folder; for router skills use
+   \`skill_search(mode="browse", relative_path="<category>/<skill>/references")\`
+   to walk in.
 4. **Report skill grounding:** in your handoff, name the skill(s) you used and
-   any important prescription you followed. If no relevant skill existed, say so
-   briefly and proceed from your expertise.
+   any important prescription you followed. If no relevant skill existed, say
+   so briefly and proceed from your expertise.
 
 Skills encode domain-validated methodology that generic model knowledge often
 misremembers (effect-size conventions, timing parameters, standard paradigms,
-counterbalancing patterns). Do not invent parameters from memory when a relevant
-skill can ground them. Cite the specific skill and version in your protocol.
+counterbalancing patterns). Do not invent parameters from memory when a
+relevant skill can ground them. Cite the specific skill and version in your
+protocol.
+
+${ROUTER_SKILL_LIBRARY}
 
 ${EXPERT_AUTHORIZATION_GATE}
 
@@ -516,28 +581,33 @@ For long jobs, deliver in phases and report status so failures surface early.
 ## Skills-driven implementation
 
 You have a curated library of tool guides, preprocessing pipelines, analysis
-workflows, and implementation patterns. Each skill's name and description appears
-in \`<available_skills>\` with a \`location\` path to its \`SKILL.md\`. Before
-writing code or choosing an implementation pipeline, ground your approach in
-validated methodology:
+workflows, and implementation patterns split across TWO paths: the always-on
+\`<available_skills>\` block (Meta-Skills only) and the much larger ROUTER
+library reached through the \`skill_search\` tool (see "Router skill library").
+Implementation skills (MNE-Python guides, fMRI GLM analysis guides, model
+builders) almost all live in the router. Before writing code or choosing an
+implementation pipeline, ground your approach in validated methodology:
 
-1. **Find relevant skills first:** scan \`<available_skills>\` for a skill
-   matching the tools or methods you need (e.g. an MNE-Python guide, an fMRI GLM
-   analysis guide, a Bayesian cognitive-model builder).
-2. **Read a skill's guide:** open its \`SKILL.md\` with the \`read\` tool (or
-   \`/skill:<name>\`) — follow its prescriptions for parameter choices, pipeline
-   order, and API usage unless the experimentalist's protocol explicitly
-   overrides them.
-3. **Explore references:** \`read\` the supplementary files under the skill's
-   folder (e.g. \`references/\`) for parameter tables, API docs, worked examples,
-   and formula guides.
+1. **Find relevant skills first:** scan \`<available_skills>\` AND call
+   \`skill_search(mode="query", keywords=[...])\` for a skill matching the
+   tools or methods you need.
+2. **Read a skill's guide:** load its \`SKILL.md\` (\`read\` for always-on;
+   \`skill_search(mode="query", skill_name="<name>")\` for router) — follow
+   its prescriptions for parameter choices, pipeline order, and API usage
+   unless the experimentalist's protocol explicitly overrides them.
+3. **Explore references:** for always-on skills \`read\` the supplementary
+   files under the folder; for router skills use
+   \`skill_search(mode="browse", relative_path="<category>/<skill>/references")\`.
 
 Use skills as your primary source for tool-specific implementation patterns —
 they encode validated practice that generic model knowledge often gets wrong
-(default parameters, package APIs, pipeline order). When a skill conflicts with
-the experimentalist's protocol, flag the tension and ask the Principal to
-resolve it via \`send_message\`. If no relevant skill exists, continue from your
-engineering judgment and say that no matching skill was found in your handoff.
+(default parameters, package APIs, pipeline order). When a skill conflicts
+with the experimentalist's protocol, flag the tension and ask the Principal to
+resolve it via \`send_message\`. If no relevant skill exists, continue from
+your engineering judgment and say that no matching skill was found in your
+handoff.
+
+${ROUTER_SKILL_LIBRARY}
 
 ${EXPERT_AUTHORIZATION_GATE}
 
@@ -574,26 +644,31 @@ logical structure, and audience awareness.
 ## Skills-driven writing
 
 Before drafting, ground your work in the skills library — a curated collection
-of writing templates, format prescriptions, style guides, and visualization best
-practices. Each skill's name and description appears in \`<available_skills>\`
-with a \`location\` path to its \`SKILL.md\`; read a skill's body on demand with
-the \`read\` tool (progressive disclosure).
+of writing templates, format prescriptions, style guides, and visualization
+best practices split across TWO paths: the always-on \`<available_skills>\`
+block (Meta-Skills only) and the much larger ROUTER library reached through
+the \`skill_search\` tool (see "Router skill library"). The writing and
+visualization skills you'll need (manuscript/IMRaD guide, grant-proposal
+guide, **14_Writing** templates, **13_Visualization** patterns) live in the
+router.
 
 ### 1. Skills-first writing preflight
 
 When you receive a writing task, your first substantive step is to scan
-\`<available_skills>\` for a skill matching the document type, audience, domain,
-and format (e.g. a markdown-report-writing skill, a manuscript/IMRaD guide, a
-grant-proposal guide), including relevant **14_Writing** and cross-category
-skills.
+\`<available_skills>\` AND call \`skill_search(mode="query", keywords=[...])\`
+for a skill matching the document type, audience, domain, and format (e.g. a
+markdown-report-writing skill, a manuscript/IMRaD guide, a grant-proposal
+guide), including the router's \`14_Writing\` and cross-category skills.
 
 ### 2. Select and apply a writing skill
 
-Select the most relevant skill by default and **read its \`SKILL.md\`** with the
-\`read\` tool (or \`/skill:<name>\`). Use the skill's guidance — structure, tone,
-formatting rules, evidence handling, and conventions — to drive every phase of
-the writing framework above. If you need templates or examples, \`read\` the
-files under the skill's folder.
+Select the most relevant skill by default and **load its \`SKILL.md\`**
+(\`read\` for always-on; \`skill_search(mode="query", skill_name="<name>")\`
+for router). Use the skill's guidance — structure, tone, formatting rules,
+evidence handling, and conventions — to drive every phase of the writing
+framework above. If you need templates or examples, \`read\` the files under
+the skill's folder (or \`skill_search(mode="browse", relative_path=...)\` for
+router skills).
 
 Do not ask the user to choose among writing skills just because several exist.
 Ask \`ask_user\` only when the audience, venue, length, or format is genuinely
@@ -603,20 +678,22 @@ rather than silently overriding either.
 
 ### 3. Visualization guidance
 
-If the document calls for figures, charts, or data presentation, look in
-\`<available_skills>\` for a visualization skill (the **13_Visualization**
-category) and \`read\` it. Apply relevant guidance on figure design, chart
-selection, colour accessibility, and data-presentation best
-practices alongside the writing skill. When the visualisation skill conflicts
-with the writing skill (e.g. figure placement, caption style), defer to the
-writing skill for document-level conventions and to the visualisation skill for
+If the document calls for figures, charts, or data presentation, search both
+libraries for a visualization skill (router category **13_Visualization** is
+the usual home) and load it. Apply relevant guidance on figure design, chart
+selection, colour accessibility, and data-presentation best practices
+alongside the writing skill. When the visualisation skill conflicts with the
+writing skill (e.g. figure placement, caption style), defer to the writing
+skill for document-level conventions and to the visualisation skill for
 figure-level execution.
 
 ### 4. Report skill grounding
 
 In your handoff, name the writing/visualization skill(s) you applied. If no
-relevant writing skill exists, proceed from the writing framework above and say
-that no matching skill was found.
+relevant writing skill exists, proceed from the writing framework above and
+say that no matching skill was found.
+
+${ROUTER_SKILL_LIBRARY}
 
 ## Discipline
 
@@ -818,6 +895,8 @@ After sending, **end your turn**. Do not continue tool calls.
   report body.
 - **End your turn after \`audit_complete\`.** Do not keep acting.
 - **At most 2 followups per audit pass, to 2 different agents.**
+
+${ROUTER_SKILL_LIBRARY}
 
 ${TRACE_EXPERT}
 

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -112,6 +112,13 @@ export interface SessionManagerOptions {
    */
   skillsDir?: string;
   /**
+   * Absolute path to the directory backing the `skill_search` tool (the second
+   * skill-loading path — long-tail domain library NOT exposed via Pi's
+   * `<available_skills>`). When omitted, defaults to
+   * `<dataRoot>/bp_template/skills-router`. Materialized alongside `skillsDir`.
+   */
+  routerSkillsDir?: string;
+  /**
    * Memory budget in bytes (issue #20 / R-4). When set, an opt-in soft watchdog
    * refuses new work past ~85% of the budget. Defaults to `BP_MEM_LIMIT_MB`
    * (parsed to bytes); `null`/absent → feature disabled, no behavior change.
@@ -196,6 +203,11 @@ export class SessionManager {
   // (`additionalSkillPaths`). The bundled @brainpilot/skills content is
   // materialized here once (lazily) on first agent creation.
   private readonly skillsDir: string;
+  // Router skills directory backing the `skill_search` Pi-native tool — the
+  // long-tail catalog NOT in `<available_skills>`. Materialized alongside
+  // `skillsDir` (each top-level category lands on the side determined by
+  // `materializeSkills`).
+  private readonly routerSkillsDir: string;
   private skillsMaterialized = false;
 
   // Opt-in memory watchdog (§R-4 / issue #20). Null when no budget is set.
@@ -222,6 +234,10 @@ export class SessionManager {
 
     // Skills are loaded by Pi from this dir (default <dataRoot>/bp_template/skills).
     this.skillsDir = opts.skillsDir ?? join(this.dataRoot, "bp_template", "skills");
+    // The router skill library is a parallel directory with the same on-disk
+    // format; `skill_search` reads from here, Pi never sees it.
+    this.routerSkillsDir =
+      opts.routerSkillsDir ?? join(this.dataRoot, "bp_template", "skills-router");
 
     const limitBytes = opts.memLimitBytes ?? parseMemLimitMb(process.env);
     this.memWatchdog =
@@ -251,8 +267,10 @@ export class SessionManager {
       const res = await materializeSkills(this.dataRoot);
       // eslint-disable-next-line no-console
       console.info(
-        `[skills] ${res.copied} skill file(s) materialized into ${res.dest}` +
-          (res.skipped ? ` (${res.skipped} preserved)` : ""),
+        `[skills] always-on: ${res.copied} copied → ${res.dest}` +
+          (res.skipped ? ` (${res.skipped} preserved)` : "") +
+          `; router: ${res.routerCopied} copied → ${res.routerDest}` +
+          (res.routerSkipped ? ` (${res.routerSkipped} preserved)` : ""),
       );
     } catch (err) {
       // eslint-disable-next-line no-console
@@ -959,6 +977,7 @@ export class SessionManager {
       },
       wakeAgent: (target) => this.wakeAgent(sessionId, target),
       requestUserInput: (req) => this.requestUserInput(entry, name, req),
+      routerSkillsDir: this.routerSkillsDir,
     };
     const systemTools = systemToolsForRole(role, name, deps);
     // External MCP tools go to non-trace agents (trace agent is graph-only, §9).

--- a/packages/runtime/src/tools/skill-search.ts
+++ b/packages/runtime/src/tools/skill-search.ts
@@ -1,0 +1,326 @@
+/**
+ * skill_search — Pi-native custom tool for the second skill-loading path.
+ *
+ * BrainPilot loads skills via TWO physically separate, identically-formatted
+ * directories:
+ *
+ *   <dataRoot>/bp_template/skills/         (always-on)
+ *     Loaded by Pi's native skill pipeline through `additionalSkillPaths`. Each
+ *     SKILL.md's name + description appears unconditionally in the agent's
+ *     `<available_skills>` system block; bodies are read on demand via the
+ *     built-in `read` tool or `/skill:<name>`. Cheap, but every entry costs
+ *     prompt tokens, so it is reserved for high-frequency Meta-Skills.
+ *
+ *   <dataRoot>/bp_template/skills-router/  (router-only)
+ *     Pi never sees this directory. Agents discover its contents only by
+ *     calling THIS tool, which lazily scans, ranks, and returns matching
+ *     skills. The router holds the long tail (~42 domain skills bundled by
+ *     default) without bloating every prompt.
+ *
+ * Both directories accept user-added skills with the same on-disk format
+ * (`<category>/<skill_name>/SKILL.md` + optional `references/` / `scripts/`).
+ *
+ * Modes (preserved verbatim from the legacy `skills_tool_local` MCP server):
+ *   - mode="query" + keywords      → top-K {name, description, paths, hits}
+ *   - mode="query" + skill_name    → full SKILL.md body
+ *   - mode="browse" + relative_path → list a directory or read a file
+ *
+ * Errors are signalled by THROWING (Pi's `AgentToolResult` carries no isError;
+ * see CLAUDE.md). The wrapping factory turns thrown errors into a tool-call
+ * failure the model can react to.
+ */
+import { readFile, readdir, stat, access } from "node:fs/promises";
+import { constants as FS } from "node:fs";
+import { join, resolve, sep } from "node:path";
+import type { SystemTool } from "../types.js";
+import type { ToolDeps } from "./system-tools.js";
+
+/* ------------------------------ types ----------------------------- */
+
+export interface SkillRecord {
+  name: string;
+  description: string;
+  /** Category-relative paths where this skill name appears (multi-category dedupe). */
+  relative_paths: string[];
+}
+
+export interface QueryResultEntry {
+  name: string;
+  description: string;
+  relative_paths: string[];
+  keyword_hits: number;
+}
+
+export interface QueryResult {
+  keywords: string[];
+  total_matched: number;
+  returned: number;
+  results: QueryResultEntry[];
+}
+
+/* --------------------------- frontmatter -------------------------- */
+
+/**
+ * Parse the `description` field from YAML frontmatter (the leading `---` block)
+ * of a SKILL.md. Handles double-quoted, single-quoted, and unquoted values.
+ * Returns "" when absent.
+ */
+export function parseFrontmatterDescription(content: string): string {
+  const fmMatch = content.match(/^---\s*\n([\s\S]*?)\n---/);
+  if (!fmMatch || !fmMatch[1]) return "";
+  const fm = fmMatch[1];
+  const m = fm.match(
+    /^description:\s*(?:["'])(.*?)(?:["'])\s*$|^description:\s*(.+?)\s*$/m,
+  );
+  if (!m) return "";
+  return (m[1] ?? m[2] ?? "").trim();
+}
+
+/* --------------------------- fs helpers --------------------------- */
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path, FS.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function listDirs(path: string): Promise<string[]> {
+  try {
+    const entries = await readdir(path, { withFileTypes: true });
+    return entries
+      .filter((d) => d.isDirectory())
+      .map((d) => d.name)
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+/* --------------------------- collection --------------------------- */
+
+/**
+ * Scan a router base directory for all skills. Mirrors the legacy collector:
+ * `<base>/<category>/<skill_name>/SKILL.md`. When the same skill_name appears
+ * in multiple categories, descriptions are taken from the first occurrence and
+ * subsequent paths are appended to `relative_paths`.
+ */
+export async function collectAllSkills(base: string): Promise<SkillRecord[]> {
+  const byName = new Map<string, SkillRecord>();
+  const categories = await listDirs(base);
+  for (const category of categories) {
+    const catPath = join(base, category);
+    const skills = await listDirs(catPath);
+    for (const skillName of skills) {
+      const skillMd = join(catPath, skillName, "SKILL.md");
+      if (!(await exists(skillMd))) continue;
+      const relPath = join(category, skillName);
+      const existing = byName.get(skillName);
+      if (existing) {
+        existing.relative_paths.push(relPath);
+        continue;
+      }
+      let description = "";
+      try {
+        const content = await readFile(skillMd, "utf8");
+        description = parseFrontmatterDescription(content);
+      } catch {
+        /* unreadable SKILL.md → empty description */
+      }
+      byName.set(skillName, { name: skillName, description, relative_paths: [relPath] });
+    }
+  }
+  return [...byName.values()];
+}
+
+/* --------------------------- ranking ------------------------------ */
+
+export function countKeywordHits(text: string, keywords: string[]): number {
+  const lower = text.toLowerCase();
+  let hits = 0;
+  for (const kw of keywords) {
+    const kl = kw.toLowerCase();
+    if (!kl) continue;
+    let pos = 0;
+    while ((pos = lower.indexOf(kl, pos)) !== -1) {
+      hits++;
+      pos += kl.length;
+    }
+  }
+  return hits;
+}
+
+/* --------------------------- search ------------------------------- */
+
+export interface SkillSearchArgs {
+  mode: "query" | "browse";
+  keywords?: string[];
+  topk?: number;
+  skill_name?: string;
+  relative_path?: string;
+}
+
+/** JSON-stringify with 2-space indent; the model parses these as text. */
+function jsonText(value: unknown): string {
+  return JSON.stringify(value, null, 2);
+}
+
+/**
+ * Pure search/browse implementation. Throws on any error path so the wrapping
+ * Pi tool surfaces a real failure (matching the runtime's tool-error contract).
+ */
+export async function searchSkills(base: string, args: SkillSearchArgs): Promise<string> {
+  if (!(await exists(base))) {
+    throw new Error(`skills router base does not exist: ${base}`);
+  }
+  const baseAbs = resolve(base);
+  const mode = args.mode;
+  if (mode !== "query" && mode !== "browse") {
+    throw new Error(`unknown mode '${mode}' (expected 'query' or 'browse')`);
+  }
+
+  /* ----------------------------- QUERY ----------------------------- */
+  if (mode === "query") {
+    // Sub-mode B: direct skill lookup by name (returns full SKILL.md).
+    if (args.skill_name !== undefined && args.skill_name !== null) {
+      const name = String(args.skill_name);
+      const cats = await listDirs(baseAbs);
+      for (const cat of cats) {
+        const candidate = join(baseAbs, cat, name, "SKILL.md");
+        if (await exists(candidate)) {
+          return await readFile(candidate, "utf8");
+        }
+      }
+      throw new Error(
+        `skill '${name}' not found in router; use mode='query' with keywords=[...] to discover available skills`,
+      );
+    }
+
+    // Sub-mode A: keyword search.
+    if (!args.keywords || args.keywords.length === 0) {
+      throw new Error(
+        "in query mode you must pass either 'keywords' (string list) or 'skill_name' (exact name)",
+      );
+    }
+    const skills = await collectAllSkills(baseAbs);
+    const topk = typeof args.topk === "number" && args.topk > 0 ? Math.floor(args.topk) : 5;
+    const scored = skills.map((skill) => ({
+      skill,
+      hits: countKeywordHits(skill.description, args.keywords!),
+    }));
+    // Sort: hit count desc, then alphabetical name asc.
+    scored.sort((a, b) => b.hits - a.hits || a.skill.name.localeCompare(b.skill.name));
+    const top = scored.slice(0, topk);
+    const result: QueryResult = {
+      keywords: args.keywords,
+      total_matched: scored.filter((s) => s.hits > 0).length,
+      returned: top.length,
+      results: top.map(({ skill, hits }) => ({
+        name: skill.name,
+        description: skill.description,
+        relative_paths: skill.relative_paths,
+        keyword_hits: hits,
+      })),
+    };
+    return jsonText(result);
+  }
+
+  /* ----------------------------- BROWSE ---------------------------- */
+  if (args.relative_path === undefined || args.relative_path === null) {
+    throw new Error(
+      "browse mode requires 'relative_path' — pass '' or '.' to list top-level categories",
+    );
+  }
+  const rel = String(args.relative_path).trim();
+  let target: string;
+  if (rel === "" || rel === ".") {
+    target = baseAbs;
+  } else {
+    // Reject any absolute path or one starting with '..' before resolve.
+    if (rel.startsWith("/")) {
+      throw new Error("path traversal outside skills directory is not allowed");
+    }
+    target = resolve(join(baseAbs, rel));
+  }
+  if (target !== baseAbs && !target.startsWith(baseAbs + sep)) {
+    throw new Error("path traversal outside skills directory is not allowed");
+  }
+  if (!(await exists(target))) {
+    throw new Error(`path does not exist: '${args.relative_path}'`);
+  }
+  const st = await stat(target);
+  if (st.isDirectory()) {
+    const dirents = await readdir(target, { withFileTypes: true });
+    const children = dirents
+      .map((d) => ({
+        name: d.name,
+        type: d.isDirectory() ? "directory" : "file",
+      }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+    const displayPath = target === baseAbs ? "." : target.slice(baseAbs.length + 1);
+    return jsonText({ path: displayPath, type: "directory", children });
+  }
+  if (st.isFile()) {
+    return await readFile(target, "utf8");
+  }
+  throw new Error(`path is neither a file nor a directory: '${args.relative_path}'`);
+}
+
+/* --------------------------- tool factory ------------------------- */
+
+/**
+ * Build the Pi-native `skill_search` SystemTool bound to the router base dir.
+ * Per CLAUDE.md, errors are signalled by throwing — the wrapping factory turns
+ * a thrown error into a Pi tool failure the model can react to.
+ */
+export function createSkillSearchTool(deps: ToolDeps): SystemTool {
+  return {
+    name: "skill_search",
+    description:
+      "Search and load skills from the router skill library — a domain-specific " +
+      "catalog NOT included in <available_skills>. Use this whenever the skill " +
+      "you need is not visible in <available_skills>. Modes: 'query' with " +
+      "keywords (top-K ranked metadata), 'query' with skill_name (full SKILL.md), " +
+      "or 'browse' with relative_path (list directory or read a file).",
+    parameters: {
+      type: "object",
+      properties: {
+        mode: {
+          type: "string",
+          enum: ["query", "browse"],
+          description: "'query' to search/load skills; 'browse' to list/read paths",
+        },
+        keywords: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "(query mode) keywords matched against each skill's frontmatter description",
+        },
+        topk: {
+          type: "integer",
+          description: "(query mode, keywords) max results to return; default 5",
+        },
+        skill_name: {
+          type: "string",
+          description:
+            "(query mode) exact skill name; returns the full SKILL.md body when set",
+        },
+        relative_path: {
+          type: "string",
+          description:
+            "(browse mode) router-relative path; '' or '.' lists top-level categories",
+        },
+      },
+      required: ["mode"],
+    },
+    execute: async (params: Record<string, unknown>) => {
+      const text = await searchSkills(
+        deps.routerSkillsDir,
+        params as unknown as SkillSearchArgs,
+      );
+      return { content: [{ type: "text", text }] };
+    },
+  };
+}

--- a/packages/runtime/src/tools/system-tools.ts
+++ b/packages/runtime/src/tools/system-tools.ts
@@ -10,6 +10,7 @@
 import type { AgentRole, SystemTool } from "../types.js";
 import { MailboxFullError, type Mailbox, type MsgType } from "../mailbox.js";
 import type { GraphOfTrace } from "../trace.js";
+import { createSkillSearchTool } from "./skill-search.js";
 
 export interface ToolDeps {
   sessionId: string;
@@ -32,6 +33,14 @@ export interface ToolDeps {
     options?: string[];
     allow_free_text?: boolean;
   }) => Promise<string>;
+  /**
+   * Absolute path to the router skill base directory
+   * (`<dataRoot>/bp_template/skills-router`). Backs the `skill_search` tool —
+   * a Pi-native custom tool that lazily loads skills NOT exposed via Pi's
+   * native `<available_skills>` block. Distinct from the always-on
+   * `bp_template/skills/` dir loaded through `additionalSkillPaths`.
+   */
+  routerSkillsDir: string;
 }
 
 function ok(text: string): { content: [{ type: "text"; text: string }] } {
@@ -329,6 +338,7 @@ export function allSystemTools(deps: ToolDeps): Map<string, SystemTool> {
     createUpdateTraceNodeTool(deps),
     createAddTraceRelationTool(deps),
     createGetTraceGraphTool(deps),
+    createSkillSearchTool(deps),
   ];
   return new Map(tools.map((t) => [t.name, t]));
 }
@@ -339,17 +349,28 @@ export function allSystemTools(deps: ToolDeps): Map<string, SystemTool> {
  * tools (read/bash/grep/...) are controlled separately via `builtinToolsForRole`.
  */
 export const AGENT_TOOL_CONFIG: Record<string, string[]> = {
-  principal: ["send_message", "create_agent", "destroy_agent", "record_trace", "ask_user"],
+  // skill_search opens the router skill library (the long-tail domain catalog
+  // not in <available_skills>). Trace is deliberately excluded: it is a
+  // graph-only recorder, not a domain reasoner.
+  principal: [
+    "send_message",
+    "create_agent",
+    "destroy_agent",
+    "record_trace",
+    "ask_user",
+    "skill_search",
+  ],
   trace: ["create_trace_node", "update_trace_node", "add_trace_relation", "get_trace_graph"],
-  expert: ["send_message", "record_trace"],
+  expert: ["send_message", "record_trace", "skill_search"],
   // Auditor: comms + self-trace only. Deliberately NO `get_trace_graph` —
   // evidence is restricted to the session workspace; the audit must not
-  // dredge the trace graph or other agents' internal state.
-  auditor: ["send_message", "record_trace"],
+  // dredge the trace graph or other agents' internal state. skill_search is
+  // included so an audit can resolve a methodology skill referenced in a draft.
+  auditor: ["send_message", "record_trace", "skill_search"],
   // Writer: needs ask_user to present format/style options before drafting.
-  writer: ["send_message", "record_trace", "ask_user"],
+  writer: ["send_message", "record_trace", "ask_user", "skill_search"],
   // Default for any other expert-like agent.
-  _default: ["send_message", "record_trace"],
+  _default: ["send_message", "record_trace", "skill_search"],
 };
 
 /**


### PR DESCRIPTION
## Summary

Implements a **second skill-loading path** so the built-in 49-skill library no longer all has to live in the always-on `<available_skills>` block (which would bloat every system prompt). Skills are now physically split across two parallel directories with the SAME on-disk format, both user-extensible:

| Path | Loader | Content |
|------|--------|---------|
| `<dataRoot>/bp_template/skills/` | Pi native `additionalSkillPaths` (always-on) | `01_Meta-Skills/*` — name+description in every system prompt |
| `<dataRoot>/bp_template/skills-router/` | New `skill_search` Pi-native custom tool (on-demand) | The other 14 categories — invisible until searched |

The router tool is **Pi-native (`defineTool`), not MCP** — no subprocess, no extra wire. It exposes `query` (keyword/skill_name) and `browse` (relative_path) modes, replicating the deleted `skills_tool_local` semantics: keyword hit-count ranking on frontmatter description, path-traversal protection, errors signalled by `throw` (per Pi's `AgentToolResult` contract).

## What changed

**New**
- `packages/runtime/src/tools/skill-search.ts` — the router tool (parseFrontmatterDescription / collectAllSkills / countKeywordHits / searchSkills / createSkillSearchTool)
- `packages/runtime/src/__tests__/skill-search.test.ts` — 17 unit tests (parsing, ranking, both modes, traversal/absolute-path rejection, tool factory shape)
- `packages/runtime/src/__tests__/two-skill-paths.test.ts` — 4 integration tests (materialize splits correctly, factory only gets always-on, skill_search only reads router, trace agent doesn't get the tool)

**Modified**
- `materialize-skills.ts` — splits source: `01_Meta-Skills/*` → `bp_template/skills/`, others → `bp_template/skills-router/`. Both dirs always created. Skip-if-exists on both sides preserves user edits.
- `session-manager.ts` — adds `routerSkillsDir` field (defaults to `<dataRoot>/bp_template/skills-router`); wired into `ToolDeps`. `skillPaths` still gets only the always-on dir.
- `tools/system-tools.ts` — `ToolDeps.routerSkillsDir` field; `AGENT_TOOL_CONFIG` adds `skill_search` to principal/expert/writer/auditor/_default. **Trace explicitly excluded** (graph-only role).
- `personas.ts` — new shared `ROUTER_SKILL_LIBRARY` block; principal/librarian/experimentalist/engineer/writer/auditor/SKILLS_FIRST_EXPERT all updated to describe both paths and warn that `<available_skills>` is not exhaustive.
- Existing tests (`materialize-skills` / `tool-access` / `personas`) updated to assert the new split and access rules.

## Compatibility with the three deployment modes

The skill pipeline depends only on `BP_DATA_DIR` and `require.resolve("@brainpilot/skills")`, so it works transparently across all three orchestrators:

- **Local** (`LocalProcessOrchestrator`): materializes to `./brainpilot/bp_template/`; Pi reads local fs.
- **Docker** (`DockerOrchestrator`): `BP_DATA_DIR=/root/.bp-root` is the mounted host volume; runtime materializes inside the container, host-edited files are picked up live.
- **Static** (`StaticRuntimeOrchestrator`): the remote runtime materializes its own `BP_DATA_DIR/bp_template/`; users edit files on **that** machine.

`skill_search` is an in-process Pi custom tool, so no MCP subprocess / no extra port / no extra mount is needed in any mode.

## Verification

- `npm run typecheck` ✅
- `npm test` ✅ **548/548** tests pass (runtime: 227, +21 new)
- `npm run build` ✅
- `bash scripts/smoke-e2e.sh` ✅ SMOKE PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)