### PR TITLE
refactor(docker): split GPU deps into a standalone publishable base image

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,15 @@ Host networking instead of bridge:
 docker compose -f docker-compose.yml -f docker-compose.host.yml up -d --build
 ```
 
+GPU sandbox (needs an NVIDIA GPU + driver and the
+[NVIDIA Container Toolkit](https://github.com/NVIDIA/nvidia-container-toolkit)):
+```bash
+docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d
+```
+This override points `sandbox` at the `brainpilot-sandbox-gpu` image (CUDA +
+PyTorch, see Publishing below) and reserves the host GPUs into the container.
+Without a GPU + toolkit, omit this file — the default `sandbox` is CPU-only.
+
 ### 3. Stop
 ```bash
 docker compose down
@@ -131,8 +140,10 @@ docker compose down
 
 ### 🧩 Customizing sandbox dependencies
 
-The `brainpilot-sandbox` image ships a **lightweight baseline** (Node + runtime
-only — no Python, no GPU, no terminal). To add dependencies, edit
+The `brainpilot-sandbox` (cpu) image ships a **lightweight baseline** (Node +
+Python3 + runtime only — no sci stack, no GPU). For CUDA + PyTorch use the
+`brainpilot-sandbox-gpu` image instead (see the GPU launch above and Publishing
+below). To add dependencies to the cpu image, edit
 **`docker/sandbox/extra-deps.sh`** — a build-time hook with worked examples for:
 - installing Python3 + pip packages,
 - installing system packages (apt),
@@ -378,18 +389,35 @@ npm run release           # version-sync, build, then publish protocol→runtime
 
 ### Docker 镜像发布
 
-镜像版本号与 npm 版本一致（根 `package.json` 的 `version`）。三个镜像：`brainpilot-main`、
-`brainpilot-sandbox`（cpu）、`brainpilot-sandbox-gpu`（CUDA torch）。
+**两层模型**：重依赖（CUDA + PyTorch + 科学栈，~9GB）住在 *独立发布* 的 base 镜像
+`brainpilot-gpu-base`，按依赖版本打 tag（如 `cu124-torch2.6.0`），**低频更新**；随版本
+迭代的代码镜像有三个：`brainpilot-main`、`brainpilot-sandbox`（cpu）、
+`brainpilot-sandbox-gpu`（`FROM` 上述 base + 业务层）。GPU runtime 镜像因此只重建薄薄的
+业务层，发版不再重装 torch。
 
 ```bash
 # 一次性：复制示范配置，填入国内镜像源 / 私有 registry 地址（两个 .local 文件均不提交）
 cp scripts/release-mirrors.example.sh scripts/release-mirrors.local.sh   # pip/apt 镜像源
 cp scripts/release-targets.example.sh scripts/release-targets.local.sh   # ACR/内网 registry
+```
 
-# 构建（默认全部；可传子串只建子集）
-bash scripts/release-build.sh                # 全部三个镜像
+**① GPU base 镜像**（仅在 torch/cuda 升级时重建；其余发版跳过本步）：
+```bash
+bash scripts/release-gpu-base.sh build         # 构建（下载 ~2.7GB torch，慢；打 <tag> + latest）
+bash scripts/release-gpu-base.sh push          # 推到全部 registry（ghcr + 私有）
+bash scripts/release-gpu-base.sh push --registry acr,intranet   # 体积大，可跳过公网 ghcr
+```
+升级 torch/cuda 时改三处保持一致：`docker/sandbox/Dockerfile.gpu-base` 的版本、
+`docker/sandbox/Dockerfile` 的 `gpu` stage `FROM ...:<tag>`、`scripts/release-images.sh`
+的 `GPU_BASE_TAG`。
+
+**② 随版本迭代的代码镜像**（镜像版本号 = 根 `package.json` 的 `version`）：
+```bash
+# 构建（默认全部；可传子串只建子集）。构建 sandbox-gpu 前 base 须已就位
+# （本地有或 ghcr 可拉，否则脚本会提示先跑 release-gpu-base.sh build）。
+bash scripts/release-build.sh                # 全部三个代码镜像
 bash scripts/release-build.sh main           # 只建 main
-bash scripts/release-build.sh sandbox-gpu    # 只建 GPU 变体（体积大、慢）
+bash scripts/release-build.sh sandbox-gpu    # 只建 GPU 变体（薄业务层，秒级）
 
 # 推送（需先 docker login 各 registry）
 bash scripts/release-push.sh --dry-run                       # 先看计划
@@ -398,7 +426,9 @@ bash scripts/release-push.sh --image sandbox-gpu --registry acr,intranet  # GPU 
 ```
 
 推送目标 registry 在 `scripts/release-images.sh`（ghcr，公开）+ `release-targets.local.sh`
-（ACR / 内网，私有）声明。GPU 镜像约 6GB，推公网 ghcr 可能超时，建议 `--registry acr,intranet`。
+（ACR / 内网，私有）声明。base 与 GPU runtime 镜像较大，推公网 ghcr 可能超时，建议
+`--registry acr,intranet`。runtime 的 `gpu` stage 只 `FROM` base 的版本 tag（绝不 `latest`，
+避免静默漂移）。
 
 ## 🧪 Testing
 

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -1,0 +1,23 @@
+# GPU override —— 让 sandbox 用 GPU 镜像并把宿主机 GPU 挂进容器。用法:
+#   docker compose -f docker-compose.yml -f docker-compose.gpu.yml up
+# 可与 host 网络叠加:
+#   docker compose -f docker-compose.yml -f docker-compose.gpu.yml -f docker-compose.host.yml up
+#
+# 前置(不满足则 `up` 直接报错,故 GPU 接线单独放本 override，不污染主 compose):
+#   1) 宿主机有 NVIDIA GPU + 驱动（nvidia-smi 可用）。
+#   2) 已装 NVIDIA Container Toolkit 并 `nvidia-ctk runtime configure` 接入 docker。
+#      没装时本 override 的 devices 段会让 docker compose 报错——这是预期，无 GPU 就别用本文件。
+#
+# 镜像:brainpilot-sandbox-gpu 由 `bash scripts/release-build.sh sandbox-gpu` 构建，
+#       它 FROM 独立的 brainpilot-gpu-base（见 scripts/release-gpu-base.sh）。
+services:
+  sandbox:
+    image: brainpilot-sandbox-gpu:latest
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              # 默认整机所有 GPU；只要部分卡可改成 count: 1 或用 device_ids: ["0"]。
+              count: all
+              capabilities: [gpu]

--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -1,18 +1,23 @@
 # =============================================================================
-# brainpilot-sandbox / -gpu — 分层 runtime 镜像（@brainpilot/runtime + Pi SDK）。
+# brainpilot-sandbox / -gpu — runtime 代码镜像（@brainpilot/runtime + Pi SDK）。
 #
-#   经典构建器专用（DOCKER_BUILDKIT=0）—— 故不用 `FROM ${ARG}`（经典构建器不支持，
-#   实测报 "base name should not be blank"）。镜像切换靠多 stage + --target：
+#   经典构建器专用（DOCKER_BUILDKIT=0）。镜像切换靠多 stage + --target：
 #     --target cpu  → brainpilot-sandbox      (python-baseline + 业务层)
-#     --target gpu  → brainpilot-sandbox-gpu  (gpu-base[+sci/cuda/torch] + 业务层)
+#     --target gpu  → brainpilot-sandbox-gpu  (brainpilot-gpu-base + 业务层)
 #
-#   分层设计目的：把 torch/cuda（~2.7GB）沉到 monorepo 业务层之下的 gpu-base 中间
-#   stage。monorepo 代码变更不触达 gpu-base，故发版时 torch 层命中缓存、不重装。
+#   两层模型（torch/cuda 与代码解耦）：
+#     - 重依赖（CUDA 12.4 + torch 2.6.0 + 科学栈，~2.7GB）住在 *独立发布* 的
+#       base 镜像 brainpilot-gpu-base（见 docker/sandbox/Dockerfile.gpu-base），
+#       低频更新、按依赖版本打 tag。
+#     - 本文件的 gpu stage 只 `FROM ghcr.io/.../brainpilot-gpu-base:<tag>` + 业务层，
+#       随 monorepo 版本迭代；代码变更只重建薄业务层，绝不重装 torch。
+#     ⚠️ base tag 写死在下面的 FROM 里（经典构建器不支持 `FROM ${ARG}`）。升级
+#        torch/cuda 时同步改：本文件 FROM、Dockerfile.gpu-base、release-images.sh。
 #
 #   业务层 6 行（COPY×3 + ENV + EXPOSE + HEALTHCHECK + CMD）在 cpu/gpu 两 stage
-#   各写一份：父 stage 不同（cpu←python-baseline / gpu←gpu-base），ENV/CMD/
-#   HEALTHCHECK 无法跨非父 stage 继承。SSOT 仍是 monorepo 源码 + extra-deps 脚本，
-#   这 6 行是声明性常量。改动业务层时务必同步改两处。
+#   各写一份：父 stage 不同（cpu←python-baseline / gpu←brainpilot-gpu-base），
+#   ENV/CMD/HEALTHCHECK 无法跨非父 stage 继承。SSOT 仍是 monorepo 源码 +
+#   extra-deps 脚本，这 6 行是声明性常量。改动业务层时务必同步改两处。
 # =============================================================================
 
 # ---- builder: install + build the runtime project chain ----
@@ -41,10 +46,8 @@ COPY docker/sandbox/_python-base.sh /tmp/_python-base.sh
 RUN bash /tmp/_python-base.sh
 
 # ---- cpu: python-baseline + 业务层 ----
-#   放在 gpu-base 之前：经典构建器（DOCKER_BUILDKIT=0）按 Dockerfile 文本顺序执行到
-#   --target 指定的 stage（不做 BuildKit 那样的依赖图剪枝）。cpu 在前 → --target cpu
-#   执行到此即止，不会触发下面 gpu-base 的 torch 安装。✅ 实测：cpu 在 gpu-base 之后会
-#   误装 torch。务必保持 cpu 在 gpu-base 之前。
+#   torch/cuda 已外移到独立 base 镜像，本文件不再有内联安装 torch 的 stage，故
+#   cpu 与 gpu 的相对顺序不再有「误装 torch」风险（gpu 直接 FROM 外部 base）。
 FROM python-baseline AS cpu
 # cpu 业务依赖注入点（python 基线已在 python-baseline 装好；默认空操作）。
 COPY docker/sandbox/extra-deps.sh /tmp/extra-deps.sh
@@ -59,18 +62,11 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
   CMD curl -f "http://localhost:${AGENT_RUNTIME_PORT:-8081}/health" || exit 1
 CMD ["node", "packages/runtime/dist/server.js"]
 
-# ---- gpu-base: cpu 之后 + 科学栈 + CUDA + torch（重依赖，独立于 monorepo）----
-#   缓存收益的核心层：不 COPY monorepo，故业务代码变更不会让这层失效、torch 不重装。
-#   FROM python-baseline：复用 python+curl 层；ENV（APT_MIRROR/PIP_*）继承，无需重声明。
-#   位于 cpu 之后、gpu 之前：仅 --target gpu 会执行它（gpu 是文本最末 stage）。
-FROM python-baseline AS gpu-base
-ARG TORCH_WHEEL_BASE=""
-ENV TORCH_WHEEL_BASE=${TORCH_WHEEL_BASE}
-COPY docker/sandbox/extra-deps.gpu-libs.sh /tmp/extra-deps.gpu-libs.sh
-RUN bash /tmp/extra-deps.gpu-libs.sh
-
-# ---- gpu: gpu-base + 同一段业务层（与 cpu 逐字相同，见文件头说明）----
-FROM gpu-base AS gpu
+# ---- gpu: 已发布的 brainpilot-gpu-base + 同一段业务层（与 cpu 逐字相同）----
+#   torch/cuda/科学栈来自外部 base 镜像（docker/sandbox/Dockerfile.gpu-base），
+#   不在此安装 → monorepo 代码变更只重建下面的业务层，base 层完全复用。
+#   ⚠️ base tag 写死（经典构建器不支持 FROM ${ARG}）；升级须同步三处（见文件头）。
+FROM ghcr.io/neuroaihub/brainpilot-gpu-base:cu124-torch2.6.0 AS gpu
 WORKDIR /app
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/packages ./packages

--- a/docker/sandbox/Dockerfile.gpu-base
+++ b/docker/sandbox/Dockerfile.gpu-base
@@ -1,0 +1,34 @@
+# =============================================================================
+# brainpilot-gpu-base — GPU 依赖 base 镜像（CUDA 12.4 + PyTorch 2.6.0 + 科学栈）。
+#
+#   ⚠️ 这是「重依赖 base 镜像」，与 monorepo 代码解耦、低频更新：
+#     - 按依赖版本打 tag（如 cu124-torch2.6.0），torch/cuda 升级才换 tag。
+#     - runtime 代码镜像（docker/sandbox/Dockerfile 的 gpu stage）以
+#       `FROM ghcr.io/neuroaihub/brainpilot-gpu-base:<tag>` 引用本镜像，
+#       故 monorepo 代码变更只重建薄薄的业务层，绝不重装 ~2.7GB torch/cuda。
+#
+#   构建 / 推送由 scripts/release-gpu-base.sh 驱动（独立于迭代式 release-build）。
+#   ⚠️ 改这里的 torch/cuda 版本时，必须同步：
+#     1) scripts/release-images.sh 的 GPU_BASE_TAG
+#     2) docker/sandbox/Dockerfile 的 gpu stage `FROM ...:<tag>`
+#
+#   经典构建器专用（DOCKER_BUILDKIT=0）。脚本 _python-base.sh /
+#   extra-deps.gpu-libs.sh 与 cpu/runtime 共享、内容不改（SSOT）。
+# =============================================================================
+FROM node:22-slim AS gpu-base
+ARG APT_MIRROR=""
+ARG PIP_INDEX_URL=""
+ARG PIP_EXTRA_INDEX_URL=""
+ARG TORCH_WHEEL_BASE=""
+ENV APT_MIRROR=${APT_MIRROR} \
+    PIP_INDEX_URL=${PIP_INDEX_URL} \
+    PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL} \
+    TORCH_WHEEL_BASE=${TORCH_WHEEL_BASE}
+
+# python3 + pip + curl + 镜像源（与 cpu sandbox 共享同一段，curl 供 HEALTHCHECK 用）
+COPY docker/sandbox/_python-base.sh /tmp/_python-base.sh
+RUN bash /tmp/_python-base.sh
+
+# 科学栈 + CUDA 12.4 runtime wheels + PyTorch 2.6.0+cu124（重依赖，~2.7GB）
+COPY docker/sandbox/extra-deps.gpu-libs.sh /tmp/extra-deps.gpu-libs.sh
+RUN bash /tmp/extra-deps.gpu-libs.sh

--- a/scripts/release-build.sh
+++ b/scripts/release-build.sh
@@ -46,20 +46,24 @@ for entry in "${RELEASE_IMAGES[@]}"; do
     echo "==> skip $name (不匹配子集)"
     continue
   fi
-  # gpu runtime 镜像依赖外部 base 镜像 brainpilot-gpu-base 先就位（FROM 引用它）。
-  # 缺则尝试 docker pull（registry 已发布时可拉），再失败给清晰指引、跳过本镜像。
+  # gpu runtime 镜像的 Dockerfile gpu stage `FROM <ghcr 全路径>:<tag>` 引用 base。
+  # 故必须保证「ghcr 全路径」的 base 镜像在本地存在，FROM 才命中本地、不去拉远端。
+  # 优先用本地构建的短名 base（release-gpu-base.sh build 产物）retag；否则 pull ghcr。
   if [ "$target" = "gpu" ]; then
-    if ! sudo docker image inspect "${GPU_BASE_IMAGE}:${GPU_BASE_TAG}" >/dev/null 2>&1; then
-      echo "==> base 镜像 ${GPU_BASE_IMAGE}:${GPU_BASE_TAG} 本地缺失，尝试 pull…"
-      _ghcr_repo="$(remote_repo "$GPU_BASE_IMAGE" "ghcr.io/neuroaihub" "flat")"
-      if sudo docker pull "${_ghcr_repo}:${GPU_BASE_TAG}" 2>/dev/null; then
-        sudo docker tag "${_ghcr_repo}:${GPU_BASE_TAG}" "${GPU_BASE_IMAGE}:${GPU_BASE_TAG}"
-        echo "==> 已 pull 并 retag 为 ${GPU_BASE_IMAGE}:${GPU_BASE_TAG}"
+    _ghcr_base="$(remote_repo "$GPU_BASE_IMAGE" "ghcr.io/neuroaihub" "flat"):${GPU_BASE_TAG}"
+    if ! sudo docker image inspect "$_ghcr_base" >/dev/null 2>&1; then
+      if sudo docker image inspect "${GPU_BASE_IMAGE}:${GPU_BASE_TAG}" >/dev/null 2>&1; then
+        # 本地有短名 base（刚 build 出、未推）→ retag 成 FROM 用的 ghcr 路径
+        sudo docker tag "${GPU_BASE_IMAGE}:${GPU_BASE_TAG}" "$_ghcr_base"
+        echo "==> 用本地 base retag 为 $_ghcr_base（供 FROM 命中本地）"
       else
-        echo "!!! 缺 GPU base 镜像且无法 pull。先构建 base：" >&2
-        echo "      bash scripts/release-gpu-base.sh build" >&2
-        echo "    然后重跑本命令。跳过 $name。" >&2
-        continue
+        echo "==> base 镜像本地缺失，尝试 pull $_ghcr_base …"
+        if ! sudo docker pull "$_ghcr_base" 2>/dev/null; then
+          echo "!!! 缺 GPU base 镜像且无法 pull。先构建 base：" >&2
+          echo "      bash scripts/release-gpu-base.sh build" >&2
+          echo "    然后重跑本命令。跳过 $name。" >&2
+          continue
+        fi
       fi
     fi
   fi

--- a/scripts/release-build.sh
+++ b/scripts/release-build.sh
@@ -46,6 +46,23 @@ for entry in "${RELEASE_IMAGES[@]}"; do
     echo "==> skip $name (不匹配子集)"
     continue
   fi
+  # gpu runtime 镜像依赖外部 base 镜像 brainpilot-gpu-base 先就位（FROM 引用它）。
+  # 缺则尝试 docker pull（registry 已发布时可拉），再失败给清晰指引、跳过本镜像。
+  if [ "$target" = "gpu" ]; then
+    if ! sudo docker image inspect "${GPU_BASE_IMAGE}:${GPU_BASE_TAG}" >/dev/null 2>&1; then
+      echo "==> base 镜像 ${GPU_BASE_IMAGE}:${GPU_BASE_TAG} 本地缺失，尝试 pull…"
+      _ghcr_repo="$(remote_repo "$GPU_BASE_IMAGE" "ghcr.io/neuroaihub" "flat")"
+      if sudo docker pull "${_ghcr_repo}:${GPU_BASE_TAG}" 2>/dev/null; then
+        sudo docker tag "${_ghcr_repo}:${GPU_BASE_TAG}" "${GPU_BASE_IMAGE}:${GPU_BASE_TAG}"
+        echo "==> 已 pull 并 retag 为 ${GPU_BASE_IMAGE}:${GPU_BASE_TAG}"
+      else
+        echo "!!! 缺 GPU base 镜像且无法 pull。先构建 base：" >&2
+        echo "      bash scripts/release-gpu-base.sh build" >&2
+        echo "    然后重跑本命令。跳过 $name。" >&2
+        continue
+      fi
+    fi
+  fi
   target_arg=(); [ -n "$target" ] && target_arg=( --target "$target" )
   echo "==> building $name (tags: latest, $VERSION${target:+, target=$target})"
   sudo DOCKER_BUILDKIT=0 docker build "${COMMON[@]}" "${target_arg[@]}" \

--- a/scripts/release-gpu-base.sh
+++ b/scripts/release-gpu-base.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# release-gpu-base.sh — GPU 重依赖 base 镜像（brainpilot-gpu-base）的构建 + 推送。
+#
+# 与 release-build.sh / release-push.sh（随 monorepo 版本迭代的 main/sandbox 镜像）
+# 分开：base 镜像与代码解耦、低频更新（仅 torch/cuda 升级时重建），故独立成脚本，
+# 避免发版时被反复重建。
+#
+# 用法:
+#   bash scripts/release-gpu-base.sh build            # 构建 base（打 <tag> + latest 两 tag）
+#   bash scripts/release-gpu-base.sh push             # 推到所有已配置 registry（ghcr + 私有）
+#   bash scripts/release-gpu-base.sh build push       # 先构建后推送
+#   bash scripts/release-gpu-base.sh push --registry ghcr        # 只推某些 registry
+#   bash scripts/release-gpu-base.sh push --dry-run             # 只打印推送计划
+#
+# 镜像源/代理来自 release-mirrors.local.sh（不提交），无则用官方源默认。
+# tag/源 SSOT 在 release-images.sh（GPU_BASE_IMAGE/TAG/DOCKERFILE、RELEASE_REGISTRIES）。
+set -uo pipefail   # 不用 -e：push 单 registry 失败要继续推其他并汇总
+cd "$(dirname "$0")/.."
+
+source scripts/release-images.sh
+[ -f scripts/release-mirrors.local.sh ] && source scripts/release-mirrors.local.sh
+
+PROXY="${BUILD_PROXY:-http://127.0.0.1:7890}"
+
+# ---- 解析子命令 + 选项 ----
+DO_BUILD=""; DO_PUSH=""; REGISTRY_FILTER=""; DRY_RUN=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    build)      DO_BUILD=1; shift ;;
+    push)       DO_PUSH=1; shift ;;
+    --registry) REGISTRY_FILTER="$2"; shift 2 ;;
+    --dry-run)  DRY_RUN=1; shift ;;
+    *) echo "未知参数: $1" >&2; exit 2 ;;
+  esac
+done
+if [ -z "$DO_BUILD" ] && [ -z "$DO_PUSH" ]; then
+  echo "用法: bash scripts/release-gpu-base.sh build|push [build push] [--registry k,..] [--dry-run]" >&2
+  exit 2
+fi
+
+_in_csv() { local key="$1" csv="$2" IFS=','; for k in $csv; do [ "$k" = "$key" ] && return 0; done; return 1; }
+
+# ---- build ----
+if [ -n "$DO_BUILD" ]; then
+  echo "==> building ${GPU_BASE_IMAGE} (tags: ${GPU_BASE_TAG}, latest)"
+  echo "    proxy=${PROXY} mirrors: pip=${PIP_INDEX_URL:-官方} apt=${APT_MIRROR:-官方} torch=${TORCH_WHEEL_BASE:-交大默认}"
+  # 经典构建器（与 release-build.sh 一致，理由见该文件注释）。DOCKER_BUILDKIT=0 内联给 sudo。
+  sudo DOCKER_BUILDKIT=0 docker build \
+    --network=host \
+    --build-arg "HTTP_PROXY=${PROXY}" \
+    --build-arg "HTTPS_PROXY=${PROXY}" \
+    --build-arg "APT_MIRROR=${APT_MIRROR:-}" \
+    --build-arg "PIP_INDEX_URL=${PIP_INDEX_URL:-}" \
+    --build-arg "PIP_EXTRA_INDEX_URL=${PIP_EXTRA_INDEX_URL:-}" \
+    --build-arg "TORCH_WHEEL_BASE=${TORCH_WHEEL_BASE:-}" \
+    -f "$GPU_BASE_DOCKERFILE" \
+    -t "${GPU_BASE_IMAGE}:${GPU_BASE_TAG}" \
+    -t "${GPU_BASE_IMAGE}:latest" .
+  echo "==> BUILD DONE: ${GPU_BASE_IMAGE}:${GPU_BASE_TAG} (+latest)"
+fi
+
+# ---- push ----
+if [ -n "$DO_PUSH" ]; then
+  if ! sudo docker image inspect "${GPU_BASE_IMAGE}:${GPU_BASE_TAG}" >/dev/null 2>&1; then
+    echo "缺本地镜像 ${GPU_BASE_IMAGE}:${GPU_BASE_TAG} —— 先跑 bash scripts/release-gpu-base.sh build" >&2
+    exit 1
+  fi
+  declare -a OK_LIST=() FAIL_LIST=()
+  for reg_entry in "${RELEASE_REGISTRIES[@]}"; do
+    IFS='|' read -r key prefix style <<< "$reg_entry"
+    if [ -n "$REGISTRY_FILTER" ] && ! _in_csv "$key" "$REGISTRY_FILTER"; then continue; fi
+    repo="$(remote_repo "$GPU_BASE_IMAGE" "$prefix" "$style")"
+    for tag in "$GPU_BASE_TAG" latest; do
+      echo "==> ${GPU_BASE_IMAGE}:${tag} → ${repo}:${tag}"
+      [ -n "$DRY_RUN" ] && { OK_LIST+=("(dry) ${repo}:${tag}"); continue; }
+      if sudo docker tag "${GPU_BASE_IMAGE}:${tag}" "${repo}:${tag}" && sudo docker push "${repo}:${tag}"; then
+        OK_LIST+=("${repo}:${tag}")
+      else
+        FAIL_LIST+=("${repo}:${tag}")
+      fi
+    done
+  done
+  echo ""; echo "==== base 推送汇总 ===="
+  echo "成功 ${#OK_LIST[@]}:"; printf '  ✓ %s\n' "${OK_LIST[@]:-（无）}"
+  if [ "${#FAIL_LIST[@]}" -gt 0 ]; then
+    echo "失败 ${#FAIL_LIST[@]}:"; printf '  ✗ %s\n' "${FAIL_LIST[@]}"
+    exit 1
+  fi
+fi

--- a/scripts/release-images.sh
+++ b/scripts/release-images.sh
@@ -6,14 +6,26 @@
 #   remote_repo()       本地镜像名 → 某 registry 的完整仓库路径
 # 私有 registry 地址在 release-targets.local.sh（不提交）里 append。
 
-# 本地镜像清单: "本地镜像名|Dockerfile 路径|构建 target(经典构建器 --target，可空)"
+# 随 monorepo 版本迭代的镜像清单: "本地镜像名|Dockerfile 路径|构建 target(可空)"
 #   main 无 target（单链 Dockerfile）；sandbox 用同一 Dockerfile 靠 --target 切 cpu/gpu
-#   （cpu = python-baseline + 业务层；gpu = gpu-base[+torch/cuda] + 业务层）。
+#   （cpu = python-baseline + 业务层；gpu = brainpilot-gpu-base + 业务层）。
+#   ⚠️ sandbox-gpu 依赖独立 base 镜像 brainpilot-gpu-base 先就位（本地或可拉），
+#      见下方 GPU_BASE_* 与 scripts/release-gpu-base.sh。
 RELEASE_IMAGES=(
   "brainpilot-main|docker/main/Dockerfile|"
   "brainpilot-sandbox|docker/sandbox/Dockerfile|cpu"
   "brainpilot-sandbox-gpu|docker/sandbox/Dockerfile|gpu"
 )
+
+# GPU 重依赖 base 镜像（CUDA+torch+科学栈）—— 与 monorepo 版本解耦、低频更新。
+#   按依赖版本打 tag；runtime 的 gpu stage `FROM ...:<tag>` 引用它。
+#   ⚠️ 改 GPU_BASE_TAG 时必须同步 docker/sandbox/Dockerfile 的 gpu stage FROM
+#      和 docker/sandbox/Dockerfile.gpu-base 里的 torch/cuda 版本。
+#   构建/推送走独立脚本 scripts/release-gpu-base.sh（不在 RELEASE_IMAGES 里，
+#   故 release-build/push 不会随版本反复重建这层）。
+GPU_BASE_IMAGE="brainpilot-gpu-base"
+GPU_BASE_TAG="cu124-torch2.6.0"
+GPU_BASE_DOCKERFILE="docker/sandbox/Dockerfile.gpu-base"
 
 # registry 清单: "registry键|前缀|命名风格(flat|acr)"
 # ghcr 地址本就公开，写死在提交版本里。


### PR DESCRIPTION
## Why

GPU sandbox 的重依赖（CUDA + PyTorch + 科学栈，~2.7GB）原本是 `docker/sandbox/Dockerfile` 里的一个**中间 stage**，「发版不重装 torch」的收益**完全依赖本地 builder layer cache** —— 换机器 / CI / `docker builder prune` 即失效。这与既定设计「独立可发布 base 镜像 + 迭代 runtime 镜像」不符。

## What

把重依赖外移成**独立发布的 base 镜像**，按依赖版本打 tag、低频更新；runtime 代码镜像 `FROM` 它再叠业务层，随 monorepo 版本迭代。

### 两层模型
```
brainpilot-gpu-base:cu124-torch2.6.0   = CUDA12.4 + torch2.6.0 + 科学栈（独立发布）
        ▲ FROM
brainpilot-sandbox-gpu:<version>        = base + @brainpilot/runtime 业务层（薄，秒级重建）
```

### 改动
- **`docker/sandbox/Dockerfile.gpu-base`**（新）：独立 base，复用 `_python-base.sh` / `extra-deps.gpu-libs.sh`（内容不改）。
- **`docker/sandbox/Dockerfile`**：删内联 gpu-base 中间 stage；gpu stage 改 `FROM ghcr.io/neuroaihub/brainpilot-gpu-base:cu124-torch2.6.0` + 业务层。经典构建器支持普通镜像 `FROM`（仅 `FROM ${ARG}` 不支持），故 base tag 写死文本。
- **`scripts/release-images.sh`**：新增 `GPU_BASE_IMAGE/TAG/DOCKERFILE` SSOT（不进 `RELEASE_IMAGES`，故发版不反复重建 base）。
- **`scripts/release-gpu-base.sh`**（新）：base 专用 build/push，打 `<tag>+latest`，推 ghcr+私有，支持 `--registry`/`--dry-run`。
- **`scripts/release-build.sh`**：构建 gpu runtime 前确保「ghcr 全路径」base 在本地——retag 本地短名 → 否则 pull → 否则提示先 build 并跳过。
- **`docker-compose.gpu.yml`**（新）：override，把 sandbox 指向 gpu 镜像 + 注入 nvidia device 预留；不带此文件即纯 CPU，主 compose 零影响。
- **README**：GPU 启动 + 两层发布流程文档。

### 升级 torch/cuda 时
三处同步：`Dockerfile.gpu-base` 版本、`Dockerfile` 的 gpu `FROM`、`release-images.sh` 的 `GPU_BASE_TAG`。runtime 只 `FROM` 版本 tag，绝不 latest。

## 本机实跑验证（CPU host）
| 项 | 结果 |
|---|---|
| base 构建 | ✅ 8.84GB，torch 2.6.0+cu124 import OK |
| runtime gpu 构建 | ✅ 9.33GB，**gpu stage 零次 torch 安装**（薄层生效） |
| runtime+torch 同在 | ✅ node v22 + torch 2.6.0+cu124 + server.js |
| health 探活 | ✅ 200，skills 物化 225 文件，runtime listening |
| compose 合并 | ✅ sandbox image + GPU device 预留正确注入 |

纯 docker/scripts 改动，不碰 packages → npm CI 不受影响。

## 首次发布顺序（base 先行）
`release-gpu-base.sh build → push` → `release-build.sh sandbox-gpu → release-push.sh --image sandbox-gpu`。之后日常发版只走后两步。

## 范围外
本机无 GPU，`torch.cuda.is_available()` 需在有卡部署机最终确认。

🤖 Generated with [Claude Code](https://claude.com/claude-code)