### PR TITLE
chore(release): bump version to 0.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brainpilot",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "brainpilot",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/protocol",
@@ -4900,6 +4900,7 @@
       "version": "11.11.1",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
       "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12.0.0"
@@ -6813,6 +6814,7 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -8321,11 +8323,11 @@
     },
     "packages/backend-core": {
       "name": "@brainpilot/backend-core",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@brainpilot/protocol": "^0.0.5",
-        "@brainpilot/runtime": "^0.0.5",
+        "@brainpilot/protocol": "^0.0.6",
+        "@brainpilot/runtime": "^0.0.6",
         "@hono/node-server": "^1.13.0",
         "hono": "^4.6.0"
       },
@@ -8341,13 +8343,13 @@
     },
     "packages/cli": {
       "name": "@brainpilot/app",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@brainpilot/backend-core": "^0.0.5",
-        "@brainpilot/protocol": "^0.0.5",
-        "@brainpilot/runtime": "^0.0.5",
-        "@brainpilot/web": "^0.0.5",
+        "@brainpilot/backend-core": "^0.0.6",
+        "@brainpilot/protocol": "^0.0.6",
+        "@brainpilot/runtime": "^0.0.6",
+        "@brainpilot/web": "^0.0.6",
         "commander": "^12.1.0",
         "picocolors": "^1.1.0"
       },
@@ -8361,7 +8363,7 @@
     },
     "packages/client-cli": {
       "name": "@brainpilot/client-cli",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "dependencies": {
         "@brainpilot/protocol": "*",
         "commander": "^12.1.0"
@@ -8372,7 +8374,7 @@
     },
     "packages/protocol": {
       "name": "@brainpilot/protocol",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.24.0"
@@ -8383,11 +8385,11 @@
     },
     "packages/runtime": {
       "name": "@brainpilot/runtime",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "Apache-2.0",
       "dependencies": {
-        "@brainpilot/protocol": "^0.0.5",
-        "@brainpilot/skills": "^0.0.5",
+        "@brainpilot/protocol": "^0.0.6",
+        "@brainpilot/skills": "^0.0.6",
         "@earendil-works/pi-coding-agent": "^0.79.0",
         "@hono/node-server": "^1.19.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
@@ -8400,7 +8402,7 @@
     },
     "packages/skills": {
       "name": "@brainpilot/skills",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=22"
@@ -8408,10 +8410,10 @@
     },
     "packages/web": {
       "name": "@brainpilot/web",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@brainpilot/protocol": "^0.0.5",
+        "@brainpilot/protocol": "^0.0.6",
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource-variable/geist-mono": "^5.2.8",
         "@types/react": "^18.3.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainpilot",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "type": "module",
   "description": "BrainPilot — multi-agent research collaboration platform (TS + Pi SDK)",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/backend-core",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "engines": {
     "node": ">=22"
   },
@@ -37,8 +37,8 @@
     "start": "node ./dist/server.js"
   },
   "dependencies": {
-    "@brainpilot/protocol": "^0.0.5",
-    "@brainpilot/runtime": "^0.0.5",
+    "@brainpilot/protocol": "^0.0.6",
+    "@brainpilot/runtime": "^0.0.6",
     "@hono/node-server": "^1.13.0",
     "hono": "^4.6.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/app",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "engines": {
     "node": ">=22"
   },
@@ -32,10 +32,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@brainpilot/backend-core": "^0.0.5",
-    "@brainpilot/protocol": "^0.0.5",
-    "@brainpilot/runtime": "^0.0.5",
-    "@brainpilot/web": "^0.0.5",
+    "@brainpilot/backend-core": "^0.0.6",
+    "@brainpilot/protocol": "^0.0.6",
+    "@brainpilot/runtime": "^0.0.6",
+    "@brainpilot/web": "^0.0.6",
     "commander": "^12.1.0",
     "picocolors": "^1.1.0"
   }

--- a/packages/client-cli/package.json
+++ b/packages/client-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/client-cli",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "type": "module",
   "description": "BrainPilot headless verification client (dev/CI) — drive a session without the web UI",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/protocol",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "engines": {
     "node": ">=22"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/runtime",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "engines": {
     "node": ">=22"
   },
@@ -37,8 +37,8 @@
     "start": "node ./dist/server.js"
   },
   "dependencies": {
-    "@brainpilot/protocol": "^0.0.5",
-    "@brainpilot/skills": "^0.0.5",
+    "@brainpilot/protocol": "^0.0.6",
+    "@brainpilot/skills": "^0.0.6",
     "@earendil-works/pi-coding-agent": "^0.79.0",
     "@hono/node-server": "^1.19.0",
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/skills",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "engines": {
     "node": ">=22"
   },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/web",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "engines": {
     "node": ">=22"
   },
@@ -31,7 +31,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@brainpilot/protocol": "^0.0.5",
+    "@brainpilot/protocol": "^0.0.6",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.8",
     "@types/react": "^18.3.12",


### PR DESCRIPTION
## What

Bump all workspace packages from `0.0.5` → `0.0.6` and regenerate the lockfile, ahead of the `development → main` release merge.

## Why

`development` has accumulated two shippable changes since 0.0.5:
- skills native-loading pipeline + `skill_search` tool (#141, #142)
- GPU deps split into a standalone publishable base image (#143)

Per the release flow, the version commit must land on `development` first so it rides into `main` with the merge commit.

## Changes
- root `package.json` `0.0.5 → 0.0.6`
- `npm run version:sync` → all 8 workspace packages + internal `^` ranges aligned
- `npm install --package-lock-only` → lockfile regenerated
- `npm run version:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)