### PR TITLE
test(cli): fix CI — assert AGPL-3.0-only license + add version/LICENSE drift guards

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -82,4 +82,4 @@ GitHub README:
 
 ## License
 
-Apache-2.0
+AGPL-3.0-only

--- a/packages/cli/test/publish-readiness.test.ts
+++ b/packages/cli/test/publish-readiness.test.ts
@@ -17,6 +17,12 @@ const PKG_PATH: Record<(typeof PUBLIC)[number], string> = {
   cli: "../package.json",
 };
 
+// License + version are standardized across the monorepo. The root package.json
+// is the single source of truth (versions kept in lockstep by
+// scripts/sync-versions.js; license must match the repo-root LICENSE file).
+const ROOT = readPkg("../../../package.json");
+const EXPECTED_LICENSE = "AGPL-3.0-only";
+
 describe.each(PUBLIC)("public package %s is publish-ready", (shortName) => {
   const pkg = readPkg(PKG_PATH[shortName]);
 
@@ -29,8 +35,16 @@ describe.each(PUBLIC)("public package %s is publish-ready", (shortName) => {
     expect(pkg.files).toContain("dist");
   });
 
-  it("is licensed Apache-2.0", () => {
-    expect(pkg.license).toBe("Apache-2.0");
+  // License is standardized to AGPL-3.0-only (matches the repo-root LICENSE
+  // and the root package.json). Every published package must agree — a drift
+  // back to Apache-2.0 (or anything else) fails CI here.
+  it(`is licensed ${EXPECTED_LICENSE}`, () => {
+    expect(pkg.license).toBe(EXPECTED_LICENSE);
+  });
+
+  // Versions are kept in lockstep with the root by scripts/sync-versions.js.
+  it("version matches the root package.json (single source of truth)", () => {
+    expect(pkg.version).toBe(ROOT.version);
   });
 
   it("has public publishConfig access", () => {
@@ -100,6 +114,20 @@ describe("targeted publish guards", () => {
     const tsconfig = readPkg("../../runtime/tsconfig.json");
     const refs: Array<{ path: string }> = tsconfig.references ?? [];
     expect(refs.some((r) => r.path === "../skills")).toBe(true);
+  });
+});
+
+describe("license is consistent across the repo", () => {
+  it(`root package.json is ${EXPECTED_LICENSE}`, () => {
+    expect(ROOT.license).toBe(EXPECTED_LICENSE);
+  });
+
+  // The declared SPDX license must match the actual LICENSE file text, so the
+  // metadata can never silently diverge from the legal terms we ship.
+  it("the LICENSE file is the AGPL-3.0 text", () => {
+    const license = readFileSync(new URL("../../../LICENSE", import.meta.url), "utf8");
+    expect(license).toMatch(/GNU AFFERO GENERAL PUBLIC LICENSE/);
+    expect(license).toMatch(/Version 3/);
   });
 });
 


### PR DESCRIPTION
## 问题

`development` 上 CI 红了(最近两个 docs commit,run 失败)。根因不是版本/构建,而是一个单测断言对不上新的开源协议:

- commit `8220c70` 把 7 个发布包的 license 元数据从 `Apache-2.0` 重新统一成 **`AGPL-3.0-only`**(对齐仓库根 `LICENSE` 的 AGPL-3.0 正文)。
- 但 `packages/cli/test/publish-readiness.test.ts:32-33` 仍硬断言 `expect(pkg.license).toBe("Apache-2.0")` → **6 个测试失败** → CI red。
- 另外 `packages/cli/README.md` 的 License 段也还写着 `Apache-2.0`。

```
AssertionError: expected 'AGPL-3.0-only' to be 'Apache-2.0'
 ❯ test/publish-readiness.test.ts:33
```

## 改动

- 把 license 断言改成统一后的 `AGPL-3.0-only`,从单一 `EXPECTED_LICENSE` 常量取值(覆盖全部 6 个发布包)。
- **加防漂移守卫**,避免协议/版本再次悄悄分叉:
  - 每个包的 `version` 必须等于根 `package.json`(版本 SSOT,由 `sync-versions.js` 锁步);
  - 根 `package.json` 的 license 必须是 `AGPL-3.0-only`;
  - 根 `LICENSE` 文件必须确实是 AGPL-3.0 正文(`GNU AFFERO GENERAL PUBLIC LICENSE` / `Version 3`)—— 让 SPDX 元数据无法和实际法律条款脱节。
- 修 `packages/cli/README.md` License 段:`Apache-2.0` → `AGPL-3.0-only`。

## 验证

`publish-readiness.test.ts`:修复前 48 passed / 6 failed → 修复后 **62 passed / 0 failed**(+8 个新守卫)。仓库内已无残留 `Apache-2.0` 引用(lockfile 除外)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)