### PR TITLE
fix(demo): preserve ask_user clarification history in export/replay (#132)

### DIFF
--- a/packages/runtime/src/__tests__/ask-user.test.ts
+++ b/packages/runtime/src/__tests__/ask-user.test.ts
@@ -36,6 +36,14 @@ describe("ask_user (SessionManager)", () => {
     const okResolved = m.resolveInput(session.id, req.request_id, "A");
     expect(okResolved).toBe(true);
 
+    // issue #132: the answer is emitted as a user_input_response so export/replay
+    // preserves the Q&A. It carries the matching request_id and the answer.
+    const resp = events.find((e) => e.type === "user_input_response") as any;
+    expect(resp).toBeTruthy();
+    expect(resp.request_id).toBe(req.request_id);
+    expect(resp.answer).toBe("A");
+    expect(parseEvent(resp)).toBeTruthy();
+
     await new Promise((r) => setTimeout(r, 20));
     const toolEnd = events.find(
       (e) => e.type === "TOOL_CALL_RESULT" && (e as any).content?.includes("A"),
@@ -45,8 +53,12 @@ describe("ask_user (SessionManager)", () => {
 
   it("resolveInput returns false for unknown request_id", async () => {
     const session = await m.createSession({ title: "T" });
+    const events: AgUiEvent[] = [];
+    m.subscribe(session.id, (e) => events.push(e));
     expect(m.resolveInput(session.id, "nope", "x")).toBe(false);
     expect(m.resolveInput("no-session", "nope", "x")).toBe(false);
+    // issue #132: a stale/unknown answer is not recorded.
+    expect(events.find((e) => e.type === "user_input_response")).toBeUndefined();
   });
 
   it("interrupt rejects pending inputs", async () => {

--- a/packages/runtime/src/events.ts
+++ b/packages/runtime/src/events.ts
@@ -150,6 +150,14 @@ export const ev = {
       allow_free_text: req.allow_free_text,
     } as AgUiEvent;
   },
+  userInputResponse(ctx: Ctx, res: { request_id: string; answer: string }): AgUiEvent {
+    return {
+      type: "user_input_response",
+      ...envelope(ctx),
+      request_id: res.request_id,
+      answer: res.answer,
+    } as AgUiEvent;
+  },
   systemMessage(
     sessionId: string,
     level: "info" | "warning" | "error" | "fatal",

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -774,6 +774,16 @@ export class SessionManager {
     if (!entry || !deferred) return false;
     entry.pendingInputs.delete(requestId);
     deferred.resolve(answer);
+    // issue #132: persist + broadcast the answer so export/replay preserves the
+    // ask_user Q&A. user_input_request is already emitted in requestUserInput;
+    // without this the response was only used to resolve the promise and never
+    // reached events.jsonl, leaving a gap in the demo replay.
+    entry.bus.emit(
+      ev.userInputResponse(
+        { sessionId: entry.id, runId: entry.activeRunId ?? undefined },
+        { request_id: requestId, answer },
+      ),
+    );
     this.touch(entry);
     return true;
   }

--- a/packages/web/src/__tests__/demoConversation.test.ts
+++ b/packages/web/src/__tests__/demoConversation.test.ts
@@ -59,12 +59,35 @@ describe("isDemoConversational (#98 multi-agent transcript)", () => {
     expect(isDemoConversational(msg({ role: "system", kind: "system_message", content: "" }))).toBe(false);
   });
 
-  it("drops reasoning, tool calls/results, hooks and interactive cards", () => {
+  it("drops reasoning, tool calls/results, hooks and auto_retry cards", () => {
     expect(isDemoConversational(msg({ kind: "thinking", content: "let me think" }))).toBe(false);
     expect(isDemoConversational(msg({ kind: "tool", content: "Tool: read" }))).toBe(false);
     expect(isDemoConversational(msg({ role: "system", kind: "hook", content: "reset" }))).toBe(false);
-    expect(isDemoConversational(msg({ kind: "ask_user", content: "pick one" }))).toBe(false);
     expect(isDemoConversational(msg({ kind: "auto_retry", content: "retrying" }))).toBe(false);
+  });
+
+  it("keeps an answered ask_user card but drops an unanswered prompt (#132)", () => {
+    // Answered: question + user answer are a user-facing decision point, kept as
+    // a read-only Q&A step in the replay.
+    expect(
+      isDemoConversational(
+        msg({
+          kind: "ask_user",
+          content: "pick one",
+          askUser: { requestId: "req_1", agent: "principal", question: "pick one", answer: "A" },
+        }),
+      ),
+    ).toBe(true);
+    // Unanswered prompt has no meaning in a read-only replay.
+    expect(
+      isDemoConversational(
+        msg({
+          kind: "ask_user",
+          content: "pick one",
+          askUser: { requestId: "req_1", agent: "principal", question: "pick one" },
+        }),
+      ),
+    ).toBe(false);
   });
 
   it("drops empty text placeholders", () => {

--- a/packages/web/src/components/demo/DemoView.tsx
+++ b/packages/web/src/components/demo/DemoView.tsx
@@ -55,14 +55,21 @@ function basename(path: string): string {
  *
  * Keep: user prompts; assistant/system plain-text replies from ANY agent;
  * error and system_message bubbles (the agent-attributed warnings/alerts the
- * live Chat shows). Drop: reasoning, tool calls/results, hook diagnostics, and
- * the interactive ask_user / auto_retry cards (the reasoning graph on the right
- * tells the internal story, and the cards have no meaning in a read-only
- * replay), plus NO-RENDER placeholders and empties.
+ * live Chat shows), plus answered ask_user cards (the question + the user's
+ * answer are a user-facing decision point, issue #132 — rendered read-only by
+ * AskUserCard since DemoView passes no onAskUserSubmit). Drop: reasoning, tool
+ * calls/results, hook diagnostics, the auto_retry card and UNANSWERED ask_user
+ * prompts (no meaning in a read-only replay), plus NO-RENDER placeholders and
+ * empties.
  */
 export function isDemoConversational(m: ChatMessage): boolean {
   if (m.role === "user") {
     return !!m.content?.trim();
+  }
+  // Answered ask_user: keep as a read-only Q&A step. Unanswered prompts have no
+  // meaning in a replay and are dropped.
+  if (m.kind === "ask_user") {
+    return m.askUser?.answer !== undefined;
   }
   // Agent-attributed warnings/errors the live Chat surfaces as standalone
   // bubbles. system_message carries its own payload; error carries content.


### PR DESCRIPTION
Closes #132

## Problem

Live Demo export/replay dropped `ask_user` clarification steps, so sessions with a user clarification could not be faithfully replayed. Two gaps:

1. **Runtime never persisted the answer.** `requestUserInput()` emits `user_input_request` (persisted), but `resolveInput()` only resolved the pending promise — the answer never reached `events.jsonl`.
2. **Live Demo filtered out ask_user cards.** `isDemoConversational()` dropped all `ask_user` cards as "meaningless in a read-only replay", which is wrong for an answered Q&A.

## Changes

- **`runtime/events.ts`** — add `ev.userInputResponse()` builder. Minimal payload (`request_id` + `answer`); the protocol schema for `user_input_response` already existed.
- **`runtime/session-manager.ts`** — `resolveInput()` emits `user_input_response` on success → persisted to `events.jsonl` and broadcast to live clients. Stale/unknown answers stay unrecorded (return `false`, no event).
- **`web/DemoView.tsx`** — `isDemoConversational()` keeps **answered** `ask_user` cards (rendered read-only by `AskUserCard`, since DemoView passes no `onAskUserSubmit`); unanswered prompts are still dropped.

No other frontend changes needed: the message reducer already handles both events, and `AskUserCard` already renders an answered card as a read-only Q&A.

## Tests

- `runtime/__tests__/ask-user.test.ts` — asserts a successful answer emits `user_input_response` (matching `request_id` + `answer`); stale/unknown answers emit nothing.
- `web/__tests__/demoConversation.test.ts` — answered ask_user is kept, unanswered is dropped.

## Verification

- ✅ Runtime tests: 23 passed (ask-user / server / event-mapping)
- ✅ Web tests: 27 passed (demoConversation / newUiEvents)
- ✅ Typecheck: runtime build chain + web `tsc -b` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)