### PR TITLE
chore(release): bump to v0.0.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainpilot",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "private": true,
   "type": "module",
   "description": "BrainPilot — multi-agent research collaboration platform (TS + Pi SDK)",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/backend-core",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "engines": {
     "node": ">=22"
   },
@@ -37,8 +37,8 @@
     "start": "node ./dist/server.js"
   },
   "dependencies": {
-    "@brainpilot/protocol": "^0.0.6",
-    "@brainpilot/runtime": "^0.0.6",
+    "@brainpilot/protocol": "^0.0.7",
+    "@brainpilot/runtime": "^0.0.7",
     "@hono/node-server": "^1.13.0",
     "hono": "^4.6.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/app",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "engines": {
     "node": ">=22"
   },
@@ -32,10 +32,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@brainpilot/backend-core": "^0.0.6",
-    "@brainpilot/protocol": "^0.0.6",
-    "@brainpilot/runtime": "^0.0.6",
-    "@brainpilot/web": "^0.0.6",
+    "@brainpilot/backend-core": "^0.0.7",
+    "@brainpilot/protocol": "^0.0.7",
+    "@brainpilot/runtime": "^0.0.7",
+    "@brainpilot/web": "^0.0.7",
     "commander": "^12.1.0",
     "picocolors": "^1.1.0"
   }

--- a/packages/client-cli/package.json
+++ b/packages/client-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/client-cli",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "private": true,
   "type": "module",
   "description": "BrainPilot headless verification client (dev/CI) — drive a session without the web UI",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/protocol",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "engines": {
     "node": ">=22"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/runtime",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "engines": {
     "node": ">=22"
   },
@@ -37,8 +37,8 @@
     "start": "node ./dist/server.js"
   },
   "dependencies": {
-    "@brainpilot/protocol": "^0.0.6",
-    "@brainpilot/skills": "^0.0.6",
+    "@brainpilot/protocol": "^0.0.7",
+    "@brainpilot/skills": "^0.0.7",
     "@earendil-works/pi-coding-agent": "^0.79.0",
     "@hono/node-server": "^1.19.0",
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/skills",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "engines": {
     "node": ">=22"
   },

--- a/packages/skills/skills/16_Animal_Behavior/ethoclaw-kinematic-parameter-generator/generate_kinematic_parameter.pyZone.Identifier
+++ b/packages/skills/skills/16_Animal_Behavior/ethoclaw-kinematic-parameter-generator/generate_kinematic_parameter.pyZone.Identifier
@@ -1,2 +1,0 @@
-[ZoneTransfer]
-ZoneId=3

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/web",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "engines": {
     "node": ">=22"
   },
@@ -31,7 +31,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@brainpilot/protocol": "^0.0.6",
+    "@brainpilot/protocol": "^0.0.7",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.8",
     "@types/react": "^18.3.12",


### PR DESCRIPTION
## 发版准备:v0.0.6 → v0.0.7

按 development→main 惯例,先把 bump 合进 development,再 promote 到 main 发布。

### 改动
- **版本 bump**:根 `package.json` 0.0.6→0.0.7,`version:sync` 对齐全部 workspace 版本号 + 内部 `@brainpilot/*` 依赖范围(16 字段)
- **清理**:删除 `skills/16_Animal_Behavior/` 下的 NTFS `Zone.Identifier` 残留(Windows 下载产生的垃圾文件,会被打进 skills npm 包)

### 验证
- `typecheck` ✅
- `build` ✅
- `npm run release:dry` ✅ — 6 个发布包(protocol/runtime/backend-core/app/web/skills)均为 0.0.7,tarball 无垃圾文件

### 后续
合并后:promote development→main → 在 main 上 `npm run release` 发布到 npm → 打 tag `v0.0.7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)