### PR TITLE
fix(windows): use pathToFileURL for cross-platform path handling (#154)

### DIFF
--- a/packages/backend-core/src/app.ts
+++ b/packages/backend-core/src/app.ts
@@ -14,6 +14,7 @@
  * `API_BASE = "/api"`), with static assets served at the root.
  */
 import { createRequire } from "node:module";
+import { join } from "node:path";
 import { Hono } from "hono";
 import { serveStatic } from "@hono/node-server/serve-static";
 import {
@@ -294,7 +295,7 @@ export function createApp(options: CreateAppOptions): Hono {
   if (options.serveWeb !== false) {
     app.use("/*", serveStatic({ root: webRoot }));
     // SPA fallback: any unmatched GET that isn't /api returns index.html.
-    app.get("/*", serveStatic({ path: `${webRoot}/index.html` }));
+    app.get("/*", serveStatic({ path: join(webRoot, "index.html") }));
   }
 
   return app;

--- a/packages/backend-core/src/server.ts
+++ b/packages/backend-core/src/server.ts
@@ -3,6 +3,7 @@
  * Exported via the package's `./server` entry. The orchestrator's runtime is
  * started lazily on the first request that needs it; graceful shutdown stops it.
  */
+import { pathToFileURL } from "node:url";
 import { serve, type ServerType } from "@hono/node-server";
 import { createApp, type CreateAppOptions } from "./app.js";
 import { createOrchestrator } from "./create-orchestrator.js";
@@ -85,9 +86,11 @@ export async function startServer(
 }
 
 // Allow `node dist/server.js` to boot directly.
+// pathToFileURL keeps the main-module check correct on Windows (a naive
+// `file://${argv[1]}` never matches import.meta.url there).
 const isMain =
   typeof process.argv[1] === "string" &&
-  import.meta.url === `file://${process.argv[1]}`;
+  import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isMain) {
   startServer().then(
     (s) => {

--- a/packages/cli/src/repo-mode.ts
+++ b/packages/cli/src/repo-mode.ts
@@ -56,7 +56,14 @@ export interface AssertRepoCwdOptions {
  */
 function samePath(a: string, b: string): boolean {
   try {
-    return realpathSync(a) === realpathSync(b);
+    const ra = realpathSync(a);
+    const rb = realpathSync(b);
+    // Windows/macOS filesystems are case-insensitive and realpathSync does not
+    // canonicalize drive-letter casing, so compare case-insensitively there.
+    if (process.platform === "win32" || process.platform === "darwin") {
+      return ra.toLowerCase() === rb.toLowerCase();
+    }
+    return ra === rb;
   } catch {
     return false;
   }

--- a/packages/runtime/src/server.ts
+++ b/packages/runtime/src/server.ts
@@ -10,6 +10,7 @@
  *   GET  /sse/:id  (+ alias GET /sessions/:id/events)
  *   POST /sessions/:id/interrupt, GET /sessions/:id/agents, POST /sessions/:id/evict
  */
+import { pathToFileURL } from "node:url";
 import { Hono } from "hono";
 import { serve } from "@hono/node-server";
 import { stream } from "hono/streaming";
@@ -315,8 +316,10 @@ export async function startServer(opts: StartServerOptions = {}): Promise<{
   };
 }
 
-// Allow `node dist/server.js` to boot directly.
-if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+// Allow `node dist/server.js` to boot directly. Use pathToFileURL for the
+// main-module check so it works on Windows too — a naive `file://${argv[1]}`
+// never matches import.meta.url there (backslashes, drive letter, file:///).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   void startServer().then(({ port }) => {
     // eslint-disable-next-line no-console
     console.log(`[runtime] listening on :${port} (mock=${process.env.BP_MOCK ?? "0"})`);


### PR DESCRIPTION
## Summary

Fixes the Windows deployment failure tracked in #154: `brainpilot up` starts the backend but the runtime never becomes healthy, and the health check on **port 8081** times out.

**Root cause** — the runtime/backend main-module guard built a `file://` URL by naive string concatenation:

```js
import.meta.url === `file://${process.argv[1]}`
```

On Windows the two strings never match (`file:///C:/...` with forward slashes & encoded drive letter vs `file://C:\...` with backslashes), so `startServer()` is never called → the spawned runtime child exits immediately → the backend's `waitForHealth()` on `:8081` times out. POSIX is unaffected because the naive form coincidentally equals `import.meta.url` there.

**Fix** — use `pathToFileURL(process.argv[1]).href` for the comparison in both entry points.

## Changes

| File | Change |
| --- | --- |
| `packages/runtime/src/server.ts` | main-module guard → `pathToFileURL` (the bug behind #154) |
| `packages/backend-core/src/server.ts` | same guard, same fix |
| `packages/backend-core/src/app.ts` | SPA fallback path built with `path.join` instead of `` `${webRoot}/index.html` `` |
| `packages/cli/src/repo-mode.ts` | `samePath` compares realpaths case-insensitively on Windows/macOS (case-insensitive FS; `realpathSync` doesn't canonicalize drive-letter casing) so the run-from-source repo-root guard doesn't wrongly reject a valid invocation |

The last two were found in a cross-platform path sweep prompted by this bug.

## Cross-platform sweep

Swept all 7 packages for the 10 common Windows path hazards (naive `file://`, manual separator split/join, hardcoded POSIX paths, path `===` without normalization, shell-assuming spawn, CRLF, etc.). The codebase is otherwise disciplined: `paths.ts`/`scaffold.ts`/`skills/index.ts` use `path.join`, traversal guards use `path.sep`, binaries use `require.resolve` + `spawn(execPath, [...])` with no shell, the browser launcher branches on platform, and dotenv parsing already splits on `/\r?\n/`. The three issues fixed here were the only genuine ones; a couple of low-severity notes (MCP stdio `env` replacement on Windows, an `events.jsonl` `\n` split) are documented in #154's analysis and left as-is since BrainPilot writes those files itself.

## Testing

- `npm run typecheck` — passes
- `npm run build` — passes
- `npx vitest run packages/cli` — 140 passed (includes `repo-mode.test.ts`)
- 6 pre-existing failures in `@brainpilot/runtime` skill-loading tests are unrelated (reproduce on a clean `development` checkout).

## Note

I cannot test on a real Windows host from here — the fix follows Node's documented cross-platform pattern (`pathToFileURL`). A quick smoke test of `brainpilot up` on Windows 10/11 before merge would be ideal.

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)
