### PR TITLE
fix(demo): preserve full conversation in live-demo export/replay

### DIFF
--- a/packages/web/src/__tests__/demoTruncatedExport.test.ts
+++ b/packages/web/src/__tests__/demoTruncatedExport.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { reduceMessagesForEvent } from "../contexts/messageReducer";
+import { normalizeAgUiEvent } from "../contracts/backend";
+import type { ChatMessage, WebSocketEvent } from "../contracts/backend";
+
+/**
+ * Regression coverage for demo bundles built from a *tail-sliced* history.
+ *
+ * When a long session was exported with a positive `limit`, the history
+ * endpoint returns only the tail of events.jsonl — the leading
+ * TEXT_MESSAGE_START of the earliest messages is gone, leaving orphaned
+ * CONTENT/END. The replay then dropped those opening replies silently
+ * ("开始的消息被截断"). The export now requests the full log (`limit: 0`), and
+ * the reducer additionally recovers gracefully if an orphan still slips
+ * through.
+ */
+describe("demo replay tolerates truncated/orphaned events", () => {
+  it("renders orphaned TEXT_MESSAGE_CONTENT whose START was sliced off", () => {
+    // Simulate a tail-sliced stream: CONTENT/END with no preceding START.
+    let msgs: ChatMessage[] = [];
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "orphan-1",
+      delta: "Librarian → methodology grounding",
+      agentName: "principal",
+    } as WebSocketEvent);
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "orphan-1",
+      delta: " against the paper",
+      agentName: "principal",
+    } as WebSocketEvent);
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_END",
+      messageId: "orphan-1",
+    } as WebSocketEvent);
+
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].id).toBe("orphan-1");
+    expect(msgs[0].content).toBe("Librarian → methodology grounding against the paper");
+    expect(msgs[0].agent).toBe("principal");
+    expect(msgs[0].streaming).toBe(false); // END finalized it
+  });
+
+  it("still folds a normal START→CONTENT→END triad into one message", () => {
+    let msgs: ChatMessage[] = [];
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_START",
+      messageId: "m1",
+      role: "assistant",
+      agentName: "principal",
+    } as WebSocketEvent);
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "m1",
+      delta: "hello",
+    } as WebSocketEvent);
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "m1",
+      delta: " world",
+    } as WebSocketEvent);
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_END",
+      messageId: "m1",
+    } as WebSocketEvent);
+
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].content).toBe("hello world");
+  });
+
+  it("strips NO-RENDER wrappers even on orphaned content", () => {
+    let msgs: ChatMessage[] = [];
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "orphan-2",
+      delta: "<!--NO-RENDER-->internal<!--/NO-RENDER-->",
+    } as WebSocketEvent);
+    // Entire delta was a NO-RENDER wrapper → nothing to render, no message created.
+    expect(msgs).toHaveLength(0);
+  });
+});
+
+describe("normalizeAgUiEvent preserves transport metadata keys", () => {
+  it("keeps _ts (and _seq) instead of mangling to Ts/Seq", () => {
+    const raw = {
+      type: "TEXT_MESSAGE_CONTENT",
+      _ts: "2026-06-22T08:43:24.619Z",
+      _seq: 42,
+      agent_name: "principal",
+      message_id: "m1",
+      delta: "hi",
+    };
+    const norm = normalizeAgUiEvent(raw) as Record<string, unknown>;
+    // The timestamp the demo timeline sorts on must survive normalization.
+    expect(norm._ts).toBe("2026-06-22T08:43:24.619Z");
+    expect(norm._seq).toBe(42);
+    expect(norm).not.toHaveProperty("Ts");
+    expect(norm).not.toHaveProperty("Seq");
+    // Internal snake_case still camelizes.
+    expect(norm.agentName).toBe("principal");
+    expect(norm.messageId).toBe("m1");
+  });
+});

--- a/packages/web/src/components/demo/demoBundle.ts
+++ b/packages/web/src/components/demo/demoBundle.ts
@@ -159,9 +159,14 @@ export async function buildDemoBundle(opts: BuildDemoOptions): Promise<DemoBundl
   let timeline: DemoBundle["timeline"] = "timestamped";
   // Pull the persisted event timeline from the new history endpoint (the
   // legacy `/sessions/:id/events` path is an SSE alias and returns no JSON).
-  // Cap at 5000 — the endpoint enforces the same cap, but stating it here
-  // documents the bundle's max footprint.
-  const historyEnvelope = await api.sessions.getHistory(session.id, { limit: 5000 });
+  // Request the FULL log (`limit: 0`) — same as the live chat rehydrate path
+  // (HISTORY_REHYDRATE_LIMIT). A positive cap returns the *tail* of the log,
+  // which slices off the oldest events: the leading TEXT_MESSAGE_START of the
+  // earliest messages is dropped, leaving orphaned CONTENT/END that the
+  // reducer can't attach to anything, so the conversation's opening replies
+  // silently vanish from the replay. The 25 MB embed budget (MAX_TOTAL_BYTES)
+  // still bounds the bundle's real footprint via the files section.
+  const historyEnvelope = await api.sessions.getHistory(session.id, { limit: 0 });
   let events: typeof historyEnvelope.events | undefined = historyEnvelope.events;
   let messages: ChatMessage[] | undefined;
   if (!events || events.length === 0) {

--- a/packages/web/src/contexts/messageReducer.ts
+++ b/packages/web/src/contexts/messageReducer.ts
@@ -171,6 +171,25 @@ export function reduceMessagesForEvent(existing: ChatMessage[], event: WebSocket
       // Strip NO-RENDER wrapper used by record_trace "Message Complete" hint
       delta = delta.replace(/<!--NO-RENDER-->[\s\S]*?<!--\/NO-RENDER-->/g, "");
       if (!delta) return existing;
+      // Orphaned CONTENT (no matching START) — recover gracefully instead of
+      // dropping it. This happens when a demo bundle was exported from a
+      // tail-sliced history: the leading START of the earliest messages is gone,
+      // and a plain `.map` here would no-op, silently swallowing the opening
+      // replies. Synthesize the message so the content still renders.
+      if (!existing.some((m) => m.id === id)) {
+        return [
+          ...existing,
+          {
+            id,
+            role: "assistant",
+            content: delta,
+            createdAt: new Date().toISOString(),
+            agent,
+            streaming: true,
+            kind: "text",
+          },
+        ];
+      }
       return existing.map((m) =>
         m.id === id ? { ...m, content: (m.content ?? "") + delta } : m,
       );

--- a/packages/web/src/contracts/backend.ts
+++ b/packages/web/src/contracts/backend.ts
@@ -481,7 +481,14 @@ function normalizeStringArray(value: unknown): string[] {
 }
 
 function camelizeKey(key: string): string {
-  return key.replace(/_([a-z])/g, (_, char: string) => char.toUpperCase());
+  // Preserve a leading-underscore prefix: `_ts` / `_seq` are AG-UI transport
+  // metadata whose underscore is significant. Without this guard the regex
+  // turns `_ts` into `Ts`, so `normalizeAgUiEvent` strips the timestamp and the
+  // demo replay's timeline collapses (every event lands at ms=0). Only internal
+  // snake_case boundaries (e.g. `agent_name` → `agentName`) are camelized.
+  const lead = key.match(/^_+/)?.[0] ?? "";
+  const rest = key.slice(lead.length);
+  return lead + rest.replace(/_([a-z])/g, (_, char: string) => char.toUpperCase());
 }
 
 function camelizeObject(value: unknown): unknown {


### PR DESCRIPTION
## Problem

Importing a real exported live-demo `.json` showed an **incomplete conversation** (对话显示不完整) — the opening messages were missing while later ones and the trace/files rendered fine.

Diagnosed against a real 3.5 MB bundle (`su-demo.json`): its `events` array was **exactly 5000** entries and its very first event was a `TEXT_MESSAGE_CONTENT` whose `TEXT_MESSAGE_START` had been sliced off (155 START vs 158 END — orphaned ENDs). It is **not** a JSON-syntax problem; the bundle was built from a tail-sliced history.

## Root causes (three independent issues)

1. **Lossy export.** `buildDemoBundle` requested `getHistory(..., { limit: 5000 })`. For sessions longer than 5000 events the history endpoint returns the **tail**, dropping the oldest events — including the leading `TEXT_MESSAGE_START` of the earliest messages. The reducer's `TEXT_MESSAGE_CONTENT` then `.map`s over a non-existent message (no-op), silently swallowing the opening replies. Fixed by requesting the full log (`limit: 0`), matching the live chat rehydrate path (`HISTORY_REHYDRATE_LIMIT`). The 25 MB embed budget still bounds the bundle footprint.

2. **`_ts` mangled by `camelizeKey`.** `"_ts".replace(/_([a-z])/g, …)` → `"Ts"`, so `normalizeAgUiEvent` stripped the timestamp and `DemoView` read `_ts === undefined`. Every event collapsed to `ms = 0`: playback/scrub were dead and trace nodes popped in all at once. Now leading-underscore transport keys (`_ts`/`_seq`) are preserved.

3. **No graceful degradation.** The reducer now recovers orphaned `TEXT_MESSAGE_CONTENT` (no matching START) by synthesizing the message, so already-exported truncated bundles still render their opening replies.

## Verification

Replaying the real `su-demo.json` through the actual normalize → reduce → filter pipeline:

| | before | after |
|---|---|---|
| folded conversational messages | opening replies dropped | **114 / 114** |
| distinct event timestamps | 1 (`ms=0`) | **2787** (real span) |

The previously-missing first reply (`"Librarian → methodology grounding…"`) now renders.

## Tests

- New `demoTruncatedExport.test.ts`: orphan-content recovery + `_ts`/`_seq` preservation (4 cases).
- Full web suite **122 passed**, `tsc -b` clean.

> Note: fix #1 applies to **new** exports. Bundles already exported truncated still miss the dropped events on disk, but fix #3 lets their opening orphan message display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)