### PR TITLE
chore(flow): adopt GitHub Flow on main — drop development branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,9 @@ name: CI
 
 on:
   push:
-    branches: [development, main, testbed]
+    branches: [main, testbed]
   pull_request:
-    branches: [development, main, testbed]
+    branches: [main, testbed]
 
 jobs:
   build-and-test:
@@ -44,7 +44,7 @@ jobs:
         run: npm run build
 
   # 黑盒测试可在 GitHub runner 跑的部分（零 token、不需真实 provider/宿主权限）。
-  # 仅 testbed 分支有 testbed/ 目录；development/main 无此目录，job 自动跳过（if 守卫）。
+  # 仅 testbed 分支有 testbed/ 目录；main 无此目录，job 自动跳过（if 守卫）。
   # 完整黑盒回归（recovery 需 kill 进程、cases/mcp 需真实 provider）由服务器 run-all.sh 跑。
   blackbox-fast:
     runs-on: ubuntu-latest
@@ -75,6 +75,10 @@ jobs:
       - name: probes 单测（质量探针，纯函数，零依赖）
         if: steps.detect.outputs.present == 'true'
         run: node testbed/suites/probes.test.mjs
+
+      - name: crossplatform 单测（Windows 路径/EOL 回归，纯函数）
+        if: steps.detect.outputs.present == 'true'
+        run: node testbed/suites/crossplatform.test.mjs
 
       - name: 起 mock 实例 + 跑 contract/scenarios（零 token）
         if: steps.detect.outputs.present == 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,14 +51,13 @@ For a no-key smoke run: `BP_MOCK=1 npm run bp -- up`.
 
 ## Development Workflow
 
-BrainPilot uses a two-branch model:
+BrainPilot follows a simple GitHub Flow: **`main` is the single source of truth.**
+You branch off `main`, open a PR, and merge back into `main` once CI is green and a
+maintainer approves.
 
-- **`development`** — the working branch; open your PRs against this.
-- **`main`** — the stable branch; changes land here only after they've been tested.
-
-1. **Fork** the repository and create a branch from `development`:
+1. **Fork** the repository and create a branch from `main`:
    ```bash
-   git checkout -b feat/your-feature development
+   git checkout -b feat/your-feature main
    ```
 2. **Branch naming:**
    - `feat/` — new features or enhancements
@@ -67,7 +66,23 @@ BrainPilot uses a two-branch model:
    - `ci/` / `chore/` — tooling and maintenance
 3. Make your changes and **test locally**.
 4. Run **all checks** before committing (see below).
-5. Open a **Pull Request** against `development`.
+5. Open a **Pull Request** against `main`.
+
+### How your PR is verified
+
+Two layers, with different jobs:
+
+- **Public CI (the merge gate)** — every PR runs the GitHub Actions workflow
+  (typecheck + unit tests + web build + the fast black-box suites). This is the
+  authoritative gate: it is fully public and reproducible, so you can see exactly
+  what is checked and reproduce any failure locally. **A PR merges once this is
+  green** (and a maintainer approves).
+- **Maintainer regression (pre-release)** — maintainers additionally run a fuller
+  regression (real provider / real sessions) on internal infrastructure before
+  cutting a release. This is a release-time smoke check, **not** a per-PR gate, so
+  it never blocks external contributors. Test cases from it are continuously
+  de-identified and folded back into the public CI above, so the public gate keeps
+  getting stronger over time.
 
 ## Before You Submit a PR
 


### PR DESCRIPTION
## What

Switch the contributor workflow to **GitHub Flow**: `main` is the single source of truth — branch off `main`, open a PR, merge back into `main`. The long-lived `development` branch is retired.

## Changes

- **CONTRIBUTING.md** — branch/PR flow now targets `main`; documents the two-layer test model:
  - **Public CI = the merge gate** (typecheck + unit + web build + fast black-box) — fully public & reproducible.
  - **Maintainer regression** (real provider / sessions, internal infra) = a pre-release smoke check, **not** a per-PR gate; its cases are continuously de-identified and folded back into public CI.
- **.github/workflows/ci.yml** — drop `development` from trigger branches (`[main, testbed]`); also sync the `crossplatform` unit-test step down from testbed (guarded by `testbed/` detection, auto-skips on main).

## Notes

- This is the first PR under the new flow.
- Testbed remains a private, self-contained branch (not open-sourced); it only ever merges *from* main, never back into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)