### PR TITLE
feat(web): collapse sidebar when dragged narrow enough (closes #159)

### DIFF
--- a/packages/web/src/__tests__/sidebarResize.test.ts
+++ b/packages/web/src/__tests__/sidebarResize.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolveResize,
+  MIN_SIDEBAR_WIDTH,
+  MAX_SIDEBAR_WIDTH,
+  COLLAPSE_THRESHOLD,
+  DEFAULT_SIDEBAR_WIDTH,
+} from "../components/shell/sidebarResize";
+
+// #159 — drag-to-collapse geometry. The monorepo has no jsdom, so the real
+// pointer-drag is exercised by DesktopShell at runtime; here we pin the pure
+// decision: when does a drag collapse the rail, and how is width clamped.
+describe("resolveResize — #159 drag-to-collapse", () => {
+  it("collapses when dragged at/below the collapse threshold", () => {
+    expect(resolveResize(COLLAPSE_THRESHOLD).collapse).toBe(true);
+    expect(resolveResize(COLLAPSE_THRESHOLD - 1).collapse).toBe(true);
+    expect(resolveResize(0).collapse).toBe(true);
+    expect(resolveResize(-50).collapse).toBe(true); // dragged past the left edge
+  });
+
+  it("does NOT collapse between the threshold and the minimum (buffer zone)", () => {
+    // Sitting at the min width is a normal narrow drag, not a collapse intent.
+    expect(resolveResize(MIN_SIDEBAR_WIDTH).collapse).toBe(false);
+    expect(resolveResize(COLLAPSE_THRESHOLD + 1).collapse).toBe(false);
+    expect(resolveResize(200).collapse).toBe(false);
+  });
+
+  it("clamps expanded width into [MIN, MAX]", () => {
+    // Above threshold but below min → clamp up to min (still expanded).
+    expect(resolveResize(190)).toEqual({ width: MIN_SIDEBAR_WIDTH, collapse: false });
+    // In range → passthrough.
+    expect(resolveResize(300)).toEqual({ width: 300, collapse: false });
+    // Above max → clamp down.
+    expect(resolveResize(999)).toEqual({ width: MAX_SIDEBAR_WIDTH, collapse: false });
+  });
+
+  it("threshold sits below the minimum so a min-width drag never collapses", () => {
+    expect(COLLAPSE_THRESHOLD).toBeLessThan(MIN_SIDEBAR_WIDTH);
+  });
+
+  it("default restore width is a valid expanded width", () => {
+    expect(DEFAULT_SIDEBAR_WIDTH).toBeGreaterThanOrEqual(MIN_SIDEBAR_WIDTH);
+    expect(DEFAULT_SIDEBAR_WIDTH).toBeLessThanOrEqual(MAX_SIDEBAR_WIDTH);
+    expect(resolveResize(DEFAULT_SIDEBAR_WIDTH).collapse).toBe(false);
+  });
+});

--- a/packages/web/src/components/shell/DesktopShell.tsx
+++ b/packages/web/src/components/shell/DesktopShell.tsx
@@ -17,9 +17,7 @@ import { SandboxStatus } from "./SandboxStatus";
 import { Sidebar } from "../sidebar/Sidebar";
 import { DiskQuotaWarningDialog } from "../quota/DiskQuotaWarningDialog";
 import { DiskQuotaCriticalDialog } from "../quota/DiskQuotaCriticalDialog";
-
-const MIN_SIDEBAR_WIDTH = 220;
-const MAX_SIDEBAR_WIDTH = 420;
+import { DEFAULT_SIDEBAR_WIDTH, resolveResize } from "./sidebarResize";
 
 export function DesktopShell() {
   const { isAuthReady } = useAuth();
@@ -87,12 +85,21 @@ export function DesktopShell() {
         return;
       }
 
+      // #159 — drag the edge left past the collapse threshold and the rail snaps
+      // to the icon rail; otherwise apply the clamped expanded width. resolveResize
+      // owns the geometry (pure + unit-tested in sidebarResize.test.ts).
       const delta = event.clientX - sidebarResizeRef.current.pointerX;
-      const nextWidth = Math.max(
-        MIN_SIDEBAR_WIDTH,
-        Math.min(MAX_SIDEBAR_WIDTH, sidebarResizeRef.current.width + delta),
-      );
-      setSidebarWidth(nextWidth);
+      const outcome = resolveResize(sidebarResizeRef.current.width + delta);
+      if (outcome.collapse) {
+        setUserCollapsed(true);
+        sidebarResizeRef.current = null;
+        setIsSidebarResizing(false);
+        // Restore a sensible width so expanding again (toggle / drag) isn't stuck
+        // at the collapsed remnant.
+        setSidebarWidth(DEFAULT_SIDEBAR_WIDTH);
+        return;
+      }
+      setSidebarWidth(outcome.width);
     };
 
     const handlePointerUp = () => {

--- a/packages/web/src/components/shell/sidebarResize.ts
+++ b/packages/web/src/components/shell/sidebarResize.ts
@@ -1,0 +1,49 @@
+/**
+ * sidebarResize.ts — pure geometry for the sidebar resize→collapse interaction
+ * (#159). Kept free of React so it can be unit-tested without jsdom (the
+ * monorepo has no jsdom/@testing-library; DesktopShell drives the real
+ * pointer events, these helpers decide the numbers).
+ *
+ * Behaviour: while dragging the sidebar's right edge leftward, once the would-be
+ * width crosses a collapse threshold that sits *below* the normal minimum, the
+ * rail snaps to the collapsed icon rail (rather than refusing to shrink past the
+ * minimum, which is what made drag-to-collapse impossible before #159).
+ */
+
+/** Normal drag bounds — the sidebar clamps here while it stays expanded. */
+export const MIN_SIDEBAR_WIDTH = 220;
+export const MAX_SIDEBAR_WIDTH = 420;
+
+/**
+ * Drag the edge below this (well under MIN, giving a deliberate "drag past the
+ * min a bit more" buffer so a normal min-width drag doesn't accidentally
+ * collapse) and the rail snaps shut.
+ */
+export const COLLAPSE_THRESHOLD = 160;
+
+/** Width the rail restores to when it expands again (matches the default). */
+export const DEFAULT_SIDEBAR_WIDTH = 268;
+
+export interface ResizeOutcome {
+  /** Clamped width to apply while expanded (ignored when collapse is true). */
+  width: number;
+  /** True when the drag has gone narrow enough to collapse to the icon rail. */
+  collapse: boolean;
+}
+
+/**
+ * Given the drag's raw proposed width (start width + pointer delta), decide
+ * whether to collapse and, if not, the clamped expanded width.
+ *
+ * - proposed <= COLLAPSE_THRESHOLD → collapse.
+ * - otherwise clamp into [MIN, MAX].
+ */
+export function resolveResize(proposedWidth: number): ResizeOutcome {
+  if (proposedWidth <= COLLAPSE_THRESHOLD) {
+    return { width: MIN_SIDEBAR_WIDTH, collapse: true };
+  }
+  return {
+    width: Math.max(MIN_SIDEBAR_WIDTH, Math.min(MAX_SIDEBAR_WIDTH, proposedWidth)),
+    collapse: false,
+  };
+}


### PR DESCRIPTION
Closes #159.

## What

Dragging the sidebar's right edge leftward used to clamp at `MIN_SIDEBAR_WIDTH` (220px) and never collapse — so the only ways to reach the icon rail were the PanelLeft toggle or shrinking the whole window below 860px. The natural "drag it narrow to collapse it" gesture did nothing.

Now dragging past a **collapse threshold (160px**, deliberately below the 220px min to leave a buffer so a normal min-width drag doesn't accidentally collapse) snaps the rail to the collapsed icon view — which already hosts the sessions popover from #131.

## Changes

- **`sidebarResize.ts`** (new) — pure, unit-tested geometry: `resolveResize(proposedWidth)` returns either a clamped expanded width or `collapse: true`. Extracted because the monorepo has no jsdom to drive a real pointer drag, so the decision logic is tested directly.
- **`DesktopShell.handlePointerMove`** — uses `resolveResize`; on collapse it `setUserCollapsed(true)`, ends the drag, and restores a default width so re-expanding (toggle or drag) isn't stuck at the collapsed remnant.
- **`sidebarResize.test.ts`** (new) — pins the collapse threshold, the buffer zone (threshold < min), width clamping, and the restore width.

## Note on test scope

Real pointer-drag interaction can't be tested here (no jsdom/@testing-library in the monorepo — see `packages/web/vitest.config.ts`). Following the repo's established pattern, the **decision logic is extracted to a pure function and unit-tested**; DesktopShell wiring is exercised at runtime.

## Verification

- `packages/web`: 16 files / 123 tests pass (incl. the new 5), typecheck clean, `vite build` ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)