### PR TITLE
release: v0.0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainpilot",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": true,
   "type": "module",
   "description": "BrainPilot — multi-agent research collaboration platform (TS + Pi SDK)",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/backend-core",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "engines": {
     "node": ">=22"
   },
@@ -37,8 +37,8 @@
     "start": "node ./dist/server.js"
   },
   "dependencies": {
-    "@brainpilot/protocol": "^0.0.7",
-    "@brainpilot/runtime": "^0.0.7",
+    "@brainpilot/protocol": "^0.0.8",
+    "@brainpilot/runtime": "^0.0.8",
     "@hono/node-server": "^1.13.0",
     "hono": "^4.6.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/app",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "engines": {
     "node": ">=22"
   },
@@ -32,10 +32,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@brainpilot/backend-core": "^0.0.7",
-    "@brainpilot/protocol": "^0.0.7",
-    "@brainpilot/runtime": "^0.0.7",
-    "@brainpilot/web": "^0.0.7",
+    "@brainpilot/backend-core": "^0.0.8",
+    "@brainpilot/protocol": "^0.0.8",
+    "@brainpilot/runtime": "^0.0.8",
+    "@brainpilot/web": "^0.0.8",
     "commander": "^12.1.0",
     "picocolors": "^1.1.0"
   }

--- a/packages/client-cli/package.json
+++ b/packages/client-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/client-cli",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": true,
   "type": "module",
   "description": "BrainPilot headless verification client (dev/CI) — drive a session without the web UI",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/protocol",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "engines": {
     "node": ">=22"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/runtime",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "engines": {
     "node": ">=22"
   },
@@ -37,8 +37,8 @@
     "start": "node ./dist/server.js"
   },
   "dependencies": {
-    "@brainpilot/protocol": "^0.0.7",
-    "@brainpilot/skills": "^0.0.7",
+    "@brainpilot/protocol": "^0.0.8",
+    "@brainpilot/skills": "^0.0.8",
     "@earendil-works/pi-coding-agent": "^0.79.0",
     "@hono/node-server": "^1.19.0",
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/skills",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "engines": {
     "node": ">=22"
   },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/web",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "engines": {
     "node": ">=22"
   },
@@ -31,7 +31,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@brainpilot/protocol": "^0.0.7",
+    "@brainpilot/protocol": "^0.0.8",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.8",
     "@types/react": "^18.3.12",


### PR DESCRIPTION
Bump all packages 0.0.7 → 0.0.8 (root version SSOT; version:sync propagated to all workspaces + internal @brainpilot/* ranges).

## Included since v0.0.7
- fix(web): remove non-functional file-upload icon (#160 → #162)
- feat(web): collapse sidebar when dragged narrow enough (#159 → #163)

## Pre-merge verification
- npm run build — ok
- npm run release:dry — 6 public packages clean at 0.0.8, client-cli skipped, no errors.

Actual npm publish happens after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)