### PR TITLE
fix(cli,backend): launchable from npm install + thread --dir to runtime (#169)

### DIFF
--- a/packages/backend-core/src/index.ts
+++ b/packages/backend-core/src/index.ts
@@ -8,7 +8,7 @@ export const BACKEND_NAME = "@brainpilot/backend-core";
 export { createApp } from "./app.js";
 export type { CreateAppOptions } from "./app.js";
 
-export { startServer } from "./server.js";
+export { startServer, buildServerOrchestrator } from "./server.js";
 export type { StartServerOptions, RunningServer } from "./server.js";
 
 export { createOrchestrator } from "./create-orchestrator.js";

--- a/packages/backend-core/src/server.ts
+++ b/packages/backend-core/src/server.ts
@@ -28,6 +28,30 @@ export interface RunningServer {
   stop: () => Promise<void>;
 }
 
+/**
+ * Build the orchestrator for a server from its options. Exposed (and pure) so
+ * the dataDir wiring is unit-testable without binding a socket.
+ *
+ * Issue #169: the local orchestrator MUST receive `options.dataDir` — it spawns
+ * the runtime child with `BP_DATA_DIR=<dataDir>`, and the runtime materializes
+ * skills / persists sessions under that root. Dropping it here made the runtime
+ * fall back to `./brainpilot` (relative to cwd) while the backend scaffold wrote
+ * to the requested `--dir`, splitting one launch across two data dirs.
+ */
+export function buildServerOrchestrator(
+  options: StartServerOptions = {},
+): Orchestrator {
+  return (
+    options.orchestrator ??
+    createOrchestrator({
+      local: {
+        dataDir: options.dataDir,
+        ...(options.stdioInherit ? { stdioInherit: true } : {}),
+      },
+    })
+  );
+}
+
 export async function startServer(
   options: StartServerOptions = {},
 ): Promise<RunningServer> {
@@ -35,11 +59,7 @@ export async function startServer(
   // 127.0.0.1 is the safe default for local/CLI use; containers set BP_HOST=0.0.0.0
   // so the published port (DNAT'd to the container IP) can reach the server.
   const hostname = options.hostname ?? process.env.BP_HOST ?? "127.0.0.1";
-  const orchestrator =
-    options.orchestrator ??
-    createOrchestrator({
-      local: options.stdioInherit ? { stdioInherit: true } : undefined,
-    });
+  const orchestrator = buildServerOrchestrator(options);
 
   const app = createApp({
     orchestrator,

--- a/packages/backend-core/test/server.test.ts
+++ b/packages/backend-core/test/server.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { buildServerOrchestrator } from "../src/server.js";
+import { LocalProcessOrchestrator } from "../src/local-orchestrator.js";
+import type { Orchestrator } from "../src/orchestrator.js";
+
+/**
+ * Regression coverage for issue #169 — `startServer` dropped `dataDir` when
+ * constructing the orchestrator, so the runtime child it spawns fell back to
+ * `./brainpilot` (relative to cwd) instead of the requested data dir. The
+ * orchestrator construction is now a pure, exported function so this seam is
+ * testable without binding a socket.
+ *
+ * The `create-orchestrator.test.ts` suite already covers the factory in
+ * isolation; what was missing was the *caller* wiring — that `options.dataDir`
+ * actually reaches the local orchestrator's `BP_DATA_DIR`.
+ */
+describe("buildServerOrchestrator", () => {
+  it("threads dataDir through to the local runtime env (#169)", () => {
+    const orch = buildServerOrchestrator({
+      dataDir: "/data/xyz",
+      // foreground/CLI mode — exercises the stdioInherit branch too.
+      stdioInherit: true,
+    });
+    expect(orch).toBeInstanceOf(LocalProcessOrchestrator);
+    const env = (orch as LocalProcessOrchestrator).buildEnv();
+    expect(env.BP_DATA_DIR).toBe("/data/xyz");
+  });
+
+  it("threads dataDir through in detached (non-stdioInherit) mode too", () => {
+    const orch = buildServerOrchestrator({ dataDir: "/data/detached" });
+    expect(orch).toBeInstanceOf(LocalProcessOrchestrator);
+    const env = (orch as LocalProcessOrchestrator).buildEnv();
+    expect(env.BP_DATA_DIR).toBe("/data/detached");
+  });
+
+  it("returns an injected orchestrator verbatim (short-circuit)", () => {
+    const injected = { id: "injected" } as unknown as Orchestrator;
+    expect(buildServerOrchestrator({ orchestrator: injected })).toBe(injected);
+  });
+
+  it("falls back to BP_DATA_DIR env when no dataDir option is given", () => {
+    const prev = process.env.BP_DATA_DIR;
+    process.env.BP_DATA_DIR = "/data/from-env";
+    try {
+      const orch = buildServerOrchestrator({ stdioInherit: true });
+      const env = (orch as LocalProcessOrchestrator).buildEnv();
+      expect(env.BP_DATA_DIR).toBe("/data/from-env");
+    } finally {
+      if (prev === undefined) delete process.env.BP_DATA_DIR;
+      else process.env.BP_DATA_DIR = prev;
+    }
+  });
+});

--- a/packages/cli/src/repo-mode.test.ts
+++ b/packages/cli/src/repo-mode.test.ts
@@ -151,4 +151,52 @@ describe("assertRepoCwd", () => {
       "__exit__",
     );
   });
+
+  // Issue #169: an npm-installed CLI ships at
+  // `<prefix>/node_modules/@brainpilot/app/dist/bin.js` — no `packages/cli/`
+  // layer ever matches the cwd compare, so the guard must recognise the
+  // node_modules layout and let it through from ANY directory. These bin paths
+  // are strings only (the install case returns before any realpath compare), so
+  // they need not exist on disk.
+  it("passes for a global install (node_modules) regardless of cwd", () => {
+    const cwd = makeForeign();
+    const binPath = join(
+      "/usr",
+      "local",
+      "lib",
+      "node_modules",
+      "@brainpilot",
+      "app",
+      "dist",
+      "bin.js",
+    );
+    expect(() =>
+      assertRepoCwd({ argv: ["up"], env: {}, cwd, binPath }),
+    ).not.toThrow();
+  });
+
+  it("passes for a local install (project node_modules) regardless of cwd", () => {
+    const cwd = makeForeign();
+    const binPath = join(
+      makeForeign(),
+      "node_modules",
+      "@brainpilot",
+      "app",
+      "dist",
+      "bin.js",
+    );
+    expect(() =>
+      assertRepoCwd({ argv: ["up"], env: {}, cwd, binPath }),
+    ).not.toThrow();
+  });
+
+  it("still rejects a from-source run launched from the wrong cwd", () => {
+    // Regression guard: the node_modules bypass must NOT weaken the repo-root
+    // contract for a genuine source checkout (bin path has no node_modules).
+    const { binPath } = makeFakeRepo();
+    const cwd = makeForeign();
+    expect(() => callAssert({ argv: [], env: {}, cwd, binPath })).toThrow(
+      "__exit__",
+    );
+  });
 });

--- a/packages/cli/src/repo-mode.ts
+++ b/packages/cli/src/repo-mode.ts
@@ -18,6 +18,16 @@
  * or set the env escape hatch `BP_ALLOW_FOREIGN_CWD=1`; those paths are
  * dev/CI/test scenarios where the cwd-is-repo assumption legitimately doesn't
  * hold.
+ *
+ * The guard is ALSO skipped when the running bin.js lives inside a
+ * `node_modules/` tree (issue #169). A global or local npm install
+ * (`npm i -g @brainpilot/app`) ships the CLI as a single extracted workspace
+ * at `<prefix>/node_modules/@brainpilot/app/dist/bin.js` — there is no
+ * `packages/cli/` layer for the cwd compare to ever match, so without this the
+ * installed CLI is unlaunchable from any directory. The #102 "configs update
+ * with `git pull`" rationale does not apply to installed users (they have no
+ * repo to pull), so the default `<cwd>/brainpilot` data dir is correct for
+ * them. The repo-root contract remains enforced for the from-source case.
  */
 import { realpathSync } from "node:fs";
 import { resolve } from "node:path";
@@ -25,6 +35,17 @@ import { fileURLToPath } from "node:url";
 
 /** Lookup of argv flags that pin the data dir explicitly (skip the cwd guard). */
 const EXPLICIT_DIR_FLAGS = new Set(["-d", "--dir"]);
+
+/**
+ * True when the running bin.js lives inside a `node_modules/` tree, i.e. the
+ * CLI was reached via an npm install (global or local) rather than run from a
+ * cloned repo's `packages/cli/dist`. Split on both separators so it holds on
+ * Windows paths too. See the header comment (#169) for why this bypasses the
+ * repo-root guard.
+ */
+function isInstalledLayout(binPath: string): boolean {
+  return binPath.split(/[\\/]/).includes("node_modules");
+}
 
 function hasExplicitDirFlag(argv: readonly string[]): boolean {
   for (let i = 0; i < argv.length; i++) {
@@ -81,6 +102,11 @@ export function assertRepoCwd(options: AssertRepoCwdOptions = {}): void {
   if (env.BP_DATA_DIR?.trim()) return;
   if (env.BP_DATA_ROOT?.trim()) return;
   if (hasExplicitDirFlag(argv)) return;
+
+  // An npm-installed CLI (node_modules) is a legitimate non-repo launch (#169):
+  // the `packages/cli/dist/bin.js` shape the cwd compare below looks for never
+  // exists for installed users, so without this they could never start it.
+  if (isInstalledLayout(binPath)) return;
 
   const expected = resolve(cwd, "packages/cli/dist/bin.js");
   if (samePath(expected, binPath)) return;


### PR DESCRIPTION
_Supersedes #170 (retargeted from the now-frozen `development` branch to `main`, which is the sole trunk since ~6/23)._

Fixes #169.

Two install-blocking bugs found while reproducing #169, each with a green regression test.

## Bug 1 — installed CLI was unlaunchable (`repo-mode` guard)

`assertRepoCwd` only passed when the running `bin.js` equalled `<cwd>/packages/cli/dist/bin.js` — a path shape that exists only in a cloned repo. A global/local `npm install` ships the CLI at `<prefix>/node_modules/@brainpilot/app/dist/bin.js`, so the guard exited (code 2) before *any* command (even `--help`/`--version`) could run.

**Fix:** skip the guard when `bin.js` lives inside a `node_modules/` tree (a legitimate non-repo launch). The repo-root contract is kept intact for genuine from-source runs. The #102 "configs update with `git pull`" rationale doesn't apply to installed users — they have no repo to pull.

## Bug 2 — `--dir` dropped on the way to the orchestrator (data dir split)

`startServer` built the orchestrator **without** `options.dataDir`, so the spawned runtime fell back to `BP_DATA_DIR=./brainpilot` (cwd-relative) and materialized skills / persisted sessions there, while the backend scaffold wrote to the requested `--dir`. One launch ended up with two data roots. (The `BP_DATA_DIR` *env var* already worked — only the `--dir` *flag* was lost, via `create-orchestrator.ts`'s `env.BP_DATA_DIR` branch.)

**Fix:** extract `buildServerOrchestrator(options)` (pure, exported) and pass `local.dataDir` through to the local orchestrator.

## Why the existing tests didn't catch these

- `packages/cli/src/repo-mode.test.ts` only modelled the *from-source* `packages/cli/dist/bin.js` layout — it never built a `node_modules` install path, so it froze the buggy behavior as "correct."
- `packages/backend-core/test/create-orchestrator.test.ts` always fed `dataDir`/`BP_DATA_DIR` straight into the factory, never exercising the `startServer` → `createOrchestrator` caller seam where the drop happened. backend-core had no `server.test.ts`, and `up.test.ts` mocks `startServer` entirely.

## Tests added (both proven RED before the fix, GREEN after)

- `repo-mode.test.ts`: global + local `node_modules` layouts launch from any cwd; a from-source run from the wrong cwd still rejects (contract preserved).
- `backend-core/test/server.test.ts` (new): `buildServerOrchestrator` threads `dataDir` into the local runtime env in both stdio modes; injected-orchestrator short-circuit; `BP_DATA_DIR` env fallback.

## Verification

- `repo-mode.test.ts` and `server.test.ts` confirmed RED with the product fix reverted, GREEN with it applied.
- Full `packages/backend-core` + `packages/cli` suites: **282 passing**. `tsc -b` typecheck clean.
- End-to-end against the built `dist`:
  - `up --dir /tmp/x/data` → skills land in `/tmp/x/data/bp_template/skills`, **nothing** leaks to `./brainpilot` (previously split).
  - install-layout `bin.js` launches from a foreign cwd; from-source wrong-cwd still shows the repo-root guard.

## Out of scope (flagged for maintainers)

This PR only unblocks launch + fixes the split. The deeper design question from #169 — whether the default data dir should move to a stable `~/.brainpilot` rather than `<cwd>/brainpilot` — is left to the maintainers, since it changes user-visible behavior beyond the bug.
