### PR TITLE
fix(cli): lock `brainpilot up` to local mode unless mode is explicit

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -75,17 +75,29 @@ npm install -g @brainpilot/app
 
 这会安装 `brainpilot` 命令（`bnpt` 是同一命令的内置短别名）。
 
-### 2. 初始化
+### 2. 配置模型服务商
+
+BrainPilot **不绑定 Anthropic** —— 支持多种服务商协议：**Anthropic Messages**、**OpenAI
+Completions**、**OpenAI Responses** 和 **Azure OpenAI Responses**。按你的模型/网关所用协议任选。
+
+推荐做法是启动后用 **Web Settings UI**：打开 **Settings → Providers（服务商）**，添加一个服务商
+（base URL / key / 协议 / 模型列表），它会自动帮你写入配置。缺少 Key 不再阻塞启动：
+**`brainpilot up` 照常启动**，所以你完全可以先跳过、在浏览器里配置服务商。
+
+<details>
+<summary><b>更想用命令行？在 init 时生成配置</b></summary>
 
 ```bash
+# Anthropic（默认协议）
 brainpilot init --api-key <你的-anthropic-key>   # 在 ./brainpilot 下生成配置
+
+# 一条命令接入网关 / 第三方端点
+brainpilot init --api-key <key> --base-url https://your-gateway.example.com/api --model kimi-k2.6
 ```
 
-缺少 Key 不再阻塞启动：
-
-- **`brainpilot up` 照常启动** —— 之后再补 Key，无需重新 init。
-- **在 Web Settings UI 里设置**（推荐）—— provider url / key / model，自动帮你写入配置。
-- **或改用环境变量 `ANTHROPIC_API_KEY` 提供 Key。**
+也可以改用环境变量 `ANTHROPIC_API_KEY` 代替 `--api-key`。多服务商 / OpenAI 兼容端点的配置，见下方
+[使用自己的模型](#-使用自己的模型)。
+</details>
 
 ### 3. 启动
 
@@ -190,10 +202,13 @@ codex exec "全局安装 @brainpilot/app 这个 npm 包，然后运行 brainpilo
 
 ## 🤖 使用自己的模型
 
-BrainPilot 默认对接 Pi 内置的 Anthropic 端点。改用其他端点最简单的方式是启动后用 **Settings
-UI**：打开 **Settings → Providers（服务商）**（Settings 按钮在侧边栏），点 **添加服务商**，填入
-base URL、API key、协议和模型列表。你还能在这里 **测试** 连接、切换当前使用的服务商 —— 它会自动
-帮你写入配置，无需手动改文件。
+BrainPilot 支持多种服务商协议 —— **Anthropic Messages**、**OpenAI Completions**、**OpenAI
+Responses** 和 **Azure OpenAI Responses** —— 可对接 Anthropic、OpenAI 兼容端点、Azure，或两者
+之间的任意网关。
+
+最简单的方式是启动后用 **Settings UI**：打开 **Settings → Providers（服务商）**（Settings 按钮在
+侧边栏），点 **添加服务商**，填入 base URL、API key、协议和模型列表。你还能在这里 **测试** 连接、
+切换当前使用的服务商 —— 它会自动帮你写入配置，无需手动改文件。
 
 也可以在 init 时用一条命令接入网关 / 第三方端点：
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -5,8 +5,7 @@
 <h1 align="center">🧠 BrainPilot</h1>
 
 <p align="center">
-  面向可信脑科学研究的开源多智能体平台 ——
-  由一个 Principal 智能体统筹多个专家智能体，替你读文献、做推理、跑真实分析。
+BrainPilot 是一个开源、人在回路的脑科学智能体研究系统。它整合专业智能体、领域知识、科研技能和工具接口，帮助研究者覆盖完整科研流程：文献综述、假设细化、实验设计、数据分析、报告撰写和科学结论审查。
 </p>
 
 <p align="center">
@@ -37,24 +36,20 @@
 
 ---
 
-## 📖 项目简介
 
-**BrainPilot** 是一个面向脑科学与认知科学研究的开源、单用户多智能体协作平台。一个
-**Principal（主控）** 智能体与你对话、规划任务，并把工作委派给 **专家智能体**（文献官、分析
-师、写作者……），它们通过基于文件的信箱（mailbox）协作。每个智能体读取、写入或生成的文件都
-会落到磁盘上真实的工作区里，整个运行过程会被记录为一张可供检视的 **轨迹图（trace graph）**。
+## 📖 概览
 
-它使用 **TypeScript + [Pi SDK](https://pi.dev)** 做智能体编排，以 **Hono** 后端配 **React**
-单页前端对外提供服务。最快的上手方式是一条 npm 安装命令 —— **无需 Docker**。
+BrainPilot 是一个面向脑科学的开源人工智能研究工作台，帮助研究者将宽泛的科学问题转化为结构化、可执行、可检查的研究流程。系统以总控智能体为核心，由它与研究者对话、理解研究目标、规划任务，并协调文献智能体、分析智能体、实验智能体、写作智能体和审查智能体等专业智能体协同工作。BrainPilot 强调人在回路的科研协作范式：研究者始终保留判断权和控制权，而智能体负责处理证据密集、跨领域和重复性的研究任务。系统集成了脑科学领域知识、方法技能、分析流程和科研工具，并通过流程追踪图记录研究过程，使中间操作、证据来源、生成结论和潜在风险都可以被检查和回溯。
 
-### 核心亮点
+## ✨ 亮点
 
-- **🚀 一条命令启动** —— `npm i -g @brainpilot/app` 后 `brainpilot up`，打开浏览器即可开工。
-- **🤝 主控 + 专家** —— 主控智能体通过文件信箱把任务委派给领域专家。
-- **📚 内置技能库** —— 经过验证的脑科学/认知科学方法学，按需经 MCP 检索调用。
-- **🔌 原生 MCP 工具** —— 接入任意 Model Context Protocol 服务（stdio / streamable-http / sse）。
-- **🔭 可检视的运行** —— 每个会话有独立工作区，外加一张记录全过程的轨迹图。
-- **🧩 自带模型** —— 默认走 Anthropic，也可在 Settings UI 配置任意 Anthropic / OpenAI 兼容网关。
+- **🧠 面向脑科学研究** — 支持从文献综述、假设细化、实验设计到数据分析、论文写作和科学审查的完整科研流程。
+- **🤝 总控智能体协调专业智能体团队** — 由总控智能体统一理解用户需求、规划任务，并协调文献智能体、分析智能体、实验智能体、写作智能体和审查智能体等专业智能体协同工作。
+- **📚 整合领域知识与科研技能** — 集成脑科学相关知识、研究方法、分析流程、写作规范和工具接口，使智能体能够调用专业知识完成具体科研任务。
+- **🛡️ 审查智能体提升科研可靠性** — 审查科学结论、证据链、引用来源、幻觉风险、遗漏信息和缺乏支撑的推理，帮助研究者发现潜在问题。
+- **🔭 流程追踪图展示研究过程** — 将任务结构、智能体行为、工具调用、证据流向和关键决策点可视化，方便研究者检查、回溯和干预。
+- **🔌 可扩展的科研工具生态** — 支持连接模型、MCP 工具、文献数据库、代码执行环境和自定义科研工具，适配不同研究场景。
+- **🚀 快速本地启动** — 简单安装后即可在浏览器中开始使用，降低脑科学智能体系统的部署和使用门槛。
 
 ---
 
@@ -64,8 +59,8 @@ BrainPilot 通过 **`@brainpilot/app`** 以本地进程方式运行 —— 无�
 
 ### 环境要求
 
-- **Node.js** ≥ 22
-- 一个 **Anthropic API Key** —— *或* 用 `BP_MOCK=1` 做无 Key 冒烟运行
+- **[Node.js](https://nodejs.org/en/download/)** ≥ 22
+- 用于智能体的**API Key**
 
 ### 1. 安装
 
@@ -77,27 +72,27 @@ npm install -g @brainpilot/app
 
 ### 2. 配置模型服务商
 
-BrainPilot **不绑定 Anthropic** —— 支持多种服务商协议：**Anthropic Messages**、**OpenAI
+BrainPilot 支持多种服务商协议：**Anthropic Messages**、**OpenAI
 Completions**、**OpenAI Responses** 和 **Azure OpenAI Responses**。按你的模型/网关所用协议任选。
 
 推荐做法是启动后用 **Web Settings UI**：打开 **Settings → Providers（服务商）**，添加一个服务商
 （base URL / key / 协议 / 模型列表），它会自动帮你写入配置。缺少 Key 不再阻塞启动：
 **`brainpilot up` 照常启动**，所以你完全可以先跳过、在浏览器里配置服务商。
 
-<details>
-<summary><b>更想用命令行？在 init 时生成配置</b></summary>
+
+<b>或者在 init 时生成配置</b>
 
 ```bash
 # Anthropic（默认协议）
 brainpilot init --api-key <你的-anthropic-key>   # 在 ./brainpilot 下生成配置
 
 # 一条命令接入网关 / 第三方端点
-brainpilot init --api-key <key> --base-url https://your-gateway.example.com/api --model kimi-k2.6
+brainpilot init --api-key <key> --base-url https://your-gateway.example.com/api --model deepseek-v4-pro
 ```
 
 也可以改用环境变量 `ANTHROPIC_API_KEY` 代替 `--api-key`。多服务商 / OpenAI 兼容端点的配置，见下方
 [使用自己的模型](#-使用自己的模型)。
-</details>
+
 
 ### 3. 启动
 

--- a/README.md
+++ b/README.md
@@ -79,17 +79,32 @@ npm install -g @brainpilot/app
 
 This installs the `brainpilot` CLI (`bnpt` is a built-in short alias for the same command).
 
-### 2. Initialize
+### 2. Configure a model provider
+
+BrainPilot is **not tied to Anthropic** — it supports multiple provider protocols:
+**Anthropic Messages**, **OpenAI Completions**, **OpenAI Responses**, and **Azure OpenAI
+Responses**. Pick whichever your model/gateway speaks.
+
+The recommended way is the **web Settings UI** after launch — open **Settings → Providers**,
+add a provider (base URL / key / protocol / model list), and it writes the config for you.
+A missing key no longer blocks launch: **`brainpilot up` starts anyway**, so you can skip
+ahead and configure the provider in the browser.
+
+<details>
+<summary><b>Prefer the command line? Scaffold config at init time</b></summary>
 
 ```bash
+# Anthropic (default protocol)
 brainpilot init --api-key <your-anthropic-key>   # scaffold config under ./brainpilot
+
+# A gateway / third-party endpoint in one command
+brainpilot init --api-key <key> --base-url https://your-gateway.example.com/api --model kimi-k2.6
 ```
 
-A missing key no longer blocks launch:
-
-- **`brainpilot up` starts anyway** — set the key later, no re-init needed.
-- **Set it in the web Settings UI** (recommended) — provider url / key / model; it writes the config for you.
-- **Or use the `ANTHROPIC_API_KEY` environment variable** instead.
+You can also supply the key via the `ANTHROPIC_API_KEY` environment variable instead of
+`--api-key`. For multi-provider / OpenAI-compatible setups, see
+[Using your own model](#-using-your-own-model) below.
+</details>
 
 ### 3. Launch
 
@@ -201,8 +216,11 @@ By default the agent pauses for approval before each command. A few tips:
 
 ## 🤖 Using your own model
 
-By default BrainPilot talks to Pi's built-in Anthropic endpoint. The easiest way to point
-it elsewhere is the **Settings UI** after launch: open **Settings → Providers** (the
+BrainPilot works with multiple provider protocols — **Anthropic Messages**, **OpenAI
+Completions**, **OpenAI Responses**, and **Azure OpenAI Responses** — so you can point it at
+Anthropic, an OpenAI-compatible endpoint, Azure, or any gateway in between.
+
+The easiest way is the **Settings UI** after launch: open **Settings → Providers** (the
 Settings button lives in the sidebar), then **Add Provider** to set the base URL, API key,
 protocol, and model list. You can **test** the connection and switch the active provider
 right there — it writes the config for you, no file editing required.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,10 @@
   <img src="assets/banner.png" alt="BrainPilot" width="680"/>
 </p> -->
 
-<h1 align="center">🧠 BrainPilot</h1>
+<h1 align="center">🧠 BrainPilot: Enabling Agentic Research for Brain Science</h1>
 
 <p align="center">
-  An open-source multi-agent platform for trustworthy neuroscience research —
-  a Principal agent that coordinates specialist agents to read, reason, and run real analyses for you.
+BrainPilot is an open-source, human-in-the-loop agentic system for brain science that brings together specialist agents, domain knowledge, skills, and tools to help researchers in all scientific stages — review literature, design studies, run analyses, draft reports, and audit scientific claims.
 </p>
 
 <p align="center">
@@ -39,25 +38,17 @@
 
 ## 📖 Overview
 
-**BrainPilot** is an open-source, single-user multi-agent collaboration platform for
-neuroscience and cognitive-science research. A **Principal** agent talks to you, plans
-the work, and delegates to **specialist agents** (librarian, analyst, writer, …) that
-collaborate over a file-based mailbox. Every file an agent reads, writes, or generates
-lands in a real workspace on disk, and the whole run is captured as a **trace graph** you
-can inspect.
-
-It is built with **TypeScript + the [Pi SDK](https://pi.dev)** for agent orchestration,
-served as a **Hono** backend with a **React** single-page UI. The fastest way to run it is
-a single npm install — **no Docker required**.
+BrainPilot is an open-source AI research workspace for brain science. It helps researchers turn broad scientific questions into structured, inspectable workflows, from literature review and hypothesis refinement to experiment design, data analysis, writing, and audit. At its center, a Principal Agent communicates with the user, plans the work, and coordinates specialist agents such as librarian, analyst, experimentalist, writer, and auditor agents. BrainPilot is designed for human-in-the-loop scientific work: researchers remain in control, while agents handle evidence-heavy and cross-disciplinary tasks. The system integrates domain knowledge, methodological skills, and research tools, and records the process as a trace graph so that intermediate actions, evidence, claims, and potential risks can be inspected.
 
 ### Highlights
 
-- **🚀 One-command launch** — `npm i -g @brainpilot/app` then `brainpilot up`; open the browser and start working.
-- **🤝 Principal + specialists** — a coordinating agent delegates to domain specialists over a file-based mailbox.
-- **📚 Built-in skills library** — validated neuroscience & cognitive-science methodology, retrieved on demand via MCP.
-- **🔌 MCP-native tools** — connect any Model Context Protocol server (stdio / streamable-http / sse).
-- **🔭 Inspectable runs** — every session has its own workspace and a trace graph of what happened.
-- **🧩 Bring your own model** — Anthropic by default, or any Anthropic-/OpenAI-compatible gateway, configured from the Settings UI.
+- 🧠 Built for brain science research — supports workflows across literature review, hypothesis refinement, experiment design, data analysis, writing, and audit.
+- 🤝 Principal Agent + specialist agents — a coordinating Principal Agent works with domain specialists including librarian, analyst, experimentalist, writer, and auditor agents.
+- 📚 Integrated domain knowledge and skills — brings together brain-science knowledge, methodological skills, analysis procedures, writing conventions, and tool interfaces.
+- 🛡️ Auditor Agent for scientific reliability — reviews claims, evidence chains, citations, hallucination risks, omitted information, and unsupported reasoning.
+- 🔭 Traceable research process — represents each session as an inspectable trace graph, making task structure, agent actions, evidence flow, and decision points visible.
+- 🔌 Extensible research tool ecosystem — connects models, MCP tools, paper databases, code execution environments, and custom research utilities.
+- 🚀 Fast local start — install, launch, and begin working in the browser with minimal setup.
 
 ---
 
@@ -68,8 +59,8 @@ This is the recommended way to get started.
 
 ### Prerequisites
 
-- **Node.js** ≥ 22
-- An **Anthropic API key** — *or* `BP_MOCK=1` for a no-key smoke run
+- **[Node.js](https://nodejs.org/en/download/)** ≥ 22
+- An **API key** for Agent
 
 ### 1. Install
 
@@ -81,7 +72,7 @@ This installs the `brainpilot` CLI (`bnpt` is a built-in short alias for the sam
 
 ### 2. Configure a model provider
 
-BrainPilot is **not tied to Anthropic** — it supports multiple provider protocols:
+BrainPilot supports multiple provider protocols:
 **Anthropic Messages**, **OpenAI Completions**, **OpenAI Responses**, and **Azure OpenAI
 Responses**. Pick whichever your model/gateway speaks.
 
@@ -90,21 +81,19 @@ add a provider (base URL / key / protocol / model list), and it writes the confi
 A missing key no longer blocks launch: **`brainpilot up` starts anyway**, so you can skip
 ahead and configure the provider in the browser.
 
-<details>
-<summary><b>Prefer the command line? Scaffold config at init time</b></summary>
+<b>Or Scaffold config at init time</b>
 
 ```bash
 # Anthropic (default protocol)
 brainpilot init --api-key <your-anthropic-key>   # scaffold config under ./brainpilot
 
 # A gateway / third-party endpoint in one command
-brainpilot init --api-key <key> --base-url https://your-gateway.example.com/api --model kimi-k2.6
+brainpilot init --api-key <key> --base-url https://your-gateway.example.com/api --model deepseek-v4-pro
 ```
 
 You can also supply the key via the `ANTHROPIC_API_KEY` environment variable instead of
 `--api-key`. For multi-provider / OpenAI-compatible setups, see
 [Using your own model](#-using-your-own-model) below.
-</details>
 
 ### 3. Launch
 

--- a/packages/backend-core/src/app.ts
+++ b/packages/backend-core/src/app.ts
@@ -14,6 +14,7 @@
  * `API_BASE = "/api"`), with static assets served at the root.
  */
 import { createRequire } from "node:module";
+import { join } from "node:path";
 import { Hono } from "hono";
 import { serveStatic } from "@hono/node-server/serve-static";
 import {
@@ -294,7 +295,7 @@ export function createApp(options: CreateAppOptions): Hono {
   if (options.serveWeb !== false) {
     app.use("/*", serveStatic({ root: webRoot }));
     // SPA fallback: any unmatched GET that isn't /api returns index.html.
-    app.get("/*", serveStatic({ path: `${webRoot}/index.html` }));
+    app.get("/*", serveStatic({ path: join(webRoot, "index.html") }));
   }
 
   return app;

--- a/packages/backend-core/src/provider-probe.ts
+++ b/packages/backend-core/src/provider-probe.ts
@@ -31,10 +31,17 @@ export interface ProbeInput {
   apiKey: string;
 }
 
-/** Strip absolute node_modules paths from any error text before surfacing it. */
+/**
+ * Strip absolute node_modules paths from any error text before surfacing it.
+ *
+ * Cross-platform (#157): accept BOTH `/` and `\` separators, plus an optional
+ * Windows drive prefix. A native Windows path like
+ * `C:\Users\<user>\…\node_modules\@pkg\file.md` previously slipped through
+ * unredacted, leaking the username into the Test-button error toast.
+ */
 function redact(text: string): string {
   return text
-    .replace(/(?:\/[^\s:]*)?node_modules\/[^\s)]*/g, "<path>")
+    .replace(/(?:[A-Za-z]:)?(?:[\\/][^\s:]*)?node_modules[\\/][^\s)]*/g, "<path>")
     .replace(/\s+/g, " ")
     .trim();
 }

--- a/packages/backend-core/src/server.ts
+++ b/packages/backend-core/src/server.ts
@@ -8,7 +8,7 @@ import { serve, type ServerType } from "@hono/node-server";
 import { createApp, type CreateAppOptions } from "./app.js";
 import { createOrchestrator } from "./create-orchestrator.js";
 import { bootstrapEnvProvider } from "./config.js";
-import type { Orchestrator } from "./orchestrator.js";
+import type { Orchestrator, OrchestratorMode } from "./orchestrator.js";
 
 export interface StartServerOptions extends Partial<CreateAppOptions> {
   /** Backend port. Default 9001 (§11A.5 决策 D). */
@@ -16,6 +16,13 @@ export interface StartServerOptions extends Partial<CreateAppOptions> {
   hostname?: string;
   /** Provide a pre-built orchestrator; otherwise one is created from env. */
   orchestrator?: Orchestrator;
+  /**
+   * Force the orchestrator mode. When omitted the mode is resolved from env
+   * (BP_ORCHESTRATOR / BP_RUNTIME_URL / BP_MODE). The `brainpilot up` CLI passes
+   * this explicitly so a stray BP_RUNTIME_URL can't silently flip a local
+   * source-launch into static (sandbox) mode.
+   */
+  mode?: OrchestratorMode;
   /** Eagerly ensure the runtime at boot (default false — lazy on first use). */
   eager?: boolean;
   /** When true, the runtime child inherits stdio (foreground CLI mode). */
@@ -39,6 +46,7 @@ export async function startServer(
   const orchestrator =
     options.orchestrator ??
     createOrchestrator({
+      ...(options.mode ? { mode: options.mode } : {}),
       local: options.stdioInherit ? { stdioInherit: true } : undefined,
     });
 

--- a/packages/backend-core/src/server.ts
+++ b/packages/backend-core/src/server.ts
@@ -3,6 +3,7 @@
  * Exported via the package's `./server` entry. The orchestrator's runtime is
  * started lazily on the first request that needs it; graceful shutdown stops it.
  */
+import { pathToFileURL } from "node:url";
 import { serve, type ServerType } from "@hono/node-server";
 import { createApp, type CreateAppOptions } from "./app.js";
 import { createOrchestrator } from "./create-orchestrator.js";
@@ -85,9 +86,11 @@ export async function startServer(
 }
 
 // Allow `node dist/server.js` to boot directly.
+// pathToFileURL keeps the main-module check correct on Windows (a naive
+// `file://${argv[1]}` never matches import.meta.url there).
 const isMain =
   typeof process.argv[1] === "string" &&
-  import.meta.url === `file://${process.argv[1]}`;
+  import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isMain) {
   startServer().then(
     (s) => {

--- a/packages/backend-core/src/static-orchestrator.ts
+++ b/packages/backend-core/src/static-orchestrator.ts
@@ -69,8 +69,14 @@ export class StaticRuntimeOrchestrator implements Orchestrator {
       if (Date.now() >= deadline) {
         throw new Error(
           `static runtime did not become healthy at ${this.url} within ` +
-            `${this.healthTimeoutMs}ms — is the sandbox container up? ` +
-            `(check \`docker compose logs sandbox\` and BP_RUNTIME_URL)`,
+            `${this.healthTimeoutMs}ms.\n` +
+            `  This is STATIC (sandbox) mode: the backend is trying to reach a ` +
+            `pre-started runtime container at BP_RUNTIME_URL.\n` +
+            `  • If you meant to run a Docker deployment: check it is up ` +
+            `(\`docker compose logs sandbox\`) and that BP_RUNTIME_URL is correct.\n` +
+            `  • If you meant to run from source: you likely have a stray ` +
+            `BP_RUNTIME_URL/BP_ORCHESTRATOR in your environment. Run ` +
+            `\`brainpilot up --mode local\` (or \`unset BP_RUNTIME_URL BP_ORCHESTRATOR\`).`,
         );
       }
       await this.sleep(this.pollMs);

--- a/packages/backend-core/test/provider-probe.test.ts
+++ b/packages/backend-core/test/provider-probe.test.ts
@@ -94,4 +94,19 @@ describe("probeProvider (#55)", () => {
     );
     expect(r.message).not.toMatch(/node_modules/);
   });
+
+  it("redacts native Windows node_modules paths (incl. username) from error messages (#157)", async () => {
+    const fetchFn = vi.fn(async () => {
+      throw new Error(
+        "boom at C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules\\undici\\lib\\x.js:1",
+      );
+    });
+    const r = await probeProvider(
+      { baseUrl: "https://gw/api", apiKey: "sk" },
+      { fetchFn: fetchFn as never },
+    );
+    expect(r.message).not.toMatch(/node_modules/);
+    expect(r.message).not.toMatch(/alice/);
+    expect(r.message).not.toMatch(/C:\\Users/i);
+  });
 });

--- a/packages/cli/src/commands/up.test.ts
+++ b/packages/cli/src/commands/up.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   up,
   buildStartServerOptions,
+  resolveUpMode,
   PortInUseError,
   portFlagHint,
   type ResolvedUpConfig,
@@ -32,6 +33,7 @@ describe("buildStartServerOptions", () => {
       webDist: "/web/dist",
       foreground: true,
       open: false,
+      mode: "local",
     };
     const opts = buildStartServerOptions(cfg);
     expect(opts).toMatchObject({
@@ -40,6 +42,7 @@ describe("buildStartServerOptions", () => {
       dataDir: "/data",
       serveWeb: true,
       webRoot: "/web/dist",
+      mode: "local",
     });
   });
 
@@ -52,10 +55,42 @@ describe("buildStartServerOptions", () => {
       webDist: null,
       foreground: true,
       open: false,
+      mode: "local",
     };
     const opts = buildStartServerOptions(cfg);
     expect(opts.serveWeb).toBe(false);
     expect("webRoot" in opts).toBe(false);
+  });
+});
+
+describe("resolveUpMode", () => {
+  it("defaults to local with an empty env (the source-launch default)", () => {
+    expect(resolveUpMode(undefined, {})).toBe("local");
+  });
+
+  it("IGNORES a stray BP_RUNTIME_URL — the core fix (no accidental sandbox)", () => {
+    // A leftover BP_RUNTIME_URL from a `docker compose` session must NOT flip a
+    // source launch into static mode. The backend's env resolver would; the CLI
+    // resolver deliberately does not.
+    expect(resolveUpMode(undefined, { BP_RUNTIME_URL: "http://sandbox:8081" })).toBe("local");
+  });
+
+  it("IGNORES a stray BP_MODE=docker", () => {
+    expect(resolveUpMode(undefined, { BP_MODE: "docker" })).toBe("local");
+  });
+
+  it("honors an explicit --mode option", () => {
+    expect(resolveUpMode("static", { BP_RUNTIME_URL: "http://x" })).toBe("static");
+    expect(resolveUpMode("docker", {})).toBe("docker");
+  });
+
+  it("honors an explicit BP_ORCHESTRATOR when no --mode given", () => {
+    expect(resolveUpMode(undefined, { BP_ORCHESTRATOR: "static" })).toBe("static");
+    expect(resolveUpMode(undefined, { BP_ORCHESTRATOR: "docker" })).toBe("docker");
+  });
+
+  it("--mode wins over BP_ORCHESTRATOR", () => {
+    expect(resolveUpMode("local", { BP_ORCHESTRATOR: "static" })).toBe("local");
   });
 });
 
@@ -198,6 +233,51 @@ describe("up — foreground start", () => {
     expect(result.server).toBe(fakeServer);
     expect(result.url).toBe("http://127.0.0.1:9500");
     expect(result.config.runtimePort).toBe(9501);
+  });
+
+  it("forces mode=local and prints a local banner even with a stray BP_RUNTIME_URL", async () => {
+    const root = join(dir, "bp");
+    let captured: StartServerOptions | undefined;
+    const logs: string[] = [];
+    await up(
+      { dir: root, port: 9550, foreground: true, open: false },
+      {
+        env: { ANTHROPIC_API_KEY: "sk", BP_RUNTIME_URL: "http://sandbox:8081" },
+        startServer: async (opts) => {
+          captured = opts;
+          return { stop: async () => {} } as unknown as RunningServer;
+        },
+        isPortFree: freePorts(),
+        webDist: () => null,
+        log: (m) => logs.push(m),
+      },
+    );
+    // The stray BP_RUNTIME_URL must NOT have flipped us into static mode.
+    expect(captured?.mode).toBe("local");
+    expect(logs.join("\n")).toContain("mode=local");
+  });
+
+  it("passes mode=static and warns when --mode static is explicit", async () => {
+    const root = join(dir, "bp");
+    let captured: StartServerOptions | undefined;
+    const logs: string[] = [];
+    await up(
+      { dir: root, port: 9560, foreground: true, open: false, mode: "static" },
+      {
+        env: { ANTHROPIC_API_KEY: "sk", BP_RUNTIME_URL: "http://sandbox:8081" },
+        startServer: async (opts) => {
+          captured = opts;
+          return { stop: async () => {} } as unknown as RunningServer;
+        },
+        isPortFree: freePorts(),
+        webDist: () => null,
+        log: (m) => logs.push(m),
+      },
+    );
+    expect(captured?.mode).toBe("static");
+    const text = logs.join("\n");
+    expect(text).toContain("mode=static");
+    expect(text).toContain("--mode");
   });
 
   it("calls the browser-open hook when open=true", async () => {

--- a/packages/cli/src/commands/up.ts
+++ b/packages/cli/src/commands/up.ts
@@ -15,7 +15,7 @@
  * is injectable so tests drive it without a real server.
  */
 import { resolveProvider, describeProviderConfig, formatProviderGuidance } from "@brainpilot/backend-core";
-import type { StartServerOptions, RunningServer } from "@brainpilot/backend-core";
+import type { StartServerOptions, RunningServer, OrchestratorMode } from "@brainpilot/backend-core";
 import { isMockMode } from "@brainpilot/runtime";
 import pc from "picocolors";
 import { resolveDataDir, dataPaths } from "../paths.js";
@@ -33,6 +33,8 @@ export interface UpOptions {
   foreground?: boolean;
   /** `--no-open` to suppress the browser. */
   open?: boolean;
+  /** `--mode <local|static|docker>` force the orchestrator mode (default local). */
+  mode?: OrchestratorMode;
 }
 
 /** Injectable collaborators (defaults wire to real implementations). */
@@ -61,6 +63,30 @@ export interface ResolvedUpConfig {
   webDist: string | null;
   foreground: boolean;
   open: boolean;
+  /** Orchestrator mode passed explicitly to the backend (default local). */
+  mode: OrchestratorMode;
+}
+
+/**
+ * Resolve the orchestrator mode for `brainpilot up`. Unlike the backend's
+ * env-based `resolveOrchestratorMode` (which reads BP_RUNTIME_URL / BP_MODE),
+ * the CLI defaults to `local` and only departs from it when the user is
+ * explicit — via `--mode` or an explicit `BP_ORCHESTRATOR`. This is the fix for
+ * "users accidentally enter sandbox mode": a stray BP_RUNTIME_URL left over
+ * from a `docker compose` session no longer hijacks a source launch into
+ * static (sandbox) mode. To run `up` against a pre-started container, the user
+ * must say so (`--mode static` or BP_ORCHESTRATOR=static).
+ */
+export function resolveUpMode(
+  optionMode: OrchestratorMode | undefined,
+  env: Record<string, string | undefined>,
+): OrchestratorMode {
+  if (optionMode) return optionMode;
+  const explicit = (env.BP_ORCHESTRATOR ?? "").toLowerCase();
+  if (explicit === "docker" || explicit === "local" || explicit === "static") {
+    return explicit as OrchestratorMode;
+  }
+  return "local";
 }
 
 /** Build the StartServerOptions from resolved config — exposed for tests. */
@@ -73,8 +99,10 @@ export function buildStartServerOptions(
     dataDir: cfg.dataDir,
     serveWeb: cfg.webDist !== null,
     stdioInherit: cfg.foreground,
+    // Pass the mode explicitly so a stray BP_RUNTIME_URL/BP_MODE in the
+    // environment can't silently flip a local source-launch into static/docker.
+    mode: cfg.mode,
     ...(cfg.webDist ? { webRoot: cfg.webDist } : {}),
-    // The backend creates a LocalProcessOrchestrator from env (BP_MODE=single).
   } satisfies StartServerOptions;
 }
 
@@ -146,6 +174,7 @@ export async function up(
   const host = "127.0.0.1";
   const foreground = options.foreground ?? true;
   const open = options.open ?? true;
+  const mode = resolveUpMode(options.mode, env);
 
   const cfg: ResolvedUpConfig = {
     dataDir,
@@ -155,7 +184,29 @@ export async function up(
     webDist: webDistFn(),
     foreground,
     open,
+    mode,
   };
+
+  // Make the resolved mode visible (the #1 cause of "I accidentally entered
+  // sandbox mode" was that the mode switch was completely silent). For the
+  // non-default static/docker modes, name the trigger so the user understands
+  // why they left local.
+  if (mode === "local") {
+    log(pc.dim(`mode=local · dataDir=${dataDir} · runtime port ${cfg.runtimePort}`));
+  } else {
+    const via = options.mode
+      ? "--mode"
+      : "BP_ORCHESTRATOR";
+    log(
+      pc.yellow(
+        `mode=${mode} (via ${via}) — connecting to an external runtime, not a local one.`,
+      ),
+    );
+    if (mode === "static") {
+      log(pc.dim(`    BP_RUNTIME_URL=${env.BP_RUNTIME_URL ?? "(unset — required for static)"}`));
+    }
+    log(pc.dim("    To run from source instead, drop --mode / BP_ORCHESTRATOR (defaults to local)."));
+  }
 
   // 2. Scaffold if absent (idempotent).
   if (!(await isScaffolded(dataDir))) {

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -22,6 +22,24 @@ describe("program — commander wiring", () => {
     expect(upFn.mock.calls[0]![0]).toMatchObject({ open: false });
   });
 
+  it("`up --mode static` forwards the orchestrator mode", async () => {
+    const upFn = vi.fn().mockResolvedValue({ url: "x", config: {} });
+    await run(["up", "--mode", "static"], { upFn });
+    expect(upFn.mock.calls[0]![0]).toMatchObject({ mode: "static" });
+  });
+
+  it("`up` with no --mode leaves mode undefined (resolver defaults to local)", async () => {
+    const upFn = vi.fn().mockResolvedValue({ url: "x", config: {} });
+    await run(["up"], { upFn });
+    expect(upFn.mock.calls[0]![0].mode).toBeUndefined();
+  });
+
+  it("rejects an invalid --mode", async () => {
+    const upFn = vi.fn();
+    await expect(run(["up", "--mode", "bogus"], { upFn })).rejects.toThrow();
+    expect(upFn).not.toHaveBeenCalled();
+  });
+
   it("dispatches `down` with --dir", async () => {
     const downFn = vi.fn().mockResolvedValue({ stopped: true, pid: 1, forced: false });
     await run(["down", "--dir", "/d"], { downFn });

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -37,6 +37,12 @@ function parsePort(value: string): number {
   return n;
 }
 
+function parseMode(value: string): "local" | "static" | "docker" {
+  const v = value.toLowerCase();
+  if (v === "local" || v === "static" || v === "docker") return v;
+  throw new Error(`Invalid mode: ${value} (expected local | static | docker)`);
+}
+
 /** Read the CLI package version from its own package.json (single source of truth). */
 function requireVersion(): string {
   const require = createRequire(import.meta.url);
@@ -67,6 +73,11 @@ export function buildProgram(deps: ProgramDeps = {}): Command {
     .option("-p, --port <n>", "backend port (runtime uses port+1)", parsePort)
     .option("--detach", "run the backend as a background process")
     .option("--no-open", "do not open the browser")
+    .option(
+      "--mode <mode>",
+      "orchestrator mode: local (default) | static (connect BP_RUNTIME_URL) | docker",
+      parseMode,
+    )
     .action(async (opts) => {
       const foreground = !opts.detach;
       await upFn(
@@ -75,6 +86,7 @@ export function buildProgram(deps: ProgramDeps = {}): Command {
           port: opts.port,
           foreground,
           open: opts.open,
+          mode: opts.mode,
         },
         { spawnDetached: spawnDetachedBackend },
       );

--- a/packages/cli/src/repo-mode.ts
+++ b/packages/cli/src/repo-mode.ts
@@ -56,7 +56,14 @@ export interface AssertRepoCwdOptions {
  */
 function samePath(a: string, b: string): boolean {
   try {
-    return realpathSync(a) === realpathSync(b);
+    const ra = realpathSync(a);
+    const rb = realpathSync(b);
+    // Windows/macOS filesystems are case-insensitive and realpathSync does not
+    // canonicalize drive-letter casing, so compare case-insensitively there.
+    if (process.platform === "win32" || process.platform === "darwin") {
+      return ra.toLowerCase() === rb.toLowerCase();
+    }
+    return ra === rb;
   } catch {
     return false;
   }

--- a/packages/cli/src/spawn-backend.ts
+++ b/packages/cli/src/spawn-backend.ts
@@ -39,6 +39,12 @@ export async function spawnDetachedBackend(
       ...process.env,
       BP_DATA_DIR: cfg.dataDir,
       BP_MODE: "single",
+      // Pin the orchestrator mode resolved by `up`. The detached server boots
+      // via `node server.js` and resolves its mode from env, so without this a
+      // stray BP_RUNTIME_URL would flip the background backend into static
+      // (sandbox) mode. BP_ORCHESTRATOR has the highest precedence and thus
+      // also neutralizes any leftover BP_RUNTIME_URL/BP_MODE in the parent env.
+      BP_ORCHESTRATOR: cfg.mode,
       BP_PORT: String(cfg.port),
       PORT: String(cfg.port),
       AGENT_RUNTIME_PORT: String(cfg.runtimePort),

--- a/packages/runtime/src/__tests__/agent-error.test.ts
+++ b/packages/runtime/src/__tests__/agent-error.test.ts
@@ -44,6 +44,43 @@ describe("normalizeAgentError (#45)", () => {
   it("handles empty input", () => {
     expect(normalizeAgentError("").message).toBe("");
   });
+
+  // #157 — the original two regexes hardcoded forward slashes, so a Windows
+  // absolute path (which carries the user's username under `C:\Users\<u>\…`)
+  // slipped through redact() verbatim and leaked into the chat error bubble
+  // and events.jsonl.
+  describe("Windows path leakage (#157)", () => {
+    const winNoKeyRaw = [
+      "No model selected.",
+      "  C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules\\@earendil-works\\pi-coding-agent\\docs\\providers.md",
+    ].join("\n");
+
+    it("does not leak a Windows absolute node_modules path in the message", () => {
+      const out = normalizeAgentError(winNoKeyRaw);
+      expect(out.message).not.toMatch(/node_modules/);
+      expect(out.message).not.toMatch(/\.md/);
+    });
+
+    it("does not leak the Windows username (privacy)", () => {
+      const out = normalizeAgentError(winNoKeyRaw);
+      expect(out.message).not.toMatch(/alice/);
+      expect(out.message).not.toMatch(/C:\\Users/i);
+    });
+
+    it("keeps the semantic head of the error", () => {
+      const out = normalizeAgentError(winNoKeyRaw);
+      expect(out.message).toContain("No model selected.");
+    });
+
+    it("drops a Windows-only path line just like the POSIX case", () => {
+      const raw =
+        "Tool failed: cannot read config.\nC:\\Users\\bob\\proj\\node_modules\\pkg\\docs\\x.md";
+      const out = normalizeAgentError(raw);
+      expect(out.message).toContain("Tool failed: cannot read config.");
+      expect(out.message).not.toMatch(/node_modules/);
+      expect(out.message).not.toMatch(/bob/);
+    });
+  });
 });
 
 describe("normalizeAgentError — provider HTTP errors (#97)", () => {

--- a/packages/runtime/src/agent-error.ts
+++ b/packages/runtime/src/agent-error.ts
@@ -146,6 +146,12 @@ function pickMessage(obj: unknown): string | undefined {
  * keeping its semantic content. Best-effort — drops lines that are purely an
  * absolute node_modules doc path or a `/login` hint, and scrubs any inline
  * absolute path that reaches into node_modules.
+ *
+ * Cross-platform (#157): the path separator class allows BOTH `/` and `\`, and
+ * the leading anchor optionally accepts a Windows drive prefix (`C:\…`). The
+ * original POSIX-only regex hardcoded forward slashes, so a native Windows path
+ * like `C:\Users\alice\…\node_modules\@pkg\docs\providers.md` slipped through
+ * verbatim and leaked the username into the chat bubble + events.jsonl.
  */
 function redact(raw: string): string {
   return raw
@@ -154,12 +160,13 @@ function redact(raw: string): string {
       const t = line.trim();
       if (/use \/login/i.test(t)) return false;
       // A line that is just an absolute path into node_modules (doc pointer).
-      if (/^\/?\S*node_modules\/\S+$/.test(t)) return false;
+      // Allows a Windows drive prefix and either separator style.
+      if (/^(?:[A-Za-z]:)?[\\/]?\S*node_modules[\\/]\S+$/.test(t)) return false;
       return true;
     })
     .map((line) =>
-      // Scrub any remaining inline absolute node_modules path.
-      line.replace(/\/\S*node_modules\/\S+/g, "").trimEnd(),
+      // Scrub any remaining inline absolute node_modules path (POSIX or Windows).
+      line.replace(/(?:[A-Za-z]:)?[\\/]\S*node_modules[\\/]\S+/g, "").trimEnd(),
     )
     .join("\n")
     .replace(/\n{2,}/g, "\n")

--- a/packages/runtime/src/server.ts
+++ b/packages/runtime/src/server.ts
@@ -10,6 +10,7 @@
  *   GET  /sse/:id  (+ alias GET /sessions/:id/events)
  *   POST /sessions/:id/interrupt, GET /sessions/:id/agents, POST /sessions/:id/evict
  */
+import { pathToFileURL } from "node:url";
 import { Hono } from "hono";
 import { serve } from "@hono/node-server";
 import { stream } from "hono/streaming";
@@ -315,8 +316,10 @@ export async function startServer(opts: StartServerOptions = {}): Promise<{
   };
 }
 
-// Allow `node dist/server.js` to boot directly.
-if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+// Allow `node dist/server.js` to boot directly. Use pathToFileURL for the
+// main-module check so it works on Windows too — a naive `file://${argv[1]}`
+// never matches import.meta.url there (backslashes, drive letter, file:///).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   void startServer().then(({ port }) => {
     // eslint-disable-next-line no-console
     console.log(`[runtime] listening on :${port} (mock=${process.env.BP_MOCK ?? "0"})`);

--- a/packages/web/src/__tests__/demoTruncatedExport.test.ts
+++ b/packages/web/src/__tests__/demoTruncatedExport.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { reduceMessagesForEvent } from "../contexts/messageReducer";
+import { normalizeAgUiEvent } from "../contracts/backend";
+import type { ChatMessage, WebSocketEvent } from "../contracts/backend";
+
+/**
+ * Regression coverage for demo bundles built from a *tail-sliced* history.
+ *
+ * When a long session was exported with a positive `limit`, the history
+ * endpoint returns only the tail of events.jsonl — the leading
+ * TEXT_MESSAGE_START of the earliest messages is gone, leaving orphaned
+ * CONTENT/END. The replay then dropped those opening replies silently
+ * ("开始的消息被截断"). The export now requests the full log (`limit: 0`), and
+ * the reducer additionally recovers gracefully if an orphan still slips
+ * through.
+ */
+describe("demo replay tolerates truncated/orphaned events", () => {
+  it("renders orphaned TEXT_MESSAGE_CONTENT whose START was sliced off", () => {
+    // Simulate a tail-sliced stream: CONTENT/END with no preceding START.
+    let msgs: ChatMessage[] = [];
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "orphan-1",
+      delta: "Librarian → methodology grounding",
+      agentName: "principal",
+    } as WebSocketEvent);
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "orphan-1",
+      delta: " against the paper",
+      agentName: "principal",
+    } as WebSocketEvent);
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_END",
+      messageId: "orphan-1",
+    } as WebSocketEvent);
+
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].id).toBe("orphan-1");
+    expect(msgs[0].content).toBe("Librarian → methodology grounding against the paper");
+    expect(msgs[0].agent).toBe("principal");
+    expect(msgs[0].streaming).toBe(false); // END finalized it
+  });
+
+  it("still folds a normal START→CONTENT→END triad into one message", () => {
+    let msgs: ChatMessage[] = [];
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_START",
+      messageId: "m1",
+      role: "assistant",
+      agentName: "principal",
+    } as WebSocketEvent);
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "m1",
+      delta: "hello",
+    } as WebSocketEvent);
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "m1",
+      delta: " world",
+    } as WebSocketEvent);
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_END",
+      messageId: "m1",
+    } as WebSocketEvent);
+
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].content).toBe("hello world");
+  });
+
+  it("strips NO-RENDER wrappers even on orphaned content", () => {
+    let msgs: ChatMessage[] = [];
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "orphan-2",
+      delta: "<!--NO-RENDER-->internal<!--/NO-RENDER-->",
+    } as WebSocketEvent);
+    // Entire delta was a NO-RENDER wrapper → nothing to render, no message created.
+    expect(msgs).toHaveLength(0);
+  });
+});
+
+describe("normalizeAgUiEvent preserves transport metadata keys", () => {
+  it("keeps _ts (and _seq) instead of mangling to Ts/Seq", () => {
+    const raw = {
+      type: "TEXT_MESSAGE_CONTENT",
+      _ts: "2026-06-22T08:43:24.619Z",
+      _seq: 42,
+      agent_name: "principal",
+      message_id: "m1",
+      delta: "hi",
+    };
+    const norm = normalizeAgUiEvent(raw) as Record<string, unknown>;
+    // The timestamp the demo timeline sorts on must survive normalization.
+    expect(norm._ts).toBe("2026-06-22T08:43:24.619Z");
+    expect(norm._seq).toBe(42);
+    expect(norm).not.toHaveProperty("Ts");
+    expect(norm).not.toHaveProperty("Seq");
+    // Internal snake_case still camelizes.
+    expect(norm.agentName).toBe("principal");
+    expect(norm.messageId).toBe("m1");
+  });
+});

--- a/packages/web/src/components/demo/demoBundle.ts
+++ b/packages/web/src/components/demo/demoBundle.ts
@@ -159,9 +159,14 @@ export async function buildDemoBundle(opts: BuildDemoOptions): Promise<DemoBundl
   let timeline: DemoBundle["timeline"] = "timestamped";
   // Pull the persisted event timeline from the new history endpoint (the
   // legacy `/sessions/:id/events` path is an SSE alias and returns no JSON).
-  // Cap at 5000 — the endpoint enforces the same cap, but stating it here
-  // documents the bundle's max footprint.
-  const historyEnvelope = await api.sessions.getHistory(session.id, { limit: 5000 });
+  // Request the FULL log (`limit: 0`) — same as the live chat rehydrate path
+  // (HISTORY_REHYDRATE_LIMIT). A positive cap returns the *tail* of the log,
+  // which slices off the oldest events: the leading TEXT_MESSAGE_START of the
+  // earliest messages is dropped, leaving orphaned CONTENT/END that the
+  // reducer can't attach to anything, so the conversation's opening replies
+  // silently vanish from the replay. The 25 MB embed budget (MAX_TOTAL_BYTES)
+  // still bounds the bundle's real footprint via the files section.
+  const historyEnvelope = await api.sessions.getHistory(session.id, { limit: 0 });
   let events: typeof historyEnvelope.events | undefined = historyEnvelope.events;
   let messages: ChatMessage[] | undefined;
   if (!events || events.length === 0) {

--- a/packages/web/src/contexts/messageReducer.ts
+++ b/packages/web/src/contexts/messageReducer.ts
@@ -171,6 +171,25 @@ export function reduceMessagesForEvent(existing: ChatMessage[], event: WebSocket
       // Strip NO-RENDER wrapper used by record_trace "Message Complete" hint
       delta = delta.replace(/<!--NO-RENDER-->[\s\S]*?<!--\/NO-RENDER-->/g, "");
       if (!delta) return existing;
+      // Orphaned CONTENT (no matching START) — recover gracefully instead of
+      // dropping it. This happens when a demo bundle was exported from a
+      // tail-sliced history: the leading START of the earliest messages is gone,
+      // and a plain `.map` here would no-op, silently swallowing the opening
+      // replies. Synthesize the message so the content still renders.
+      if (!existing.some((m) => m.id === id)) {
+        return [
+          ...existing,
+          {
+            id,
+            role: "assistant",
+            content: delta,
+            createdAt: new Date().toISOString(),
+            agent,
+            streaming: true,
+            kind: "text",
+          },
+        ];
+      }
       return existing.map((m) =>
         m.id === id ? { ...m, content: (m.content ?? "") + delta } : m,
       );

--- a/packages/web/src/contracts/backend.ts
+++ b/packages/web/src/contracts/backend.ts
@@ -481,7 +481,14 @@ function normalizeStringArray(value: unknown): string[] {
 }
 
 function camelizeKey(key: string): string {
-  return key.replace(/_([a-z])/g, (_, char: string) => char.toUpperCase());
+  // Preserve a leading-underscore prefix: `_ts` / `_seq` are AG-UI transport
+  // metadata whose underscore is significant. Without this guard the regex
+  // turns `_ts` into `Ts`, so `normalizeAgUiEvent` strips the timestamp and the
+  // demo replay's timeline collapses (every event lands at ms=0). Only internal
+  // snake_case boundaries (e.g. `agent_name` → `agentName`) are camelized.
+  const lead = key.match(/^_+/)?.[0] ?? "";
+  const rest = key.slice(lead.length);
+  return lead + rest.replace(/_([a-z])/g, (_, char: string) => char.toUpperCase());
 }
 
 function camelizeObject(value: unknown): unknown {


### PR DESCRIPTION
## Problem

Users launching from source (`npm run bp -- up`) could **silently land in static (sandbox) mode**. The orchestrator mode was resolved purely from the environment, so a stray `BP_RUNTIME_URL` left over from a `docker compose` session flipped a source launch into static mode with no indication. The only symptom was a confusing `static runtime did not become healthy ... is the sandbox container up?` timeout — which points users at fixing a sandbox they never meant to use.

Root cause: `resolveOrchestratorMode()` precedence is `BP_ORCHESTRATOR` → `BP_RUNTIME_URL` (→static) → `BP_MODE` → local, and `brainpilot up` neither overrode it nor surfaced the result.

## Fix (1 + 2 + 3)

1. **Visibility** — `up` prints a mode banner on every launch: `mode=local` (dim) or, for static/docker, a yellow warning that names the trigger (`--mode` vs `BP_ORCHESTRATOR`) and echoes `BP_RUNTIME_URL`. The switch is never silent again.
2. **Lock to local unless explicit** — new `resolveUpMode()` defaults to `local` and honors only `--mode` and an explicit `BP_ORCHESTRATOR`; it **deliberately ignores `BP_RUNTIME_URL` / `BP_MODE`** so leftover env can't hijack a source launch. The resolved mode is passed explicitly via `StartServerOptions.mode`; the detached path pins `BP_ORCHESTRATOR` so the background server agrees. Adds `--mode <local|static|docker>`.
3. **Better error** — the static-orchestrator timeout now splits the two cases (real Docker deploy vs. stray env on a source launch) and gives the exact escape hatch (`brainpilot up --mode local` / `unset BP_RUNTIME_URL BP_ORCHESTRATOR`).

## Safety

Backend `startServer` env resolution is **unchanged**, so Docker compose — which selects static via `BP_RUNTIME_URL` on `node server.js` — is unaffected.

## Tests

+11 tests (`resolveUpMode`, `up` banner/mode passthrough, `--mode` flag + validation). All **572 non-web tests pass**; typecheck clean. Verified end-to-end:
- `BP_RUNTIME_URL=… up` (no `--mode`) → stays `mode=local`, starts normally ✅
- `BP_RUNTIME_URL=… up --mode static` → warns + names trigger ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)