### PR TITLE
fix(cli): lock `brainpilot up` to local mode unless mode is explicit

### DIFF
--- a/packages/backend-core/src/server.ts
+++ b/packages/backend-core/src/server.ts
@@ -7,7 +7,7 @@ import { serve, type ServerType } from "@hono/node-server";
 import { createApp, type CreateAppOptions } from "./app.js";
 import { createOrchestrator } from "./create-orchestrator.js";
 import { bootstrapEnvProvider } from "./config.js";
-import type { Orchestrator } from "./orchestrator.js";
+import type { Orchestrator, OrchestratorMode } from "./orchestrator.js";
 
 export interface StartServerOptions extends Partial<CreateAppOptions> {
   /** Backend port. Default 9001 (§11A.5 决策 D). */
@@ -15,6 +15,13 @@ export interface StartServerOptions extends Partial<CreateAppOptions> {
   hostname?: string;
   /** Provide a pre-built orchestrator; otherwise one is created from env. */
   orchestrator?: Orchestrator;
+  /**
+   * Force the orchestrator mode. When omitted the mode is resolved from env
+   * (BP_ORCHESTRATOR / BP_RUNTIME_URL / BP_MODE). The `brainpilot up` CLI passes
+   * this explicitly so a stray BP_RUNTIME_URL can't silently flip a local
+   * source-launch into static (sandbox) mode.
+   */
+  mode?: OrchestratorMode;
   /** Eagerly ensure the runtime at boot (default false — lazy on first use). */
   eager?: boolean;
   /** When true, the runtime child inherits stdio (foreground CLI mode). */
@@ -44,6 +51,11 @@ export function buildServerOrchestrator(
   return (
     options.orchestrator ??
     createOrchestrator({
+      // Pass the mode explicitly when set (the `brainpilot up` CLI does) so a
+      // stray BP_RUNTIME_URL/BP_MODE in the environment can't silently flip a
+      // local source-launch into static/docker. When omitted, createOrchestrator
+      // falls back to env resolution (Docker compose relies on that path).
+      ...(options.mode ? { mode: options.mode } : {}),
       local: {
         dataDir: options.dataDir,
         ...(options.stdioInherit ? { stdioInherit: true } : {}),

--- a/packages/backend-core/src/static-orchestrator.ts
+++ b/packages/backend-core/src/static-orchestrator.ts
@@ -69,8 +69,14 @@ export class StaticRuntimeOrchestrator implements Orchestrator {
       if (Date.now() >= deadline) {
         throw new Error(
           `static runtime did not become healthy at ${this.url} within ` +
-            `${this.healthTimeoutMs}ms — is the sandbox container up? ` +
-            `(check \`docker compose logs sandbox\` and BP_RUNTIME_URL)`,
+            `${this.healthTimeoutMs}ms.\n` +
+            `  This is STATIC (sandbox) mode: the backend is trying to reach a ` +
+            `pre-started runtime container at BP_RUNTIME_URL.\n` +
+            `  • If you meant to run a Docker deployment: check it is up ` +
+            `(\`docker compose logs sandbox\`) and that BP_RUNTIME_URL is correct.\n` +
+            `  • If you meant to run from source: you likely have a stray ` +
+            `BP_RUNTIME_URL/BP_ORCHESTRATOR in your environment. Run ` +
+            `\`brainpilot up --mode local\` (or \`unset BP_RUNTIME_URL BP_ORCHESTRATOR\`).`,
         );
       }
       await this.sleep(this.pollMs);

--- a/packages/cli/src/commands/up.test.ts
+++ b/packages/cli/src/commands/up.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   up,
   buildStartServerOptions,
+  resolveUpMode,
   PortInUseError,
   portFlagHint,
   type ResolvedUpConfig,
@@ -32,6 +33,7 @@ describe("buildStartServerOptions", () => {
       webDist: "/web/dist",
       foreground: true,
       open: false,
+      mode: "local",
     };
     const opts = buildStartServerOptions(cfg);
     expect(opts).toMatchObject({
@@ -40,6 +42,7 @@ describe("buildStartServerOptions", () => {
       dataDir: "/data",
       serveWeb: true,
       webRoot: "/web/dist",
+      mode: "local",
     });
   });
 
@@ -52,10 +55,42 @@ describe("buildStartServerOptions", () => {
       webDist: null,
       foreground: true,
       open: false,
+      mode: "local",
     };
     const opts = buildStartServerOptions(cfg);
     expect(opts.serveWeb).toBe(false);
     expect("webRoot" in opts).toBe(false);
+  });
+});
+
+describe("resolveUpMode", () => {
+  it("defaults to local with an empty env (the source-launch default)", () => {
+    expect(resolveUpMode(undefined, {})).toBe("local");
+  });
+
+  it("IGNORES a stray BP_RUNTIME_URL — the core fix (no accidental sandbox)", () => {
+    // A leftover BP_RUNTIME_URL from a `docker compose` session must NOT flip a
+    // source launch into static mode. The backend's env resolver would; the CLI
+    // resolver deliberately does not.
+    expect(resolveUpMode(undefined, { BP_RUNTIME_URL: "http://sandbox:8081" })).toBe("local");
+  });
+
+  it("IGNORES a stray BP_MODE=docker", () => {
+    expect(resolveUpMode(undefined, { BP_MODE: "docker" })).toBe("local");
+  });
+
+  it("honors an explicit --mode option", () => {
+    expect(resolveUpMode("static", { BP_RUNTIME_URL: "http://x" })).toBe("static");
+    expect(resolveUpMode("docker", {})).toBe("docker");
+  });
+
+  it("honors an explicit BP_ORCHESTRATOR when no --mode given", () => {
+    expect(resolveUpMode(undefined, { BP_ORCHESTRATOR: "static" })).toBe("static");
+    expect(resolveUpMode(undefined, { BP_ORCHESTRATOR: "docker" })).toBe("docker");
+  });
+
+  it("--mode wins over BP_ORCHESTRATOR", () => {
+    expect(resolveUpMode("local", { BP_ORCHESTRATOR: "static" })).toBe("local");
   });
 });
 
@@ -198,6 +233,51 @@ describe("up — foreground start", () => {
     expect(result.server).toBe(fakeServer);
     expect(result.url).toBe("http://127.0.0.1:9500");
     expect(result.config.runtimePort).toBe(9501);
+  });
+
+  it("forces mode=local and prints a local banner even with a stray BP_RUNTIME_URL", async () => {
+    const root = join(dir, "bp");
+    let captured: StartServerOptions | undefined;
+    const logs: string[] = [];
+    await up(
+      { dir: root, port: 9550, foreground: true, open: false },
+      {
+        env: { ANTHROPIC_API_KEY: "sk", BP_RUNTIME_URL: "http://sandbox:8081" },
+        startServer: async (opts) => {
+          captured = opts;
+          return { stop: async () => {} } as unknown as RunningServer;
+        },
+        isPortFree: freePorts(),
+        webDist: () => null,
+        log: (m) => logs.push(m),
+      },
+    );
+    // The stray BP_RUNTIME_URL must NOT have flipped us into static mode.
+    expect(captured?.mode).toBe("local");
+    expect(logs.join("\n")).toContain("mode=local");
+  });
+
+  it("passes mode=static and warns when --mode static is explicit", async () => {
+    const root = join(dir, "bp");
+    let captured: StartServerOptions | undefined;
+    const logs: string[] = [];
+    await up(
+      { dir: root, port: 9560, foreground: true, open: false, mode: "static" },
+      {
+        env: { ANTHROPIC_API_KEY: "sk", BP_RUNTIME_URL: "http://sandbox:8081" },
+        startServer: async (opts) => {
+          captured = opts;
+          return { stop: async () => {} } as unknown as RunningServer;
+        },
+        isPortFree: freePorts(),
+        webDist: () => null,
+        log: (m) => logs.push(m),
+      },
+    );
+    expect(captured?.mode).toBe("static");
+    const text = logs.join("\n");
+    expect(text).toContain("mode=static");
+    expect(text).toContain("--mode");
   });
 
   it("calls the browser-open hook when open=true", async () => {

--- a/packages/cli/src/commands/up.ts
+++ b/packages/cli/src/commands/up.ts
@@ -15,7 +15,7 @@
  * is injectable so tests drive it without a real server.
  */
 import { resolveProvider, describeProviderConfig, formatProviderGuidance } from "@brainpilot/backend-core";
-import type { StartServerOptions, RunningServer } from "@brainpilot/backend-core";
+import type { StartServerOptions, RunningServer, OrchestratorMode } from "@brainpilot/backend-core";
 import { isMockMode } from "@brainpilot/runtime";
 import pc from "picocolors";
 import { resolveDataDir, dataPaths } from "../paths.js";
@@ -33,6 +33,8 @@ export interface UpOptions {
   foreground?: boolean;
   /** `--no-open` to suppress the browser. */
   open?: boolean;
+  /** `--mode <local|static|docker>` force the orchestrator mode (default local). */
+  mode?: OrchestratorMode;
 }
 
 /** Injectable collaborators (defaults wire to real implementations). */
@@ -61,6 +63,30 @@ export interface ResolvedUpConfig {
   webDist: string | null;
   foreground: boolean;
   open: boolean;
+  /** Orchestrator mode passed explicitly to the backend (default local). */
+  mode: OrchestratorMode;
+}
+
+/**
+ * Resolve the orchestrator mode for `brainpilot up`. Unlike the backend's
+ * env-based `resolveOrchestratorMode` (which reads BP_RUNTIME_URL / BP_MODE),
+ * the CLI defaults to `local` and only departs from it when the user is
+ * explicit — via `--mode` or an explicit `BP_ORCHESTRATOR`. This is the fix for
+ * "users accidentally enter sandbox mode": a stray BP_RUNTIME_URL left over
+ * from a `docker compose` session no longer hijacks a source launch into
+ * static (sandbox) mode. To run `up` against a pre-started container, the user
+ * must say so (`--mode static` or BP_ORCHESTRATOR=static).
+ */
+export function resolveUpMode(
+  optionMode: OrchestratorMode | undefined,
+  env: Record<string, string | undefined>,
+): OrchestratorMode {
+  if (optionMode) return optionMode;
+  const explicit = (env.BP_ORCHESTRATOR ?? "").toLowerCase();
+  if (explicit === "docker" || explicit === "local" || explicit === "static") {
+    return explicit as OrchestratorMode;
+  }
+  return "local";
 }
 
 /** Build the StartServerOptions from resolved config — exposed for tests. */
@@ -73,8 +99,10 @@ export function buildStartServerOptions(
     dataDir: cfg.dataDir,
     serveWeb: cfg.webDist !== null,
     stdioInherit: cfg.foreground,
+    // Pass the mode explicitly so a stray BP_RUNTIME_URL/BP_MODE in the
+    // environment can't silently flip a local source-launch into static/docker.
+    mode: cfg.mode,
     ...(cfg.webDist ? { webRoot: cfg.webDist } : {}),
-    // The backend creates a LocalProcessOrchestrator from env (BP_MODE=single).
   } satisfies StartServerOptions;
 }
 
@@ -146,6 +174,7 @@ export async function up(
   const host = "127.0.0.1";
   const foreground = options.foreground ?? true;
   const open = options.open ?? true;
+  const mode = resolveUpMode(options.mode, env);
 
   const cfg: ResolvedUpConfig = {
     dataDir,
@@ -155,7 +184,29 @@ export async function up(
     webDist: webDistFn(),
     foreground,
     open,
+    mode,
   };
+
+  // Make the resolved mode visible (the #1 cause of "I accidentally entered
+  // sandbox mode" was that the mode switch was completely silent). For the
+  // non-default static/docker modes, name the trigger so the user understands
+  // why they left local.
+  if (mode === "local") {
+    log(pc.dim(`mode=local · dataDir=${dataDir} · runtime port ${cfg.runtimePort}`));
+  } else {
+    const via = options.mode
+      ? "--mode"
+      : "BP_ORCHESTRATOR";
+    log(
+      pc.yellow(
+        `mode=${mode} (via ${via}) — connecting to an external runtime, not a local one.`,
+      ),
+    );
+    if (mode === "static") {
+      log(pc.dim(`    BP_RUNTIME_URL=${env.BP_RUNTIME_URL ?? "(unset — required for static)"}`));
+    }
+    log(pc.dim("    To run from source instead, drop --mode / BP_ORCHESTRATOR (defaults to local)."));
+  }
 
   // 2. Scaffold if absent (idempotent).
   if (!(await isScaffolded(dataDir))) {

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -22,6 +22,24 @@ describe("program — commander wiring", () => {
     expect(upFn.mock.calls[0]![0]).toMatchObject({ open: false });
   });
 
+  it("`up --mode static` forwards the orchestrator mode", async () => {
+    const upFn = vi.fn().mockResolvedValue({ url: "x", config: {} });
+    await run(["up", "--mode", "static"], { upFn });
+    expect(upFn.mock.calls[0]![0]).toMatchObject({ mode: "static" });
+  });
+
+  it("`up` with no --mode leaves mode undefined (resolver defaults to local)", async () => {
+    const upFn = vi.fn().mockResolvedValue({ url: "x", config: {} });
+    await run(["up"], { upFn });
+    expect(upFn.mock.calls[0]![0].mode).toBeUndefined();
+  });
+
+  it("rejects an invalid --mode", async () => {
+    const upFn = vi.fn();
+    await expect(run(["up", "--mode", "bogus"], { upFn })).rejects.toThrow();
+    expect(upFn).not.toHaveBeenCalled();
+  });
+
   it("dispatches `down` with --dir", async () => {
     const downFn = vi.fn().mockResolvedValue({ stopped: true, pid: 1, forced: false });
     await run(["down", "--dir", "/d"], { downFn });

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -37,6 +37,12 @@ function parsePort(value: string): number {
   return n;
 }
 
+function parseMode(value: string): "local" | "static" | "docker" {
+  const v = value.toLowerCase();
+  if (v === "local" || v === "static" || v === "docker") return v;
+  throw new Error(`Invalid mode: ${value} (expected local | static | docker)`);
+}
+
 /** Read the CLI package version from its own package.json (single source of truth). */
 function requireVersion(): string {
   const require = createRequire(import.meta.url);
@@ -67,6 +73,11 @@ export function buildProgram(deps: ProgramDeps = {}): Command {
     .option("-p, --port <n>", "backend port (runtime uses port+1)", parsePort)
     .option("--detach", "run the backend as a background process")
     .option("--no-open", "do not open the browser")
+    .option(
+      "--mode <mode>",
+      "orchestrator mode: local (default) | static (connect BP_RUNTIME_URL) | docker",
+      parseMode,
+    )
     .action(async (opts) => {
       const foreground = !opts.detach;
       await upFn(
@@ -75,6 +86,7 @@ export function buildProgram(deps: ProgramDeps = {}): Command {
           port: opts.port,
           foreground,
           open: opts.open,
+          mode: opts.mode,
         },
         { spawnDetached: spawnDetachedBackend },
       );

--- a/packages/cli/src/spawn-backend.ts
+++ b/packages/cli/src/spawn-backend.ts
@@ -39,6 +39,12 @@ export async function spawnDetachedBackend(
       ...process.env,
       BP_DATA_DIR: cfg.dataDir,
       BP_MODE: "single",
+      // Pin the orchestrator mode resolved by `up`. The detached server boots
+      // via `node server.js` and resolves its mode from env, so without this a
+      // stray BP_RUNTIME_URL would flip the background backend into static
+      // (sandbox) mode. BP_ORCHESTRATOR has the highest precedence and thus
+      // also neutralizes any leftover BP_RUNTIME_URL/BP_MODE in the parent env.
+      BP_ORCHESTRATOR: cfg.mode,
       BP_PORT: String(cfg.port),
       PORT: String(cfg.port),
       AGENT_RUNTIME_PORT: String(cfg.runtimePort),


### PR DESCRIPTION
## Problem

Users launching from source (`npm run bp -- up`) could **silently land in static (sandbox) mode**. The orchestrator mode was resolved purely from the environment, so a stray `BP_RUNTIME_URL` left over from a `docker compose` session flipped a source launch into static mode with no indication. The only visible symptom was a confusing `static runtime did not become healthy ... is the sandbox container up?` timeout — which points users at fixing a sandbox they never meant to use.

Root cause: `resolveOrchestratorMode()` precedence is `BP_ORCHESTRATOR` → `BP_RUNTIME_URL` (→ static) → `BP_MODE` → local, and `brainpilot up` neither overrode it nor surfaced the result.

## Fix (1 + 2 + 3)

1. **Visibility** — `up` prints a mode banner on every launch: `mode=local` (dim) or, for static/docker, a yellow warning that names the trigger (`--mode` vs `BP_ORCHESTRATOR`) and echoes `BP_RUNTIME_URL`. The switch is never silent again.
2. **Lock to local unless explicit** — new `resolveUpMode()` defaults to `local` and honors only `--mode` and an explicit `BP_ORCHESTRATOR`; it **deliberately ignores `BP_RUNTIME_URL` / `BP_MODE`** so leftover env can't hijack a source launch. The resolved mode is passed explicitly via `StartServerOptions.mode` (threaded through `buildServerOrchestrator`); the detached path pins `BP_ORCHESTRATOR` so the background server agrees. Adds `--mode <local|static|docker>`.
3. **Better error** — the static-orchestrator timeout now splits the two cases (real Docker deploy vs. stray env on a source launch) and gives the exact escape hatch (`brainpilot up --mode local` / `unset BP_RUNTIME_URL BP_ORCHESTRATOR`).

## Safety

Backend `startServer` env resolution is **unchanged** when no explicit mode is passed, so Docker compose — which selects static via `BP_RUNTIME_URL` on `node server.js` — is unaffected. The `mode` passthrough composes with #169's `buildServerOrchestrator(dataDir)` wiring (local orchestrator still receives `options.dataDir`).

## Tests

+11 tests (`resolveUpMode`, `up` banner/mode passthrough, `--mode` flag + validation). All **574 tests pass**; typecheck clean. Verified end-to-end:
- `BP_RUNTIME_URL=… up` (no `--mode`) → stays `mode=local`, starts normally ✅
- `BP_RUNTIME_URL=… up --mode static` → warns + names trigger ✅

> Note: branched directly from `main` (supersedes #173, which was cut from a diverged local `development`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)