### PR TITLE
fix(windows): redact native Windows node_modules paths in agent error output (#157)

### DIFF
--- a/packages/backend-core/src/provider-probe.ts
+++ b/packages/backend-core/src/provider-probe.ts
@@ -31,10 +31,17 @@ export interface ProbeInput {
   apiKey: string;
 }
 
-/** Strip absolute node_modules paths from any error text before surfacing it. */
+/**
+ * Strip absolute node_modules paths from any error text before surfacing it.
+ *
+ * Cross-platform (#157): accept BOTH `/` and `\` separators, plus an optional
+ * Windows drive prefix. A native Windows path like
+ * `C:\Users\<user>\…\node_modules\@pkg\file.md` previously slipped through
+ * unredacted, leaking the username into the Test-button error toast.
+ */
 function redact(text: string): string {
   return text
-    .replace(/(?:\/[^\s:]*)?node_modules\/[^\s)]*/g, "<path>")
+    .replace(/(?:[A-Za-z]:)?(?:[\\/][^\s:]*)?node_modules[\\/][^\s)]*/g, "<path>")
     .replace(/\s+/g, " ")
     .trim();
 }

--- a/packages/backend-core/test/provider-probe.test.ts
+++ b/packages/backend-core/test/provider-probe.test.ts
@@ -94,4 +94,19 @@ describe("probeProvider (#55)", () => {
     );
     expect(r.message).not.toMatch(/node_modules/);
   });
+
+  it("redacts native Windows node_modules paths (incl. username) from error messages (#157)", async () => {
+    const fetchFn = vi.fn(async () => {
+      throw new Error(
+        "boom at C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules\\undici\\lib\\x.js:1",
+      );
+    });
+    const r = await probeProvider(
+      { baseUrl: "https://gw/api", apiKey: "sk" },
+      { fetchFn: fetchFn as never },
+    );
+    expect(r.message).not.toMatch(/node_modules/);
+    expect(r.message).not.toMatch(/alice/);
+    expect(r.message).not.toMatch(/C:\\Users/i);
+  });
 });

--- a/packages/runtime/src/__tests__/agent-error.test.ts
+++ b/packages/runtime/src/__tests__/agent-error.test.ts
@@ -44,6 +44,43 @@ describe("normalizeAgentError (#45)", () => {
   it("handles empty input", () => {
     expect(normalizeAgentError("").message).toBe("");
   });
+
+  // #157 — the original two regexes hardcoded forward slashes, so a Windows
+  // absolute path (which carries the user's username under `C:\Users\<u>\…`)
+  // slipped through redact() verbatim and leaked into the chat error bubble
+  // and events.jsonl.
+  describe("Windows path leakage (#157)", () => {
+    const winNoKeyRaw = [
+      "No model selected.",
+      "  C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules\\@earendil-works\\pi-coding-agent\\docs\\providers.md",
+    ].join("\n");
+
+    it("does not leak a Windows absolute node_modules path in the message", () => {
+      const out = normalizeAgentError(winNoKeyRaw);
+      expect(out.message).not.toMatch(/node_modules/);
+      expect(out.message).not.toMatch(/\.md/);
+    });
+
+    it("does not leak the Windows username (privacy)", () => {
+      const out = normalizeAgentError(winNoKeyRaw);
+      expect(out.message).not.toMatch(/alice/);
+      expect(out.message).not.toMatch(/C:\\Users/i);
+    });
+
+    it("keeps the semantic head of the error", () => {
+      const out = normalizeAgentError(winNoKeyRaw);
+      expect(out.message).toContain("No model selected.");
+    });
+
+    it("drops a Windows-only path line just like the POSIX case", () => {
+      const raw =
+        "Tool failed: cannot read config.\nC:\\Users\\bob\\proj\\node_modules\\pkg\\docs\\x.md";
+      const out = normalizeAgentError(raw);
+      expect(out.message).toContain("Tool failed: cannot read config.");
+      expect(out.message).not.toMatch(/node_modules/);
+      expect(out.message).not.toMatch(/bob/);
+    });
+  });
 });
 
 describe("normalizeAgentError — provider HTTP errors (#97)", () => {

--- a/packages/runtime/src/agent-error.ts
+++ b/packages/runtime/src/agent-error.ts
@@ -146,6 +146,12 @@ function pickMessage(obj: unknown): string | undefined {
  * keeping its semantic content. Best-effort — drops lines that are purely an
  * absolute node_modules doc path or a `/login` hint, and scrubs any inline
  * absolute path that reaches into node_modules.
+ *
+ * Cross-platform (#157): the path separator class allows BOTH `/` and `\`, and
+ * the leading anchor optionally accepts a Windows drive prefix (`C:\…`). The
+ * original POSIX-only regex hardcoded forward slashes, so a native Windows path
+ * like `C:\Users\alice\…\node_modules\@pkg\docs\providers.md` slipped through
+ * verbatim and leaked the username into the chat bubble + events.jsonl.
  */
 function redact(raw: string): string {
   return raw
@@ -154,12 +160,13 @@ function redact(raw: string): string {
       const t = line.trim();
       if (/use \/login/i.test(t)) return false;
       // A line that is just an absolute path into node_modules (doc pointer).
-      if (/^\/?\S*node_modules\/\S+$/.test(t)) return false;
+      // Allows a Windows drive prefix and either separator style.
+      if (/^(?:[A-Za-z]:)?[\\/]?\S*node_modules[\\/]\S+$/.test(t)) return false;
       return true;
     })
     .map((line) =>
-      // Scrub any remaining inline absolute node_modules path.
-      line.replace(/\/\S*node_modules\/\S+/g, "").trimEnd(),
+      // Scrub any remaining inline absolute node_modules path (POSIX or Windows).
+      line.replace(/(?:[A-Za-z]:)?[\\/]\S*node_modules[\\/]\S+/g, "").trimEnd(),
     )
     .join("\n")
     .replace(/\n{2,}/g, "\n")


### PR DESCRIPTION
## Problem

On Windows, agent error blobs that carry an absolute `node_modules` doc pointer leaked the user's **full path — including their Windows username** — into the chat error bubble and into `events.jsonl`.

The redaction regexes in `packages/runtime/src/agent-error.ts` and the parallel one in `packages/backend-core/src/provider-probe.ts` hardcoded a forward-slash separator, so a native path like `C:\Users\<user>\…\node_modules\@earendil-works\pi-coding-agent\docs\providers.md` matched neither the path-only-line filter nor the inline scrub, and slipped through verbatim.

## Fix

Loosen all three regexes to accept **either separator** (`[\\/]`) and an **optional Windows drive prefix** (`(?:[A-Za-z]:)?`). The semantic head of the error ("No model selected.", "Tool failed: cannot read config.", …) is preserved exactly as before.

Adds Windows-path test fixtures to both suites (agent-error + provider-probe), asserting that neither the absolute path nor the username survives redaction. The deterministic reproducer from #157 now returns `"No model selected."` for both POSIX and Windows inputs.

Fixes #157.

## Tests

All tests pass (371 in runtime + backend-core; full suite green). `agent-error.test.ts` and `provider-probe.test.ts` extended with the Windows fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)