### PR TITLE
fix(windows): POSIX-normalize workspace + skill-search paths and harden traversal guard

### DIFF
--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -181,6 +181,64 @@ async function waitFor(pred: () => boolean, timeoutMs = 2000): Promise<void> {
   }
 }
 
+// #5 — cross-platform: every workspace-relative path the runtime hands out
+// (writeSessionFile result, skill_search responses) must use POSIX `/` so the
+// API contract is identical on Windows and POSIX, the model never sees a
+// backslash it has to JSON-escape, and URL query strings stay valid. And the
+// inverse: paths echoed back by the model — including round-tripped ones with
+// the backslash form — must still resolve. `\` is not a legal Windows
+// filename character, so collapsing `\` → `/` on input is unambiguous.
+describe("SessionManager workspace path normalization (#5)", () => {
+  let root: string;
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "bp-fs-"));
+  });
+
+  it("writeSessionFile returns nested paths in POSIX form", async () => {
+    const m = new SessionManager({
+      dataRoot: root,
+      persist: false,
+      agentFactory: mockAgentFactory,
+    });
+    const s = await m.createSession({ title: "fs" });
+    const b64 = Buffer.from("hello", "utf8").toString("base64");
+    const out = await m.writeSessionFile(s.id, "docs/sub/note.txt", b64);
+    expect(out.path).toBe("docs/sub/note.txt");
+    expect(out.path).not.toMatch(/\\/);
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("accepts a backslash-shaped relative path on input and resolves identically", async () => {
+    const m = new SessionManager({
+      dataRoot: root,
+      persist: false,
+      agentFactory: mockAgentFactory,
+    });
+    const s = await m.createSession({ title: "fs" });
+    const b64 = Buffer.from("x", "utf8").toString("base64");
+    const a = await m.writeSessionFile(s.id, "a/b/c.txt", b64);
+    const b = await m.writeSessionFile(s.id, "a\\b\\c.txt", b64);
+    // Same logical path → both resolve to the same workspace location, both
+    // returned in POSIX form.
+    expect(a.path).toBe("a/b/c.txt");
+    expect(b.path).toBe("a/b/c.txt");
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("returns the empty string for a write at the workspace root", async () => {
+    const m = new SessionManager({
+      dataRoot: root,
+      persist: false,
+      agentFactory: mockAgentFactory,
+    });
+    const s = await m.createSession({ title: "fs" });
+    const b64 = Buffer.from("y", "utf8").toString("base64");
+    const out = await m.writeSessionFile(s.id, "top.txt", b64);
+    expect(out.path).toBe("top.txt");
+    await rm(root, { recursive: true, force: true });
+  });
+});
+
 describe("SessionManager memory watchdog (§R-4 / #20)", () => {
   it("is fully opt-out when no budget is set (identical to today)", async () => {
     const m = new SessionManager({ persist: false, agentFactory: mockAgentFactory });

--- a/packages/runtime/src/__tests__/skill-search.test.ts
+++ b/packages/runtime/src/__tests__/skill-search.test.ts
@@ -206,10 +206,62 @@ describe("searchSkills — browse mode", () => {
     ).rejects.toThrow(/traversal/);
   });
 
+  // #2 — cross-platform: the previous guard hardcoded POSIX `/` so a Windows
+  // absolute path like `C:\Windows\System32` or `\Windows` was let through to
+  // the second-line containment guard, which still saved it but with a less
+  // specific error. Reject them up-front instead.
+  it("rejects Windows-style absolute paths (drive prefix and leading backslash) (#2)", async () => {
+    await expect(
+      searchSkills(base, { mode: "browse", relative_path: "C:\\Windows\\System32" }),
+    ).rejects.toThrow(/traversal/);
+    await expect(
+      searchSkills(base, { mode: "browse", relative_path: "C:/Windows" }),
+    ).rejects.toThrow(/traversal/);
+    await expect(
+      searchSkills(base, { mode: "browse", relative_path: "\\windows" }),
+    ).rejects.toThrow(/traversal/);
+  });
+
+  // #2 — the original comment promised to reject `..` segments before the
+  // resolve step, but the code never actually did; only the second-line
+  // containment check caught them after the fact. Make the up-front guard
+  // honest. Also covers backslash-separated `..` for Windows-shaped inputs.
+  it("rejects any `..` segment up front, not just at the containment guard (#2)", async () => {
+    await expect(
+      searchSkills(base, { mode: "browse", relative_path: "foo/../bar" }),
+    ).rejects.toThrow(/traversal/);
+    await expect(
+      searchSkills(base, { mode: "browse", relative_path: "foo\\..\\bar" }),
+    ).rejects.toThrow(/traversal/);
+  });
+
   it("throws on a missing path", async () => {
     await expect(
       searchSkills(base, { mode: "browse", relative_path: "nope/nada" }),
     ).rejects.toThrow(/does not exist/);
+  });
+
+  // #5 — paths handed back to the model must use POSIX separators so they
+  // round-trip safely through JSON and URL query strings, and so the API
+  // contract is identical on Windows and POSIX hosts.
+  it("emits POSIX-style separators in browse `path` and search `relative_paths` (#5)", async () => {
+    const out = JSON.parse(
+      await searchSkills(base, {
+        mode: "browse",
+        relative_path: "02_Cross-Domain/eeg-paradigm-designer",
+      }),
+    );
+    expect(out.path).toBe("02_Cross-Domain/eeg-paradigm-designer");
+    expect(out.path).not.toMatch(/\\/);
+
+    const query = JSON.parse(
+      await searchSkills(base, { mode: "query", keywords: ["EEG"] }),
+    );
+    for (const r of query.results) {
+      for (const p of r.relative_paths) {
+        expect(p).not.toMatch(/\\/);
+      }
+    }
   });
 });
 

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -345,6 +345,13 @@ export class SessionManager {
     let rel = rawPath ?? "";
     if (rel === "/workspace") rel = "";
     else if (rel.startsWith("/workspace/")) rel = rel.slice("/workspace/".length);
+    // Cross-platform (#5): the runtime now emits POSIX `/` in all
+    // workspace-relative paths it hands out (writeSessionFile, skill_search).
+    // Accept either separator on the way back in so an LLM that round-trips
+    // a path we gave it (or pre-#5 clients with cached `\` paths) still
+    // resolves correctly. `\` is not a legal Windows filename character, so
+    // this collapse is unambiguous.
+    rel = rel.replace(/\\/g, "/");
     rel = rel.replace(/^\/+/, ""); // never let a leading slash make it absolute
     const abs = resolve(root, rel);
     if (abs !== root && !abs.startsWith(root + sep)) {
@@ -432,8 +439,12 @@ export class SessionManager {
     await mkdir(dirname(abs), { recursive: true });
     await writeFile(abs, buf);
     // Return the workspace-relative path (strip the absolute root prefix).
+    // Cross-platform (#5): always emit POSIX `/` so the API contract is
+    // identical across hosts; the frontend embeds this in URL query strings
+    // (`?path=foo/bar.txt`) and the model echoes it back via `read_file`.
     const root = this.workspaceDir(sid);
-    const relOut = abs === root ? "" : abs.slice(root.length + 1);
+    const relOut =
+      abs === root ? "" : abs.slice(root.length + 1).split(sep).join("/");
     return { path: relOut, size: buf.byteLength };
   }
 

--- a/packages/runtime/src/tools/skill-search.ts
+++ b/packages/runtime/src/tools/skill-search.ts
@@ -31,7 +31,7 @@
  */
 import { readFile, readdir, stat, access } from "node:fs/promises";
 import { constants as FS } from "node:fs";
-import { join, resolve, sep } from "node:path";
+import { isAbsolute, join, resolve, sep, posix } from "node:path";
 import type { SystemTool } from "../types.js";
 import type { ToolDeps } from "./system-tools.js";
 
@@ -116,7 +116,12 @@ export async function collectAllSkills(base: string): Promise<SkillRecord[]> {
     for (const skillName of skills) {
       const skillMd = join(catPath, skillName, "SKILL.md");
       if (!(await exists(skillMd))) continue;
-      const relPath = join(category, skillName);
+      // Cross-platform (#5): the relative path leaves the runtime and is
+      // shown both to the model (in `relative_paths`) and round-tripped back
+      // through the `browse` mode. Standardize on POSIX `/` so the API
+      // surface is identical on Windows and POSIX, the model never sees a
+      // backslash it has to JSON-escape, and URL/query forms stay valid.
+      const relPath = posix.join(category, skillName);
       const existing = byName.get(skillName);
       if (existing) {
         existing.relative_paths.push(relPath);
@@ -238,8 +243,25 @@ export async function searchSkills(base: string, args: SkillSearchArgs): Promise
   if (rel === "" || rel === ".") {
     target = baseAbs;
   } else {
-    // Reject any absolute path or one starting with '..' before resolve.
-    if (rel.startsWith("/")) {
+    // Reject any absolute path or one containing a `..` segment before resolve.
+    // Cross-platform (#2): the previous guard hardcoded POSIX `/`, so a
+    // Windows absolute path slipped past to the second-line containment
+    // guard with a less specific error. The check below recognizes:
+    //   - POSIX absolute paths (`/foo`)             — `isAbsolute` + `startsWith("/")`
+    //   - Windows absolute paths native to the host — `isAbsolute` (only true on Win)
+    //   - Windows-shaped paths inspected on POSIX   — `^[A-Za-z]:[\\/]` regex
+    //     (POSIX `isAbsolute("C:\\foo")` is false, so we have to match the
+    //     drive prefix explicitly to keep the guard host-platform-agnostic)
+    //   - Leading-backslash form                    — `startsWith("\\")`
+    // and the `..`-segment check the comment already promised but the code
+    // never actually did (across both separators).
+    if (
+      isAbsolute(rel) ||
+      rel.startsWith("/") ||
+      rel.startsWith("\\") ||
+      /^[A-Za-z]:[\\/]/.test(rel) ||
+      rel.split(/[\\/]/).some((seg) => seg === "..")
+    ) {
       throw new Error("path traversal outside skills directory is not allowed");
     }
     target = resolve(join(baseAbs, rel));
@@ -259,7 +281,12 @@ export async function searchSkills(base: string, args: SkillSearchArgs): Promise
         type: d.isDirectory() ? "directory" : "file",
       }))
       .sort((a, b) => a.name.localeCompare(b.name));
-    const displayPath = target === baseAbs ? "." : target.slice(baseAbs.length + 1);
+    // Cross-platform (#5): emit POSIX-style separators in the response so
+    // the model and frontend never see OS-native backslashes.
+    const displayPath =
+      target === baseAbs
+        ? "."
+        : target.slice(baseAbs.length + 1).split(sep).join("/");
     return jsonText({ path: displayPath, type: "directory", children });
   }
   if (st.isFile()) {


### PR DESCRIPTION
## Summary

Cross-platform pass — **PR 2 of 6**. Makes every workspace-relative path the runtime emits use POSIX `/` on every host, accepts either separator on the way back in, and tightens the skill-search traversal guard to recognize Windows-shaped absolute paths.

## Why

The runtime hands relative paths to two consumers — the React frontend (in URL query strings) and the LLM (in JSON tool replies). On Windows the old code emitted OS-native paths with backslashes, which:
- made `writeSessionFile` (multi-segment paths) inconsistent with `listSessionFiles` (leaf names) on the same API,
- forced the model to JSON-escape `\` correctly when echoing a path back,
- put non-URL-safe characters into query strings,
- and meant any cache/export round-trip landed in a different shape.

## What

* **(#5) session-manager.ts** — `writeSessionFile` normalizes the returned `path` with `split(sep).join("/")`; `resolveWorkspacePath` folds incoming `\` → `/` before the leading-slash strip (unambiguous: `\` is not a legal Windows filename character).
* **(#5) tools/skill-search.ts** — `collectAllSkills` uses `posix.join` for `relative_paths`; `browse` mode normalizes `displayPath`. Model never sees a backslash.
* **(#2) tools/skill-search.ts traversal guard** — `startsWith("/")` missed Windows absolute paths on POSIX hosts (`isAbsolute("C:\\foo")` is false on POSIX). The new guard covers POSIX absolute, Windows absolute (`C:\\…` or `C:/…`), leading-backslash, and `..`-segments — including the `..` rejection the inline comment had promised for years.

## Tests (+6)

- skill-search: rejects Windows-shaped absolute paths up-front; rejects `..` segments across both separators up-front; `relative_paths` and browse `path` never contain `\`
- session-manager: `writeSessionFile` returns POSIX `/` for nested paths; backslash-shaped input round-trips to the same POSIX output; workspace-root write returns just the leaf

Pre/post: 563 → 569

🤖 Generated with [Claude Code](https://claude.com/claude-code)