### PR TITLE
fix(windows): collapse CRLF before persona drift compare so Windows installs aren't false-drift

### DIFF
--- a/packages/cli/src/commands/template.test.ts
+++ b/packages/cli/src/commands/template.test.ts
@@ -53,6 +53,35 @@ describe("templateList", () => {
   });
 });
 
+// #3 — cross-platform: Windows editors and `git autocrlf=true` save the
+// on-disk `prompt.md` with CRLF, but `PERSONAS[name]` is shipped as an LF
+// TypeScript string literal. Without the CRLF collapse, every line from the
+// second onward differs by one `\r`, every agent reports `drift` on every
+// Windows install, and `bp template diff` paints the whole file red/green.
+describe("CRLF tolerance (#3)", () => {
+  it("a CRLF-line-ended on-disk file matching the built-in is `in-sync`, not `drift`", async () => {
+    const crlf = PERSONAS.principal!.replace(/\n/g, "\r\n");
+    await writePrompt("principal", crlf);
+    const rows = await templateList({ dir, env: {}, cwd: "/" });
+    expect(rows.find((r) => r.name === "principal")?.state).toBe("in-sync");
+  });
+
+  it("`detectPromptDrift` reports a CRLF-converted file as no-drift", async () => {
+    await writePrompt("principal", PERSONAS.principal!.replace(/\n/g, "\r\n"));
+    await writePrompt("librarian", PERSONAS.librarian!.replace(/\n/g, "\r\n"));
+    expect(await detectPromptDrift(dir)).toEqual([]);
+  });
+
+  it("`runDiff` produces no `+`/`-` rows for a CRLF copy of the built-in", async () => {
+    await writePrompt("trace", PERSONAS.trace!.replace(/\n/g, "\r\n"));
+    const out: string[] = [];
+    await runDiff({ dir, env: {}, cwd: "/", agent: "trace", log: (m) => out.push(m) });
+    // After the CRLF fold, the on-disk file should match the built-in, so the
+    // command's "no drift" path is hit and no diff body is emitted.
+    expect(out.join("\n")).toMatch(/no drift/);
+  });
+});
+
 describe("detectPromptDrift", () => {
   it("returns only drifted agents", async () => {
     await writePrompt("principal", PERSONAS.principal!);

--- a/packages/cli/src/commands/template.ts
+++ b/packages/cli/src/commands/template.ts
@@ -63,10 +63,17 @@ async function readOrNull(p: string): Promise<string | null> {
   }
 }
 
-/** Normalize for byte-level comparison: strip a single trailing newline so
- *  hand-edited files don't show as `drift` over a meaningless EOL. */
+/** Normalize for byte-level comparison so an EOL-only or line-ending-only
+ *  divergence doesn't show as `drift`. Cross-platform (#3): Windows editors
+ *  and git's `autocrlf=true` save `prompt.md` with CRLF, but the built-in
+ *  persona strings ship as LF — without the CRLF collapse, every line from
+ *  the second onward differs by one `\r`, so every agent reports `drift` on
+ *  every Windows install and `bp template diff` paints the whole file
+ *  red/green. We fold CRLF → LF first, then strip a single trailing
+ *  newline. */
 function normalize(s: string): string {
-  return s.endsWith("\n") ? s.slice(0, -1) : s;
+  const lf = s.replace(/\r\n/g, "\n");
+  return lf.endsWith("\n") ? lf.slice(0, -1) : lf;
 }
 
 /** Compute drift status for every built-in agent (or just one). */
@@ -151,8 +158,11 @@ export async function runList(options: CommonOptions = {}): Promise<void> {
  * in a `diff` dependency for what is effectively a debug helper.
  */
 function unifiedDiff(a: string, b: string, label: string): string {
-  const aLines = a.split("\n");
-  const bLines = b.split("\n");
+  // Cross-platform (#3): the diff is computed line-by-line on `\n` splits,
+  // so a CRLF disk file vs an LF built-in would otherwise compare every line
+  // as "different by one `\r`" and paint the entire output. Fold first.
+  const aLines = a.replace(/\r\n/g, "\n").split("\n");
+  const bLines = b.replace(/\r\n/g, "\n").split("\n");
   const lines: string[] = [];
   lines.push(pc.bold(`--- ${label} (built-in)`));
   lines.push(pc.bold(`+++ ${label} (on-disk)`));


### PR DESCRIPTION
## Summary

Cross-platform pass — **PR 3 of 6**. `bp template list`, the `up` drift banner, and `bp template diff` all compared on-disk `prompt.md` to the LF-only built-in persona byte-for-byte. Windows editors and `git autocrlf=true` save the file as CRLF, so every line from the second onward differed by one `\r` and:

- every agent reported `drift` on every Windows install
- `bp template diff` painted the whole file red/green and was unreadable

## What

Fold CRLF → LF in both comparison paths:
- `normalize()` — used by `templateList` / `detectPromptDrift`
- `unifiedDiff()` — used by `runDiff`

CRLF vs LF in a markdown persona file is semantically meaningless, so collapsing is the right semantic. Keeps the existing trailing-newline tolerance `normalize()` already had.

## Tests (+3)

- A CRLF copy of `PERSONAS.principal` reports `in-sync`
- `detectPromptDrift` finds nothing with CRLF copies of two personas
- `runDiff` says "no drift" for a CRLF copy and emits no `+`/`-` rows

Pre/post: 563 → 566

🤖 Generated with [Claude Code](https://claude.com/claude-code)