### PR TITLE
fix(windows): use structured Mounts API for Docker bind so Windows drive paths stop tripping the colon delimiter

### DIFF
--- a/packages/backend-core/src/docker-orchestrator.ts
+++ b/packages/backend-core/src/docker-orchestrator.ts
@@ -151,8 +151,26 @@ export class DockerOrchestrator implements Orchestrator {
       ExposedPorts: { [portKey]: {} },
       HostConfig: {
         PortBindings: { [portKey]: [{ HostPort: String(this.hostPort) }] },
+        // Cross-platform (#1): the legacy `Binds: ["src:dst:mode"]` colon-
+        // delimited form is unparseable when `src` is a Windows path that
+        // already contains a colon after the drive letter
+        // (`C:\Users\foo\bp` → `C:\Users\foo\bp:/root/...:rw`), causing
+        // dockerode/Docker Engine to mis-split the spec and either 422 the
+        // container create or mount a host directory named just `C`. Use the
+        // structured `Mounts` API (Docker Engine ≥1.25) instead — Source /
+        // Target / ReadOnly are separate fields, so Engine's own
+        // Windows-aware path translation does the right thing.
         ...(this.dataDir
-          ? { Binds: [`${this.dataDir}:${this.containerDataDir}:rw`] }
+          ? {
+              Mounts: [
+                {
+                  Type: "bind",
+                  Source: this.dataDir,
+                  Target: this.containerDataDir,
+                  ReadOnly: false,
+                },
+              ],
+            }
           : {}),
       },
     };

--- a/packages/backend-core/test/create-orchestrator.test.ts
+++ b/packages/backend-core/test/create-orchestrator.test.ts
@@ -107,6 +107,66 @@ describe("DockerOrchestrator (stubbed dockerode)", () => {
     expect(container.stop).toHaveBeenCalledTimes(1);
   });
 
+  // #1 — cross-platform: the legacy `Binds: ["src:dst:rw"]` colon-string is
+  // unparseable when `src` is a Windows path that already contains a colon
+  // after the drive letter, so we use the structured `Mounts` API instead.
+  // The two assertions below pin that contract: a structured `Mounts` array
+  // exists with the bind shape, and the deprecated `Binds` field is gone.
+  it("uses HostConfig.Mounts (structured) instead of Binds for bind mounts (#1)", async () => {
+    const container = {
+      start: vi.fn(async () => {}),
+      stop: vi.fn(async () => {}),
+      remove: vi.fn(async () => {}),
+    };
+    const docker = {
+      createContainer: vi.fn(async () => container),
+    } as never;
+    const orch = new DockerOrchestrator({
+      docker,
+      image: "brainpilot-sandbox:test",
+      containerPort: 8081,
+      hostPort: 18081,
+      dataDir: "/host/bp",
+      containerDataDir: "/root/.bp-root",
+      healthProbe: async () => true,
+      sleep: async () => {},
+    });
+    await orch.ensureRuntime();
+    const createArg = (docker as { createContainer: ReturnType<typeof vi.fn> })
+      .createContainer.mock.calls[0]![0] as { HostConfig?: Record<string, unknown> };
+    const hostConfig = createArg.HostConfig!;
+    expect(hostConfig.Binds).toBeUndefined();
+    expect(hostConfig.Mounts).toEqual([
+      { Type: "bind", Source: "/host/bp", Target: "/root/.bp-root", ReadOnly: false },
+    ]);
+  });
+
+  // The bind-mount block is conditional on `dataDir` — when no dataDir is
+  // configured the container runs without a host bind, and neither field
+  // should be present (matches the original code path's intent).
+  it("emits neither Binds nor Mounts when no dataDir is configured (#1)", async () => {
+    const container = {
+      start: vi.fn(async () => {}),
+      stop: vi.fn(async () => {}),
+      remove: vi.fn(async () => {}),
+    };
+    const docker = {
+      createContainer: vi.fn(async () => container),
+    } as never;
+    const orch = new DockerOrchestrator({
+      docker,
+      image: "brainpilot-sandbox:test",
+      healthProbe: async () => true,
+      sleep: async () => {},
+    });
+    await orch.ensureRuntime();
+    const createArg = (docker as { createContainer: ReturnType<typeof vi.fn> })
+      .createContainer.mock.calls[0]![0] as { HostConfig?: Record<string, unknown> };
+    const hostConfig = createArg.HostConfig!;
+    expect(hostConfig.Binds).toBeUndefined();
+    expect(hostConfig.Mounts).toBeUndefined();
+  });
+
   it("auto-pulls the image when createContainer reports it is missing", async () => {
     const container = {
       start: vi.fn(async () => {}),


### PR DESCRIPTION
## Summary

Cross-platform pass — **PR 4 of 6**. `HostConfig.Binds: ["src:dst:rw"]` legacy colon-string form is unparseable when `src` is a Windows path that already contains a colon after the drive letter:

```
C:\Users\foo\bp + /root/.bp-root + rw
  → "C:\Users\foo\bp:/root/.bp-root:rw"
```

dockerode / Docker Engine split on `:` and see four segments instead of three, so the create call either 422s or creates a phantom mount of a host directory literally named `C`. The `DockerOrchestrator` dynamic mode was therefore unusable on Windows out of the box.

## What

Switch to `HostConfig.Mounts` (Docker Engine ≥1.25 structured API). `Source` / `Target` / `ReadOnly` are separate fields, so the Engine's platform-aware path translation does the right thing on every host.

## Tests (+2)

- With `dataDir` set: emitted `HostConfig.Mounts` is the structured array; `Binds` is absent.
- Without `dataDir`: neither field emitted (matches original conditional intent).

Pre/post: 563 → 565

🤖 Generated with [Claude Code](https://claude.com/claude-code)