### PR TITLE
chore(tests): replace hardcoded /tmp paths with os.tmpdir() so tests are Windows-shape-safe

### DIFF
--- a/packages/cli/src/paths.test.ts
+++ b/packages/cli/src/paths.test.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect } from "vitest";
 import { resolveDataDir, dataPaths } from "./paths.js";
+import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 describe("resolveDataDir precedence", () => {
-  const cwd = "/tmp/launch";
+  // Use the OS tmpdir so the cwd literal is a valid absolute path on every
+  // host (Windows in particular — `/tmp/launch` resolves to `C:\tmp\launch`
+  // there, which is technically fine for resolve()-based equality but
+  // depends on a fragile detail). (#9 — cross-platform pass.)
+  const cwd = join(tmpdir(), "launch");
 
   it("uses --dir when provided (highest priority)", () => {
     const d = resolveDataDir({

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -1,13 +1,20 @@
 import { describe, it, expect, vi } from "vitest";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { run } from "./program.js";
+
+// Use the OS tmpdir so the `--dir` argv literal is shaped the same way on
+// Windows and POSIX. The CLI just echoes the option value back through
+// commander; we never touch the filesystem. (#9 — cross-platform pass.)
+const TMP_DIR = join(tmpdir(), "x");
 
 describe("program — commander wiring", () => {
   it("dispatches `up` with parsed --dir/--port and foreground default", async () => {
     const upFn = vi.fn().mockResolvedValue({ url: "x", config: {} });
-    await run(["up", "--dir", "/tmp/x", "--port", "9100"], { upFn });
+    await run(["up", "--dir", TMP_DIR, "--port", "9100"], { upFn });
     expect(upFn).toHaveBeenCalledOnce();
     const [opts] = upFn.mock.calls[0]!;
-    expect(opts).toMatchObject({ dir: "/tmp/x", port: 9100, foreground: true });
+    expect(opts).toMatchObject({ dir: TMP_DIR, port: 9100, foreground: true });
   });
 
   it("`up --detach` sets foreground false", async () => {

--- a/packages/cli/src/repo-mode.test.ts
+++ b/packages/cli/src/repo-mode.test.ts
@@ -18,6 +18,14 @@ function makeForeign(): string {
   return realpathSync(mkdtempSync(join(tmpdir(), "bp-foreign-")));
 }
 
+// Argv-literal placeholders for `--dir`/`BP_DATA_DIR`. The tests never touch
+// these as real paths — `assertRepoCwd` only inspects their *presence* in
+// argv/env — but using the OS tmpdir keeps the values well-shaped on
+// Windows where `/tmp/...` is not a real path. (#9 — cross-platform pass.)
+const TMP_DIR = join(tmpdir(), "somewhere");
+const TMP_DIR_EQUALS = `--dir=${join(tmpdir(), "foo")}`;
+const TMP_DATA_DIR = join(tmpdir(), "dd");
+
 function callAssert(opts: Parameters<typeof assertRepoCwd>[0]): {
   exited: number | null;
   err: string;
@@ -83,7 +91,7 @@ describe("assertRepoCwd", () => {
     const cwd = makeForeign();
     expect(() =>
       assertRepoCwd({
-        argv: ["up", "--dir", "/tmp/somewhere"],
+        argv: ["up", "--dir", TMP_DIR],
         env: {},
         cwd,
         binPath,
@@ -96,7 +104,7 @@ describe("assertRepoCwd", () => {
     const cwd = makeForeign();
     expect(() =>
       assertRepoCwd({
-        argv: ["up", "-d", "/tmp/somewhere"],
+        argv: ["up", "-d", TMP_DIR],
         env: {},
         cwd,
         binPath,
@@ -109,7 +117,7 @@ describe("assertRepoCwd", () => {
     const cwd = makeForeign();
     expect(() =>
       assertRepoCwd({
-        argv: ["up", "--dir=/tmp/foo"],
+        argv: ["up", TMP_DIR_EQUALS],
         env: {},
         cwd,
         binPath,
@@ -123,7 +131,7 @@ describe("assertRepoCwd", () => {
     expect(() =>
       assertRepoCwd({
         argv: ["up"],
-        env: { BP_DATA_DIR: "/tmp/dd" },
+        env: { BP_DATA_DIR: TMP_DATA_DIR },
         cwd,
         binPath,
       }),

--- a/packages/runtime/src/__tests__/tool-access.test.ts
+++ b/packages/runtime/src/__tests__/tool-access.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "vitest";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   systemToolNamesForRole,
   systemToolsForRole,
@@ -18,7 +20,11 @@ function deps(name: string): ToolDeps {
     destroyAgent: async () => {},
     wakeAgent: () => {},
     requestUserInput: async () => "stub-answer",
-    routerSkillsDir: "/tmp/bp-test-router",
+    // Field is required by ToolDeps but the access-control tests never read
+    // it. Use the OS tmpdir so the path is at least well-formed on Windows
+    // (where `/tmp/...` is not a real directory) if a future change starts
+    // exercising it. (#8 — cross-platform pass.)
+    routerSkillsDir: join(tmpdir(), "bp-test-router"),
   };
 }
 


### PR DESCRIPTION
## Summary

Cross-platform pass — **PR 6 of 6**. Mechanical cleanup, no behaviour change.

Five test files used `/tmp/...` literals as path placeholders. They all pass on Windows today because the affected fields are either never read or fed to `path.resolve()` whose Windows mapping (`/tmp/launch` → `C:\tmp\launch`) lands on the same value the assertion expects — a brittle coincidence, not a guarantee. A future refactor that compares the input literal before resolve, or any code that actually fs-touches the path, would silently start failing only on Windows.

## What

Replace literals with `join(tmpdir(), "…")` in:
- `packages/runtime/src/__tests__/tool-access.test.ts`
- `packages/cli/src/paths.test.ts`
- `packages/cli/src/program.test.ts`
- `packages/cli/src/repo-mode.test.ts`

No behavioural change on POSIX. No new tests. Existing assertions unchanged because the constants flow through both sides of the equality.

Pre/post: 563 → 563

🤖 Generated with [Claude Code](https://claude.com/claude-code)