### PR TITLE
fix(cli): foreground `up` honours --port for the runtime (#171)

### DIFF
--- a/packages/backend-core/src/server.ts
+++ b/packages/backend-core/src/server.ts
@@ -19,6 +19,13 @@ export interface StartServerOptions extends Partial<CreateAppOptions> {
   eager?: boolean;
   /** When true, the runtime child inherits stdio (foreground CLI mode). */
   stdioInherit?: boolean;
+  /**
+   * Port the local runtime should bind. Forwarded to the local orchestrator so
+   * the foreground (in-process) path honours `--port` (runtime = backend + 1)
+   * instead of falling back to AGENT_RUNTIME_PORT/8081 (#171). The detached path
+   * injects the same value via the AGENT_RUNTIME_PORT env var (spawn-backend).
+   */
+  runtimePort?: number;
 }
 
 export interface RunningServer {
@@ -46,6 +53,7 @@ export function buildServerOrchestrator(
     createOrchestrator({
       local: {
         dataDir: options.dataDir,
+        ...(options.runtimePort !== undefined ? { port: options.runtimePort } : {}),
         ...(options.stdioInherit ? { stdioInherit: true } : {}),
       },
     })

--- a/packages/backend-core/test/server.test.ts
+++ b/packages/backend-core/test/server.test.ts
@@ -33,6 +33,32 @@ describe("buildServerOrchestrator", () => {
     expect(env.BP_DATA_DIR).toBe("/data/detached");
   });
 
+  it("threads runtimePort through to the local runtime env (#171)", () => {
+    // Foreground path: `up` prechecks port+1 and must pass it to the backend so
+    // the runtime binds there instead of the AGENT_RUNTIME_PORT/8081 fallback.
+    const orch = buildServerOrchestrator({
+      dataDir: "/data/xyz",
+      stdioInherit: true,
+      runtimePort: 9501,
+    });
+    expect(orch).toBeInstanceOf(LocalProcessOrchestrator);
+    const env = (orch as LocalProcessOrchestrator).buildEnv();
+    expect(env.AGENT_RUNTIME_PORT).toBe("9501");
+  });
+
+  it("falls back to the default runtime port when runtimePort is omitted (#171)", () => {
+    const prev = process.env.AGENT_RUNTIME_PORT;
+    delete process.env.AGENT_RUNTIME_PORT;
+    try {
+      const orch = buildServerOrchestrator({ dataDir: "/data/xyz", stdioInherit: true });
+      const env = (orch as LocalProcessOrchestrator).buildEnv();
+      expect(env.AGENT_RUNTIME_PORT).toBe("8081");
+    } finally {
+      if (prev === undefined) delete process.env.AGENT_RUNTIME_PORT;
+      else process.env.AGENT_RUNTIME_PORT = prev;
+    }
+  });
+
   it("returns an injected orchestrator verbatim (short-circuit)", () => {
     const injected = { id: "injected" } as unknown as Orchestrator;
     expect(buildServerOrchestrator({ orchestrator: injected })).toBe(injected);

--- a/packages/cli/src/commands/up.test.ts
+++ b/packages/cli/src/commands/up.test.ts
@@ -194,6 +194,9 @@ describe("up — foreground start", () => {
       dataDir: root,
       serveWeb: true,
       webRoot: "/web/dist",
+      // #171: the prechecked runtime port (port + 1) must reach the backend,
+      // not just be computed into result.config.
+      runtimePort: 9501,
     });
     expect(result.server).toBe(fakeServer);
     expect(result.url).toBe("http://127.0.0.1:9500");

--- a/packages/cli/src/commands/up.ts
+++ b/packages/cli/src/commands/up.ts
@@ -73,8 +73,12 @@ export function buildStartServerOptions(
     dataDir: cfg.dataDir,
     serveWeb: cfg.webDist !== null,
     stdioInherit: cfg.foreground,
+    // #171: carry the prechecked runtime port into the in-process backend so the
+    // foreground path binds the runtime on `port + 1` (honouring `--port`)
+    // instead of the orchestrator's AGENT_RUNTIME_PORT/8081 fallback. The
+    // detached path passes the same value via env (spawn-backend.ts).
+    runtimePort: cfg.runtimePort,
     ...(cfg.webDist ? { webRoot: cfg.webDist } : {}),
-    // The backend creates a LocalProcessOrchestrator from env (BP_MODE=single).
   } satisfies StartServerOptions;
 }
 


### PR DESCRIPTION
## Problem

`brainpilot up` (foreground / in-process mode) computed the runtime port as `port + 1`, **prechecked it was free**, and then never told the backend to use it. `StartServerOptions` had no field for the runtime port, so `buildServerOrchestrator` fell back to `AGENT_RUNTIME_PORT`/`8081`. Result, on all platforms:

- `--port <n>` silently moved only the backend; the runtime always bound **8081**;
- the `port + 1` precheck was a no-op (it validated a port the runtime never used);
- a busy 8081 broke startup *after* the precheck "passed".

The **detached** path was already correct — it injects `AGENT_RUNTIME_PORT` via env in `spawn-backend.ts`. This was a foreground/detached asymmetry.

## Fix (option A from the issue — structured field)

- `StartServerOptions.runtimePort?: number` (new field).
- `buildServerOrchestrator` threads it into the local orchestrator's `port`, which already sets `AGENT_RUNTIME_PORT`/`PORT` for the runtime child (`local-orchestrator.ts:177-178`).
- `buildStartServerOptions` carries `cfg.runtimePort`.

The detached path is untouched (still env-based); only the in-process path is brought into line.

## Why it slipped past tests

`up.test.ts` asserted `result.config.runtimePort` (the CLI's internal computation) but never that the value **reached the backend**. Added:

- `up — foreground start`: captured `startServer` opts now assert `runtimePort: 9501`.
- `buildServerOrchestrator`: asserts the runtime env carries the forwarded port, and falls back to `8081` when omitted.

## Verification

- `npm run typecheck` clean; full suite **565 tests pass**.
- The issue's deterministic reproducer now reports `opts carry 9501? = true` (was `false`), `cap.runtimePort = 9501`.

Fixes #171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)