### PR TITLE
fix(web): file tree addresses by session id in remote mode (#168)

### DIFF
--- a/packages/web/src/components/files/FileSidebar.tsx
+++ b/packages/web/src/components/files/FileSidebar.tsx
@@ -15,7 +15,6 @@ import {
 import { FileContent, FileEntry } from "../../contracts/backend";
 import { useSandbox } from "../../contexts/SandboxContext";
 import { useSessions } from "../../contexts/SessionContext";
-import { runtimeConfig } from "../../config";
 import { useT } from "../../i18n/useT";
 import { api } from "../../utils/api";
 import { downloadBlob } from "../../utils/download";
@@ -128,10 +127,14 @@ function findNode(root: FileNode, path: string | null): FileNode | null {
 export function FileSidebar({ isOpen, onClose, onResize, onResizeEnd, onResizeStart, width }: FileSidebarProps) {
   const { currentSandbox } = useSandbox();
   const { currentSession } = useSessions();
-  // In single-user local mode the workspace is addressed by the active session
-  // id (workspaces/<sid>/), not a container id. Elsewhere the sandbox id is the
-  // addressing key. `currentSandbox.status` still gates whether files are live.
-  const sandboxId = runtimeConfig.localMode ? currentSession?.id ?? null : currentSandbox?.id ?? null;
+  // The runtime always addresses a workspace by session id (workspaces/<sid>/),
+  // never by container id — in both local and remote mode. A container can host
+  // several sessions, and the file tree shows the *current session's* workspace.
+  // (#168) `currentSandbox.status` still gates whether files are live; the
+  // variable name stays `sandboxId` only because the call sites/sub-component
+  // prop are named that way — it has always carried the session id in local
+  // mode. A full rename rides with the planned session-management cleanup.
+  const sandboxId = currentSession?.id ?? null;
   const t = useT();
   const [tree, setTree] = useState<FileNode>(rootNode);
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => new Set(["/workspace"]));


### PR DESCRIPTION
## Problem

The runtime addresses every workspace by **session id** (`workspaces/<sid>/`) in both local and remote mode — a container can host several sessions, and the file tree shows the *current session's* workspace.

But `FileSidebar` only used `currentSession?.id` in local mode and fell back to `currentSandbox?.id` (the **container id**) in remote mode:

```ts
const sandboxId = runtimeConfig.localMode ? currentSession?.id ?? null : currentSandbox?.id ?? null;
```

In single-user mode this happens to work because backend-core forwards `/sandbox/:id/files*` → `/sessions/:id/files*` ("the sandbox id IS the session id"). But in **multi-user hosting** the container id ≠ session id, so the runtime looks up `workspaces/<containerId>/` — an empty/missing directory → the file tree 404s / shows blank on every remote deployment.

## Fix

Use `currentSession?.id` unconditionally:

```ts
const sandboxId = currentSession?.id ?? null;
```

- **No-op for local mode** — that branch already used `currentSession?.id`.
- **Correct for remote mode** — files belong to the session workspace, independent of the container id.
- Lets the downstream `brainpilot-cloud` gateway drop its temporary sandbox→active-session mapping workaround.
- `currentSandbox?.status === "running"` liveness gating is unchanged.
- Drops the now-unused `runtimeConfig` import.

The variable name stays `sandboxId` for now (it has always carried the session id in local mode); a full rename rides with the planned session-management cleanup.

## Verification

- `tsc -b` clean
- web vitest: 126 tests pass

Fixes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)