### PR TITLE
fix(runtime): skill_search accepts comma-separated keyword string

### DIFF
--- a/packages/runtime/src/__tests__/skill-search.test.ts
+++ b/packages/runtime/src/__tests__/skill-search.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   collectAllSkills,
   countKeywordHits,
+  normalizeKeywords,
   parseFrontmatterDescription,
   searchSkills,
   createSkillSearchTool,
@@ -91,6 +92,37 @@ describe("countKeywordHits", () => {
   });
 });
 
+describe("normalizeKeywords", () => {
+  it("returns empty array for undefined / null-ish input", () => {
+    expect(normalizeKeywords(undefined)).toEqual([]);
+    expect(normalizeKeywords("")).toEqual([]);
+  });
+
+  it("splits a comma-separated string and trims each entry", () => {
+    expect(normalizeKeywords("EEG, preprocessing, ICA")).toEqual([
+      "EEG",
+      "preprocessing",
+      "ICA",
+    ]);
+  });
+
+  it("drops empty entries from comma-separated string", () => {
+    expect(normalizeKeywords("EEG,,, ICA, ")).toEqual(["EEG", "ICA"]);
+  });
+
+  it("handles a single keyword string with no commas", () => {
+    expect(normalizeKeywords("fMRI")).toEqual(["fMRI"]);
+  });
+
+  it("passes through a string array unchanged (trimming + dedup empties)", () => {
+    expect(normalizeKeywords(["EEG", " ICA ", ""])).toEqual(["EEG", "ICA"]);
+  });
+
+  it("handles an already-clean string array", () => {
+    expect(normalizeKeywords(["a", "b", "c"])).toEqual(["a", "b", "c"]);
+  });
+});
+
 describe("collectAllSkills", () => {
   let base: string;
   beforeAll(async () => {
@@ -153,6 +185,37 @@ describe("searchSkills — query mode", () => {
 
   it("query mode requires keywords or skill_name", async () => {
     await expect(searchSkills(base, { mode: "query" })).rejects.toThrow(/keywords/);
+  });
+
+  it("accepts keywords as a comma-separated string", async () => {
+    const out = JSON.parse(
+      await searchSkills(base, { mode: "query", keywords: "EEG, paradigm" }),
+    );
+    expect(out.keywords).toEqual(["EEG", "paradigm"]);
+    expect(out.results[0].name).toBe("eeg-paradigm-designer");
+    expect(out.results[0].keyword_hits).toBeGreaterThan(0);
+  });
+
+  it("comma string with empties and whitespace normalises correctly", async () => {
+    const out = JSON.parse(
+      await searchSkills(base, { mode: "query", keywords: " EEG ,, , paradigm " }),
+    );
+    expect(out.keywords).toEqual(["EEG", "paradigm"]);
+    expect(out.total_matched).toBe(1);
+  });
+
+  it("single keyword string (no commas) works", async () => {
+    const out = JSON.parse(
+      await searchSkills(base, { mode: "query", keywords: "figure" }),
+    );
+    expect(out.keywords).toEqual(["figure"]);
+    expect(out.results[0].name).toBe("figure-builder");
+  });
+
+  it("empty comma string throws (no valid keywords)", async () => {
+    await expect(
+      searchSkills(base, { mode: "query", keywords: " , , " }),
+    ).rejects.toThrow(/keywords/);
   });
 });
 
@@ -260,5 +323,25 @@ describe("createSkillSearchTool", () => {
     };
     const tool = createSkillSearchTool(deps);
     await expect(tool.execute({ mode: "query" })).rejects.toThrow(/keywords/);
+  });
+
+  it("accepts comma-separated keyword string via execute()", async () => {
+    const base = await makeFixtureBase();
+    const deps: ToolDeps = {
+      sessionId: "s",
+      fromAgent: "principal",
+      mailbox: new Mailbox("s"),
+      trace: new GraphOfTrace("s"),
+      ensureAgent: async () => {},
+      destroyAgent: async () => {},
+      wakeAgent: () => {},
+      requestUserInput: async () => "",
+      routerSkillsDir: base,
+    };
+    const tool = createSkillSearchTool(deps);
+    const out = await tool.execute({ mode: "query", keywords: "EEG, paradigm" });
+    const payload = JSON.parse(out.content[0]!.text);
+    expect(payload.keywords).toEqual(["EEG", "paradigm"]);
+    expect(payload.results[0].name).toBe("eeg-paradigm-designer");
   });
 });

--- a/packages/runtime/src/tools/skill-search.ts
+++ b/packages/runtime/src/tools/skill-search.ts
@@ -168,7 +168,7 @@ export interface SkillSearchArgs {
  * comma-separated string (e.g. `"EEG, preprocessing, ICA"`), trim each entry,
  * and drop empties — matching `skills_tool.py` behaviour.
  */
-function normalizeKeywords(raw: string[] | string | undefined): string[] {
+export function normalizeKeywords(raw: string[] | string | undefined): string[] {
   if (!raw) return [];
   if (typeof raw === "string") {
     return raw.split(",").map((s) => s.trim()).filter(Boolean);

--- a/packages/runtime/src/tools/skill-search.ts
+++ b/packages/runtime/src/tools/skill-search.ts
@@ -156,10 +156,25 @@ export function countKeywordHits(text: string, keywords: string[]): number {
 
 export interface SkillSearchArgs {
   mode: "query" | "browse";
-  keywords?: string[];
+  /** Accepts a string[] or a single comma-separated string (e.g. "EEG, ICA"). */
+  keywords?: string[] | string;
   topk?: number;
   skill_name?: string;
   relative_path?: string;
+}
+
+/**
+ * Normalise the `keywords` parameter: accept either `string[]` or a single
+ * comma-separated string (e.g. `"EEG, preprocessing, ICA"`), trim each entry,
+ * and drop empties — matching `skills_tool.py` behaviour.
+ */
+function normalizeKeywords(raw: string[] | string | undefined): string[] {
+  if (!raw) return [];
+  if (typeof raw === "string") {
+    return raw.split(",").map((s) => s.trim()).filter(Boolean);
+  }
+  // Already an array — still trim and drop empties for robustness.
+  return raw.map((s) => String(s).trim()).filter(Boolean);
 }
 
 /** JSON-stringify with 2-space indent; the model parses these as text. */
@@ -199,22 +214,23 @@ export async function searchSkills(base: string, args: SkillSearchArgs): Promise
     }
 
     // Sub-mode A: keyword search.
-    if (!args.keywords || args.keywords.length === 0) {
+    const kws = normalizeKeywords(args.keywords);
+    if (kws.length === 0) {
       throw new Error(
-        "in query mode you must pass either 'keywords' (string list) or 'skill_name' (exact name)",
+        "in query mode you must pass either 'keywords' (string list or comma-separated string) or 'skill_name' (exact name)",
       );
     }
     const skills = await collectAllSkills(baseAbs);
     const topk = typeof args.topk === "number" && args.topk > 0 ? Math.floor(args.topk) : 5;
     const scored = skills.map((skill) => ({
       skill,
-      hits: countKeywordHits(skill.description, args.keywords!),
+      hits: countKeywordHits(skill.description, kws),
     }));
     // Sort: hit count desc, then alphabetical name asc.
     scored.sort((a, b) => b.hits - a.hits || a.skill.name.localeCompare(b.skill.name));
     const top = scored.slice(0, topk);
     const result: QueryResult = {
-      keywords: args.keywords,
+      keywords: kws,
       total_matched: scored.filter((s) => s.hits > 0).length,
       returned: top.length,
       results: top.map(({ skill, hits }) => ({
@@ -293,10 +309,13 @@ export function createSkillSearchTool(deps: ToolDeps): SystemTool {
           description: "'query' to search/load skills; 'browse' to list/read paths",
         },
         keywords: {
-          type: "array",
-          items: { type: "string" },
+          oneOf: [
+            { type: "array", items: { type: "string" } },
+            { type: "string" },
+          ],
           description:
-            "(query mode) keywords matched against each skill's frontmatter description",
+            "(query mode) keywords matched against each skill's frontmatter description; " +
+            "pass an array of strings or a single comma-separated string",
         },
         topk: {
           type: "integer",


### PR DESCRIPTION
## Summary

`skill_search` now accepts `keywords` as either a `string[]` or a single comma-separated string (e.g. `"EEG, preprocessing, ICA"`), matching the behaviour of the original `skills_tool.py`.

## Changes

- **`normalizeKeywords()`** helper: splits comma-separated strings, trims whitespace, drops empties
- **`SkillSearchArgs.keywords`** type: `string[]` → `string[] | string`
- **Tool JSON Schema**: `keywords` field uses `oneOf: [array, string]` so models know both forms are accepted
- **`QueryResult.keywords`**: always returns the normalised array (not the raw input)

## Testing

- Build: `npm run build -w packages/runtime` ✅
- Tests: `vitest run skill-search.test.ts` — 17/17 passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)