### PR TITLE
Merge win-compat batch (#174–184) into main — testbed-verified, no Linux regression

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -75,17 +75,29 @@ npm install -g @brainpilot/app
 
 这会安装 `brainpilot` 命令（`bnpt` 是同一命令的内置短别名）。
 
-### 2. 初始化
+### 2. 配置模型服务商
+
+BrainPilot **不绑定 Anthropic** —— 支持多种服务商协议：**Anthropic Messages**、**OpenAI
+Completions**、**OpenAI Responses** 和 **Azure OpenAI Responses**。按你的模型/网关所用协议任选。
+
+推荐做法是启动后用 **Web Settings UI**：打开 **Settings → Providers（服务商）**，添加一个服务商
+（base URL / key / 协议 / 模型列表），它会自动帮你写入配置。缺少 Key 不再阻塞启动：
+**`brainpilot up` 照常启动**，所以你完全可以先跳过、在浏览器里配置服务商。
+
+<details>
+<summary><b>更想用命令行？在 init 时生成配置</b></summary>
 
 ```bash
+# Anthropic（默认协议）
 brainpilot init --api-key <你的-anthropic-key>   # 在 ./brainpilot 下生成配置
+
+# 一条命令接入网关 / 第三方端点
+brainpilot init --api-key <key> --base-url https://your-gateway.example.com/api --model kimi-k2.6
 ```
 
-缺少 Key 不再阻塞启动：
-
-- **`brainpilot up` 照常启动** —— 之后再补 Key，无需重新 init。
-- **在 Web Settings UI 里设置**（推荐）—— provider url / key / model，自动帮你写入配置。
-- **或改用环境变量 `ANTHROPIC_API_KEY` 提供 Key。**
+也可以改用环境变量 `ANTHROPIC_API_KEY` 代替 `--api-key`。多服务商 / OpenAI 兼容端点的配置，见下方
+[使用自己的模型](#-使用自己的模型)。
+</details>
 
 ### 3. 启动
 
@@ -190,10 +202,13 @@ codex exec "全局安装 @brainpilot/app 这个 npm 包，然后运行 brainpilo
 
 ## 🤖 使用自己的模型
 
-BrainPilot 默认对接 Pi 内置的 Anthropic 端点。改用其他端点最简单的方式是启动后用 **Settings
-UI**：打开 **Settings → Providers（服务商）**（Settings 按钮在侧边栏），点 **添加服务商**，填入
-base URL、API key、协议和模型列表。你还能在这里 **测试** 连接、切换当前使用的服务商 —— 它会自动
-帮你写入配置，无需手动改文件。
+BrainPilot 支持多种服务商协议 —— **Anthropic Messages**、**OpenAI Completions**、**OpenAI
+Responses** 和 **Azure OpenAI Responses** —— 可对接 Anthropic、OpenAI 兼容端点、Azure，或两者
+之间的任意网关。
+
+最简单的方式是启动后用 **Settings UI**：打开 **Settings → Providers（服务商）**（Settings 按钮在
+侧边栏），点 **添加服务商**，填入 base URL、API key、协议和模型列表。你还能在这里 **测试** 连接、
+切换当前使用的服务商 —— 它会自动帮你写入配置，无需手动改文件。
 
 也可以在 init 时用一条命令接入网关 / 第三方端点：
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -5,8 +5,7 @@
 <h1 align="center">🧠 BrainPilot</h1>
 
 <p align="center">
-  面向可信脑科学研究的开源多智能体平台 ——
-  由一个 Principal 智能体统筹多个专家智能体，替你读文献、做推理、跑真实分析。
+BrainPilot 是一个开源、人在回路的脑科学智能体研究系统。它整合专业智能体、领域知识、科研技能和工具接口，帮助研究者覆盖完整科研流程：文献综述、假设细化、实验设计、数据分析、报告撰写和科学结论审查。
 </p>
 
 <p align="center">
@@ -37,24 +36,20 @@
 
 ---
 
-## 📖 项目简介
 
-**BrainPilot** 是一个面向脑科学与认知科学研究的开源、单用户多智能体协作平台。一个
-**Principal（主控）** 智能体与你对话、规划任务，并把工作委派给 **专家智能体**（文献官、分析
-师、写作者……），它们通过基于文件的信箱（mailbox）协作。每个智能体读取、写入或生成的文件都
-会落到磁盘上真实的工作区里，整个运行过程会被记录为一张可供检视的 **轨迹图（trace graph）**。
+## 📖 概览
 
-它使用 **TypeScript + [Pi SDK](https://pi.dev)** 做智能体编排，以 **Hono** 后端配 **React**
-单页前端对外提供服务。最快的上手方式是一条 npm 安装命令 —— **无需 Docker**。
+BrainPilot 是一个面向脑科学的开源人工智能研究工作台，帮助研究者将宽泛的科学问题转化为结构化、可执行、可检查的研究流程。系统以总控智能体为核心，由它与研究者对话、理解研究目标、规划任务，并协调文献智能体、分析智能体、实验智能体、写作智能体和审查智能体等专业智能体协同工作。BrainPilot 强调人在回路的科研协作范式：研究者始终保留判断权和控制权，而智能体负责处理证据密集、跨领域和重复性的研究任务。系统集成了脑科学领域知识、方法技能、分析流程和科研工具，并通过流程追踪图记录研究过程，使中间操作、证据来源、生成结论和潜在风险都可以被检查和回溯。
 
-### 核心亮点
+## ✨ 亮点
 
-- **🚀 一条命令启动** —— `npm i -g @brainpilot/app` 后 `brainpilot up`，打开浏览器即可开工。
-- **🤝 主控 + 专家** —— 主控智能体通过文件信箱把任务委派给领域专家。
-- **📚 内置技能库** —— 经过验证的脑科学/认知科学方法学，按需经 MCP 检索调用。
-- **🔌 原生 MCP 工具** —— 接入任意 Model Context Protocol 服务（stdio / streamable-http / sse）。
-- **🔭 可检视的运行** —— 每个会话有独立工作区，外加一张记录全过程的轨迹图。
-- **🧩 自带模型** —— 默认走 Anthropic，也可在 Settings UI 配置任意 Anthropic / OpenAI 兼容网关。
+- **🧠 面向脑科学研究** — 支持从文献综述、假设细化、实验设计到数据分析、论文写作和科学审查的完整科研流程。
+- **🤝 总控智能体协调专业智能体团队** — 由总控智能体统一理解用户需求、规划任务，并协调文献智能体、分析智能体、实验智能体、写作智能体和审查智能体等专业智能体协同工作。
+- **📚 整合领域知识与科研技能** — 集成脑科学相关知识、研究方法、分析流程、写作规范和工具接口，使智能体能够调用专业知识完成具体科研任务。
+- **🛡️ 审查智能体提升科研可靠性** — 审查科学结论、证据链、引用来源、幻觉风险、遗漏信息和缺乏支撑的推理，帮助研究者发现潜在问题。
+- **🔭 流程追踪图展示研究过程** — 将任务结构、智能体行为、工具调用、证据流向和关键决策点可视化，方便研究者检查、回溯和干预。
+- **🔌 可扩展的科研工具生态** — 支持连接模型、MCP 工具、文献数据库、代码执行环境和自定义科研工具，适配不同研究场景。
+- **🚀 快速本地启动** — 简单安装后即可在浏览器中开始使用，降低脑科学智能体系统的部署和使用门槛。
 
 ---
 
@@ -64,8 +59,8 @@ BrainPilot 通过 **`@brainpilot/app`** 以本地进程方式运行 —— 无�
 
 ### 环境要求
 
-- **Node.js** ≥ 22
-- 一个 **Anthropic API Key** —— *或* 用 `BP_MOCK=1` 做无 Key 冒烟运行
+- **[Node.js](https://nodejs.org/en/download/)** ≥ 22
+- 用于智能体的**API Key**
 
 ### 1. 安装
 
@@ -77,27 +72,27 @@ npm install -g @brainpilot/app
 
 ### 2. 配置模型服务商
 
-BrainPilot **不绑定 Anthropic** —— 支持多种服务商协议：**Anthropic Messages**、**OpenAI
+BrainPilot 支持多种服务商协议：**Anthropic Messages**、**OpenAI
 Completions**、**OpenAI Responses** 和 **Azure OpenAI Responses**。按你的模型/网关所用协议任选。
 
 推荐做法是启动后用 **Web Settings UI**：打开 **Settings → Providers（服务商）**，添加一个服务商
 （base URL / key / 协议 / 模型列表），它会自动帮你写入配置。缺少 Key 不再阻塞启动：
 **`brainpilot up` 照常启动**，所以你完全可以先跳过、在浏览器里配置服务商。
 
-<details>
-<summary><b>更想用命令行？在 init 时生成配置</b></summary>
+
+<b>或者在 init 时生成配置</b>
 
 ```bash
 # Anthropic（默认协议）
 brainpilot init --api-key <你的-anthropic-key>   # 在 ./brainpilot 下生成配置
 
 # 一条命令接入网关 / 第三方端点
-brainpilot init --api-key <key> --base-url https://your-gateway.example.com/api --model kimi-k2.6
+brainpilot init --api-key <key> --base-url https://your-gateway.example.com/api --model deepseek-v4-pro
 ```
 
 也可以改用环境变量 `ANTHROPIC_API_KEY` 代替 `--api-key`。多服务商 / OpenAI 兼容端点的配置，见下方
 [使用自己的模型](#-使用自己的模型)。
-</details>
+
 
 ### 3. 启动
 

--- a/README.md
+++ b/README.md
@@ -79,17 +79,32 @@ npm install -g @brainpilot/app
 
 This installs the `brainpilot` CLI (`bnpt` is a built-in short alias for the same command).
 
-### 2. Initialize
+### 2. Configure a model provider
+
+BrainPilot is **not tied to Anthropic** — it supports multiple provider protocols:
+**Anthropic Messages**, **OpenAI Completions**, **OpenAI Responses**, and **Azure OpenAI
+Responses**. Pick whichever your model/gateway speaks.
+
+The recommended way is the **web Settings UI** after launch — open **Settings → Providers**,
+add a provider (base URL / key / protocol / model list), and it writes the config for you.
+A missing key no longer blocks launch: **`brainpilot up` starts anyway**, so you can skip
+ahead and configure the provider in the browser.
+
+<details>
+<summary><b>Prefer the command line? Scaffold config at init time</b></summary>
 
 ```bash
+# Anthropic (default protocol)
 brainpilot init --api-key <your-anthropic-key>   # scaffold config under ./brainpilot
+
+# A gateway / third-party endpoint in one command
+brainpilot init --api-key <key> --base-url https://your-gateway.example.com/api --model kimi-k2.6
 ```
 
-A missing key no longer blocks launch:
-
-- **`brainpilot up` starts anyway** — set the key later, no re-init needed.
-- **Set it in the web Settings UI** (recommended) — provider url / key / model; it writes the config for you.
-- **Or use the `ANTHROPIC_API_KEY` environment variable** instead.
+You can also supply the key via the `ANTHROPIC_API_KEY` environment variable instead of
+`--api-key`. For multi-provider / OpenAI-compatible setups, see
+[Using your own model](#-using-your-own-model) below.
+</details>
 
 ### 3. Launch
 
@@ -201,8 +216,11 @@ By default the agent pauses for approval before each command. A few tips:
 
 ## 🤖 Using your own model
 
-By default BrainPilot talks to Pi's built-in Anthropic endpoint. The easiest way to point
-it elsewhere is the **Settings UI** after launch: open **Settings → Providers** (the
+BrainPilot works with multiple provider protocols — **Anthropic Messages**, **OpenAI
+Completions**, **OpenAI Responses**, and **Azure OpenAI Responses** — so you can point it at
+Anthropic, an OpenAI-compatible endpoint, Azure, or any gateway in between.
+
+The easiest way is the **Settings UI** after launch: open **Settings → Providers** (the
 Settings button lives in the sidebar), then **Add Provider** to set the base URL, API key,
 protocol, and model list. You can **test** the connection and switch the active provider
 right there — it writes the config for you, no file editing required.

--- a/README.md
+++ b/README.md
@@ -2,11 +2,10 @@
   <img src="assets/banner.png" alt="BrainPilot" width="680"/>
 </p> -->
 
-<h1 align="center">🧠 BrainPilot</h1>
+<h1 align="center">🧠 BrainPilot: Enabling Agentic Research for Brain Science</h1>
 
 <p align="center">
-  An open-source multi-agent platform for trustworthy neuroscience research —
-  a Principal agent that coordinates specialist agents to read, reason, and run real analyses for you.
+BrainPilot is an open-source, human-in-the-loop agentic system for brain science that brings together specialist agents, domain knowledge, skills, and tools to help researchers in all scientific stages — review literature, design studies, run analyses, draft reports, and audit scientific claims.
 </p>
 
 <p align="center">
@@ -39,25 +38,17 @@
 
 ## 📖 Overview
 
-**BrainPilot** is an open-source, single-user multi-agent collaboration platform for
-neuroscience and cognitive-science research. A **Principal** agent talks to you, plans
-the work, and delegates to **specialist agents** (librarian, analyst, writer, …) that
-collaborate over a file-based mailbox. Every file an agent reads, writes, or generates
-lands in a real workspace on disk, and the whole run is captured as a **trace graph** you
-can inspect.
-
-It is built with **TypeScript + the [Pi SDK](https://pi.dev)** for agent orchestration,
-served as a **Hono** backend with a **React** single-page UI. The fastest way to run it is
-a single npm install — **no Docker required**.
+BrainPilot is an open-source AI research workspace for brain science. It helps researchers turn broad scientific questions into structured, inspectable workflows, from literature review and hypothesis refinement to experiment design, data analysis, writing, and audit. At its center, a Principal Agent communicates with the user, plans the work, and coordinates specialist agents such as librarian, analyst, experimentalist, writer, and auditor agents. BrainPilot is designed for human-in-the-loop scientific work: researchers remain in control, while agents handle evidence-heavy and cross-disciplinary tasks. The system integrates domain knowledge, methodological skills, and research tools, and records the process as a trace graph so that intermediate actions, evidence, claims, and potential risks can be inspected.
 
 ### Highlights
 
-- **🚀 One-command launch** — `npm i -g @brainpilot/app` then `brainpilot up`; open the browser and start working.
-- **🤝 Principal + specialists** — a coordinating agent delegates to domain specialists over a file-based mailbox.
-- **📚 Built-in skills library** — validated neuroscience & cognitive-science methodology, retrieved on demand via MCP.
-- **🔌 MCP-native tools** — connect any Model Context Protocol server (stdio / streamable-http / sse).
-- **🔭 Inspectable runs** — every session has its own workspace and a trace graph of what happened.
-- **🧩 Bring your own model** — Anthropic by default, or any Anthropic-/OpenAI-compatible gateway, configured from the Settings UI.
+- 🧠 Built for brain science research — supports workflows across literature review, hypothesis refinement, experiment design, data analysis, writing, and audit.
+- 🤝 Principal Agent + specialist agents — a coordinating Principal Agent works with domain specialists including librarian, analyst, experimentalist, writer, and auditor agents.
+- 📚 Integrated domain knowledge and skills — brings together brain-science knowledge, methodological skills, analysis procedures, writing conventions, and tool interfaces.
+- 🛡️ Auditor Agent for scientific reliability — reviews claims, evidence chains, citations, hallucination risks, omitted information, and unsupported reasoning.
+- 🔭 Traceable research process — represents each session as an inspectable trace graph, making task structure, agent actions, evidence flow, and decision points visible.
+- 🔌 Extensible research tool ecosystem — connects models, MCP tools, paper databases, code execution environments, and custom research utilities.
+- 🚀 Fast local start — install, launch, and begin working in the browser with minimal setup.
 
 ---
 
@@ -68,8 +59,8 @@ This is the recommended way to get started.
 
 ### Prerequisites
 
-- **Node.js** ≥ 22
-- An **Anthropic API key** — *or* `BP_MOCK=1` for a no-key smoke run
+- **[Node.js](https://nodejs.org/en/download/)** ≥ 22
+- An **API key** for Agent
 
 ### 1. Install
 
@@ -81,7 +72,7 @@ This installs the `brainpilot` CLI (`bnpt` is a built-in short alias for the sam
 
 ### 2. Configure a model provider
 
-BrainPilot is **not tied to Anthropic** — it supports multiple provider protocols:
+BrainPilot supports multiple provider protocols:
 **Anthropic Messages**, **OpenAI Completions**, **OpenAI Responses**, and **Azure OpenAI
 Responses**. Pick whichever your model/gateway speaks.
 
@@ -90,21 +81,19 @@ add a provider (base URL / key / protocol / model list), and it writes the confi
 A missing key no longer blocks launch: **`brainpilot up` starts anyway**, so you can skip
 ahead and configure the provider in the browser.
 
-<details>
-<summary><b>Prefer the command line? Scaffold config at init time</b></summary>
+<b>Or Scaffold config at init time</b>
 
 ```bash
 # Anthropic (default protocol)
 brainpilot init --api-key <your-anthropic-key>   # scaffold config under ./brainpilot
 
 # A gateway / third-party endpoint in one command
-brainpilot init --api-key <key> --base-url https://your-gateway.example.com/api --model kimi-k2.6
+brainpilot init --api-key <key> --base-url https://your-gateway.example.com/api --model deepseek-v4-pro
 ```
 
 You can also supply the key via the `ANTHROPIC_API_KEY` environment variable instead of
 `--api-key`. For multi-provider / OpenAI-compatible setups, see
 [Using your own model](#-using-your-own-model) below.
-</details>
 
 ### 3. Launch
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "brainpilot",
-  "version": "0.0.6",
+  "version": "0.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "brainpilot",
-      "version": "0.0.6",
-      "license": "Apache-2.0",
+      "version": "0.0.8",
+      "license": "AGPL-3.0-only",
       "workspaces": [
         "packages/protocol",
         "packages/runtime",
@@ -854,7 +854,7 @@
         "typebox": "1.1.38"
       },
       "bin": {
-        "pi-ai": "dist/cli.js"
+        "pi-ai": "./dist/cli.js"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -8323,11 +8323,11 @@
     },
     "packages/backend-core": {
       "name": "@brainpilot/backend-core",
-      "version": "0.0.6",
-      "license": "Apache-2.0",
+      "version": "0.0.8",
+      "license": "AGPL-3.0-only",
       "dependencies": {
-        "@brainpilot/protocol": "^0.0.6",
-        "@brainpilot/runtime": "^0.0.6",
+        "@brainpilot/protocol": "^0.0.8",
+        "@brainpilot/runtime": "^0.0.8",
         "@hono/node-server": "^1.13.0",
         "hono": "^4.6.0"
       },
@@ -8343,13 +8343,13 @@
     },
     "packages/cli": {
       "name": "@brainpilot/app",
-      "version": "0.0.6",
-      "license": "Apache-2.0",
+      "version": "0.0.8",
+      "license": "AGPL-3.0-only",
       "dependencies": {
-        "@brainpilot/backend-core": "^0.0.6",
-        "@brainpilot/protocol": "^0.0.6",
-        "@brainpilot/runtime": "^0.0.6",
-        "@brainpilot/web": "^0.0.6",
+        "@brainpilot/backend-core": "^0.0.8",
+        "@brainpilot/protocol": "^0.0.8",
+        "@brainpilot/runtime": "^0.0.8",
+        "@brainpilot/web": "^0.0.8",
         "commander": "^12.1.0",
         "picocolors": "^1.1.0"
       },
@@ -8363,7 +8363,7 @@
     },
     "packages/client-cli": {
       "name": "@brainpilot/client-cli",
-      "version": "0.0.6",
+      "version": "0.0.8",
       "dependencies": {
         "@brainpilot/protocol": "*",
         "commander": "^12.1.0"
@@ -8374,8 +8374,8 @@
     },
     "packages/protocol": {
       "name": "@brainpilot/protocol",
-      "version": "0.0.6",
-      "license": "Apache-2.0",
+      "version": "0.0.8",
+      "license": "AGPL-3.0-only",
       "dependencies": {
         "zod": "^3.24.0"
       },
@@ -8385,11 +8385,11 @@
     },
     "packages/runtime": {
       "name": "@brainpilot/runtime",
-      "version": "0.0.6",
-      "license": "Apache-2.0",
+      "version": "0.0.8",
+      "license": "AGPL-3.0-only",
       "dependencies": {
-        "@brainpilot/protocol": "^0.0.6",
-        "@brainpilot/skills": "^0.0.6",
+        "@brainpilot/protocol": "^0.0.8",
+        "@brainpilot/skills": "^0.0.8",
         "@earendil-works/pi-coding-agent": "^0.79.0",
         "@hono/node-server": "^1.19.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
@@ -8402,18 +8402,18 @@
     },
     "packages/skills": {
       "name": "@brainpilot/skills",
-      "version": "0.0.6",
-      "license": "Apache-2.0",
+      "version": "0.0.8",
+      "license": "AGPL-3.0-only",
       "engines": {
         "node": ">=22"
       }
     },
     "packages/web": {
       "name": "@brainpilot/web",
-      "version": "0.0.6",
-      "license": "Apache-2.0",
+      "version": "0.0.8",
+      "license": "AGPL-3.0-only",
       "devDependencies": {
-        "@brainpilot/protocol": "^0.0.6",
+        "@brainpilot/protocol": "^0.0.8",
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource-variable/geist-mono": "^5.2.8",
         "@types/react": "^18.3.12",

--- a/packages/backend-core/src/app.ts
+++ b/packages/backend-core/src/app.ts
@@ -14,6 +14,7 @@
  * `API_BASE = "/api"`), with static assets served at the root.
  */
 import { createRequire } from "node:module";
+import { join } from "node:path";
 import { Hono } from "hono";
 import { serveStatic } from "@hono/node-server/serve-static";
 import {
@@ -294,7 +295,7 @@ export function createApp(options: CreateAppOptions): Hono {
   if (options.serveWeb !== false) {
     app.use("/*", serveStatic({ root: webRoot }));
     // SPA fallback: any unmatched GET that isn't /api returns index.html.
-    app.get("/*", serveStatic({ path: `${webRoot}/index.html` }));
+    app.get("/*", serveStatic({ path: join(webRoot, "index.html") }));
   }
 
   return app;

--- a/packages/backend-core/src/config.ts
+++ b/packages/backend-core/src/config.ts
@@ -106,10 +106,22 @@ export interface ResolveProviderOptions {
 /* ----------------------------- providers.json ----------------------------- *
  * The provider registry is the SSOT for LLM credentials in single-user mode.
  * It stores FULL profiles (incl. plaintext apiKey) on disk under bp_template/;
- * the data dir is gitignored and written 0600. The HTTP layer never returns the
- * plaintext key — it masks it (see app.ts `toHttpProfile`). A session selects a
- * profile + model by id; resolveProvider() resolves the *selected* profile
- * first, falling back to the legacy env/dotenv chain for backward compat.
+ * the data dir is gitignored. The HTTP layer never returns the plaintext key
+ * — it masks it (see app.ts `toHttpProfile`). A session selects a profile +
+ * model by id; resolveProvider() resolves the *selected* profile first,
+ * falling back to the legacy env/dotenv chain for backward compat.
+ *
+ * #4 — cross-platform file-mode caveat:
+ *   - POSIX hosts: we write providers.json with `mode: 0o600` (owner R/W only),
+ *     which is the standard "this file contains a secret" guard.
+ *   - Windows hosts: Node's `mode` parameter only maps to the FAT-era read-
+ *     only attribute; it does NOT translate to a Windows ACL. The file ends
+ *     up with whatever ACL it inherits from the parent directory (typically
+ *     `Users: Read`), so other local user accounts on the same machine can
+ *     read it. Treat the at-rest key on Windows as protected at the
+ *     filesystem-permission level only by your account login / disk encryption
+ *     (BitLocker, EFS). Future work: OS keychain (Win Credential Manager /
+ *     macOS Keychain / libsecret) for true plaintext-free at-rest storage.
  * -------------------------------------------------------------------------- */
 
 /** A stored provider profile (internal — holds the plaintext key). */

--- a/packages/backend-core/src/docker-orchestrator.ts
+++ b/packages/backend-core/src/docker-orchestrator.ts
@@ -151,8 +151,26 @@ export class DockerOrchestrator implements Orchestrator {
       ExposedPorts: { [portKey]: {} },
       HostConfig: {
         PortBindings: { [portKey]: [{ HostPort: String(this.hostPort) }] },
+        // Cross-platform (#1): the legacy `Binds: ["src:dst:mode"]` colon-
+        // delimited form is unparseable when `src` is a Windows path that
+        // already contains a colon after the drive letter
+        // (`C:\Users\foo\bp` → `C:\Users\foo\bp:/root/...:rw`), causing
+        // dockerode/Docker Engine to mis-split the spec and either 422 the
+        // container create or mount a host directory named just `C`. Use the
+        // structured `Mounts` API (Docker Engine ≥1.25) instead — Source /
+        // Target / ReadOnly are separate fields, so Engine's own
+        // Windows-aware path translation does the right thing.
         ...(this.dataDir
-          ? { Binds: [`${this.dataDir}:${this.containerDataDir}:rw`] }
+          ? {
+              Mounts: [
+                {
+                  Type: "bind",
+                  Source: this.dataDir,
+                  Target: this.containerDataDir,
+                  ReadOnly: false,
+                },
+              ],
+            }
           : {}),
       },
     };

--- a/packages/backend-core/src/local-orchestrator.ts
+++ b/packages/backend-core/src/local-orchestrator.ts
@@ -16,6 +16,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { createRequire } from "node:module";
 import { openSync, closeSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
 import { dirname } from "node:path";
+import { gracefulSignalsSupported } from "@brainpilot/runtime";
 import type {
   EnsureRuntimeOptions,
   Orchestrator,
@@ -231,7 +232,13 @@ export class LocalProcessOrchestrator implements Orchestrator {
     this.removePidFile();
     if (child) {
       try {
-        child.kill("SIGTERM");
+        // Cross-platform (#6): on Windows `child.kill("SIGTERM")` is translated
+        // to `TerminateProcess` (a forceful kill the child cannot intercept),
+        // so the SIGTERM/SIGKILL distinction is meaningless. We call the
+        // platform-appropriate signal explicitly so the intent reads correctly
+        // at the call-site and Windows logs don't show a phantom "graceful"
+        // shutdown that never actually ran the child's signal handlers.
+        child.kill(gracefulSignalsSupported ? "SIGTERM" : "SIGKILL");
       } catch {
         /* already gone */
       }

--- a/packages/backend-core/src/provider-probe.ts
+++ b/packages/backend-core/src/provider-probe.ts
@@ -31,10 +31,17 @@ export interface ProbeInput {
   apiKey: string;
 }
 
-/** Strip absolute node_modules paths from any error text before surfacing it. */
+/**
+ * Strip absolute node_modules paths from any error text before surfacing it.
+ *
+ * Cross-platform (#157): accept BOTH `/` and `\` separators, plus an optional
+ * Windows drive prefix. A native Windows path like
+ * `C:\Users\<user>\…\node_modules\@pkg\file.md` previously slipped through
+ * unredacted, leaking the username into the Test-button error toast.
+ */
 function redact(text: string): string {
   return text
-    .replace(/(?:\/[^\s:]*)?node_modules\/[^\s)]*/g, "<path>")
+    .replace(/(?:[A-Za-z]:)?(?:[\\/][^\s:]*)?node_modules[\\/][^\s)]*/g, "<path>")
     .replace(/\s+/g, " ")
     .trim();
 }

--- a/packages/backend-core/src/server.ts
+++ b/packages/backend-core/src/server.ts
@@ -19,6 +19,13 @@ export interface StartServerOptions extends Partial<CreateAppOptions> {
   eager?: boolean;
   /** When true, the runtime child inherits stdio (foreground CLI mode). */
   stdioInherit?: boolean;
+  /**
+   * Port the local runtime should bind. Forwarded to the local orchestrator so
+   * the foreground (in-process) path honours `--port` (runtime = backend + 1)
+   * instead of falling back to AGENT_RUNTIME_PORT/8081 (#171). The detached path
+   * injects the same value via the AGENT_RUNTIME_PORT env var (spawn-backend).
+   */
+  runtimePort?: number;
 }
 
 export interface RunningServer {
@@ -46,6 +53,7 @@ export function buildServerOrchestrator(
     createOrchestrator({
       local: {
         dataDir: options.dataDir,
+        ...(options.runtimePort !== undefined ? { port: options.runtimePort } : {}),
         ...(options.stdioInherit ? { stdioInherit: true } : {}),
       },
     })

--- a/packages/backend-core/src/server.ts
+++ b/packages/backend-core/src/server.ts
@@ -3,6 +3,7 @@
  * Exported via the package's `./server` entry. The orchestrator's runtime is
  * started lazily on the first request that needs it; graceful shutdown stops it.
  */
+import { pathToFileURL } from "node:url";
 import { serve, type ServerType } from "@hono/node-server";
 import { createApp, type CreateAppOptions } from "./app.js";
 import { createOrchestrator } from "./create-orchestrator.js";
@@ -85,9 +86,11 @@ export async function startServer(
 }
 
 // Allow `node dist/server.js` to boot directly.
+// pathToFileURL keeps the main-module check correct on Windows (a naive
+// `file://${argv[1]}` never matches import.meta.url there).
 const isMain =
   typeof process.argv[1] === "string" &&
-  import.meta.url === `file://${process.argv[1]}`;
+  import.meta.url === pathToFileURL(process.argv[1]).href;
 if (isMain) {
   startServer().then(
     (s) => {

--- a/packages/backend-core/src/server.ts
+++ b/packages/backend-core/src/server.ts
@@ -7,7 +7,7 @@ import { serve, type ServerType } from "@hono/node-server";
 import { createApp, type CreateAppOptions } from "./app.js";
 import { createOrchestrator } from "./create-orchestrator.js";
 import { bootstrapEnvProvider } from "./config.js";
-import type { Orchestrator } from "./orchestrator.js";
+import type { Orchestrator, OrchestratorMode } from "./orchestrator.js";
 
 export interface StartServerOptions extends Partial<CreateAppOptions> {
   /** Backend port. Default 9001 (§11A.5 决策 D). */
@@ -15,6 +15,13 @@ export interface StartServerOptions extends Partial<CreateAppOptions> {
   hostname?: string;
   /** Provide a pre-built orchestrator; otherwise one is created from env. */
   orchestrator?: Orchestrator;
+  /**
+   * Force the orchestrator mode. When omitted the mode is resolved from env
+   * (BP_ORCHESTRATOR / BP_RUNTIME_URL / BP_MODE). The `brainpilot up` CLI passes
+   * this explicitly so a stray BP_RUNTIME_URL can't silently flip a local
+   * source-launch into static (sandbox) mode.
+   */
+  mode?: OrchestratorMode;
   /** Eagerly ensure the runtime at boot (default false — lazy on first use). */
   eager?: boolean;
   /** When true, the runtime child inherits stdio (foreground CLI mode). */
@@ -44,6 +51,11 @@ export function buildServerOrchestrator(
   return (
     options.orchestrator ??
     createOrchestrator({
+      // Pass the mode explicitly when set (the `brainpilot up` CLI does) so a
+      // stray BP_RUNTIME_URL/BP_MODE in the environment can't silently flip a
+      // local source-launch into static/docker. When omitted, createOrchestrator
+      // falls back to env resolution (Docker compose relies on that path).
+      ...(options.mode ? { mode: options.mode } : {}),
       local: {
         dataDir: options.dataDir,
         ...(options.stdioInherit ? { stdioInherit: true } : {}),

--- a/packages/backend-core/src/static-orchestrator.ts
+++ b/packages/backend-core/src/static-orchestrator.ts
@@ -69,8 +69,14 @@ export class StaticRuntimeOrchestrator implements Orchestrator {
       if (Date.now() >= deadline) {
         throw new Error(
           `static runtime did not become healthy at ${this.url} within ` +
-            `${this.healthTimeoutMs}ms — is the sandbox container up? ` +
-            `(check \`docker compose logs sandbox\` and BP_RUNTIME_URL)`,
+            `${this.healthTimeoutMs}ms.\n` +
+            `  This is STATIC (sandbox) mode: the backend is trying to reach a ` +
+            `pre-started runtime container at BP_RUNTIME_URL.\n` +
+            `  • If you meant to run a Docker deployment: check it is up ` +
+            `(\`docker compose logs sandbox\`) and that BP_RUNTIME_URL is correct.\n` +
+            `  • If you meant to run from source: you likely have a stray ` +
+            `BP_RUNTIME_URL/BP_ORCHESTRATOR in your environment. Run ` +
+            `\`brainpilot up --mode local\` (or \`unset BP_RUNTIME_URL BP_ORCHESTRATOR\`).`,
         );
       }
       await this.sleep(this.pollMs);

--- a/packages/backend-core/test/create-orchestrator.test.ts
+++ b/packages/backend-core/test/create-orchestrator.test.ts
@@ -107,6 +107,66 @@ describe("DockerOrchestrator (stubbed dockerode)", () => {
     expect(container.stop).toHaveBeenCalledTimes(1);
   });
 
+  // #1 — cross-platform: the legacy `Binds: ["src:dst:rw"]` colon-string is
+  // unparseable when `src` is a Windows path that already contains a colon
+  // after the drive letter, so we use the structured `Mounts` API instead.
+  // The two assertions below pin that contract: a structured `Mounts` array
+  // exists with the bind shape, and the deprecated `Binds` field is gone.
+  it("uses HostConfig.Mounts (structured) instead of Binds for bind mounts (#1)", async () => {
+    const container = {
+      start: vi.fn(async () => {}),
+      stop: vi.fn(async () => {}),
+      remove: vi.fn(async () => {}),
+    };
+    const docker = {
+      createContainer: vi.fn(async () => container),
+    } as never;
+    const orch = new DockerOrchestrator({
+      docker,
+      image: "brainpilot-sandbox:test",
+      containerPort: 8081,
+      hostPort: 18081,
+      dataDir: "/host/bp",
+      containerDataDir: "/root/.bp-root",
+      healthProbe: async () => true,
+      sleep: async () => {},
+    });
+    await orch.ensureRuntime();
+    const createArg = (docker as { createContainer: ReturnType<typeof vi.fn> })
+      .createContainer.mock.calls[0]![0] as { HostConfig?: Record<string, unknown> };
+    const hostConfig = createArg.HostConfig!;
+    expect(hostConfig.Binds).toBeUndefined();
+    expect(hostConfig.Mounts).toEqual([
+      { Type: "bind", Source: "/host/bp", Target: "/root/.bp-root", ReadOnly: false },
+    ]);
+  });
+
+  // The bind-mount block is conditional on `dataDir` — when no dataDir is
+  // configured the container runs without a host bind, and neither field
+  // should be present (matches the original code path's intent).
+  it("emits neither Binds nor Mounts when no dataDir is configured (#1)", async () => {
+    const container = {
+      start: vi.fn(async () => {}),
+      stop: vi.fn(async () => {}),
+      remove: vi.fn(async () => {}),
+    };
+    const docker = {
+      createContainer: vi.fn(async () => container),
+    } as never;
+    const orch = new DockerOrchestrator({
+      docker,
+      image: "brainpilot-sandbox:test",
+      healthProbe: async () => true,
+      sleep: async () => {},
+    });
+    await orch.ensureRuntime();
+    const createArg = (docker as { createContainer: ReturnType<typeof vi.fn> })
+      .createContainer.mock.calls[0]![0] as { HostConfig?: Record<string, unknown> };
+    const hostConfig = createArg.HostConfig!;
+    expect(hostConfig.Binds).toBeUndefined();
+    expect(hostConfig.Mounts).toBeUndefined();
+  });
+
   it("auto-pulls the image when createContainer reports it is missing", async () => {
     const container = {
       start: vi.fn(async () => {}),

--- a/packages/backend-core/test/provider-probe.test.ts
+++ b/packages/backend-core/test/provider-probe.test.ts
@@ -94,4 +94,19 @@ describe("probeProvider (#55)", () => {
     );
     expect(r.message).not.toMatch(/node_modules/);
   });
+
+  it("redacts native Windows node_modules paths (incl. username) from error messages (#157)", async () => {
+    const fetchFn = vi.fn(async () => {
+      throw new Error(
+        "boom at C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules\\undici\\lib\\x.js:1",
+      );
+    });
+    const r = await probeProvider(
+      { baseUrl: "https://gw/api", apiKey: "sk" },
+      { fetchFn: fetchFn as never },
+    );
+    expect(r.message).not.toMatch(/node_modules/);
+    expect(r.message).not.toMatch(/alice/);
+    expect(r.message).not.toMatch(/C:\\Users/i);
+  });
 });

--- a/packages/backend-core/test/server.test.ts
+++ b/packages/backend-core/test/server.test.ts
@@ -33,6 +33,32 @@ describe("buildServerOrchestrator", () => {
     expect(env.BP_DATA_DIR).toBe("/data/detached");
   });
 
+  it("threads runtimePort through to the local runtime env (#171)", () => {
+    // Foreground path: `up` prechecks port+1 and must pass it to the backend so
+    // the runtime binds there instead of the AGENT_RUNTIME_PORT/8081 fallback.
+    const orch = buildServerOrchestrator({
+      dataDir: "/data/xyz",
+      stdioInherit: true,
+      runtimePort: 9501,
+    });
+    expect(orch).toBeInstanceOf(LocalProcessOrchestrator);
+    const env = (orch as LocalProcessOrchestrator).buildEnv();
+    expect(env.AGENT_RUNTIME_PORT).toBe("9501");
+  });
+
+  it("falls back to the default runtime port when runtimePort is omitted (#171)", () => {
+    const prev = process.env.AGENT_RUNTIME_PORT;
+    delete process.env.AGENT_RUNTIME_PORT;
+    try {
+      const orch = buildServerOrchestrator({ dataDir: "/data/xyz", stdioInherit: true });
+      const env = (orch as LocalProcessOrchestrator).buildEnv();
+      expect(env.AGENT_RUNTIME_PORT).toBe("8081");
+    } finally {
+      if (prev === undefined) delete process.env.AGENT_RUNTIME_PORT;
+      else process.env.AGENT_RUNTIME_PORT = prev;
+    }
+  });
+
   it("returns an injected orchestrator verbatim (short-circuit)", () => {
     const injected = { id: "injected" } as unknown as Orchestrator;
     expect(buildServerOrchestrator({ orchestrator: injected })).toBe(injected);

--- a/packages/cli/src/commands/down-status.test.ts
+++ b/packages/cli/src/commands/down-status.test.ts
@@ -112,6 +112,36 @@ describe("down", () => {
     // Only the backend was signalled; no runtime pid to chase.
     expect(procs.signals).toEqual([{ pid: 1234, sig: "SIGTERM" }]);
   });
+
+  // #6 — cross-platform: on Windows POSIX signals are translated to
+  // TerminateProcess (a force kill the target can't intercept), so the
+  // SIGTERM-then-wait dance is pure waste. With gracefulSignals=false the
+  // stop path must skip straight to a single SIGKILL and report `forced`.
+  it("skips SIGTERM and goes straight to SIGKILL when graceful signals unsupported (#6)", async () => {
+    const root = join(dir, "bp");
+    const p = dataPaths(root);
+    await writePid(p.backendPid, 1234);
+    // The process stays "alive" until signalled — fakeProcs deletes on
+    // SIGTERM|SIGKILL, so a single SIGKILL is enough.
+    const procs = fakeProcs(new Set([1234]));
+    // Track how long we'd have slept if the wait loop ran. Should be zero.
+    let sleeps = 0;
+    const trackedSleep = async (_ms: number): Promise<void> => {
+      sleeps += 1;
+    };
+
+    const res = await down(
+      { dir: root, timeoutMs: 10_000 },
+      { ...procs, sleep: trackedSleep, gracefulSignals: false, log: () => {} },
+    );
+
+    expect(res.stopped).toBe(true);
+    expect(res.pid).toBe(1234);
+    expect(res.forced).toBe(true);
+    // Exactly one signal: SIGKILL. No SIGTERM, no poll-loop sleeping.
+    expect(procs.signals).toEqual([{ pid: 1234, sig: "SIGKILL" }]);
+    expect(sleeps).toBe(0);
+  });
 });
 
 describe("status", () => {

--- a/packages/cli/src/commands/down.ts
+++ b/packages/cli/src/commands/down.ts
@@ -40,6 +40,7 @@ export async function down(
     isAlive: deps.isAlive,
     signal: deps.signal,
     sleep: deps.sleep,
+    gracefulSignals: deps.gracefulSignals,
   });
 
   // Backstop the runtime (issue #58): the backend normally kills its runtime
@@ -52,6 +53,7 @@ export async function down(
     isAlive: deps.isAlive,
     signal: deps.signal,
     sleep: deps.sleep,
+    gracefulSignals: deps.gracefulSignals,
   });
   // Drop the persisted server state so a later `status` doesn't report a dead
   // server's ports (issue #41).

--- a/packages/cli/src/commands/template.test.ts
+++ b/packages/cli/src/commands/template.test.ts
@@ -53,6 +53,35 @@ describe("templateList", () => {
   });
 });
 
+// #3 — cross-platform: Windows editors and `git autocrlf=true` save the
+// on-disk `prompt.md` with CRLF, but `PERSONAS[name]` is shipped as an LF
+// TypeScript string literal. Without the CRLF collapse, every line from the
+// second onward differs by one `\r`, every agent reports `drift` on every
+// Windows install, and `bp template diff` paints the whole file red/green.
+describe("CRLF tolerance (#3)", () => {
+  it("a CRLF-line-ended on-disk file matching the built-in is `in-sync`, not `drift`", async () => {
+    const crlf = PERSONAS.principal!.replace(/\n/g, "\r\n");
+    await writePrompt("principal", crlf);
+    const rows = await templateList({ dir, env: {}, cwd: "/" });
+    expect(rows.find((r) => r.name === "principal")?.state).toBe("in-sync");
+  });
+
+  it("`detectPromptDrift` reports a CRLF-converted file as no-drift", async () => {
+    await writePrompt("principal", PERSONAS.principal!.replace(/\n/g, "\r\n"));
+    await writePrompt("librarian", PERSONAS.librarian!.replace(/\n/g, "\r\n"));
+    expect(await detectPromptDrift(dir)).toEqual([]);
+  });
+
+  it("`runDiff` produces no `+`/`-` rows for a CRLF copy of the built-in", async () => {
+    await writePrompt("trace", PERSONAS.trace!.replace(/\n/g, "\r\n"));
+    const out: string[] = [];
+    await runDiff({ dir, env: {}, cwd: "/", agent: "trace", log: (m) => out.push(m) });
+    // After the CRLF fold, the on-disk file should match the built-in, so the
+    // command's "no drift" path is hit and no diff body is emitted.
+    expect(out.join("\n")).toMatch(/no drift/);
+  });
+});
+
 describe("detectPromptDrift", () => {
   it("returns only drifted agents", async () => {
     await writePrompt("principal", PERSONAS.principal!);

--- a/packages/cli/src/commands/template.ts
+++ b/packages/cli/src/commands/template.ts
@@ -63,10 +63,17 @@ async function readOrNull(p: string): Promise<string | null> {
   }
 }
 
-/** Normalize for byte-level comparison: strip a single trailing newline so
- *  hand-edited files don't show as `drift` over a meaningless EOL. */
+/** Normalize for byte-level comparison so an EOL-only or line-ending-only
+ *  divergence doesn't show as `drift`. Cross-platform (#3): Windows editors
+ *  and git's `autocrlf=true` save `prompt.md` with CRLF, but the built-in
+ *  persona strings ship as LF — without the CRLF collapse, every line from
+ *  the second onward differs by one `\r`, so every agent reports `drift` on
+ *  every Windows install and `bp template diff` paints the whole file
+ *  red/green. We fold CRLF → LF first, then strip a single trailing
+ *  newline. */
 function normalize(s: string): string {
-  return s.endsWith("\n") ? s.slice(0, -1) : s;
+  const lf = s.replace(/\r\n/g, "\n");
+  return lf.endsWith("\n") ? lf.slice(0, -1) : lf;
 }
 
 /** Compute drift status for every built-in agent (or just one). */
@@ -151,8 +158,11 @@ export async function runList(options: CommonOptions = {}): Promise<void> {
  * in a `diff` dependency for what is effectively a debug helper.
  */
 function unifiedDiff(a: string, b: string, label: string): string {
-  const aLines = a.split("\n");
-  const bLines = b.split("\n");
+  // Cross-platform (#3): the diff is computed line-by-line on `\n` splits,
+  // so a CRLF disk file vs an LF built-in would otherwise compare every line
+  // as "different by one `\r`" and paint the entire output. Fold first.
+  const aLines = a.replace(/\r\n/g, "\n").split("\n");
+  const bLines = b.replace(/\r\n/g, "\n").split("\n");
   const lines: string[] = [];
   lines.push(pc.bold(`--- ${label} (built-in)`));
   lines.push(pc.bold(`+++ ${label} (on-disk)`));

--- a/packages/cli/src/commands/up.test.ts
+++ b/packages/cli/src/commands/up.test.ts
@@ -194,6 +194,9 @@ describe("up — foreground start", () => {
       dataDir: root,
       serveWeb: true,
       webRoot: "/web/dist",
+      // #171: the prechecked runtime port (port + 1) must reach the backend,
+      // not just be computed into result.config.
+      runtimePort: 9501,
     });
     expect(result.server).toBe(fakeServer);
     expect(result.url).toBe("http://127.0.0.1:9500");

--- a/packages/cli/src/commands/up.test.ts
+++ b/packages/cli/src/commands/up.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   up,
   buildStartServerOptions,
+  resolveUpMode,
   PortInUseError,
   portFlagHint,
   type ResolvedUpConfig,
@@ -32,6 +33,7 @@ describe("buildStartServerOptions", () => {
       webDist: "/web/dist",
       foreground: true,
       open: false,
+      mode: "local",
     };
     const opts = buildStartServerOptions(cfg);
     expect(opts).toMatchObject({
@@ -40,6 +42,7 @@ describe("buildStartServerOptions", () => {
       dataDir: "/data",
       serveWeb: true,
       webRoot: "/web/dist",
+      mode: "local",
     });
   });
 
@@ -52,10 +55,42 @@ describe("buildStartServerOptions", () => {
       webDist: null,
       foreground: true,
       open: false,
+      mode: "local",
     };
     const opts = buildStartServerOptions(cfg);
     expect(opts.serveWeb).toBe(false);
     expect("webRoot" in opts).toBe(false);
+  });
+});
+
+describe("resolveUpMode", () => {
+  it("defaults to local with an empty env (the source-launch default)", () => {
+    expect(resolveUpMode(undefined, {})).toBe("local");
+  });
+
+  it("IGNORES a stray BP_RUNTIME_URL — the core fix (no accidental sandbox)", () => {
+    // A leftover BP_RUNTIME_URL from a `docker compose` session must NOT flip a
+    // source launch into static mode. The backend's env resolver would; the CLI
+    // resolver deliberately does not.
+    expect(resolveUpMode(undefined, { BP_RUNTIME_URL: "http://sandbox:8081" })).toBe("local");
+  });
+
+  it("IGNORES a stray BP_MODE=docker", () => {
+    expect(resolveUpMode(undefined, { BP_MODE: "docker" })).toBe("local");
+  });
+
+  it("honors an explicit --mode option", () => {
+    expect(resolveUpMode("static", { BP_RUNTIME_URL: "http://x" })).toBe("static");
+    expect(resolveUpMode("docker", {})).toBe("docker");
+  });
+
+  it("honors an explicit BP_ORCHESTRATOR when no --mode given", () => {
+    expect(resolveUpMode(undefined, { BP_ORCHESTRATOR: "static" })).toBe("static");
+    expect(resolveUpMode(undefined, { BP_ORCHESTRATOR: "docker" })).toBe("docker");
+  });
+
+  it("--mode wins over BP_ORCHESTRATOR", () => {
+    expect(resolveUpMode("local", { BP_ORCHESTRATOR: "static" })).toBe("local");
   });
 });
 
@@ -198,6 +233,51 @@ describe("up — foreground start", () => {
     expect(result.server).toBe(fakeServer);
     expect(result.url).toBe("http://127.0.0.1:9500");
     expect(result.config.runtimePort).toBe(9501);
+  });
+
+  it("forces mode=local and prints a local banner even with a stray BP_RUNTIME_URL", async () => {
+    const root = join(dir, "bp");
+    let captured: StartServerOptions | undefined;
+    const logs: string[] = [];
+    await up(
+      { dir: root, port: 9550, foreground: true, open: false },
+      {
+        env: { ANTHROPIC_API_KEY: "sk", BP_RUNTIME_URL: "http://sandbox:8081" },
+        startServer: async (opts) => {
+          captured = opts;
+          return { stop: async () => {} } as unknown as RunningServer;
+        },
+        isPortFree: freePorts(),
+        webDist: () => null,
+        log: (m) => logs.push(m),
+      },
+    );
+    // The stray BP_RUNTIME_URL must NOT have flipped us into static mode.
+    expect(captured?.mode).toBe("local");
+    expect(logs.join("\n")).toContain("mode=local");
+  });
+
+  it("passes mode=static and warns when --mode static is explicit", async () => {
+    const root = join(dir, "bp");
+    let captured: StartServerOptions | undefined;
+    const logs: string[] = [];
+    await up(
+      { dir: root, port: 9560, foreground: true, open: false, mode: "static" },
+      {
+        env: { ANTHROPIC_API_KEY: "sk", BP_RUNTIME_URL: "http://sandbox:8081" },
+        startServer: async (opts) => {
+          captured = opts;
+          return { stop: async () => {} } as unknown as RunningServer;
+        },
+        isPortFree: freePorts(),
+        webDist: () => null,
+        log: (m) => logs.push(m),
+      },
+    );
+    expect(captured?.mode).toBe("static");
+    const text = logs.join("\n");
+    expect(text).toContain("mode=static");
+    expect(text).toContain("--mode");
   });
 
   it("calls the browser-open hook when open=true", async () => {

--- a/packages/cli/src/commands/up.ts
+++ b/packages/cli/src/commands/up.ts
@@ -73,8 +73,12 @@ export function buildStartServerOptions(
     dataDir: cfg.dataDir,
     serveWeb: cfg.webDist !== null,
     stdioInherit: cfg.foreground,
+    // #171: carry the prechecked runtime port into the in-process backend so the
+    // foreground path binds the runtime on `port + 1` (honouring `--port`)
+    // instead of the orchestrator's AGENT_RUNTIME_PORT/8081 fallback. The
+    // detached path passes the same value via env (spawn-backend.ts).
+    runtimePort: cfg.runtimePort,
     ...(cfg.webDist ? { webRoot: cfg.webDist } : {}),
-    // The backend creates a LocalProcessOrchestrator from env (BP_MODE=single).
   } satisfies StartServerOptions;
 }
 

--- a/packages/cli/src/commands/up.ts
+++ b/packages/cli/src/commands/up.ts
@@ -16,7 +16,7 @@
  */
 import { resolveProvider, describeProviderConfig, formatProviderGuidance } from "@brainpilot/backend-core";
 import type { StartServerOptions, RunningServer } from "@brainpilot/backend-core";
-import { isMockMode } from "@brainpilot/runtime";
+import { isMockMode, isMacOS, isWindows } from "@brainpilot/runtime";
 import pc from "picocolors";
 import { resolveDataDir, dataPaths } from "../paths.js";
 import { scaffold, isScaffolded, DEFAULT_PORT } from "../scaffold.js";
@@ -245,13 +245,11 @@ async function maybeOpen(deps: UpDeps, url: string): Promise<void> {
 /** Open a URL in the OS default browser using the platform launcher (no deps). */
 const defaultOpenBrowser = async (url: string): Promise<void> => {
   const { spawn } = await import("node:child_process");
-  const platform = process.platform;
-  const [cmd, args] =
-    platform === "darwin"
-      ? ["open", [url]]
-      : platform === "win32"
-        ? ["cmd", ["/c", "start", "", url]]
-        : ["xdg-open", [url]];
+  const [cmd, args] = isMacOS
+    ? ["open", [url]]
+    : isWindows
+      ? ["cmd", ["/c", "start", "", url]]
+      : ["xdg-open", [url]];
   const child = spawn(cmd as string, args as string[], { stdio: "ignore", detached: true });
   child.on("error", () => {}); // launcher missing (e.g. headless Linux) — ignore
   child.unref();

--- a/packages/cli/src/commands/up.ts
+++ b/packages/cli/src/commands/up.ts
@@ -15,7 +15,7 @@
  * is injectable so tests drive it without a real server.
  */
 import { resolveProvider, describeProviderConfig, formatProviderGuidance } from "@brainpilot/backend-core";
-import type { StartServerOptions, RunningServer } from "@brainpilot/backend-core";
+import type { StartServerOptions, RunningServer, OrchestratorMode } from "@brainpilot/backend-core";
 import { isMockMode } from "@brainpilot/runtime";
 import pc from "picocolors";
 import { resolveDataDir, dataPaths } from "../paths.js";
@@ -33,6 +33,8 @@ export interface UpOptions {
   foreground?: boolean;
   /** `--no-open` to suppress the browser. */
   open?: boolean;
+  /** `--mode <local|static|docker>` force the orchestrator mode (default local). */
+  mode?: OrchestratorMode;
 }
 
 /** Injectable collaborators (defaults wire to real implementations). */
@@ -61,6 +63,30 @@ export interface ResolvedUpConfig {
   webDist: string | null;
   foreground: boolean;
   open: boolean;
+  /** Orchestrator mode passed explicitly to the backend (default local). */
+  mode: OrchestratorMode;
+}
+
+/**
+ * Resolve the orchestrator mode for `brainpilot up`. Unlike the backend's
+ * env-based `resolveOrchestratorMode` (which reads BP_RUNTIME_URL / BP_MODE),
+ * the CLI defaults to `local` and only departs from it when the user is
+ * explicit — via `--mode` or an explicit `BP_ORCHESTRATOR`. This is the fix for
+ * "users accidentally enter sandbox mode": a stray BP_RUNTIME_URL left over
+ * from a `docker compose` session no longer hijacks a source launch into
+ * static (sandbox) mode. To run `up` against a pre-started container, the user
+ * must say so (`--mode static` or BP_ORCHESTRATOR=static).
+ */
+export function resolveUpMode(
+  optionMode: OrchestratorMode | undefined,
+  env: Record<string, string | undefined>,
+): OrchestratorMode {
+  if (optionMode) return optionMode;
+  const explicit = (env.BP_ORCHESTRATOR ?? "").toLowerCase();
+  if (explicit === "docker" || explicit === "local" || explicit === "static") {
+    return explicit as OrchestratorMode;
+  }
+  return "local";
 }
 
 /** Build the StartServerOptions from resolved config — exposed for tests. */
@@ -73,8 +99,10 @@ export function buildStartServerOptions(
     dataDir: cfg.dataDir,
     serveWeb: cfg.webDist !== null,
     stdioInherit: cfg.foreground,
+    // Pass the mode explicitly so a stray BP_RUNTIME_URL/BP_MODE in the
+    // environment can't silently flip a local source-launch into static/docker.
+    mode: cfg.mode,
     ...(cfg.webDist ? { webRoot: cfg.webDist } : {}),
-    // The backend creates a LocalProcessOrchestrator from env (BP_MODE=single).
   } satisfies StartServerOptions;
 }
 
@@ -146,6 +174,7 @@ export async function up(
   const host = "127.0.0.1";
   const foreground = options.foreground ?? true;
   const open = options.open ?? true;
+  const mode = resolveUpMode(options.mode, env);
 
   const cfg: ResolvedUpConfig = {
     dataDir,
@@ -155,7 +184,29 @@ export async function up(
     webDist: webDistFn(),
     foreground,
     open,
+    mode,
   };
+
+  // Make the resolved mode visible (the #1 cause of "I accidentally entered
+  // sandbox mode" was that the mode switch was completely silent). For the
+  // non-default static/docker modes, name the trigger so the user understands
+  // why they left local.
+  if (mode === "local") {
+    log(pc.dim(`mode=local · dataDir=${dataDir} · runtime port ${cfg.runtimePort}`));
+  } else {
+    const via = options.mode
+      ? "--mode"
+      : "BP_ORCHESTRATOR";
+    log(
+      pc.yellow(
+        `mode=${mode} (via ${via}) — connecting to an external runtime, not a local one.`,
+      ),
+    );
+    if (mode === "static") {
+      log(pc.dim(`    BP_RUNTIME_URL=${env.BP_RUNTIME_URL ?? "(unset — required for static)"}`));
+    }
+    log(pc.dim("    To run from source instead, drop --mode / BP_ORCHESTRATOR (defaults to local)."));
+  }
 
   // 2. Scaffold if absent (idempotent).
   if (!(await isScaffolded(dataDir))) {

--- a/packages/cli/src/paths.test.ts
+++ b/packages/cli/src/paths.test.ts
@@ -1,9 +1,14 @@
 import { describe, it, expect } from "vitest";
 import { resolveDataDir, dataPaths } from "./paths.js";
+import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 describe("resolveDataDir precedence", () => {
-  const cwd = "/tmp/launch";
+  // Use the OS tmpdir so the cwd literal is a valid absolute path on every
+  // host (Windows in particular — `/tmp/launch` resolves to `C:\tmp\launch`
+  // there, which is technically fine for resolve()-based equality but
+  // depends on a fragile detail). (#9 — cross-platform pass.)
+  const cwd = join(tmpdir(), "launch");
 
   it("uses --dir when provided (highest priority)", () => {
     const d = resolveDataDir({

--- a/packages/cli/src/process-control.ts
+++ b/packages/cli/src/process-control.ts
@@ -5,6 +5,7 @@
  */
 import { writeFile, readFile, rm, mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
+import { gracefulSignalsSupported } from "@brainpilot/runtime";
 
 export interface ProcessControlDeps {
   /** Probe liveness. Defaults to `process.kill(pid, 0)`. */
@@ -13,6 +14,12 @@ export interface ProcessControlDeps {
   signal?: (pid: number, sig: NodeJS.Signals) => void;
   /** Sleep impl (injectable for tests). */
   sleep?: (ms: number) => Promise<void>;
+  /**
+   * Whether the OS supports graceful POSIX signal delivery. Defaults to the
+   * runtime helper (`gracefulSignalsSupported`, false on Windows). Tests inject
+   * this to exercise both branches deterministically. (#6 — cross-platform.)
+   */
+  gracefulSignals?: boolean;
 }
 
 const realIsAlive = (pid: number): boolean => {
@@ -123,6 +130,15 @@ export interface StopResult {
 /**
  * Gracefully stop the process recorded in `pidFile`: SIGTERM, wait up to
  * `timeoutMs`, then SIGKILL. Removes the pid file afterward.
+ *
+ * Cross-platform (#6): Windows can't deliver POSIX signals to another process
+ * — any signal sent via `process.kill` is translated to `TerminateProcess`,
+ * which is a forceful kill the target can't intercept. Sending SIGTERM and
+ * then polling for up to `timeoutMs` wastes time (the process is already dead
+ * the moment the call returns) and the registered SIGTERM handler in the
+ * server never runs. On platforms where graceful signals don't work we skip
+ * straight to a single SIGKILL and report `forced: true` to be honest about
+ * the shutdown mode.
  */
 export async function stop(
   pidFile: string,
@@ -131,6 +147,7 @@ export async function stop(
   const isAlive = options.isAlive ?? realIsAlive;
   const signal = options.signal ?? realSignal;
   const sleep = options.sleep ?? realSleep;
+  const graceful = options.gracefulSignals ?? gracefulSignalsSupported;
   const timeoutMs = options.timeoutMs ?? 10_000;
   const pollMs = options.pollMs ?? 100;
 
@@ -141,6 +158,19 @@ export async function stop(
   if (!isAlive(pid)) {
     await removePid(pidFile);
     return { stopped: true, pid, forced: false };
+  }
+
+  // Windows / no-graceful-signals path: skip SIGTERM-then-wait, force-kill once.
+  if (!graceful) {
+    let forced = false;
+    try {
+      signal(pid, "SIGKILL");
+      forced = true;
+    } catch {
+      // already gone between probe and signal — fall through to cleanup.
+    }
+    await removePid(pidFile);
+    return { stopped: true, pid, forced };
   }
 
   try {

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -1,13 +1,20 @@
 import { describe, it, expect, vi } from "vitest";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { run } from "./program.js";
+
+// Use the OS tmpdir so the `--dir` argv literal is shaped the same way on
+// Windows and POSIX. The CLI just echoes the option value back through
+// commander; we never touch the filesystem. (#9 — cross-platform pass.)
+const TMP_DIR = join(tmpdir(), "x");
 
 describe("program — commander wiring", () => {
   it("dispatches `up` with parsed --dir/--port and foreground default", async () => {
     const upFn = vi.fn().mockResolvedValue({ url: "x", config: {} });
-    await run(["up", "--dir", "/tmp/x", "--port", "9100"], { upFn });
+    await run(["up", "--dir", TMP_DIR, "--port", "9100"], { upFn });
     expect(upFn).toHaveBeenCalledOnce();
     const [opts] = upFn.mock.calls[0]!;
-    expect(opts).toMatchObject({ dir: "/tmp/x", port: 9100, foreground: true });
+    expect(opts).toMatchObject({ dir: TMP_DIR, port: 9100, foreground: true });
   });
 
   it("`up --detach` sets foreground false", async () => {

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -22,6 +22,24 @@ describe("program — commander wiring", () => {
     expect(upFn.mock.calls[0]![0]).toMatchObject({ open: false });
   });
 
+  it("`up --mode static` forwards the orchestrator mode", async () => {
+    const upFn = vi.fn().mockResolvedValue({ url: "x", config: {} });
+    await run(["up", "--mode", "static"], { upFn });
+    expect(upFn.mock.calls[0]![0]).toMatchObject({ mode: "static" });
+  });
+
+  it("`up` with no --mode leaves mode undefined (resolver defaults to local)", async () => {
+    const upFn = vi.fn().mockResolvedValue({ url: "x", config: {} });
+    await run(["up"], { upFn });
+    expect(upFn.mock.calls[0]![0].mode).toBeUndefined();
+  });
+
+  it("rejects an invalid --mode", async () => {
+    const upFn = vi.fn();
+    await expect(run(["up", "--mode", "bogus"], { upFn })).rejects.toThrow();
+    expect(upFn).not.toHaveBeenCalled();
+  });
+
   it("dispatches `down` with --dir", async () => {
     const downFn = vi.fn().mockResolvedValue({ stopped: true, pid: 1, forced: false });
     await run(["down", "--dir", "/d"], { downFn });

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -37,6 +37,12 @@ function parsePort(value: string): number {
   return n;
 }
 
+function parseMode(value: string): "local" | "static" | "docker" {
+  const v = value.toLowerCase();
+  if (v === "local" || v === "static" || v === "docker") return v;
+  throw new Error(`Invalid mode: ${value} (expected local | static | docker)`);
+}
+
 /** Read the CLI package version from its own package.json (single source of truth). */
 function requireVersion(): string {
   const require = createRequire(import.meta.url);
@@ -67,6 +73,11 @@ export function buildProgram(deps: ProgramDeps = {}): Command {
     .option("-p, --port <n>", "backend port (runtime uses port+1)", parsePort)
     .option("--detach", "run the backend as a background process")
     .option("--no-open", "do not open the browser")
+    .option(
+      "--mode <mode>",
+      "orchestrator mode: local (default) | static (connect BP_RUNTIME_URL) | docker",
+      parseMode,
+    )
     .action(async (opts) => {
       const foreground = !opts.detach;
       await upFn(
@@ -75,6 +86,7 @@ export function buildProgram(deps: ProgramDeps = {}): Command {
           port: opts.port,
           foreground,
           open: opts.open,
+          mode: opts.mode,
         },
         { spawnDetached: spawnDetachedBackend },
       );

--- a/packages/cli/src/repo-mode.test.ts
+++ b/packages/cli/src/repo-mode.test.ts
@@ -18,6 +18,14 @@ function makeForeign(): string {
   return realpathSync(mkdtempSync(join(tmpdir(), "bp-foreign-")));
 }
 
+// Argv-literal placeholders for `--dir`/`BP_DATA_DIR`. The tests never touch
+// these as real paths — `assertRepoCwd` only inspects their *presence* in
+// argv/env — but using the OS tmpdir keeps the values well-shaped on
+// Windows where `/tmp/...` is not a real path. (#9 — cross-platform pass.)
+const TMP_DIR = join(tmpdir(), "somewhere");
+const TMP_DIR_EQUALS = `--dir=${join(tmpdir(), "foo")}`;
+const TMP_DATA_DIR = join(tmpdir(), "dd");
+
 function callAssert(opts: Parameters<typeof assertRepoCwd>[0]): {
   exited: number | null;
   err: string;
@@ -83,7 +91,7 @@ describe("assertRepoCwd", () => {
     const cwd = makeForeign();
     expect(() =>
       assertRepoCwd({
-        argv: ["up", "--dir", "/tmp/somewhere"],
+        argv: ["up", "--dir", TMP_DIR],
         env: {},
         cwd,
         binPath,
@@ -96,7 +104,7 @@ describe("assertRepoCwd", () => {
     const cwd = makeForeign();
     expect(() =>
       assertRepoCwd({
-        argv: ["up", "-d", "/tmp/somewhere"],
+        argv: ["up", "-d", TMP_DIR],
         env: {},
         cwd,
         binPath,
@@ -109,7 +117,7 @@ describe("assertRepoCwd", () => {
     const cwd = makeForeign();
     expect(() =>
       assertRepoCwd({
-        argv: ["up", "--dir=/tmp/foo"],
+        argv: ["up", TMP_DIR_EQUALS],
         env: {},
         cwd,
         binPath,
@@ -123,7 +131,7 @@ describe("assertRepoCwd", () => {
     expect(() =>
       assertRepoCwd({
         argv: ["up"],
-        env: { BP_DATA_DIR: "/tmp/dd" },
+        env: { BP_DATA_DIR: TMP_DATA_DIR },
         cwd,
         binPath,
       }),

--- a/packages/cli/src/repo-mode.ts
+++ b/packages/cli/src/repo-mode.ts
@@ -56,7 +56,14 @@ export interface AssertRepoCwdOptions {
  */
 function samePath(a: string, b: string): boolean {
   try {
-    return realpathSync(a) === realpathSync(b);
+    const ra = realpathSync(a);
+    const rb = realpathSync(b);
+    // Windows/macOS filesystems are case-insensitive and realpathSync does not
+    // canonicalize drive-letter casing, so compare case-insensitively there.
+    if (process.platform === "win32" || process.platform === "darwin") {
+      return ra.toLowerCase() === rb.toLowerCase();
+    }
+    return ra === rb;
   } catch {
     return false;
   }

--- a/packages/cli/src/spawn-backend.ts
+++ b/packages/cli/src/spawn-backend.ts
@@ -39,6 +39,12 @@ export async function spawnDetachedBackend(
       ...process.env,
       BP_DATA_DIR: cfg.dataDir,
       BP_MODE: "single",
+      // Pin the orchestrator mode resolved by `up`. The detached server boots
+      // via `node server.js` and resolves its mode from env, so without this a
+      // stray BP_RUNTIME_URL would flip the background backend into static
+      // (sandbox) mode. BP_ORCHESTRATOR has the highest precedence and thus
+      // also neutralizes any leftover BP_RUNTIME_URL/BP_MODE in the parent env.
+      BP_ORCHESTRATOR: cfg.mode,
       BP_PORT: String(cfg.port),
       PORT: String(cfg.port),
       AGENT_RUNTIME_PORT: String(cfg.runtimePort),

--- a/packages/runtime/src/__tests__/agent-error.test.ts
+++ b/packages/runtime/src/__tests__/agent-error.test.ts
@@ -44,6 +44,43 @@ describe("normalizeAgentError (#45)", () => {
   it("handles empty input", () => {
     expect(normalizeAgentError("").message).toBe("");
   });
+
+  // #157 — the original two regexes hardcoded forward slashes, so a Windows
+  // absolute path (which carries the user's username under `C:\Users\<u>\…`)
+  // slipped through redact() verbatim and leaked into the chat error bubble
+  // and events.jsonl.
+  describe("Windows path leakage (#157)", () => {
+    const winNoKeyRaw = [
+      "No model selected.",
+      "  C:\\Users\\alice\\AppData\\Roaming\\npm\\node_modules\\@earendil-works\\pi-coding-agent\\docs\\providers.md",
+    ].join("\n");
+
+    it("does not leak a Windows absolute node_modules path in the message", () => {
+      const out = normalizeAgentError(winNoKeyRaw);
+      expect(out.message).not.toMatch(/node_modules/);
+      expect(out.message).not.toMatch(/\.md/);
+    });
+
+    it("does not leak the Windows username (privacy)", () => {
+      const out = normalizeAgentError(winNoKeyRaw);
+      expect(out.message).not.toMatch(/alice/);
+      expect(out.message).not.toMatch(/C:\\Users/i);
+    });
+
+    it("keeps the semantic head of the error", () => {
+      const out = normalizeAgentError(winNoKeyRaw);
+      expect(out.message).toContain("No model selected.");
+    });
+
+    it("drops a Windows-only path line just like the POSIX case", () => {
+      const raw =
+        "Tool failed: cannot read config.\nC:\\Users\\bob\\proj\\node_modules\\pkg\\docs\\x.md";
+      const out = normalizeAgentError(raw);
+      expect(out.message).toContain("Tool failed: cannot read config.");
+      expect(out.message).not.toMatch(/node_modules/);
+      expect(out.message).not.toMatch(/bob/);
+    });
+  });
 });
 
 describe("normalizeAgentError — provider HTTP errors (#97)", () => {

--- a/packages/runtime/src/__tests__/mcp-bridge.test.ts
+++ b/packages/runtime/src/__tests__/mcp-bridge.test.ts
@@ -6,6 +6,7 @@ import {
   McpBridge,
   loadMcpServersConfig,
   openTransport,
+  resolveStdioCommand,
   type McpClientLike,
 } from "../mcp-bridge.js";
 
@@ -127,5 +128,50 @@ describe("openTransport", () => {
 
   it("rejects a stdio spec with no command", async () => {
     await expect(openTransport("fs", { type: "stdio" })).rejects.toThrow(/requires a 'command'/);
+  });
+});
+
+// #7 — cross-platform: Windows can't spawn npm-ecosystem shims by bare name
+// (they only exist as `.cmd`), so the bridge auto-suffixes a known short list.
+// POSIX must remain a pass-through to preserve historical behaviour.
+describe("resolveStdioCommand (cross-platform, #7)", () => {
+  describe("on POSIX (windows=false)", () => {
+    it("returns the command unchanged for all inputs", () => {
+      expect(resolveStdioCommand("npx", false)).toBe("npx");
+      expect(resolveStdioCommand("npm", false)).toBe("npm");
+      expect(resolveStdioCommand("/usr/local/bin/node", false)).toBe("/usr/local/bin/node");
+      expect(resolveStdioCommand("some-binary", false)).toBe("some-binary");
+    });
+  });
+
+  describe("on Windows (windows=true)", () => {
+    it("appends `.cmd` to the npm-ecosystem allow-list", () => {
+      expect(resolveStdioCommand("npx", true)).toBe("npx.cmd");
+      expect(resolveStdioCommand("npm", true)).toBe("npm.cmd");
+      expect(resolveStdioCommand("yarn", true)).toBe("yarn.cmd");
+      expect(resolveStdioCommand("pnpm", true)).toBe("pnpm.cmd");
+    });
+
+    it("matches the allow-list case-insensitively", () => {
+      expect(resolveStdioCommand("NPX", true)).toBe("NPX.cmd");
+      expect(resolveStdioCommand("Pnpm", true)).toBe("Pnpm.cmd");
+    });
+
+    it("leaves a command alone when the user already gave an extension", () => {
+      expect(resolveStdioCommand("npx.cmd", true)).toBe("npx.cmd");
+      expect(resolveStdioCommand("npm.bat", true)).toBe("npm.bat");
+      expect(resolveStdioCommand("node.exe", true)).toBe("node.exe");
+      expect(resolveStdioCommand("foo.ps1", true)).toBe("foo.ps1");
+    });
+
+    it("does NOT touch commands outside the allow-list (incl. node)", () => {
+      // Node itself is .exe and Windows handles that fallback natively.
+      expect(resolveStdioCommand("node", true)).toBe("node");
+      expect(resolveStdioCommand("python", true)).toBe("python");
+      expect(resolveStdioCommand("uvx", true)).toBe("uvx");
+      expect(resolveStdioCommand("C:\\Users\\u\\bin\\custom", true)).toBe(
+        "C:\\Users\\u\\bin\\custom",
+      );
+    });
   });
 });

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -181,6 +181,64 @@ async function waitFor(pred: () => boolean, timeoutMs = 2000): Promise<void> {
   }
 }
 
+// #5 — cross-platform: every workspace-relative path the runtime hands out
+// (writeSessionFile result, skill_search responses) must use POSIX `/` so the
+// API contract is identical on Windows and POSIX, the model never sees a
+// backslash it has to JSON-escape, and URL query strings stay valid. And the
+// inverse: paths echoed back by the model — including round-tripped ones with
+// the backslash form — must still resolve. `\` is not a legal Windows
+// filename character, so collapsing `\` → `/` on input is unambiguous.
+describe("SessionManager workspace path normalization (#5)", () => {
+  let root: string;
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "bp-fs-"));
+  });
+
+  it("writeSessionFile returns nested paths in POSIX form", async () => {
+    const m = new SessionManager({
+      dataRoot: root,
+      persist: false,
+      agentFactory: mockAgentFactory,
+    });
+    const s = await m.createSession({ title: "fs" });
+    const b64 = Buffer.from("hello", "utf8").toString("base64");
+    const out = await m.writeSessionFile(s.id, "docs/sub/note.txt", b64);
+    expect(out.path).toBe("docs/sub/note.txt");
+    expect(out.path).not.toMatch(/\\/);
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("accepts a backslash-shaped relative path on input and resolves identically", async () => {
+    const m = new SessionManager({
+      dataRoot: root,
+      persist: false,
+      agentFactory: mockAgentFactory,
+    });
+    const s = await m.createSession({ title: "fs" });
+    const b64 = Buffer.from("x", "utf8").toString("base64");
+    const a = await m.writeSessionFile(s.id, "a/b/c.txt", b64);
+    const b = await m.writeSessionFile(s.id, "a\\b\\c.txt", b64);
+    // Same logical path → both resolve to the same workspace location, both
+    // returned in POSIX form.
+    expect(a.path).toBe("a/b/c.txt");
+    expect(b.path).toBe("a/b/c.txt");
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it("returns the empty string for a write at the workspace root", async () => {
+    const m = new SessionManager({
+      dataRoot: root,
+      persist: false,
+      agentFactory: mockAgentFactory,
+    });
+    const s = await m.createSession({ title: "fs" });
+    const b64 = Buffer.from("y", "utf8").toString("base64");
+    const out = await m.writeSessionFile(s.id, "top.txt", b64);
+    expect(out.path).toBe("top.txt");
+    await rm(root, { recursive: true, force: true });
+  });
+});
+
 describe("SessionManager memory watchdog (§R-4 / #20)", () => {
   it("is fully opt-out when no budget is set (identical to today)", async () => {
     const m = new SessionManager({ persist: false, agentFactory: mockAgentFactory });

--- a/packages/runtime/src/__tests__/skill-search.test.ts
+++ b/packages/runtime/src/__tests__/skill-search.test.ts
@@ -206,10 +206,62 @@ describe("searchSkills — browse mode", () => {
     ).rejects.toThrow(/traversal/);
   });
 
+  // #2 — cross-platform: the previous guard hardcoded POSIX `/` so a Windows
+  // absolute path like `C:\Windows\System32` or `\Windows` was let through to
+  // the second-line containment guard, which still saved it but with a less
+  // specific error. Reject them up-front instead.
+  it("rejects Windows-style absolute paths (drive prefix and leading backslash) (#2)", async () => {
+    await expect(
+      searchSkills(base, { mode: "browse", relative_path: "C:\\Windows\\System32" }),
+    ).rejects.toThrow(/traversal/);
+    await expect(
+      searchSkills(base, { mode: "browse", relative_path: "C:/Windows" }),
+    ).rejects.toThrow(/traversal/);
+    await expect(
+      searchSkills(base, { mode: "browse", relative_path: "\\windows" }),
+    ).rejects.toThrow(/traversal/);
+  });
+
+  // #2 — the original comment promised to reject `..` segments before the
+  // resolve step, but the code never actually did; only the second-line
+  // containment check caught them after the fact. Make the up-front guard
+  // honest. Also covers backslash-separated `..` for Windows-shaped inputs.
+  it("rejects any `..` segment up front, not just at the containment guard (#2)", async () => {
+    await expect(
+      searchSkills(base, { mode: "browse", relative_path: "foo/../bar" }),
+    ).rejects.toThrow(/traversal/);
+    await expect(
+      searchSkills(base, { mode: "browse", relative_path: "foo\\..\\bar" }),
+    ).rejects.toThrow(/traversal/);
+  });
+
   it("throws on a missing path", async () => {
     await expect(
       searchSkills(base, { mode: "browse", relative_path: "nope/nada" }),
     ).rejects.toThrow(/does not exist/);
+  });
+
+  // #5 — paths handed back to the model must use POSIX separators so they
+  // round-trip safely through JSON and URL query strings, and so the API
+  // contract is identical on Windows and POSIX hosts.
+  it("emits POSIX-style separators in browse `path` and search `relative_paths` (#5)", async () => {
+    const out = JSON.parse(
+      await searchSkills(base, {
+        mode: "browse",
+        relative_path: "02_Cross-Domain/eeg-paradigm-designer",
+      }),
+    );
+    expect(out.path).toBe("02_Cross-Domain/eeg-paradigm-designer");
+    expect(out.path).not.toMatch(/\\/);
+
+    const query = JSON.parse(
+      await searchSkills(base, { mode: "query", keywords: ["EEG"] }),
+    );
+    for (const r of query.results) {
+      for (const p of r.relative_paths) {
+        expect(p).not.toMatch(/\\/);
+      }
+    }
   });
 });
 

--- a/packages/runtime/src/__tests__/skill-search.test.ts
+++ b/packages/runtime/src/__tests__/skill-search.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   collectAllSkills,
   countKeywordHits,
+  normalizeKeywords,
   parseFrontmatterDescription,
   searchSkills,
   createSkillSearchTool,
@@ -91,6 +92,37 @@ describe("countKeywordHits", () => {
   });
 });
 
+describe("normalizeKeywords", () => {
+  it("returns empty array for undefined / null-ish input", () => {
+    expect(normalizeKeywords(undefined)).toEqual([]);
+    expect(normalizeKeywords("")).toEqual([]);
+  });
+
+  it("splits a comma-separated string and trims each entry", () => {
+    expect(normalizeKeywords("EEG, preprocessing, ICA")).toEqual([
+      "EEG",
+      "preprocessing",
+      "ICA",
+    ]);
+  });
+
+  it("drops empty entries from comma-separated string", () => {
+    expect(normalizeKeywords("EEG,,, ICA, ")).toEqual(["EEG", "ICA"]);
+  });
+
+  it("handles a single keyword string with no commas", () => {
+    expect(normalizeKeywords("fMRI")).toEqual(["fMRI"]);
+  });
+
+  it("passes through a string array unchanged (trimming + dedup empties)", () => {
+    expect(normalizeKeywords(["EEG", " ICA ", ""])).toEqual(["EEG", "ICA"]);
+  });
+
+  it("handles an already-clean string array", () => {
+    expect(normalizeKeywords(["a", "b", "c"])).toEqual(["a", "b", "c"]);
+  });
+});
+
 describe("collectAllSkills", () => {
   let base: string;
   beforeAll(async () => {
@@ -153,6 +185,37 @@ describe("searchSkills — query mode", () => {
 
   it("query mode requires keywords or skill_name", async () => {
     await expect(searchSkills(base, { mode: "query" })).rejects.toThrow(/keywords/);
+  });
+
+  it("accepts keywords as a comma-separated string", async () => {
+    const out = JSON.parse(
+      await searchSkills(base, { mode: "query", keywords: "EEG, paradigm" }),
+    );
+    expect(out.keywords).toEqual(["EEG", "paradigm"]);
+    expect(out.results[0].name).toBe("eeg-paradigm-designer");
+    expect(out.results[0].keyword_hits).toBeGreaterThan(0);
+  });
+
+  it("comma string with empties and whitespace normalises correctly", async () => {
+    const out = JSON.parse(
+      await searchSkills(base, { mode: "query", keywords: " EEG ,, , paradigm " }),
+    );
+    expect(out.keywords).toEqual(["EEG", "paradigm"]);
+    expect(out.total_matched).toBe(1);
+  });
+
+  it("single keyword string (no commas) works", async () => {
+    const out = JSON.parse(
+      await searchSkills(base, { mode: "query", keywords: "figure" }),
+    );
+    expect(out.keywords).toEqual(["figure"]);
+    expect(out.results[0].name).toBe("figure-builder");
+  });
+
+  it("empty comma string throws (no valid keywords)", async () => {
+    await expect(
+      searchSkills(base, { mode: "query", keywords: " , , " }),
+    ).rejects.toThrow(/keywords/);
   });
 });
 
@@ -260,5 +323,25 @@ describe("createSkillSearchTool", () => {
     };
     const tool = createSkillSearchTool(deps);
     await expect(tool.execute({ mode: "query" })).rejects.toThrow(/keywords/);
+  });
+
+  it("accepts comma-separated keyword string via execute()", async () => {
+    const base = await makeFixtureBase();
+    const deps: ToolDeps = {
+      sessionId: "s",
+      fromAgent: "principal",
+      mailbox: new Mailbox("s"),
+      trace: new GraphOfTrace("s"),
+      ensureAgent: async () => {},
+      destroyAgent: async () => {},
+      wakeAgent: () => {},
+      requestUserInput: async () => "",
+      routerSkillsDir: base,
+    };
+    const tool = createSkillSearchTool(deps);
+    const out = await tool.execute({ mode: "query", keywords: "EEG, paradigm" });
+    const payload = JSON.parse(out.content[0]!.text);
+    expect(payload.keywords).toEqual(["EEG", "paradigm"]);
+    expect(payload.results[0].name).toBe("eeg-paradigm-designer");
   });
 });

--- a/packages/runtime/src/__tests__/tool-access.test.ts
+++ b/packages/runtime/src/__tests__/tool-access.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from "vitest";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   systemToolNamesForRole,
   systemToolsForRole,
@@ -18,7 +20,11 @@ function deps(name: string): ToolDeps {
     destroyAgent: async () => {},
     wakeAgent: () => {},
     requestUserInput: async () => "stub-answer",
-    routerSkillsDir: "/tmp/bp-test-router",
+    // Field is required by ToolDeps but the access-control tests never read
+    // it. Use the OS tmpdir so the path is at least well-formed on Windows
+    // (where `/tmp/...` is not a real directory) if a future change starts
+    // exercising it. (#8 — cross-platform pass.)
+    routerSkillsDir: join(tmpdir(), "bp-test-router"),
   };
 }
 

--- a/packages/runtime/src/agent-error.ts
+++ b/packages/runtime/src/agent-error.ts
@@ -146,6 +146,12 @@ function pickMessage(obj: unknown): string | undefined {
  * keeping its semantic content. Best-effort — drops lines that are purely an
  * absolute node_modules doc path or a `/login` hint, and scrubs any inline
  * absolute path that reaches into node_modules.
+ *
+ * Cross-platform (#157): the path separator class allows BOTH `/` and `\`, and
+ * the leading anchor optionally accepts a Windows drive prefix (`C:\…`). The
+ * original POSIX-only regex hardcoded forward slashes, so a native Windows path
+ * like `C:\Users\alice\…\node_modules\@pkg\docs\providers.md` slipped through
+ * verbatim and leaked the username into the chat bubble + events.jsonl.
  */
 function redact(raw: string): string {
   return raw
@@ -154,12 +160,13 @@ function redact(raw: string): string {
       const t = line.trim();
       if (/use \/login/i.test(t)) return false;
       // A line that is just an absolute path into node_modules (doc pointer).
-      if (/^\/?\S*node_modules\/\S+$/.test(t)) return false;
+      // Allows a Windows drive prefix and either separator style.
+      if (/^(?:[A-Za-z]:)?[\\/]?\S*node_modules[\\/]\S+$/.test(t)) return false;
       return true;
     })
     .map((line) =>
-      // Scrub any remaining inline absolute node_modules path.
-      line.replace(/\/\S*node_modules\/\S+/g, "").trimEnd(),
+      // Scrub any remaining inline absolute node_modules path (POSIX or Windows).
+      line.replace(/(?:[A-Za-z]:)?[\\/]\S*node_modules[\\/]\S+/g, "").trimEnd(),
     )
     .join("\n")
     .replace(/\n{2,}/g, "\n")

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -53,6 +53,8 @@ export type { McpServersConfig, McpServerSpec, McpClientLike, McpConnectFn } fro
 export { materializeSkills, resolveBundledSkillsDir } from "./materialize-skills.js";
 export type { MaterializeSkillsResult } from "./materialize-skills.js";
 
+export { isWindows, isMacOS, isLinux, gracefulSignalsSupported } from "./platform.js";
+
 export type {
   AgentRole,
   IAgentSession,

--- a/packages/runtime/src/mcp-bridge.ts
+++ b/packages/runtime/src/mcp-bridge.ts
@@ -18,6 +18,7 @@
  */
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
+import { isWindows } from "./platform.js";
 import type { SystemTool, SystemToolResult } from "./types.js";
 
 /** Wire transport for an MCP server. Absent ⇒ "stdio" (back-compat). */
@@ -118,10 +119,37 @@ export async function openTransport(name: string, spec: McpServerSpec) {
   }
   const { StdioClientTransport } = await import("@modelcontextprotocol/sdk/client/stdio.js");
   return new StdioClientTransport({
-    command: spec.command,
+    command: resolveStdioCommand(spec.command, isWindows),
     args: spec.args ?? [],
     ...(spec.env ? { env: spec.env } : {}),
   });
+}
+
+/**
+ * Windows shim resolution for stdio MCP servers (#7 — cross-platform pass).
+ *
+ * On Windows the npm-ecosystem launchers (`npx`, `npm`, `yarn`, `pnpm`) only
+ * exist as `.cmd` batch shims, never as a bare-name executable. Node ≥20.12's
+ * CVE-2024-27980 fix made `child_process.spawn("npx", …, { shell: false })`
+ * fail with EINVAL/ENOENT instead of silently routing through cmd.exe — so the
+ * de-facto MCP install form (`npx -y @modelcontextprotocol/server-*`) which
+ * appears in every published config and in our own scaffold blows up on Windows
+ * unless callers know to write `npx.cmd` themselves.
+ *
+ * We auto-append `.cmd` for that exact short list on Windows when the caller
+ * didn't already provide an extension. `node` is intentionally excluded — it's
+ * `node.exe` on Windows and Node's own launcher handles the `.exe` fallback.
+ * Anything outside the allow-list is passed through verbatim (we don't want to
+ * second-guess a user-supplied binary path).
+ *
+ * Exported so unit tests can exercise both branches without OS mocking — the
+ * `windows` flag is injected, not read from `process.platform`, here.
+ */
+export function resolveStdioCommand(cmd: string, windows: boolean): string {
+  if (!windows) return cmd;
+  if (/\.(cmd|bat|exe|ps1|com)$/i.test(cmd)) return cmd;
+  if (/^(npx|npm|yarn|pnpm)$/i.test(cmd)) return `${cmd}.cmd`;
+  return cmd;
 }
 
 export class McpBridge {

--- a/packages/runtime/src/platform.ts
+++ b/packages/runtime/src/platform.ts
@@ -1,0 +1,37 @@
+/**
+ * platform.ts — single source of truth for cross-platform branch logic.
+ *
+ * Centralizes `process.platform` checks so callers consume semantic constants
+ * (`isWindows`, `gracefulSignalsSupported`) instead of scattering raw string
+ * comparisons (`process.platform === "win32"`) across the codebase. Re-exported
+ * from `@brainpilot/runtime` so `backend-core` and the CLI consume the same
+ * helpers without duplicating the detection.
+ *
+ * Resolved once at module load; we never observe `process.platform` mutating
+ * inside a single Node process, so caching as `const` is safe and lets V8
+ * fold the branches.
+ */
+
+const platform = process.platform;
+
+/** True when running on Windows (`win32`). Use this instead of literal compares. */
+export const isWindows = platform === "win32";
+
+/** True on macOS / Darwin. */
+export const isMacOS = platform === "darwin";
+
+/** True on Linux. */
+export const isLinux = platform === "linux";
+
+/**
+ * Whether the OS surfaces graceful POSIX signals (SIGINT/SIGTERM) to a Node
+ * child process via `process.kill` / `child.kill`. On Windows, Node maps any
+ * inter-process signal to `TerminateProcess`, which is a forceful kill that
+ * the target process cannot intercept — so a `SIGTERM` issued to a Windows
+ * BrainPilot server will NOT run the registered handlers, and any code that
+ * waits for "graceful exit" after SIGTERM will time out for no reason.
+ *
+ * Callers should use this to short-circuit the SIGTERM-then-wait path on
+ * Windows and proceed straight to the force-kill code.
+ */
+export const gracefulSignalsSupported = !isWindows;

--- a/packages/runtime/src/server.ts
+++ b/packages/runtime/src/server.ts
@@ -10,6 +10,7 @@
  *   GET  /sse/:id  (+ alias GET /sessions/:id/events)
  *   POST /sessions/:id/interrupt, GET /sessions/:id/agents, POST /sessions/:id/evict
  */
+import { pathToFileURL } from "node:url";
 import { Hono } from "hono";
 import { serve } from "@hono/node-server";
 import { stream } from "hono/streaming";
@@ -315,8 +316,10 @@ export async function startServer(opts: StartServerOptions = {}): Promise<{
   };
 }
 
-// Allow `node dist/server.js` to boot directly.
-if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+// Allow `node dist/server.js` to boot directly. Use pathToFileURL for the
+// main-module check so it works on Windows too — a naive `file://${argv[1]}`
+// never matches import.meta.url there (backslashes, drive letter, file:///).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   void startServer().then(({ port }) => {
     // eslint-disable-next-line no-console
     console.log(`[runtime] listening on :${port} (mock=${process.env.BP_MOCK ?? "0"})`);

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -345,6 +345,13 @@ export class SessionManager {
     let rel = rawPath ?? "";
     if (rel === "/workspace") rel = "";
     else if (rel.startsWith("/workspace/")) rel = rel.slice("/workspace/".length);
+    // Cross-platform (#5): the runtime now emits POSIX `/` in all
+    // workspace-relative paths it hands out (writeSessionFile, skill_search).
+    // Accept either separator on the way back in so an LLM that round-trips
+    // a path we gave it (or pre-#5 clients with cached `\` paths) still
+    // resolves correctly. `\` is not a legal Windows filename character, so
+    // this collapse is unambiguous.
+    rel = rel.replace(/\\/g, "/");
     rel = rel.replace(/^\/+/, ""); // never let a leading slash make it absolute
     const abs = resolve(root, rel);
     if (abs !== root && !abs.startsWith(root + sep)) {
@@ -432,8 +439,12 @@ export class SessionManager {
     await mkdir(dirname(abs), { recursive: true });
     await writeFile(abs, buf);
     // Return the workspace-relative path (strip the absolute root prefix).
+    // Cross-platform (#5): always emit POSIX `/` so the API contract is
+    // identical across hosts; the frontend embeds this in URL query strings
+    // (`?path=foo/bar.txt`) and the model echoes it back via `read_file`.
     const root = this.workspaceDir(sid);
-    const relOut = abs === root ? "" : abs.slice(root.length + 1);
+    const relOut =
+      abs === root ? "" : abs.slice(root.length + 1).split(sep).join("/");
     return { path: relOut, size: buf.byteLength };
   }
 

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -36,6 +36,7 @@ import { McpBridge, loadMcpServersConfig } from "./mcp-bridge.js";
 import { materializeSkills } from "./materialize-skills.js";
 import { resolveSessionProvider, type SessionProviderRef } from "./provider-config.js";
 import { MemWatchdog, parseMemLimitMb } from "./mem-watchdog.js";
+import { isWindows } from "./platform.js";
 import type { AgentRole, AgentSessionFactory, EventListener, SystemTool, SystemToolResult } from "./types.js";
 
 interface Deferred<T> {
@@ -376,7 +377,11 @@ export class SessionManager {
           const st = await stat(join(dir, d.name));
           size = st.size;
           modified = Math.floor(st.mtimeMs / 1000);
-          permissions = (st.mode & 0o777).toString(8);
+          // POSIX permission bits are meaningless on Windows (`st.mode` reflects
+          // FAT-era read-only attr only and would always render `666`/`777`/`444`),
+          // so emit an empty string and let the frontend show `-` instead of a
+          // misleading octal value. (#10 — cross-platform pass.)
+          permissions = isWindows ? "" : (st.mode & 0o777).toString(8);
         } catch {
           /* broken symlink / race — report zeros */
         }

--- a/packages/runtime/src/tools/skill-search.ts
+++ b/packages/runtime/src/tools/skill-search.ts
@@ -168,7 +168,7 @@ export interface SkillSearchArgs {
  * comma-separated string (e.g. `"EEG, preprocessing, ICA"`), trim each entry,
  * and drop empties — matching `skills_tool.py` behaviour.
  */
-function normalizeKeywords(raw: string[] | string | undefined): string[] {
+export function normalizeKeywords(raw: string[] | string | undefined): string[] {
   if (!raw) return [];
   if (typeof raw === "string") {
     return raw.split(",").map((s) => s.trim()).filter(Boolean);

--- a/packages/runtime/src/tools/skill-search.ts
+++ b/packages/runtime/src/tools/skill-search.ts
@@ -31,7 +31,7 @@
  */
 import { readFile, readdir, stat, access } from "node:fs/promises";
 import { constants as FS } from "node:fs";
-import { join, resolve, sep } from "node:path";
+import { isAbsolute, join, resolve, sep, posix } from "node:path";
 import type { SystemTool } from "../types.js";
 import type { ToolDeps } from "./system-tools.js";
 
@@ -116,7 +116,12 @@ export async function collectAllSkills(base: string): Promise<SkillRecord[]> {
     for (const skillName of skills) {
       const skillMd = join(catPath, skillName, "SKILL.md");
       if (!(await exists(skillMd))) continue;
-      const relPath = join(category, skillName);
+      // Cross-platform (#5): the relative path leaves the runtime and is
+      // shown both to the model (in `relative_paths`) and round-tripped back
+      // through the `browse` mode. Standardize on POSIX `/` so the API
+      // surface is identical on Windows and POSIX, the model never sees a
+      // backslash it has to JSON-escape, and URL/query forms stay valid.
+      const relPath = posix.join(category, skillName);
       const existing = byName.get(skillName);
       if (existing) {
         existing.relative_paths.push(relPath);
@@ -238,8 +243,25 @@ export async function searchSkills(base: string, args: SkillSearchArgs): Promise
   if (rel === "" || rel === ".") {
     target = baseAbs;
   } else {
-    // Reject any absolute path or one starting with '..' before resolve.
-    if (rel.startsWith("/")) {
+    // Reject any absolute path or one containing a `..` segment before resolve.
+    // Cross-platform (#2): the previous guard hardcoded POSIX `/`, so a
+    // Windows absolute path slipped past to the second-line containment
+    // guard with a less specific error. The check below recognizes:
+    //   - POSIX absolute paths (`/foo`)             — `isAbsolute` + `startsWith("/")`
+    //   - Windows absolute paths native to the host — `isAbsolute` (only true on Win)
+    //   - Windows-shaped paths inspected on POSIX   — `^[A-Za-z]:[\\/]` regex
+    //     (POSIX `isAbsolute("C:\\foo")` is false, so we have to match the
+    //     drive prefix explicitly to keep the guard host-platform-agnostic)
+    //   - Leading-backslash form                    — `startsWith("\\")`
+    // and the `..`-segment check the comment already promised but the code
+    // never actually did (across both separators).
+    if (
+      isAbsolute(rel) ||
+      rel.startsWith("/") ||
+      rel.startsWith("\\") ||
+      /^[A-Za-z]:[\\/]/.test(rel) ||
+      rel.split(/[\\/]/).some((seg) => seg === "..")
+    ) {
       throw new Error("path traversal outside skills directory is not allowed");
     }
     target = resolve(join(baseAbs, rel));
@@ -259,7 +281,12 @@ export async function searchSkills(base: string, args: SkillSearchArgs): Promise
         type: d.isDirectory() ? "directory" : "file",
       }))
       .sort((a, b) => a.name.localeCompare(b.name));
-    const displayPath = target === baseAbs ? "." : target.slice(baseAbs.length + 1);
+    // Cross-platform (#5): emit POSIX-style separators in the response so
+    // the model and frontend never see OS-native backslashes.
+    const displayPath =
+      target === baseAbs
+        ? "."
+        : target.slice(baseAbs.length + 1).split(sep).join("/");
     return jsonText({ path: displayPath, type: "directory", children });
   }
   if (st.isFile()) {

--- a/packages/runtime/src/tools/skill-search.ts
+++ b/packages/runtime/src/tools/skill-search.ts
@@ -156,10 +156,25 @@ export function countKeywordHits(text: string, keywords: string[]): number {
 
 export interface SkillSearchArgs {
   mode: "query" | "browse";
-  keywords?: string[];
+  /** Accepts a string[] or a single comma-separated string (e.g. "EEG, ICA"). */
+  keywords?: string[] | string;
   topk?: number;
   skill_name?: string;
   relative_path?: string;
+}
+
+/**
+ * Normalise the `keywords` parameter: accept either `string[]` or a single
+ * comma-separated string (e.g. `"EEG, preprocessing, ICA"`), trim each entry,
+ * and drop empties — matching `skills_tool.py` behaviour.
+ */
+function normalizeKeywords(raw: string[] | string | undefined): string[] {
+  if (!raw) return [];
+  if (typeof raw === "string") {
+    return raw.split(",").map((s) => s.trim()).filter(Boolean);
+  }
+  // Already an array — still trim and drop empties for robustness.
+  return raw.map((s) => String(s).trim()).filter(Boolean);
 }
 
 /** JSON-stringify with 2-space indent; the model parses these as text. */
@@ -199,22 +214,23 @@ export async function searchSkills(base: string, args: SkillSearchArgs): Promise
     }
 
     // Sub-mode A: keyword search.
-    if (!args.keywords || args.keywords.length === 0) {
+    const kws = normalizeKeywords(args.keywords);
+    if (kws.length === 0) {
       throw new Error(
-        "in query mode you must pass either 'keywords' (string list) or 'skill_name' (exact name)",
+        "in query mode you must pass either 'keywords' (string list or comma-separated string) or 'skill_name' (exact name)",
       );
     }
     const skills = await collectAllSkills(baseAbs);
     const topk = typeof args.topk === "number" && args.topk > 0 ? Math.floor(args.topk) : 5;
     const scored = skills.map((skill) => ({
       skill,
-      hits: countKeywordHits(skill.description, args.keywords!),
+      hits: countKeywordHits(skill.description, kws),
     }));
     // Sort: hit count desc, then alphabetical name asc.
     scored.sort((a, b) => b.hits - a.hits || a.skill.name.localeCompare(b.skill.name));
     const top = scored.slice(0, topk);
     const result: QueryResult = {
-      keywords: args.keywords,
+      keywords: kws,
       total_matched: scored.filter((s) => s.hits > 0).length,
       returned: top.length,
       results: top.map(({ skill, hits }) => ({
@@ -293,10 +309,13 @@ export function createSkillSearchTool(deps: ToolDeps): SystemTool {
           description: "'query' to search/load skills; 'browse' to list/read paths",
         },
         keywords: {
-          type: "array",
-          items: { type: "string" },
+          oneOf: [
+            { type: "array", items: { type: "string" } },
+            { type: "string" },
+          ],
           description:
-            "(query mode) keywords matched against each skill's frontmatter description",
+            "(query mode) keywords matched against each skill's frontmatter description; " +
+            "pass an array of strings or a single comma-separated string",
         },
         topk: {
           type: "integer",

--- a/packages/web/src/__tests__/demoTruncatedExport.test.ts
+++ b/packages/web/src/__tests__/demoTruncatedExport.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import { reduceMessagesForEvent } from "../contexts/messageReducer";
+import { normalizeAgUiEvent } from "../contracts/backend";
+import type { ChatMessage, WebSocketEvent } from "../contracts/backend";
+
+/**
+ * Regression coverage for demo bundles built from a *tail-sliced* history.
+ *
+ * When a long session was exported with a positive `limit`, the history
+ * endpoint returns only the tail of events.jsonl — the leading
+ * TEXT_MESSAGE_START of the earliest messages is gone, leaving orphaned
+ * CONTENT/END. The replay then dropped those opening replies silently
+ * ("开始的消息被截断"). The export now requests the full log (`limit: 0`), and
+ * the reducer additionally recovers gracefully if an orphan still slips
+ * through.
+ */
+describe("demo replay tolerates truncated/orphaned events", () => {
+  it("renders orphaned TEXT_MESSAGE_CONTENT whose START was sliced off", () => {
+    // Simulate a tail-sliced stream: CONTENT/END with no preceding START.
+    let msgs: ChatMessage[] = [];
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "orphan-1",
+      delta: "Librarian → methodology grounding",
+      agentName: "principal",
+    } as WebSocketEvent);
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "orphan-1",
+      delta: " against the paper",
+      agentName: "principal",
+    } as WebSocketEvent);
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_END",
+      messageId: "orphan-1",
+    } as WebSocketEvent);
+
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].id).toBe("orphan-1");
+    expect(msgs[0].content).toBe("Librarian → methodology grounding against the paper");
+    expect(msgs[0].agent).toBe("principal");
+    expect(msgs[0].streaming).toBe(false); // END finalized it
+  });
+
+  it("still folds a normal START→CONTENT→END triad into one message", () => {
+    let msgs: ChatMessage[] = [];
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_START",
+      messageId: "m1",
+      role: "assistant",
+      agentName: "principal",
+    } as WebSocketEvent);
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "m1",
+      delta: "hello",
+    } as WebSocketEvent);
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "m1",
+      delta: " world",
+    } as WebSocketEvent);
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_END",
+      messageId: "m1",
+    } as WebSocketEvent);
+
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].content).toBe("hello world");
+  });
+
+  it("strips NO-RENDER wrappers even on orphaned content", () => {
+    let msgs: ChatMessage[] = [];
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "orphan-2",
+      delta: "<!--NO-RENDER-->internal<!--/NO-RENDER-->",
+    } as WebSocketEvent);
+    // Entire delta was a NO-RENDER wrapper → nothing to render, no message created.
+    expect(msgs).toHaveLength(0);
+  });
+});
+
+describe("normalizeAgUiEvent preserves transport metadata keys", () => {
+  it("keeps _ts (and _seq) instead of mangling to Ts/Seq", () => {
+    const raw = {
+      type: "TEXT_MESSAGE_CONTENT",
+      _ts: "2026-06-22T08:43:24.619Z",
+      _seq: 42,
+      agent_name: "principal",
+      message_id: "m1",
+      delta: "hi",
+    };
+    const norm = normalizeAgUiEvent(raw) as Record<string, unknown>;
+    // The timestamp the demo timeline sorts on must survive normalization.
+    expect(norm._ts).toBe("2026-06-22T08:43:24.619Z");
+    expect(norm._seq).toBe(42);
+    expect(norm).not.toHaveProperty("Ts");
+    expect(norm).not.toHaveProperty("Seq");
+    // Internal snake_case still camelizes.
+    expect(norm.agentName).toBe("principal");
+    expect(norm.messageId).toBe("m1");
+  });
+});

--- a/packages/web/src/components/demo/demoBundle.ts
+++ b/packages/web/src/components/demo/demoBundle.ts
@@ -159,9 +159,14 @@ export async function buildDemoBundle(opts: BuildDemoOptions): Promise<DemoBundl
   let timeline: DemoBundle["timeline"] = "timestamped";
   // Pull the persisted event timeline from the new history endpoint (the
   // legacy `/sessions/:id/events` path is an SSE alias and returns no JSON).
-  // Cap at 5000 — the endpoint enforces the same cap, but stating it here
-  // documents the bundle's max footprint.
-  const historyEnvelope = await api.sessions.getHistory(session.id, { limit: 5000 });
+  // Request the FULL log (`limit: 0`) — same as the live chat rehydrate path
+  // (HISTORY_REHYDRATE_LIMIT). A positive cap returns the *tail* of the log,
+  // which slices off the oldest events: the leading TEXT_MESSAGE_START of the
+  // earliest messages is dropped, leaving orphaned CONTENT/END that the
+  // reducer can't attach to anything, so the conversation's opening replies
+  // silently vanish from the replay. The 25 MB embed budget (MAX_TOTAL_BYTES)
+  // still bounds the bundle's real footprint via the files section.
+  const historyEnvelope = await api.sessions.getHistory(session.id, { limit: 0 });
   let events: typeof historyEnvelope.events | undefined = historyEnvelope.events;
   let messages: ChatMessage[] | undefined;
   if (!events || events.length === 0) {

--- a/packages/web/src/components/files/FileSidebar.tsx
+++ b/packages/web/src/components/files/FileSidebar.tsx
@@ -15,7 +15,6 @@ import {
 import { FileContent, FileEntry } from "../../contracts/backend";
 import { useSandbox } from "../../contexts/SandboxContext";
 import { useSessions } from "../../contexts/SessionContext";
-import { runtimeConfig } from "../../config";
 import { useT } from "../../i18n/useT";
 import { api } from "../../utils/api";
 import { downloadBlob } from "../../utils/download";
@@ -128,10 +127,14 @@ function findNode(root: FileNode, path: string | null): FileNode | null {
 export function FileSidebar({ isOpen, onClose, onResize, onResizeEnd, onResizeStart, width }: FileSidebarProps) {
   const { currentSandbox } = useSandbox();
   const { currentSession } = useSessions();
-  // In single-user local mode the workspace is addressed by the active session
-  // id (workspaces/<sid>/), not a container id. Elsewhere the sandbox id is the
-  // addressing key. `currentSandbox.status` still gates whether files are live.
-  const sandboxId = runtimeConfig.localMode ? currentSession?.id ?? null : currentSandbox?.id ?? null;
+  // The runtime always addresses a workspace by session id (workspaces/<sid>/),
+  // never by container id — in both local and remote mode. A container can host
+  // several sessions, and the file tree shows the *current session's* workspace.
+  // (#168) `currentSandbox.status` still gates whether files are live; the
+  // variable name stays `sandboxId` only because the call sites/sub-component
+  // prop are named that way — it has always carried the session id in local
+  // mode. A full rename rides with the planned session-management cleanup.
+  const sandboxId = currentSession?.id ?? null;
   const t = useT();
   const [tree, setTree] = useState<FileNode>(rootNode);
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(() => new Set(["/workspace"]));

--- a/packages/web/src/contexts/messageReducer.ts
+++ b/packages/web/src/contexts/messageReducer.ts
@@ -171,6 +171,25 @@ export function reduceMessagesForEvent(existing: ChatMessage[], event: WebSocket
       // Strip NO-RENDER wrapper used by record_trace "Message Complete" hint
       delta = delta.replace(/<!--NO-RENDER-->[\s\S]*?<!--\/NO-RENDER-->/g, "");
       if (!delta) return existing;
+      // Orphaned CONTENT (no matching START) — recover gracefully instead of
+      // dropping it. This happens when a demo bundle was exported from a
+      // tail-sliced history: the leading START of the earliest messages is gone,
+      // and a plain `.map` here would no-op, silently swallowing the opening
+      // replies. Synthesize the message so the content still renders.
+      if (!existing.some((m) => m.id === id)) {
+        return [
+          ...existing,
+          {
+            id,
+            role: "assistant",
+            content: delta,
+            createdAt: new Date().toISOString(),
+            agent,
+            streaming: true,
+            kind: "text",
+          },
+        ];
+      }
       return existing.map((m) =>
         m.id === id ? { ...m, content: (m.content ?? "") + delta } : m,
       );

--- a/packages/web/src/contracts/backend.ts
+++ b/packages/web/src/contracts/backend.ts
@@ -481,7 +481,14 @@ function normalizeStringArray(value: unknown): string[] {
 }
 
 function camelizeKey(key: string): string {
-  return key.replace(/_([a-z])/g, (_, char: string) => char.toUpperCase());
+  // Preserve a leading-underscore prefix: `_ts` / `_seq` are AG-UI transport
+  // metadata whose underscore is significant. Without this guard the regex
+  // turns `_ts` into `Ts`, so `normalizeAgUiEvent` strips the timestamp and the
+  // demo replay's timeline collapses (every event lands at ms=0). Only internal
+  // snake_case boundaries (e.g. `agent_name` → `agentName`) are camelized.
+  const lead = key.match(/^_+/)?.[0] ?? "";
+  const rest = key.slice(lead.length);
+  return lead + rest.replace(/_([a-z])/g, (_, char: string) => char.toUpperCase());
 }
 
 function camelizeObject(value: unknown): unknown {


### PR DESCRIPTION
## 概要

将 `development`（= `main` + win-compat 批次 #174–184 + 附带项）合入 `main`。
被测对象在 GPU 测试床（bp-test，A10）对 `development@e2f9ee1` 跑过完整回归，结论：**无 Linux 回归，可合**。

## 包含的 11 个 PR（#185 已集成进 development）

| PR | 内容 | 类型 |
|----|------|------|
| #174 | lock `up` to local mode unless mode explicit | CLI |
| #175 | redact native Windows node_modules paths (#157) | Windows/隐私 |
| #176 | centralize platform detection; Windows signal/MCP/permissions | Windows |
| #177 | POSIX-normalize workspace + skill-search paths; harden traversal guard | Windows |
| #178 | collapse CRLF before persona drift compare | Windows |
| #179 | structured Mounts API for Docker bind (Windows drive paths) | Windows |
| #180 | docs: providers.json mode is no-op on Windows | docs |
| #181 | tests use os.tmpdir() instead of /tmp literals | chore |
| #182 | foreground `up` honours --port for the runtime (#171) | CLI |
| #183 | file tree addresses by session id in remote mode (#168) | Web |
| #184 | skill_search accepts comma-separated keyword string | runtime |

附带项（development 已有、随之并入）：#155（Windows pathToFileURL）、#158（demo 全量对话）、README×2 同步。

## 测试床验收（2026-06-28，SUT=development@e2f9ee1）

- **上游单测全绿**：6 包 72 test files / **739 tests passed, 0 failed**（protocol/runtime/backend-core/app(cli)/client-cli/web）。这是 6 个 Windows PR 在 Linux 上唯一诚实的验证面——它们用 mock 平台检测把 Windows 形状回归钉死。
- **黑盒 fast 全 PASS**：demo-bundle / probes(65) / crossplatform / up-runtime-port / contract / scenarios(21) / web-journeys / recovery(M5)。
- **两条缺口转回归守卫**（实测先复现绿、回退即翻红）：
  - #175 → testbed `crossplatform §2.3`（agent-error redact 跨分隔符，Windows 用户名不再泄漏）由 open-gap 升级为正向断言；案例库 BPCASE-0045 转 fixed。
  - #182 → testbed `up-runtime-port`（前台 `--port` 真正送达 runtime）5/5 转绿；案例库 BPCASE-0046 转 fixed。

**诚实边界**：6 个 Windows PR 无法在 Linux 真机走 Windows 运行时路径，本轮只跑上游单测 + Linux 无回归，未做真 Windows 验证。

合并后 `main == development`，自动 close #174–184。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
