### PR TITLE
feat(web): show real on-disk workspace path in Files panel (#156)

### DIFF
--- a/packages/backend-core/src/app.ts
+++ b/packages/backend-core/src/app.ts
@@ -14,7 +14,7 @@
  * `API_BASE = "/api"`), with static assets served at the root.
  */
 import { createRequire } from "node:module";
-import { join } from "node:path";
+import { resolve, join } from "node:path";
 import { Hono } from "hono";
 import { serveStatic } from "@hono/node-server/serve-static";
 import {
@@ -101,6 +101,25 @@ export function createApp(options: CreateAppOptions): Hono {
   api.get("/health", (c) => c.json({ status: "ok" }));
 
   api.get("/version", (c) => c.json({ name: pkg.name, version: pkg.version }));
+
+  // ---- Runtime info (backend-local; #156) ------------------------------
+  // Exposes the real on-disk data root so the Files panel can show users
+  // where a session's workspace actually lives (e.g. to open it in a file
+  // manager). Host paths are sensitive in multi-user hosting, so this is
+  // gated to local mode: hosted deployments set BP_LOCAL_MODE=0 (mirroring
+  // the web build's VITE_LOCAL_MODE) and then only `{ localMode: false }`
+  // is returned — never a host path. A per-session workspace dir is
+  // `<workspacesRoot>/<sessionId>` (the SPA joins the active id itself).
+  const localMode = (env?.BP_LOCAL_MODE ?? process.env.BP_LOCAL_MODE) !== "0";
+  api.get("/info", (c) => {
+    if (!localMode) return c.json({ localMode: false });
+    const absDataDir = resolve(dataDir);
+    return c.json({
+      localMode: true,
+      dataDir: absDataDir,
+      workspacesRoot: join(absDataDir, "workspaces"),
+    });
+  });
 
   // ---- Identity (backend-local) ----------------------------------------
   // Trust-front (#21): hosted deployments resolve identity at the upstream

--- a/packages/backend-core/test/app.test.ts
+++ b/packages/backend-core/test/app.test.ts
@@ -231,6 +231,46 @@ describe("Hono app — REST forwarding", () => {
     expect(pkg.version).not.toBe("0.1.0"); // the old hardcoded drift value
     expect(fetchFn).not.toHaveBeenCalled();
   });
+
+  // #156: /api/info exposes the real on-disk data root for the Files panel,
+  // gated to local mode. It must never touch the runtime.
+  it("GET /api/info returns absolute dataDir + workspacesRoot in local mode", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "bp-info-"));
+    const fetchFn = vi.fn();
+    const app = createApp({
+      orchestrator: fakeOrchestrator(),
+      fetchFn: fetchFn as never,
+      serveWeb: false,
+      dataDir: dir,
+      env: {}, // BP_LOCAL_MODE unset → defaults to local mode
+    });
+    const res = await app.request("/api/info");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { localMode: boolean; dataDir: string; workspacesRoot: string };
+    expect(body.localMode).toBe(true);
+    expect(body.dataDir).toBe(path.resolve(dir));
+    expect(body.workspacesRoot).toBe(path.join(path.resolve(dir), "workspaces"));
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("GET /api/info hides host paths when BP_LOCAL_MODE=0 (hosted)", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "bp-info-hosted-"));
+    const fetchFn = vi.fn();
+    const app = createApp({
+      orchestrator: fakeOrchestrator(),
+      fetchFn: fetchFn as never,
+      serveWeb: false,
+      dataDir: dir,
+      env: { BP_LOCAL_MODE: "0" },
+    });
+    const res = await app.request("/api/info");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { localMode: boolean; dataDir?: string; workspacesRoot?: string };
+    expect(body).toEqual({ localMode: false });
+    expect(body.dataDir).toBeUndefined();
+    expect(body.workspacesRoot).toBeUndefined();
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
 });
 
 describe("Hono app — SSE byte passthrough (修正4)", () => {

--- a/packages/web/src/components/files/FileSidebar.tsx
+++ b/packages/web/src/components/files/FileSidebar.tsx
@@ -13,6 +13,7 @@ import {
   X,
 } from "lucide-react";
 import { FileContent, FileEntry } from "../../contracts/backend";
+import { runtimeConfig } from "../../config";
 import { useSandbox } from "../../contexts/SandboxContext";
 import { useSessions } from "../../contexts/SessionContext";
 import { useT } from "../../i18n/useT";
@@ -146,6 +147,49 @@ export function FileSidebar({ isOpen, onClose, onResize, onResizeEnd, onResizeSt
   const [error, setError] = useState<string | null>(null);
   const [isPreviewMaximized, setIsPreviewMaximized] = useState(false);
   const resizeStartRef = useRef<{ pointerX: number; width: number } | null>(null);
+
+  // #156: in local mode, surface the real on-disk workspace dir so users know
+  // which directory the agent writes into. `workspacesRoot` comes from the
+  // backend (gated to local mode there too); the per-session dir is
+  // `<workspacesRoot>/<sessionId>`. Null in hosted mode → keep showing the
+  // virtual `/workspace` and never disclose a host path.
+  const [workspacesRoot, setWorkspacesRoot] = useState<string | null>(null);
+  useEffect(() => {
+    if (!runtimeConfig.localMode) return;
+    let cancelled = false;
+    void api.getInfo().then((info) => {
+      if (!cancelled && info.localMode && info.workspacesRoot) {
+        setWorkspacesRoot(info.workspacesRoot);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Join with the platform's separator: a Windows root contains "\", a POSIX
+  // root "/". Detect from the root itself rather than assuming the host.
+  const realWorkspacePath = useMemo(() => {
+    if (!workspacesRoot || !currentSession?.id) return null;
+    const sepChar = workspacesRoot.includes("\\") && !workspacesRoot.includes("/") ? "\\" : "/";
+    return `${workspacesRoot.replace(/[\\/]$/, "")}${sepChar}${currentSession.id}`;
+  }, [workspacesRoot, currentSession?.id]);
+
+  // Map a virtual `/workspace[/...]` path to its real on-disk equivalent for
+  // display. Returns the original virtual path when no real root is known.
+  const toDisplayPath = useCallback(
+    (virtualPath: string): string => {
+      if (!realWorkspacePath) return virtualPath;
+      const sepChar = realWorkspacePath.includes("\\") && !realWorkspacePath.includes("/") ? "\\" : "/";
+      if (virtualPath === "/workspace") return realWorkspacePath;
+      if (virtualPath.startsWith("/workspace/")) {
+        const rel = virtualPath.slice("/workspace/".length).split("/").join(sepChar);
+        return `${realWorkspacePath}${sepChar}${rel}`;
+      }
+      return virtualPath;
+    },
+    [realWorkspacePath],
+  );
 
   const loadDirectory = useCallback(
     async (path: string) => {
@@ -446,7 +490,7 @@ export function FileSidebar({ isOpen, onClose, onResize, onResizeEnd, onResizeSt
         </header>
 
         <div className="file-sidebar__path">
-          <span>/workspace</span>
+          <span title={realWorkspacePath ?? "/workspace"}>{realWorkspacePath ?? "/workspace"}</span>
           <small>{currentSandbox?.status === "running" ? t("files.live") : t("files.offline")}</small>
         </div>
 
@@ -466,6 +510,7 @@ export function FileSidebar({ isOpen, onClose, onResize, onResizeEnd, onResizeSt
           setIsPreviewMaximized(false);
         }}
         sandboxId={sandboxId}
+        toDisplayPath={toDisplayPath}
         onToggleMaximize={() => setIsPreviewMaximized((current) => !current)}
       />
     </>
@@ -478,6 +523,7 @@ function FilePreviewPanel({
   isMaximized,
   onClose,
   sandboxId,
+  toDisplayPath,
   onToggleMaximize,
 }: {
   file: FileNode | null;
@@ -485,6 +531,7 @@ function FilePreviewPanel({
   isMaximized: boolean;
   onClose: () => void;
   sandboxId: string | null;
+  toDisplayPath: (virtualPath: string) => string;
   onToggleMaximize: () => void;
 }) {
   const t = useT();
@@ -637,7 +684,7 @@ function FilePreviewPanel({
       <dl className="file-preview__meta">
         <div>
           <dt>{t("files.preview.path")}</dt>
-          <dd>{file.path}</dd>
+          <dd>{toDisplayPath(file.path)}</dd>
         </div>
         <div>
           <dt>{t("files.preview.size")}</dt>

--- a/packages/web/src/utils/api.ts
+++ b/packages/web/src/utils/api.ts
@@ -123,6 +123,20 @@ export const api = {
     return handleJson(await apiFetch(`${API_BASE}/version`));
   },
 
+  // #156: real on-disk paths for the Files panel (local mode only). Hosted
+  // backends return `{ localMode: false }` with no host path. Best-effort:
+  // any failure resolves to a non-local shape so callers fall back cleanly.
+  async getInfo(): Promise<{ localMode: boolean; dataDir?: string; workspacesRoot?: string }> {
+    if (runtimeConfig.useMockBackend) {
+      return { localMode: false };
+    }
+    try {
+      return await handleJson(await apiFetch(`${API_BASE}/info`));
+    } catch {
+      return { localMode: false };
+    }
+  },
+
   auth: {
     async me(): Promise<User> {
       if (runtimeConfig.useMockBackend) {


### PR DESCRIPTION
## What

In local mode the Files panel showed only the virtual `/workspace` root, so users couldn't tell which on-disk directory the agent actually writes into. This surfaces the real path (e.g. to open it in a file manager), while keeping host paths private in hosted deployments.

## Changes

- **backend-core** (`app.ts`): new `GET /api/info` returns `{ localMode, dataDir, workspacesRoot }`. Gated on `BP_LOCAL_MODE` — hosted (`BP_LOCAL_MODE=0`) returns only `{ localMode: false }` and never discloses a host path. Backend-local, never proxied to the runtime.
- **web api** (`api.ts`): `api.getInfo()` client; degrades to `{ localMode: false }` on any error.
- **FileSidebar**: fetches the real root in local mode and maps virtual `/workspace[/...]` paths to their on-disk equivalent for display (path header + preview meta), handling both POSIX and Windows separators.
- **Tests**: `/api/info` local vs hosted behaviour (in `app.test.ts`).

## Fixes applied while integrating

This work existed as an uncommitted WIP that didn't build. Two fixes were needed to land it on top of the current `development`:
- Added the missing `runtimeConfig` import in `FileSidebar.tsx` — the change referenced `runtimeConfig.localMode` without importing it, which broke the web build (`TS2304: Cannot find name 'runtimeConfig'`).
- Imported `resolve` alongside the existing `join` in `app.ts` (`development` already imports `join`).

## Verification

- monorepo typecheck: pass
- backend tests: 611/611 pass (incl. the new `/api/info` tests)
- web tests: 132/132 pass
- web build: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)