### PR TITLE
fix(web): Timeline axis ends at last message unless running (#166)

### DIFF
--- a/packages/web/src/__tests__/timelineBounds.test.ts
+++ b/packages/web/src/__tests__/timelineBounds.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { computeTimeBounds } from "../components/session/TimelineTab";
+
+describe("computeTimeBounds (#166)", () => {
+  const now = 1_000_000;
+
+  it("falls back to a 60s window ending at `now` when there are no dots", () => {
+    expect(computeTimeBounds([], now, false)).toEqual({ start: now - 60_000, end: now });
+    expect(computeTimeBounds([], now, true)).toEqual({ start: now - 60_000, end: now });
+  });
+
+  it("ends at the last message for a finished (not running) session", () => {
+    const first = 100_000;
+    const last = 200_000;
+    // `now` is far in the future, but the axis must NOT stretch to it.
+    const bounds = computeTimeBounds([first, last], now, false);
+    expect(bounds).toEqual({ start: first, end: last });
+  });
+
+  it("does not grow the axis as wall-clock `now` advances when idle", () => {
+    const ts = [100_000, 200_000];
+    const a = computeTimeBounds(ts, 500_000, false);
+    const b = computeTimeBounds(ts, 9_000_000, false);
+    // Same dots, later `now` → identical bounds (no creeping right edge).
+    expect(a).toEqual(b);
+    expect(b.end).toBe(200_000);
+  });
+
+  it("extends to `now` while the session is actively running", () => {
+    const ts = [100_000, 200_000];
+    const bounds = computeTimeBounds(ts, now, true);
+    expect(bounds).toEqual({ start: 100_000, end: now });
+  });
+
+  it("when running but `now` is before the last message, keeps the last message", () => {
+    const ts = [100_000, 200_000];
+    const bounds = computeTimeBounds(ts, 150_000, true);
+    expect(bounds.end).toBe(200_000);
+  });
+
+  it("expands a degenerate (single-dot / identical-ts) span to 60s", () => {
+    const bounds = computeTimeBounds([100_000], 100_000, false);
+    expect(bounds).toEqual({ start: 100_000, end: 160_000 });
+  });
+
+  it("expands a degenerate span even while running", () => {
+    // Single dot, now == that dot → end would equal start, must be padded.
+    const bounds = computeTimeBounds([100_000], 100_000, true);
+    expect(bounds).toEqual({ start: 100_000, end: 160_000 });
+  });
+});

--- a/packages/web/src/components/session/AgentNetwork.tsx
+++ b/packages/web/src/components/session/AgentNetwork.tsx
@@ -822,6 +822,7 @@ export function AgentNetwork({ agents, messages, agentFilters, onSetAgentFilter 
             <TimelineTab
               messages={messages}
               now={now}
+              isRunning={runningCount > 0}
               onSelectMessage={(agentName) => selectNode(agentName)}
             />
           )}

--- a/packages/web/src/components/session/TimelineTab.tsx
+++ b/packages/web/src/components/session/TimelineTab.tsx
@@ -15,6 +15,13 @@ import { getMessageEdge, msgTypeKind } from "./agentNetworkShared";
 interface TimelineTabProps {
   messages: ChatMessage[];
   now: number;
+  /**
+   * Whether the session is actively running (≥1 agent in a running state).
+   * Only while running does the axis track wall-clock `now` and show the
+   * live "now" marker; a finished session freezes the axis at the last
+   * message so the plot doesn't grow a blank right gutter over time (#166).
+   */
+  isRunning?: boolean;
   /** Click a dot → caller selects that agent (and flips to Detail tab). */
   onSelectMessage: (agentName: string) => void;
 }
@@ -33,7 +40,30 @@ const LABEL_W = 88;
 const PAD_TOP = 28;
 const TICK_COUNT = 6;
 
-export function TimelineTab({ messages, now, onSelectMessage }: TimelineTabProps) {
+/**
+ * Compute the timeline's [start, end] axis bounds (#166).
+ *
+ * The axis always starts at the first message. It ends at the LAST message,
+ * and only extends to wall-clock `now` while the session is actively running.
+ * A finished session therefore freezes its right edge at the last event
+ * instead of accreting blank space as real time marches on.
+ *
+ * `tsList` must be ascending (as produced by the sorted `dots`).
+ */
+export function computeTimeBounds(
+  tsList: number[],
+  now: number,
+  isRunning: boolean,
+): { start: number; end: number } {
+  if (tsList.length === 0) return { start: now - 60_000, end: now };
+  const start = tsList[0];
+  const lastTs = tsList[tsList.length - 1];
+  const end = isRunning ? Math.max(now, lastTs) : lastTs;
+  // Degenerate span (single dot / identical timestamps): give it a minute.
+  return { start, end: end === start ? start + 60_000 : end };
+}
+
+export function TimelineTab({ messages, now, isRunning = false, onSelectMessage }: TimelineTabProps) {
   const t = useT();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [zoom, setZoom] = useState(1);
@@ -78,12 +108,10 @@ export function TimelineTab({ messages, now, onSelectMessage }: TimelineTabProps
     return names;
   }, [dots]);
 
-  const timeBounds = useMemo(() => {
-    if (dots.length === 0) return { start: now - 60_000, end: now };
-    const start = dots[0].ts;
-    const end = Math.max(now, dots[dots.length - 1].ts);
-    return { start, end: end === start ? start + 60_000 : end };
-  }, [dots, now]);
+  const timeBounds = useMemo(
+    () => computeTimeBounds(dots.map((d) => d.ts), now, isRunning),
+    [dots, now, isRunning],
+  );
 
   if (dots.length === 0) {
     return (
@@ -243,8 +271,10 @@ export function TimelineTab({ messages, now, onSelectMessage }: TimelineTabProps
             </g>
           ))}
 
-          {/* "now" marker */}
-          <line x1={xOf(now)} x2={xOf(now)} y1={PAD_TOP - 6} y2={svgH - 4} className="agent-timeline__now" />
+          {/* "now" marker — only meaningful while the session is live (#166) */}
+          {isRunning && (
+            <line x1={xOf(now)} x2={xOf(now)} y1={PAD_TOP - 6} y2={svgH - 4} className="agent-timeline__now" />
+          )}
 
           {/* delegate→result arcs */}
           {arcs.map((a) => {


### PR DESCRIPTION
## Summary
The Timeline tab forced the time axis to end at wall-clock `now` (`end = Math.max(now, lastDotTs)`), so a **finished** session kept growing a blank right gutter as real time advanced and the dots got squeezed left. A 5s ticker re-rendered the tab to keep `now` moving, making the dead space visibly creep.

This clamps the axis end to the last message; the axis only stretches to `now` while the session is actively running. The live "now" marker is likewise shown only while running (otherwise it just sits glued to the right edge).

## Changes
- Extract `computeTimeBounds(tsList, now, isRunning)` as a pure, tested function; `TimelineTab` consumes it via the existing memo.
- Thread `isRunning={runningCount > 0}` from `AgentNetwork` into `TimelineTab`.
- Add `timelineBounds.test.ts` (7 cases: idle freeze, running stretch, degenerate-span padding, no-creep-on-now).

## Test
- `packages/web` → `vitest run src/__tests__/timelineBounds.test.ts` → 7/7 pass.
- Clean (conflict-free) merge into `development`; touched files unchanged on `development` since the branch point.

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)