### PR TITLE
Development

### DIFF
--- a/packages/backend-core/src/app.ts
+++ b/packages/backend-core/src/app.ts
@@ -14,7 +14,7 @@
  * `API_BASE = "/api"`), with static assets served at the root.
  */
 import { createRequire } from "node:module";
-import { join } from "node:path";
+import { resolve, join } from "node:path";
 import { Hono } from "hono";
 import { serveStatic } from "@hono/node-server/serve-static";
 import {
@@ -101,6 +101,25 @@ export function createApp(options: CreateAppOptions): Hono {
   api.get("/health", (c) => c.json({ status: "ok" }));
 
   api.get("/version", (c) => c.json({ name: pkg.name, version: pkg.version }));
+
+  // ---- Runtime info (backend-local; #156) ------------------------------
+  // Exposes the real on-disk data root so the Files panel can show users
+  // where a session's workspace actually lives (e.g. to open it in a file
+  // manager). Host paths are sensitive in multi-user hosting, so this is
+  // gated to local mode: hosted deployments set BP_LOCAL_MODE=0 (mirroring
+  // the web build's VITE_LOCAL_MODE) and then only `{ localMode: false }`
+  // is returned — never a host path. A per-session workspace dir is
+  // `<workspacesRoot>/<sessionId>` (the SPA joins the active id itself).
+  const localMode = (env?.BP_LOCAL_MODE ?? process.env.BP_LOCAL_MODE) !== "0";
+  api.get("/info", (c) => {
+    if (!localMode) return c.json({ localMode: false });
+    const absDataDir = resolve(dataDir);
+    return c.json({
+      localMode: true,
+      dataDir: absDataDir,
+      workspacesRoot: join(absDataDir, "workspaces"),
+    });
+  });
 
   // ---- Identity (backend-local) ----------------------------------------
   // Trust-front (#21): hosted deployments resolve identity at the upstream

--- a/packages/backend-core/test/app.test.ts
+++ b/packages/backend-core/test/app.test.ts
@@ -231,6 +231,46 @@ describe("Hono app — REST forwarding", () => {
     expect(pkg.version).not.toBe("0.1.0"); // the old hardcoded drift value
     expect(fetchFn).not.toHaveBeenCalled();
   });
+
+  // #156: /api/info exposes the real on-disk data root for the Files panel,
+  // gated to local mode. It must never touch the runtime.
+  it("GET /api/info returns absolute dataDir + workspacesRoot in local mode", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "bp-info-"));
+    const fetchFn = vi.fn();
+    const app = createApp({
+      orchestrator: fakeOrchestrator(),
+      fetchFn: fetchFn as never,
+      serveWeb: false,
+      dataDir: dir,
+      env: {}, // BP_LOCAL_MODE unset → defaults to local mode
+    });
+    const res = await app.request("/api/info");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { localMode: boolean; dataDir: string; workspacesRoot: string };
+    expect(body.localMode).toBe(true);
+    expect(body.dataDir).toBe(path.resolve(dir));
+    expect(body.workspacesRoot).toBe(path.join(path.resolve(dir), "workspaces"));
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("GET /api/info hides host paths when BP_LOCAL_MODE=0 (hosted)", async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), "bp-info-hosted-"));
+    const fetchFn = vi.fn();
+    const app = createApp({
+      orchestrator: fakeOrchestrator(),
+      fetchFn: fetchFn as never,
+      serveWeb: false,
+      dataDir: dir,
+      env: { BP_LOCAL_MODE: "0" },
+    });
+    const res = await app.request("/api/info");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { localMode: boolean; dataDir?: string; workspacesRoot?: string };
+    expect(body).toEqual({ localMode: false });
+    expect(body.dataDir).toBeUndefined();
+    expect(body.workspacesRoot).toBeUndefined();
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
 });
 
 describe("Hono app — SSE byte passthrough (修正4)", () => {

--- a/packages/web/src/__tests__/api.test.ts
+++ b/packages/web/src/__tests__/api.test.ts
@@ -219,3 +219,44 @@ describe("api.sessions.interrupt — hits the interrupt route, not /messages (#9
     expect(url.endsWith("/messages")).toBe(false);
   });
 });
+
+describe("api.sandbox.uploadFile — #47 base64 upload to the workspace", () => {
+  // blobToBase64 uses the browser FileReader, absent in the node test env; stub
+  // it with a minimal readAsDataURL that emits a data: URL so the base64 path
+  // (prefix stripping) is exercised end-to-end.
+  beforeEach(() => {
+    class FakeFileReader {
+      result: string | null = null;
+      error: unknown = null;
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      readAsDataURL(_blob: Blob) {
+        // "hi" → aGk= ; the helper must strip the "data:...;base64," prefix.
+        this.result = "data:text/plain;base64,aGk=";
+        this.onload?.();
+      }
+    }
+    vi.stubGlobal("FileReader", FakeFileReader);
+  });
+
+  it("POSTs { path, contentBase64 } and returns the runtime's { path, size }", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({ status: 201, contentType: "application/json", json: { path: "notes.txt", size: 2 } }),
+    );
+    const out = await api.sandbox.uploadFile("s1", "notes.txt", new Blob(["hi"]));
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toMatch(/\/sandbox\/s1\/files$/);
+    expect((init as RequestInit).method).toBe("POST");
+    const body = JSON.parse(String((init as RequestInit).body));
+    expect(body).toEqual({ path: "notes.txt", contentBase64: "aGk=" });
+    expect(out).toEqual({ path: "notes.txt", size: 2 });
+  });
+
+  it("throws the backend error message on a non-ok response", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({ ok: false, status: 400, contentType: "application/json", json: { detail: "file too large" } }),
+    );
+    await expect(api.sandbox.uploadFile("s1", "big.bin", new Blob(["hi"]))).rejects.toThrow("file too large");
+  });
+});

--- a/packages/web/src/__tests__/timelineBounds.test.ts
+++ b/packages/web/src/__tests__/timelineBounds.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { computeTimeBounds } from "../components/session/TimelineTab";
+
+describe("computeTimeBounds (#166)", () => {
+  const now = 1_000_000;
+
+  it("falls back to a 60s window ending at `now` when there are no dots", () => {
+    expect(computeTimeBounds([], now, false)).toEqual({ start: now - 60_000, end: now });
+    expect(computeTimeBounds([], now, true)).toEqual({ start: now - 60_000, end: now });
+  });
+
+  it("ends at the last message for a finished (not running) session", () => {
+    const first = 100_000;
+    const last = 200_000;
+    // `now` is far in the future, but the axis must NOT stretch to it.
+    const bounds = computeTimeBounds([first, last], now, false);
+    expect(bounds).toEqual({ start: first, end: last });
+  });
+
+  it("does not grow the axis as wall-clock `now` advances when idle", () => {
+    const ts = [100_000, 200_000];
+    const a = computeTimeBounds(ts, 500_000, false);
+    const b = computeTimeBounds(ts, 9_000_000, false);
+    // Same dots, later `now` → identical bounds (no creeping right edge).
+    expect(a).toEqual(b);
+    expect(b.end).toBe(200_000);
+  });
+
+  it("extends to `now` while the session is actively running", () => {
+    const ts = [100_000, 200_000];
+    const bounds = computeTimeBounds(ts, now, true);
+    expect(bounds).toEqual({ start: 100_000, end: now });
+  });
+
+  it("when running but `now` is before the last message, keeps the last message", () => {
+    const ts = [100_000, 200_000];
+    const bounds = computeTimeBounds(ts, 150_000, true);
+    expect(bounds.end).toBe(200_000);
+  });
+
+  it("expands a degenerate (single-dot / identical-ts) span to 60s", () => {
+    const bounds = computeTimeBounds([100_000], 100_000, false);
+    expect(bounds).toEqual({ start: 100_000, end: 160_000 });
+  });
+
+  it("expands a degenerate span even while running", () => {
+    // Single dot, now == that dot → end would equal start, must be padded.
+    const bounds = computeTimeBounds([100_000], 100_000, true);
+    expect(bounds).toEqual({ start: 100_000, end: 160_000 });
+  });
+});

--- a/packages/web/src/components/chat/PromptComposer.tsx
+++ b/packages/web/src/components/chat/PromptComposer.tsx
@@ -1,4 +1,4 @@
-import { Bot, Square } from "lucide-react";
+import { Bot, Paperclip, Square, X } from "lucide-react";
 import { FormEvent, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { ProviderProfile } from "../../contracts/backend";
 import { useSandbox } from "../../contexts/SandboxContext";
@@ -34,6 +34,14 @@ export function PromptComposer() {
   const commandsRef = useRef<HTMLDivElement | null>(null);
   const menuRef = useRef<HTMLDivElement | null>(null);
   const [menuPos, setMenuPos] = useState<{ top: number; left: number } | null>(null);
+  // #47: file upload — names of files uploaded into the workspace this turn,
+  // shown as removable chips and announced to the agent on send. (Restored: the
+  // backend upload chain — writeFile route + #60 staging/drain — was always
+  // present; only this composer UI was removed in #160. It now lives in the
+  // left tool cluster, not the send cluster guarded by composerSendTools.test.)
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [attachments, setAttachments] = useState<string[]>([]);
+  const [uploading, setUploading] = useState(false);
   const { status: sandboxStatus, currentSandbox, reloadConfig } = useSandbox();
   const [composerError, setComposerError] = useState<string | null>(null);
   const { currentSession, messages, isSending, error, sendPrompt, isConnected, isDraft, agents, runActive, agentFilters, interruptCurrent, respondToInput, messageFilters } = useSessions();
@@ -220,17 +228,53 @@ export function PromptComposer() {
       return;
     }
     draftStore.set(sessionId, "");
+    // #47: if files were uploaded this turn, prepend a notice so the agent knows
+    // they exist in its workspace and can `read` them. Cleared after send.
+    const notice =
+      attachments.length > 0 ? `${t("chat.upload.notice", { names: attachments.join(", ") })}\n\n` : "";
+    const sentAttachments = attachments;
+    if (attachments.length > 0) setAttachments([]);
     // Carry the chosen provider/model so a freshly-created session records its
     // per-session selection (no-op for an already-running session).
-    const ok = await sendPrompt(content, {
+    const ok = await sendPrompt(`${notice}${content}`, {
       providerId: activeProvider?.id,
       modelId: selectedModel || undefined,
     });
     // #106: a failed/timed-out send must not silently eat the user's input.
-    // Restore the draft so they can retry without retyping. Only restore if they
-    // haven't already started typing again.
-    if (!ok && draftStore.get(sessionId).trim().length === 0) {
-      draftStore.set(sessionId, content);
+    // Restore the draft (and attachment chips) so they can retry without
+    // retyping. Only restore if they haven't already started typing again.
+    if (!ok) {
+      if (draftStore.get(sessionId).trim().length === 0) {
+        draftStore.set(sessionId, content);
+      }
+      if (sentAttachments.length > 0) {
+        setAttachments((prev) => (prev.length === 0 ? sentAttachments : prev));
+      }
+    }
+  };
+
+  // #47: upload the chosen files into the session workspace, then track their
+  // names as chips. In single-user mode the sandbox id and session id are the
+  // same; a draft has no real session yet, so uploads land in the `"local"`
+  // staging area and the runtime drains them into the real workspace on send
+  // (#60 drainLocalUploads). Files are uploaded to the workspace root by name.
+  const handleFilesChosen = async (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    const uploadId = currentSession?.id ?? currentSandbox?.id;
+    if (!uploadId) return;
+    setUploading(true);
+    setComposerError(null);
+    try {
+      for (const file of Array.from(files)) {
+        await api.sandbox.uploadFile(uploadId, file.name, file);
+        setAttachments((prev) => (prev.includes(file.name) ? prev : [...prev, file.name]));
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setComposerError(t("chat.upload.failed", { msg }));
+    } finally {
+      setUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = ""; // allow re-selecting the same file
     }
   };
 
@@ -288,6 +332,26 @@ export function PromptComposer() {
             ariaLabel={t("chat.srAsk")}
           />
 
+          {attachments.length > 0 || uploading ? (
+            <div className="composer__attachments" aria-label={t("chat.aria.attachFile")}>
+              {attachments.map((name) => (
+                <span className="composer__chip" key={name}>
+                  <Paperclip size={12} />
+                  <span className="composer__chip-name">{name}</span>
+                  <button
+                    type="button"
+                    className="composer__chip-remove"
+                    aria-label={t("chat.aria.removeAttachment")}
+                    onClick={() => setAttachments((prev) => prev.filter((n) => n !== name))}
+                  >
+                    <X size={12} />
+                  </button>
+                </span>
+              ))}
+              {uploading ? <span className="composer__chip composer__chip--pending">{t("chat.upload.uploading")}</span> : null}
+            </div>
+          ) : null}
+
           <div className="composer__toolbar">
             <div className="composer__tools">
               {/*
@@ -298,6 +362,27 @@ export function PromptComposer() {
                 <Plus size={18} />
               </IconButton>
               */}
+              {/*
+                #47: file upload. The button lives here in the left tool cluster
+                (not the send cluster, which composerSendTools.test.tsx guards
+                against an upload control under #160). The hidden <input> is
+                clicked programmatically; chosen files upload to the workspace
+                root and are announced to the agent on send.
+              */}
+              <input
+                ref={fileInputRef}
+                type="file"
+                multiple
+                style={{ display: "none" }}
+                onChange={(e) => void handleFilesChosen(e.target.files)}
+              />
+              <IconButton
+                label={t("chat.aria.attachFile")}
+                onClick={() => fileInputRef.current?.click()}
+                disabled={uploading || !currentSandbox}
+              >
+                <Paperclip size={17} />
+              </IconButton>
               {SHOW_SLASH_COMMANDS && slashCommands.length > 0 && (
                 <div className="command-picker" ref={commandsRef}>
                   <IconButton

--- a/packages/web/src/components/files/FileSidebar.tsx
+++ b/packages/web/src/components/files/FileSidebar.tsx
@@ -13,6 +13,7 @@ import {
   X,
 } from "lucide-react";
 import { FileContent, FileEntry } from "../../contracts/backend";
+import { runtimeConfig } from "../../config";
 import { useSandbox } from "../../contexts/SandboxContext";
 import { useSessions } from "../../contexts/SessionContext";
 import { useT } from "../../i18n/useT";
@@ -146,6 +147,49 @@ export function FileSidebar({ isOpen, onClose, onResize, onResizeEnd, onResizeSt
   const [error, setError] = useState<string | null>(null);
   const [isPreviewMaximized, setIsPreviewMaximized] = useState(false);
   const resizeStartRef = useRef<{ pointerX: number; width: number } | null>(null);
+
+  // #156: in local mode, surface the real on-disk workspace dir so users know
+  // which directory the agent writes into. `workspacesRoot` comes from the
+  // backend (gated to local mode there too); the per-session dir is
+  // `<workspacesRoot>/<sessionId>`. Null in hosted mode → keep showing the
+  // virtual `/workspace` and never disclose a host path.
+  const [workspacesRoot, setWorkspacesRoot] = useState<string | null>(null);
+  useEffect(() => {
+    if (!runtimeConfig.localMode) return;
+    let cancelled = false;
+    void api.getInfo().then((info) => {
+      if (!cancelled && info.localMode && info.workspacesRoot) {
+        setWorkspacesRoot(info.workspacesRoot);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Join with the platform's separator: a Windows root contains "\", a POSIX
+  // root "/". Detect from the root itself rather than assuming the host.
+  const realWorkspacePath = useMemo(() => {
+    if (!workspacesRoot || !currentSession?.id) return null;
+    const sepChar = workspacesRoot.includes("\\") && !workspacesRoot.includes("/") ? "\\" : "/";
+    return `${workspacesRoot.replace(/[\\/]$/, "")}${sepChar}${currentSession.id}`;
+  }, [workspacesRoot, currentSession?.id]);
+
+  // Map a virtual `/workspace[/...]` path to its real on-disk equivalent for
+  // display. Returns the original virtual path when no real root is known.
+  const toDisplayPath = useCallback(
+    (virtualPath: string): string => {
+      if (!realWorkspacePath) return virtualPath;
+      const sepChar = realWorkspacePath.includes("\\") && !realWorkspacePath.includes("/") ? "\\" : "/";
+      if (virtualPath === "/workspace") return realWorkspacePath;
+      if (virtualPath.startsWith("/workspace/")) {
+        const rel = virtualPath.slice("/workspace/".length).split("/").join(sepChar);
+        return `${realWorkspacePath}${sepChar}${rel}`;
+      }
+      return virtualPath;
+    },
+    [realWorkspacePath],
+  );
 
   const loadDirectory = useCallback(
     async (path: string) => {
@@ -446,7 +490,7 @@ export function FileSidebar({ isOpen, onClose, onResize, onResizeEnd, onResizeSt
         </header>
 
         <div className="file-sidebar__path">
-          <span>/workspace</span>
+          <span title={realWorkspacePath ?? "/workspace"}>{realWorkspacePath ?? "/workspace"}</span>
           <small>{currentSandbox?.status === "running" ? t("files.live") : t("files.offline")}</small>
         </div>
 
@@ -466,6 +510,7 @@ export function FileSidebar({ isOpen, onClose, onResize, onResizeEnd, onResizeSt
           setIsPreviewMaximized(false);
         }}
         sandboxId={sandboxId}
+        toDisplayPath={toDisplayPath}
         onToggleMaximize={() => setIsPreviewMaximized((current) => !current)}
       />
     </>
@@ -478,6 +523,7 @@ function FilePreviewPanel({
   isMaximized,
   onClose,
   sandboxId,
+  toDisplayPath,
   onToggleMaximize,
 }: {
   file: FileNode | null;
@@ -485,6 +531,7 @@ function FilePreviewPanel({
   isMaximized: boolean;
   onClose: () => void;
   sandboxId: string | null;
+  toDisplayPath: (virtualPath: string) => string;
   onToggleMaximize: () => void;
 }) {
   const t = useT();
@@ -637,7 +684,7 @@ function FilePreviewPanel({
       <dl className="file-preview__meta">
         <div>
           <dt>{t("files.preview.path")}</dt>
-          <dd>{file.path}</dd>
+          <dd>{toDisplayPath(file.path)}</dd>
         </div>
         <div>
           <dt>{t("files.preview.size")}</dt>

--- a/packages/web/src/components/session/AgentNetwork.tsx
+++ b/packages/web/src/components/session/AgentNetwork.tsx
@@ -822,6 +822,7 @@ export function AgentNetwork({ agents, messages, agentFilters, onSetAgentFilter 
             <TimelineTab
               messages={messages}
               now={now}
+              isRunning={runningCount > 0}
               onSelectMessage={(agentName) => selectNode(agentName)}
             />
           )}

--- a/packages/web/src/components/session/TimelineTab.tsx
+++ b/packages/web/src/components/session/TimelineTab.tsx
@@ -15,6 +15,13 @@ import { getMessageEdge, msgTypeKind } from "./agentNetworkShared";
 interface TimelineTabProps {
   messages: ChatMessage[];
   now: number;
+  /**
+   * Whether the session is actively running (≥1 agent in a running state).
+   * Only while running does the axis track wall-clock `now` and show the
+   * live "now" marker; a finished session freezes the axis at the last
+   * message so the plot doesn't grow a blank right gutter over time (#166).
+   */
+  isRunning?: boolean;
   /** Click a dot → caller selects that agent (and flips to Detail tab). */
   onSelectMessage: (agentName: string) => void;
 }
@@ -33,7 +40,30 @@ const LABEL_W = 88;
 const PAD_TOP = 28;
 const TICK_COUNT = 6;
 
-export function TimelineTab({ messages, now, onSelectMessage }: TimelineTabProps) {
+/**
+ * Compute the timeline's [start, end] axis bounds (#166).
+ *
+ * The axis always starts at the first message. It ends at the LAST message,
+ * and only extends to wall-clock `now` while the session is actively running.
+ * A finished session therefore freezes its right edge at the last event
+ * instead of accreting blank space as real time marches on.
+ *
+ * `tsList` must be ascending (as produced by the sorted `dots`).
+ */
+export function computeTimeBounds(
+  tsList: number[],
+  now: number,
+  isRunning: boolean,
+): { start: number; end: number } {
+  if (tsList.length === 0) return { start: now - 60_000, end: now };
+  const start = tsList[0];
+  const lastTs = tsList[tsList.length - 1];
+  const end = isRunning ? Math.max(now, lastTs) : lastTs;
+  // Degenerate span (single dot / identical timestamps): give it a minute.
+  return { start, end: end === start ? start + 60_000 : end };
+}
+
+export function TimelineTab({ messages, now, isRunning = false, onSelectMessage }: TimelineTabProps) {
   const t = useT();
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [zoom, setZoom] = useState(1);
@@ -78,12 +108,10 @@ export function TimelineTab({ messages, now, onSelectMessage }: TimelineTabProps
     return names;
   }, [dots]);
 
-  const timeBounds = useMemo(() => {
-    if (dots.length === 0) return { start: now - 60_000, end: now };
-    const start = dots[0].ts;
-    const end = Math.max(now, dots[dots.length - 1].ts);
-    return { start, end: end === start ? start + 60_000 : end };
-  }, [dots, now]);
+  const timeBounds = useMemo(
+    () => computeTimeBounds(dots.map((d) => d.ts), now, isRunning),
+    [dots, now, isRunning],
+  );
 
   if (dots.length === 0) {
     return (
@@ -243,8 +271,10 @@ export function TimelineTab({ messages, now, onSelectMessage }: TimelineTabProps
             </g>
           ))}
 
-          {/* "now" marker */}
-          <line x1={xOf(now)} x2={xOf(now)} y1={PAD_TOP - 6} y2={svgH - 4} className="agent-timeline__now" />
+          {/* "now" marker — only meaningful while the session is live (#166) */}
+          {isRunning && (
+            <line x1={xOf(now)} x2={xOf(now)} y1={PAD_TOP - 6} y2={svgH - 4} className="agent-timeline__now" />
+          )}
 
           {/* delegate→result arcs */}
           {arcs.map((a) => {

--- a/packages/web/src/utils/api.ts
+++ b/packages/web/src/utils/api.ts
@@ -123,6 +123,20 @@ export const api = {
     return handleJson(await apiFetch(`${API_BASE}/version`));
   },
 
+  // #156: real on-disk paths for the Files panel (local mode only). Hosted
+  // backends return `{ localMode: false }` with no host path. Best-effort:
+  // any failure resolves to a non-local shape so callers fall back cleanly.
+  async getInfo(): Promise<{ localMode: boolean; dataDir?: string; workspacesRoot?: string }> {
+    if (runtimeConfig.useMockBackend) {
+      return { localMode: false };
+    }
+    try {
+      return await handleJson(await apiFetch(`${API_BASE}/info`));
+    } catch {
+      return { localMode: false };
+    }
+  },
+
   auth: {
     async me(): Promise<User> {
       if (runtimeConfig.useMockBackend) {


### PR DESCRIPTION
## Summary

Promotes three web-focused changes from `development` to `main`:

- **feat(web): restore composer file upload (paperclip) (#47)** — restores the composer upload UI (paperclip button + hidden multi-file input in the left tool cluster, removable attachment chips, an "uploading…" pending chip). The end-to-end backend (writeFile route, `SessionManager.writeSessionFile`, #60 staging/drain) and the `api.sandbox.uploadFile` client already existed; only the UI was removed in #160. On send, a `[Uploaded file: …]` notice is prepended so the agent knows the files exist in its cwd; chips are restored if the send fails.
- **feat(web): show real on-disk workspace path in Files panel (#156)** — in local mode the Files panel now surfaces the real on-disk workspace directory instead of only the virtual `/workspace` root. New `GET /api/info` returns `{ localMode, dataDir, workspacesRoot }`, gated on `BP_LOCAL_MODE` so hosted deployments never disclose a host path. `FileSidebar` maps virtual `/workspace[/...]` paths to their on-disk equivalents (POSIX + Windows).
- **fix(web): Timeline axis ends at last message unless running (#166) (#191)** — clamps the Timeline time axis to the last message instead of wall-clock `now`, so a finished session no longer grows a blank right gutter as time advances. The axis only stretches to `now` (and shows the live "now" marker) while the session is running. Extracts the pure, tested `computeTimeBounds(tsList, now, isRunning)` helper.

## Related Issues

- Closes #47
- Closes #156
- Closes #166
- Supersedes #191

## Changes

- Restore composer file upload UI (paperclip button, attachment chips, pending state) in `PromptComposer.tsx`; prepend `[Uploaded file: …]` notice on send.
- Add `GET /api/info` endpoint (backend-core `app.ts`) returning local-mode workspace paths, gated on `BP_LOCAL_MODE`.
- Add `api.getInfo()` web client (`utils/api.ts`); degrades to `{ localMode: false }` on error.
- `FileSidebar.tsx`: fetch and display the real on-disk workspace root in local mode.
- `TimelineTab.tsx` / `AgentNetwork.tsx`: clamp axis end to last message unless running; thread `isRunning` through; extract `computeTimeBounds`.
- Tests: `app.test.ts` (`/api/info` local vs hosted), `api.test.ts` (`uploadFile` / `getInfo`), `timelineBounds.test.ts` (7 cases).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Verification

### How to test

1. Run locally in local mode; open the Files panel and confirm the real on-disk workspace path is shown.
2. Use the paperclip in the composer to attach a file, send a message, and confirm the agent can read the uploaded file from its cwd.
3. Run a session to completion and confirm the Timeline axis stops at the last message (no growing blank right gutter); start a new run and confirm the axis stretches to `now` with the live marker.

### What you personally verified

- `/api/info` returns host paths only when `BP_LOCAL_MODE` is set; hosted returns `{ localMode: false }`.
- Upload chips are restored when a send fails.
- Timeline axis no longer creeps on idle sessions.

### Checks

- [x] `npm run typecheck` passes
- [x] `BP_MOCK=1 npx vitest run` passes
- [x] Web build passes (`cd packages/web && npm test && npm run build`)
- [x] Manually tested locally

## Checklist

- [x] This PR is AI-assisted, and I have self-reviewed the generated code (see CONTRIBUTING.md)
- [x] My code follows the project's style
- [x] I have performed a self-review
- [x] My changes do not introduce new warnings
