### PR TITLE
fix(docker): default sandbox build to cpu target (#188)

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -429,6 +429,10 @@ docker compose up -d --build
 
 打开 <http://localhost:9001>（或你的 `BP_MAIN_PORT`）。停止用 `docker compose down`。
 
+默认构建使用 **CPU** 沙箱 stage —— 无需 GPU,也无需私有镜像访问权限。
+GPU 模式（`docker-compose.gpu.yml`）基于私有的 `brainpilot-gpu-base` 镜像,仅供内部用户使用;
+没有 ghcr 访问权限无法拉取,CPU 默认路径也不需要它。
+
 <details>
 <summary><b>沙箱依赖、部署模式与内存预算</b></summary>
 

--- a/README.md
+++ b/README.md
@@ -461,6 +461,10 @@ docker compose up -d --build
 
 Open <http://localhost:9001> (or your `BP_MAIN_PORT`). Stop with `docker compose down`.
 
+The default build targets the **CPU** sandbox stage — no GPU or private image access required.
+GPU mode (`docker-compose.gpu.yml`) builds on a private `brainpilot-gpu-base` image reserved for
+internal users; it is not pullable without ghcr access and is not needed for the CPU default path.
+
 <details>
 <summary><b>Sandbox dependencies, deployment modes &amp; memory budget</b></summary>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,11 @@ services:
     build:
       context: .
       dockerfile: docker/sandbox/Dockerfile
+      # Default to the CPU stage. The sandbox Dockerfile is multi-stage and its
+      # last stage is `gpu` (FROM a private ghcr base); a targetless build would
+      # resolve to that last stage and fail with 403 for users without private
+      # ghcr access. GPU users opt in via docker-compose.gpu.yml (prebuilt image).
+      target: cpu
       args:
         HTTP_PROXY: ${HTTP_PROXY:-}
         HTTPS_PROXY: ${HTTPS_PROXY:-}


### PR DESCRIPTION
## What

Default the Docker `sandbox` build to the **CPU** stage so the README's default
`docker compose up -d --build` works for users without private ghcr access.

Fixes #188.

## Why

`docker/sandbox/Dockerfile` is multi-stage; its **last** stage is `gpu`
(`FROM ghcr.io/neuroaihub/brainpilot-gpu-base:...`, a **private** base). The
default `docker-compose.yml` `sandbox.build` set no `target:`, so a targetless
build resolves to that last stage and fails with **403 Forbidden** pulling the
private GPU base — even for users who only want CPU.

## Change

- `docker-compose.yml`: add `target: cpu` to `sandbox.build` (symmetric with the
  `docker-compose.gpu.yml` override, which uses a prebuilt `image:` and is
  unaffected).
- `README.md` / `README-zh.md`: note the default is CPU (no GPU/private access
  needed); GPU mode is internal-only.

GPU stays internal-user-only by design — the base image is not made public.

## Verification

- `docker compose config` validates.
- No code paths touched; GPU override path unchanged (prebuilt image, not a build target).
