### PR TITLE
fix(web,runtime): restore full chat history on refresh (#165, #194)

### DIFF
--- a/packages/runtime/src/__tests__/history-read-from-disk.test.ts
+++ b/packages/runtime/src/__tests__/history-read-from-disk.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgUiEvent } from "@brainpilot/protocol";
+import { SessionManager } from "../session-manager.js";
+import { mockAgentFactory } from "../agent-factory.js";
+
+/**
+ * #165 / #194-B2: history must be readable off disk even after the session has
+ * been evicted from memory (idle reaper / runtime restart). Before the fix,
+ * `readEventHistory` returned undefined the moment the session left the
+ * in-memory map, so a post-refresh rehydrate got a 404 and rendered an empty
+ * transcript despite events.jsonl being intact on disk.
+ */
+describe("readEventHistory disk fallback (#165/#194-B2)", () => {
+  let dataRoot: string;
+  let m: SessionManager;
+
+  beforeEach(async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), "bp-history-"));
+    m = new SessionManager({ persist: true, dataRoot, agentFactory: mockAgentFactory });
+  });
+
+  afterEach(async () => {
+    await rm(dataRoot, { recursive: true, force: true });
+  });
+
+  it("serves persisted history after the session is evicted from memory", async () => {
+    const s = await m.createSession({ title: "Evicted" });
+    const events: AgUiEvent[] = [];
+    const unsub = m.subscribe(s.id, (e) => events.push(e));
+    const res = await m.sendMessage(s.id, "hello principal");
+    expect(res.accepted).toBe(true);
+    await waitFor(() => events.some((e) => e.type === "RUN_FINISHED"));
+    unsub?.();
+
+    // Evict from memory — evictSession flushes the persist write-chain first, so
+    // the disk transcript is complete and must survive the in-memory drop.
+    const { evicted } = await m.evictSession(s.id);
+    expect(evicted).toBe(true);
+    expect(m.getSession(s.id)).toBeUndefined();
+
+    // The whole point: history still resolves from disk (not undefined/404),
+    // with the full transcript that was emitted during the run.
+    const afterEvict = await m.readEventHistory(s.id, { limit: 0 });
+    expect(afterEvict).toBeDefined();
+    expect(afterEvict!.events.length).toBeGreaterThan(0);
+    expect(afterEvict!.total).toBe(afterEvict!.events.length);
+    expect(afterEvict!.events.some((e) => e.type === "RUN_FINISHED")).toBe(true);
+  });
+
+  it("returns undefined for a session with no transcript on disk", async () => {
+    const missing = await m.readEventHistory("does-not-exist", { limit: 0 });
+    expect(missing).toBeUndefined();
+  });
+
+  it("non-persisting manager still returns undefined for unknown sessions", async () => {
+    const mem = new SessionManager({ persist: false, agentFactory: mockAgentFactory });
+    const r = await mem.readEventHistory("whoever", { limit: 0 });
+    expect(r).toBeUndefined();
+  });
+});
+
+async function waitFor(pred: () => boolean, timeoutMs = 5000): Promise<void> {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timed out");
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -1443,14 +1443,23 @@ export class SessionManager {
    * the web rehydrate path so long sessions are not sliced through the middle
    * of a streamed message.
    *
-   * Returns `undefined` if the session id isn't in memory — this method is
-   * only useful for known sessions (call `restoreFromDisk` first if needed).
+   * History is a **disk read** (`<dataRoot>/.bp/<sid>/events.jsonl`), so it does
+   * NOT require the session to be live in memory: a session evicted by the idle
+   * reaper (or lost to a runtime restart) keeps its transcript on disk
+   * (`evictSession` flushes + drops the in-memory entry but never deletes the
+   * file). Returning `undefined` only when neither memory nor disk knows the
+   * session is what lets a post-refresh rehydrate replay an evicted session
+   * instead of getting a 404 and rendering an empty transcript (#165 / #194-B2).
+   *
+   * In non-persisting mode (`persist:false`, e.g. unit tests) there is no disk
+   * backing, so an unknown session is genuinely `undefined`.
    */
   async readEventHistory(
     sessionId: string,
     opts: { limit?: number } = {},
   ): Promise<{ events: AgUiEvent[]; total: number; truncated: boolean } | undefined> {
-    if (!this.sessions.has(sessionId)) return undefined;
+    // Without persistence the only source of truth is memory.
+    if (!this.persist && !this.sessions.has(sessionId)) return undefined;
     const requestedLimit = opts.limit;
     const limit =
       requestedLimit === undefined || !Number.isFinite(requestedLimit)
@@ -1463,7 +1472,10 @@ export class SessionManager {
     try {
       raw = await readFile(path, "utf8");
     } catch {
-      // No events file yet — empty history is valid (newly created session).
+      // No events file. For a live (or persisting-but-new) session this is a
+      // valid empty history. For an unknown session with no transcript on disk
+      // there is nothing to serve → undefined so the route can 404.
+      if (!this.sessions.has(sessionId)) return undefined;
       return { events: [], total: 0, truncated: false };
     }
     const lines = raw.split("\n");

--- a/packages/web/src/__tests__/rehydrateMerge.test.ts
+++ b/packages/web/src/__tests__/rehydrateMerge.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { mergeRehydratedMessages } from "../contexts/SessionContext";
+import type { ChatMessage } from "../contracts/backend";
+
+function msg(id: string, content = id): ChatMessage {
+  return { id, role: "assistant", content, createdAt: "2026-01-01T00:00:00.000Z" };
+}
+
+describe("mergeRehydratedMessages (#194-B1)", () => {
+  it("seeds the full history when nothing is live yet", () => {
+    const history = [msg("a"), msg("b"), msg("c")];
+    expect(mergeRehydratedMessages([], history).map((m) => m.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("does NOT drop history when SSE has already seeded a recent tail", () => {
+    // The regression: refresh → SSE ring buffer delivers only the last 2 msgs
+    // before history (the full log) lands. Old guard kept just these two.
+    const sseTail = [msg("y"), msg("z")];
+    const fullHistory = [msg("v"), msg("w"), msg("x"), msg("y"), msg("z")];
+    const merged = mergeRehydratedMessages(sseTail, fullHistory);
+    // Full history is restored, in order, with no duplicates.
+    expect(merged.map((m) => m.id)).toEqual(["v", "w", "x", "y", "z"]);
+  });
+
+  it("preserves live-only messages history does not contain (optimistic/newer)", () => {
+    const live = [msg("x"), msg("optimistic-1"), msg("newer-2")];
+    const history = [msg("w"), msg("x")];
+    const merged = mergeRehydratedMessages(live, history);
+    // History base first, then the live-only tail in its original order.
+    expect(merged.map((m) => m.id)).toEqual(["w", "x", "optimistic-1", "newer-2"]);
+  });
+
+  it("dedupes by id (history wins the shared ids)", () => {
+    const live = [msg("a", "stale"), msg("b", "live-only")];
+    const history = [msg("a", "canonical")];
+    const merged = mergeRehydratedMessages(live, history);
+    expect(merged.map((m) => m.id)).toEqual(["a", "b"]);
+    expect(merged.find((m) => m.id === "a")!.content).toBe("canonical");
+  });
+});

--- a/packages/web/src/contexts/SessionContext.tsx
+++ b/packages/web/src/contexts/SessionContext.tsx
@@ -102,6 +102,25 @@ const SessionContext = createContext<SessionContextValue | null>(null);
 // CONTENT / END leaves old long sessions looking empty.
 const HISTORY_REHYDRATE_LIMIT = 0;
 
+/**
+ * #194-B1: merge the full rehydrated history under whatever the live message
+ * list already holds. On refresh the SSE ring-buffer tail seeds a few recent
+ * messages before history arrives; we must NOT discard the (complete) history
+ * just because the list is non-empty. The persisted history is the base; we
+ * append only the messages already shown that history doesn't contain (by id) —
+ * in-flight optimistic sends, or events newer than the persisted file. Ordering
+ * matters: history first (chronological), then the live-only tail.
+ */
+export function mergeRehydratedMessages(
+  existing: ChatMessage[],
+  history: ChatMessage[],
+): ChatMessage[] {
+  if (existing.length === 0) return history;
+  const historyIds = new Set(history.map((m) => m.id));
+  const extra = existing.filter((m) => !historyIds.has(m.id));
+  return [...history, ...extra];
+}
+
 function foldSessionHistory(events: unknown[], sessionId: string): {
   messages: ChatMessage[];
   trace: TraceGraph | null;
@@ -293,13 +312,18 @@ export function SessionProvider({ children }: { children: ReactNode }) {
         hydratedSessionsRef.current.add(sessionId);
         if (lastUsage) setTokenUsage(lastUsage);
 
-        // Only seed the message list if the user hasn't already started typing
-        // / receiving live SSE for this session in the brief window before
-        // history arrived (otherwise we'd clobber their in-flight messages).
-        setMessagesBySession((current) => {
-          if ((current[sessionId]?.length ?? 0) > 0) return current;
-          return { ...current, [sessionId]: nextMessages };
-        });
+        // Merge the full history under whatever SSE / optimistic messages have
+        // already landed — do NOT bail just because the list is non-empty
+        // (#194-B1). On refresh the SSE ring-buffer tail arrives first and seeds
+        // a few recent messages; the old `length > 0 → skip` guard then dropped
+        // the entire rehydrated history, leaving only those few. The persisted
+        // history is the complete log, so use it as the base and append only the
+        // messages SSE already showed that the history doesn't contain (by id) —
+        // in-flight optimistic sends, or events newer than the persisted file.
+        setMessagesBySession((current) => ({
+          ...current,
+          [sessionId]: mergeRehydratedMessages(current[sessionId] ?? [], nextMessages),
+        }));
         if (nextTrace) {
           setTraceBySession((current) =>
             current[sessionId] ? current : { ...current, [sessionId]: nextTrace! },


### PR DESCRIPTION
## What

Make a browser refresh restore the **full** chat transcript. Two independent
paths dropped history after refresh even though `events.jsonl` was intact on disk.

Fixes #165. Fixes #194.

## B2 / #165 — evicted-session history 404

`SessionManager.readEventHistory` began with
`if (!this.sessions.has(sessionId)) return undefined`, so once a session left
memory (idle reaper / runtime restart), `GET …/history` returned 404 and the SPA
rendered an empty transcript. `evictSession` flushes + drops the in-memory entry
but never deletes the file, and `bpDir(sid)` depends only on the session id — so
the transcript is readable off disk.

**Fix**: read it back from disk; only return `undefined` when **neither** memory
nor disk has the session. `persist:false` (tests) keeps the memory-only behavior.

## B1 / #194 — SSE-tail race truncated rehydrate

On refresh the SSE ring buffer delivers a few recent messages **before** the
async full-history fetch lands. The old seed guard
(`if (length > 0) return current`) then discarded the entire rehydrated history,
leaving only that tail → "refresh keeps only the last few messages".

**Fix**: merge instead of skip. Use the persisted history as the base and append
only live-only messages history lacks (by id) — optimistic sends / events newer
than the file — so SSE-tail + full-history converge regardless of arrival order.
Extracted as `mergeRehydratedMessages` for unit testing.

## Tests

- runtime: `history-read-from-disk.test.ts` — evicted session still served from
  disk; unknown session → undefined; non-persisting manager → undefined.
- web: `rehydrateMerge.test.ts` — no-drop when SSE tail present; optimistic
  preserved; dedupe by id.
- Full suites green: runtime 256, web 143, typecheck, web build.
