### PR TITLE
chore(release): bump version to 0.0.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brainpilot",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "brainpilot",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "AGPL-3.0-only",
       "workspaces": [
         "packages/protocol",
@@ -8323,11 +8323,11 @@
     },
     "packages/backend-core": {
       "name": "@brainpilot/backend-core",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@brainpilot/protocol": "^0.0.8",
-        "@brainpilot/runtime": "^0.0.8",
+        "@brainpilot/protocol": "^0.0.9",
+        "@brainpilot/runtime": "^0.0.9",
         "@hono/node-server": "^1.13.0",
         "hono": "^4.6.0"
       },
@@ -8343,13 +8343,13 @@
     },
     "packages/cli": {
       "name": "@brainpilot/app",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@brainpilot/backend-core": "^0.0.8",
-        "@brainpilot/protocol": "^0.0.8",
-        "@brainpilot/runtime": "^0.0.8",
-        "@brainpilot/web": "^0.0.8",
+        "@brainpilot/backend-core": "^0.0.9",
+        "@brainpilot/protocol": "^0.0.9",
+        "@brainpilot/runtime": "^0.0.9",
+        "@brainpilot/web": "^0.0.9",
         "commander": "^12.1.0",
         "picocolors": "^1.1.0"
       },
@@ -8363,7 +8363,7 @@
     },
     "packages/client-cli": {
       "name": "@brainpilot/client-cli",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "dependencies": {
         "@brainpilot/protocol": "*",
         "commander": "^12.1.0"
@@ -8374,7 +8374,7 @@
     },
     "packages/protocol": {
       "name": "@brainpilot/protocol",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "zod": "^3.24.0"
@@ -8385,11 +8385,11 @@
     },
     "packages/runtime": {
       "name": "@brainpilot/runtime",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@brainpilot/protocol": "^0.0.8",
-        "@brainpilot/skills": "^0.0.8",
+        "@brainpilot/protocol": "^0.0.9",
+        "@brainpilot/skills": "^0.0.9",
         "@earendil-works/pi-coding-agent": "^0.79.0",
         "@hono/node-server": "^1.19.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
@@ -8402,7 +8402,7 @@
     },
     "packages/skills": {
       "name": "@brainpilot/skills",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "AGPL-3.0-only",
       "engines": {
         "node": ">=22"
@@ -8410,10 +8410,10 @@
     },
     "packages/web": {
       "name": "@brainpilot/web",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "AGPL-3.0-only",
       "devDependencies": {
-        "@brainpilot/protocol": "^0.0.8",
+        "@brainpilot/protocol": "^0.0.9",
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource-variable/geist-mono": "^5.2.8",
         "@types/react": "^18.3.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainpilot",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "private": true,
   "type": "module",
   "description": "BrainPilot — multi-agent research collaboration platform (TS + Pi SDK)",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/backend-core",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "engines": {
     "node": ">=22"
   },
@@ -37,8 +37,8 @@
     "start": "node ./dist/server.js"
   },
   "dependencies": {
-    "@brainpilot/protocol": "^0.0.8",
-    "@brainpilot/runtime": "^0.0.8",
+    "@brainpilot/protocol": "^0.0.9",
+    "@brainpilot/runtime": "^0.0.9",
     "@hono/node-server": "^1.13.0",
     "hono": "^4.6.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/app",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "engines": {
     "node": ">=22"
   },
@@ -32,10 +32,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@brainpilot/backend-core": "^0.0.8",
-    "@brainpilot/protocol": "^0.0.8",
-    "@brainpilot/runtime": "^0.0.8",
-    "@brainpilot/web": "^0.0.8",
+    "@brainpilot/backend-core": "^0.0.9",
+    "@brainpilot/protocol": "^0.0.9",
+    "@brainpilot/runtime": "^0.0.9",
+    "@brainpilot/web": "^0.0.9",
     "commander": "^12.1.0",
     "picocolors": "^1.1.0"
   }

--- a/packages/client-cli/package.json
+++ b/packages/client-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/client-cli",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "private": true,
   "type": "module",
   "description": "BrainPilot headless verification client (dev/CI) — drive a session without the web UI",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/protocol",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "engines": {
     "node": ">=22"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/runtime",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "engines": {
     "node": ">=22"
   },
@@ -37,8 +37,8 @@
     "start": "node ./dist/server.js"
   },
   "dependencies": {
-    "@brainpilot/protocol": "^0.0.8",
-    "@brainpilot/skills": "^0.0.8",
+    "@brainpilot/protocol": "^0.0.9",
+    "@brainpilot/skills": "^0.0.9",
     "@earendil-works/pi-coding-agent": "^0.79.0",
     "@hono/node-server": "^1.19.0",
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/skills",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "engines": {
     "node": ">=22"
   },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/web",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "engines": {
     "node": ">=22"
   },
@@ -31,7 +31,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@brainpilot/protocol": "^0.0.8",
+    "@brainpilot/protocol": "^0.0.9",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.8",
     "@types/react": "^18.3.12",


### PR DESCRIPTION
## What

Bump all workspace packages and the lockfile to **0.0.9** ahead of the `development → main` release merge.

This carries the version commit into `development` so it rides into `main` with the release merge — no separate version-sync PR needed afterward.

## Changes

- Root `package.json` version `0.0.8 → 0.0.9`
- `npm run version:sync` propagated to all workspace packages + internal `@brainpilot/*` dep ranges (16 fields)
- `npm install --package-lock-only` regenerated `package-lock.json`

## Verification

- ✅ `version:check` — all packages aligned at 0.0.9
- ✅ `npm ci` — lockfile consistent
- ✅ `npm run typecheck` — no errors
- ✅ tests: 618 non-web + 143 web passing
- ✅ `npm run build` — all workspaces
- ✅ `npm run release:dry` — 6 public packages pack cleanly (client-cli private, skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)