### PR TITLE
fix(runtime): make trace-reminder read-only exemption actually fire (#211)

### DIFF
--- a/packages/runtime/src/__tests__/trace-reminder.test.ts
+++ b/packages/runtime/src/__tests__/trace-reminder.test.ts
@@ -1,0 +1,147 @@
+/**
+ * trace-reminder extension — unit tests driving the extension directly with a
+ * fake Pi ExtensionAPI (no SessionManager, no provider). The SessionManager
+ * tests deliberately use a scripted factory that does NOT load this extension,
+ * so the reminder logic was previously unasserted — which let #211 (the
+ * read-only exemption being dead due to a tool-name case mismatch) ship in #210.
+ * These tests pin the exact followUp messages emitted per role/tool sequence.
+ *
+ * Pi emits builtin tool names LOWERCASE (BUILTIN_TOOL_CONFIG in
+ * tools/system-tools.ts: principal = read/write/edit/bash/grep/find/glob/ls), so
+ * the scenarios use those real names.
+ */
+import { describe, it, expect } from "vitest";
+import { makeTraceReminderExt, type TraceReminderDeps } from "../extensions/trace-reminder.js";
+import type { AgentRole } from "../types.js";
+
+interface SentMessage {
+  content: string;
+  deliverAs?: string;
+}
+
+/** A minimal fake of the slice of Pi's ExtensionAPI the extension uses. */
+function fakePi() {
+  const handlers: Record<string, Array<(e: unknown) => unknown>> = {};
+  const sent: SentMessage[] = [];
+  return {
+    on(ev: string, fn: (e: unknown) => unknown) {
+      (handlers[ev] ||= []).push(fn);
+    },
+    sendUserMessage(content: string, opts?: { deliverAs?: string }) {
+      sent.push({ content, deliverAs: opts?.deliverAs });
+    },
+    fire(ev: string, e?: unknown) {
+      for (const fn of handlers[ev] || []) fn(e);
+    },
+    sent,
+  };
+}
+
+/** The kind sub-tag of each emitted [SYSTEM-MESSAGE:kind] followUp, in order. */
+function kindsOf(sent: SentMessage[]): string[] {
+  return sent.map((s) => (s.content.match(/\[SYSTEM-MESSAGE:(\w+)\]/) || [])[1]);
+}
+
+/**
+ * Run ONE agent loop: agent_start → successful tool calls → a clean agent_end,
+ * and return the kinds of followUp reminders the extension emitted.
+ */
+function runOnce(
+  role: AgentRole,
+  tools: string[],
+  deps?: Partial<TraceReminderDeps>,
+): { kinds: string[]; sent: SentMessage[] } {
+  const pi = fakePi();
+  makeTraceReminderExt({ role, name: deps?.name ?? role, onUnreplied: deps?.onUnreplied ?? (() => {}) })(
+    pi as never,
+  );
+  pi.fire("agent_start");
+  for (const t of tools) pi.fire("tool_execution_end", { toolName: t, isError: false });
+  pi.fire("agent_end", { messages: [{ role: "assistant", stopReason: "end_turn" }] });
+  return { kinds: kindsOf(pi.sent), sent: pi.sent };
+}
+
+describe("trace-reminder: principal delegate reminder (意图三, #211)", () => {
+  // A read-only principal turn that DID record a trace must not be nudged at all:
+  // trace dimension is satisfied and read-only work is exempt from delegate.
+  it.each(["read", "grep", "glob", "ls", "find"])(
+    "read-only tool %s + record_trace → no reminder (exempt)",
+    (tool) => {
+      expect(runOnce("principal", [tool, "record_trace"]).kinds).toEqual([]);
+    },
+  );
+
+  it("substantive tool (bash) + record_trace → delegate reminder", () => {
+    expect(runOnce("principal", ["bash", "record_trace"]).kinds).toEqual(["delegate"]);
+  });
+
+  it("write/edit are substantive → delegate reminder", () => {
+    expect(runOnce("principal", ["write", "record_trace"]).kinds).toEqual(["delegate"]);
+    expect(runOnce("principal", ["edit", "record_trace"]).kinds).toEqual(["delegate"]);
+  });
+
+  it("external/domain (unknown) tool is substantive → delegate reminder", () => {
+    expect(runOnce("principal", ["mcp__foo__do_thing", "record_trace"]).kinds).toEqual(["delegate"]);
+  });
+
+  it("management tools (create_agent) are exempt → no delegate reminder", () => {
+    expect(runOnce("principal", ["create_agent", "record_trace"]).kinds).toEqual([]);
+  });
+
+  it("tool-name case does not matter (Read == read)", () => {
+    expect(runOnce("principal", ["Read", "record_trace"]).kinds).toEqual([]);
+    expect(runOnce("principal", ["READ", "record_trace"]).kinds).toEqual([]);
+  });
+
+  it("a principal that delegated (create_agent) is never told to delegate, even after substantive work", () => {
+    // create_agent sets `delegated` → delegate branch is suppressed; only the
+    // trace lapse (no record_trace here) remains.
+    expect(runOnce("principal", ["bash", "create_agent"]).kinds).toEqual(["trace"]);
+  });
+});
+
+describe("trace-reminder: trace + reply (意图一/二) still work", () => {
+  it("principal with no record_trace → trace reminder", () => {
+    expect(runOnce("principal", ["read"]).kinds).toEqual(["trace"]);
+  });
+
+  it("expert that neither traced nor replied → single merged reminder", () => {
+    expect(runOnce("expert", ["read"]).kinds).toEqual(["merged"]);
+  });
+
+  it("expert that traced but did not reply → reply reminder", () => {
+    expect(runOnce("expert", ["read", "record_trace"]).kinds).toEqual(["reply"]);
+  });
+
+  it("expert that replied but did not trace → trace reminder", () => {
+    expect(runOnce("expert", ["read", "send_message"]).kinds).toEqual(["trace"]);
+  });
+
+  it("expert that both traced and replied → no reminder", () => {
+    expect(runOnce("expert", ["record_trace", "send_message"]).kinds).toEqual([]);
+  });
+
+  it("trace agent is never nudged", () => {
+    expect(runOnce("trace", ["read"]).kinds).toEqual([]);
+  });
+});
+
+describe("trace-reminder: error short-circuit (#97)", () => {
+  it("a run that ended in error emits no reminder", () => {
+    const pi = fakePi();
+    makeTraceReminderExt({ role: "expert", name: "expert", onUnreplied: () => {} })(pi as never);
+    pi.fire("agent_start");
+    pi.fire("tool_execution_end", { toolName: "read", isError: false });
+    pi.fire("agent_end", { messages: [{ role: "assistant", stopReason: "error" }] });
+    expect(kindsOf(pi.sent)).toEqual([]);
+  });
+});
+
+describe("trace-reminder: every injected message is wrapped (问题④)", () => {
+  it("followUp content is wrapped in a strip-able [SYSTEM-MESSAGE:kind] … [/SYSTEM-MESSAGE] marker", () => {
+    const { sent } = runOnce("expert", ["read"]); // merged reminder
+    expect(sent).toHaveLength(1);
+    expect(sent[0].deliverAs).toBe("followUp");
+    expect(sent[0].content).toMatch(/^\[SYSTEM-MESSAGE:merged\] [\s\S]+ \[\/SYSTEM-MESSAGE\]$/);
+  });
+});

--- a/packages/runtime/src/extensions/trace-reminder.ts
+++ b/packages/runtime/src/extensions/trace-reminder.ts
@@ -87,13 +87,16 @@ export interface TraceReminderDeps {
  * substantive work and arms the delegate reminder.
  */
 const PI_ALLOWED_TOOLS = new Set([
-  // information-gathering / read-only
-  "Read",
-  "Grep",
-  "Glob",
-  "LS",
-  "WebFetch",
-  "WebSearch",
+  // information-gathering / read-only. These MUST be Pi's real emitted tool
+  // names, which are lowercase (see BUILTIN_TOOL_CONFIG in tools/system-tools.ts:
+  // principal = ["read","write","edit","bash","grep","find","glob","ls"]). Names
+  // are matched case-insensitively below, but keep them lowercase to match the
+  // source of truth. (The principal has no WebFetch/WebSearch tool — omitted.)
+  "read",
+  "grep",
+  "glob",
+  "ls",
+  "find",
   // management / coordination
   "create_agent",
   "destroy_agent",
@@ -182,8 +185,10 @@ export function makeTraceReminderExt(deps: TraceReminderDeps): (pi: PiExtensionA
       if (t === "send_message") replied = true;
       if (t === "create_agent") delegated = true;
       // 意图三: any successful call NOT in the allow-set (a write/run, or an
-      // external MCP/domain tool) is the principal doing the work itself.
-      if (deps.role === "principal" && !PI_ALLOWED_TOOLS.has(t)) didSubstantiveWork = true;
+      // external MCP/domain tool) is the principal doing the work itself. Match
+      // case-insensitively — Pi emits builtins lowercase, but normalizing here
+      // keeps the exemption working if a tool ever surfaces in another case.
+      if (deps.role === "principal" && !PI_ALLOWED_TOOLS.has(t.toLowerCase())) didSubstantiveWork = true;
     });
 
     pi.on("agent_end", (e) => {


### PR DESCRIPTION
Follow-up to #210. PR #210 was merged at its first commit (`3966a34`) before this fix commit (`de7a646`) made it into the merge, so the #211 fix landed nowhere. This PR carries that one commit into `main`.

## Background

#210 added a read-only-tool exemption to the principal's "did substantive work" check (意图三 / the *delegate* reminder). The exemption was **dead code**: `PI_ALLOWED_TOOLS` listed the read-only tools capitalized (`Read`/`Grep`/`Glob`/`LS`) but Pi emits builtin tool names lowercase (`read`/`grep`/`glob`/`ls` — see `BUILTIN_TOOL_CONFIG`). `Set.has` is case-sensitive, so a principal doing only read-only work was still classified as "doing the work itself" and got a spurious `[SYSTEM-MESSAGE:delegate]` followUp. (The coordination entries happened to be lowercase and matched, masking the symptom.)

## Fix

- Read-only entries → real lowercase names `read`/`grep`/`glob`/`ls`, add the missing `find`, drop `WebFetch`/`WebSearch` (the principal has no such tool).
- Normalize case at the check site (`t.toLowerCase()`) so a tool surfacing in another case can't silently re-break the exemption.
- Add `packages/runtime/src/__tests__/trace-reminder.test.ts` (19 tests) driving the extension with a fake Pi, asserting per-role/per-tool followUp kinds — incl. all five read-only cases from the #211 repro, `Read`/`READ` case-insensitivity, SYSTEM-MESSAGE wrapping, and the #97 error short-circuit. This logic was previously unasserted (SessionManager tests use a scripted factory that doesn't load the extension), which is why the case bug shipped.

## Verification

- `tsc -b` ✅
- full suite ✅ 637 tests

Fixes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)