### PR TITLE
fix(config): validate URLs, reject duplicate names, surface validation errors (#203 #204 #205 #206)

### DIFF
--- a/packages/backend-core/src/app.ts
+++ b/packages/backend-core/src/app.ts
@@ -202,6 +202,15 @@ export function createApp(options: CreateAppOptions): Hono {
     if (!parsed.success) {
       return c.json({ error: "invalid provider profile", details: parsed.error.issues }, 400);
     }
+    // #205: reject a duplicate name (trimmed, case-insensitive) so the list
+    // can't grow two indistinguishable same-named profiles where `Use` is
+    // ambiguous. Enforced here at the route layer only — internal callers
+    // (scaffold / writeLocalSettings) intentionally bypass this.
+    const name = parsed.data.name.trim().toLowerCase();
+    const { profiles } = await readProviders(dataDir);
+    if (profiles.some((p) => p.name.trim().toLowerCase() === name)) {
+      return c.json({ error: `a provider named "${parsed.data.name.trim()}" already exists` }, 409);
+    }
     const created = await createProfile(dataDir, fromHttpBody(parsed.data));
     const { selectedProfileId } = await readProviders(dataDir);
     return c.json(toHttpProfile(created, selectedProfileId), 201);
@@ -280,6 +289,13 @@ export function createApp(options: CreateAppOptions): Hono {
     const parsed = McpServerConfigSchema.safeParse(config);
     if (!parsed.success) {
       return c.json({ error: "invalid mcp server config", details: parsed.error.issues }, 400);
+    }
+    // #204: POST creates — a name that already exists is a conflict, not a
+    // silent overwrite (which lost the prior config, e.g. a token-bearing URL).
+    // Editing an existing server goes through PUT /mcp-servers/:name instead.
+    const existing = await readMcpServers(dataDir);
+    if (existing.some((s) => s.name === name)) {
+      return c.json({ error: `an MCP server named "${name}" already exists` }, 409);
     }
     return c.json(await createMcpServer(dataDir, name, parsed.data), 201);
   });

--- a/packages/backend-core/test/app.test.ts
+++ b/packages/backend-core/test/app.test.ts
@@ -621,6 +621,35 @@ describe("Hono app — local config routes", () => {
       });
       expect(res.status).toBe(400);
     });
+
+    it("#203 rejects a non-URL base_url with 400", async () => {
+      const { app } = await provApp();
+      const res = await postProfile(app, { name: "Bad URL", base_url: "not a url", api_key: "sk-x", models: ["m"] });
+      expect(res.status).toBe(400);
+    });
+
+    it("#203 accepts an empty base_url and localhost base_url", async () => {
+      const { app } = await provApp();
+      expect((await postProfile(app, { name: "Empty Base", base_url: "", api_key: "sk-x", models: ["m"] })).status).toBe(
+        201,
+      );
+      expect(
+        (await postProfile(app, { name: "Local Base", base_url: "http://127.0.0.1:1234", api_key: "sk-x", models: ["m"] }))
+          .status,
+      ).toBe(201);
+    });
+
+    it("#205 rejects a duplicate provider name with 409 (case-insensitive)", async () => {
+      const { app } = await provApp();
+      expect((await postProfile(app, { name: "sqz", base_url: "https://a", api_key: "k", models: ["m"] })).status).toBe(
+        201,
+      );
+      const dup = await postProfile(app, { name: "  SQZ  ", base_url: "https://b", api_key: "k", models: ["m"] });
+      expect(dup.status).toBe(409);
+      // only the first profile persisted
+      const list = (await (await app.request("/api/provider/profiles")).json()) as unknown[];
+      expect(list).toHaveLength(1);
+    });
   });
 
   // #55: the Test button must do a real connectivity probe, not echo unknown.

--- a/packages/backend-core/test/mcp-servers.test.ts
+++ b/packages/backend-core/test/mcp-servers.test.ts
@@ -83,13 +83,14 @@ describe("MCP Servers CRUD (/api/mcp-servers)", () => {
     expect(entry.headers).toEqual({ Authorization: "Bearer t" });
   });
 
-  it("POST with an existing name overwrites", async () => {
+  it("#204 POST with an existing name returns 409 and does not overwrite", async () => {
     const { app } = await setup();
-    await post(app, { name: "s", config: { type: "stdio", command: "old" } });
-    await post(app, { name: "s", config: { type: "stdio", command: "new" } });
+    expect((await post(app, { name: "s", config: { type: "stdio", command: "old" } })).status).toBe(201);
+    const dup = await post(app, { name: "s", config: { type: "stdio", command: "new" } });
+    expect(dup.status).toBe(409);
     const list = await (await app.request("/api/mcp-servers")).json();
     expect(list).toHaveLength(1);
-    expect(list[0].command).toBe("new");
+    expect(list[0].command).toBe("old"); // original preserved, not overwritten
   });
 
   it("POST returns 400 when name or config is missing", async () => {
@@ -167,6 +168,24 @@ describe("MCP Servers CRUD (/api/mcp-servers)", () => {
       await post(app, { name: "s", config: { type: "stdio", command: "a" } });
       expect((await put(app, "s", { type: "http" })).status).toBe(400);
       expect((await put(app, "s", { type: "wat", url: "http://x" })).status).toBe(400);
+    });
+
+    it("#203 rejects a non-URL http/sse url with 400", async () => {
+      const { app } = await setup();
+      expect((await post(app, { name: "a", config: { type: "http", url: "not a url" } })).status).toBe(400);
+      expect((await post(app, { name: "b", config: { type: "sse", url: "not a url" } })).status).toBe(400);
+      // a non-http scheme is rejected too
+      expect((await post(app, { name: "c", config: { type: "http", url: "ftp://h/x" } })).status).toBe(400);
+    });
+
+    it("#203 accepts localhost / 127.0.0.1 http urls", async () => {
+      const { app } = await setup();
+      expect(
+        (await post(app, { name: "a", config: { type: "http", url: "http://localhost:8080/mcp" } })).status,
+      ).toBe(201);
+      expect(
+        (await post(app, { name: "b", config: { type: "sse", url: "http://127.0.0.1:3000/sse" } })).status,
+      ).toBe(201);
     });
   });
 

--- a/packages/protocol/src/domain.ts
+++ b/packages/protocol/src/domain.ts
@@ -208,6 +208,29 @@ export type McpServerEntry = z.infer<typeof McpServerEntrySchema>;
  * 400 and never reach disk.
  */
 const nonEmpty = z.string().trim().min(1);
+/** #203: true when the string parses as a WHATWG URL. */
+function isParseableUrl(value: string): boolean {
+  try {
+    new URL(value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+/**
+ * #203: a syntactically valid http(s) URL. Bare-non-empty (`nonEmpty`) let typos
+ * like `"not a url"` save successfully and only fail later at provider test /
+ * runtime / tool-call time. This trims, requires a parseable URL, and restricts
+ * the scheme to http/https — which still admits the local-dev cases the issue
+ * calls out (`http://localhost`, `http://127.0.0.1`). The custom message keeps
+ * the field-level Zod issue readable once the UI surfaces `details` (#206).
+ */
+const httpUrl = z
+  .string()
+  .trim()
+  .refine((u) => /^https?:\/\//i.test(u) && isParseableUrl(u), {
+    message: "must be a valid http(s) URL (e.g. https://host/path)",
+  });
 export const McpServerConfigSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("stdio"),
@@ -218,13 +241,13 @@ export const McpServerConfigSchema = z.discriminatedUnion("type", [
   }),
   z.object({
     type: z.literal("http"),
-    url: nonEmpty,
+    url: httpUrl,
     headers: z.record(z.string(), z.string()).optional(),
     timeout: z.number().optional(),
   }),
   z.object({
     type: z.literal("sse"),
-    url: nonEmpty,
+    url: httpUrl,
     headers: z.record(z.string(), z.string()).optional(),
     timeout: z.number().optional(),
   }),
@@ -335,10 +358,24 @@ const modelsField = z
   })
   .min(1, "models must not be empty");
 
+/**
+ * #203: provider base URL — optional, but when a non-empty value is present it
+ * must be a valid http(s) URL. Empty string / omitted stays allowed (the base
+ * URL is optional and defaults downstream), so only a real typo like
+ * `"not a url"` 400s. `localhost`/`127.0.0.1` pass (see `httpUrl`).
+ */
+const optionalHttpUrl = z
+  .string()
+  .trim()
+  .refine((u) => u === "" || (/^https?:\/\//i.test(u) && isParseableUrl(u)), {
+    message: "base_url must be a valid URL (e.g. https://host) or empty",
+  })
+  .optional();
+
 export const ProviderProfileCreateSchema = z.object({
   name: z.string().trim().min(1, "name is required"),
-  base_url: z.string().optional(),
-  baseUrl: z.string().optional(),
+  base_url: optionalHttpUrl,
+  baseUrl: optionalHttpUrl,
   // #63: provider wire protocol. Optional on create (defaults to
   // anthropic-messages downstream); on update, omit to leave unchanged.
   api: ProviderApiSchema.optional(),

--- a/packages/protocol/test/domain.test.ts
+++ b/packages/protocol/test/domain.test.ts
@@ -3,6 +3,7 @@ import {
   AgentStateSchema,
   FileContentSchema,
   FileEntrySchema,
+  McpServerConfigSchema,
   McpServerEntrySchema,
   ProviderProfileSchema,
   ProviderProfileCreateSchema,
@@ -152,5 +153,33 @@ describe("domain schemas", () => {
   it("validates UserRole", () => {
     expect(UserRoleSchema.parse("admin")).toBe("admin");
     expect(UserRoleSchema.safeParse("root").success).toBe(false);
+  });
+
+  // #203: http/sse url and provider base_url must be syntactically valid URLs,
+  // while local-dev (localhost / 127.0.0.1) and an empty provider base_url stay
+  // allowed.
+  describe("#203 URL validation", () => {
+    it("rejects a non-URL http/sse url", () => {
+      expect(McpServerConfigSchema.safeParse({ type: "http", url: "not a url" }).success).toBe(false);
+      expect(McpServerConfigSchema.safeParse({ type: "sse", url: "not a url" }).success).toBe(false);
+      // non-http scheme rejected
+      expect(McpServerConfigSchema.safeParse({ type: "http", url: "ftp://h/x" }).success).toBe(false);
+    });
+
+    it("accepts a valid + localhost http/sse url", () => {
+      expect(McpServerConfigSchema.safeParse({ type: "http", url: "https://host/mcp" }).success).toBe(true);
+      expect(McpServerConfigSchema.safeParse({ type: "http", url: "http://localhost:8080" }).success).toBe(true);
+      expect(McpServerConfigSchema.safeParse({ type: "sse", url: "http://127.0.0.1:3000/sse" }).success).toBe(true);
+    });
+
+    it("rejects a non-URL provider base_url but allows empty / localhost", () => {
+      const base = { name: "x", models: ["m"] };
+      expect(ProviderProfileCreateSchema.safeParse({ ...base, base_url: "not a url" }).success).toBe(false);
+      expect(ProviderProfileCreateSchema.safeParse({ ...base, base_url: "" }).success).toBe(true);
+      expect(ProviderProfileCreateSchema.safeParse({ ...base, base_url: "http://127.0.0.1:1234" }).success).toBe(true);
+      expect(ProviderProfileCreateSchema.safeParse({ ...base, base_url: "https://api.x.com" }).success).toBe(true);
+      // omitted entirely is fine (optional)
+      expect(ProviderProfileCreateSchema.safeParse(base).success).toBe(true);
+    });
   });
 });

--- a/packages/web/src/__tests__/api.test.ts
+++ b/packages/web/src/__tests__/api.test.ts
@@ -260,3 +260,46 @@ describe("api.sandbox.uploadFile — #47 base64 upload to the workspace", () => 
     await expect(api.sandbox.uploadFile("s1", "big.bin", new Blob(["hi"]))).rejects.toThrow("file too large");
   });
 });
+
+// #206: parseError previously read only `detail`, so the backend's Zod shape
+// `{ error, details }` and bare `{ error }` (e.g. 409) degraded to the generic
+// "Request failed (...)". Driven through api.providers.create (handleJson path).
+describe("#206 parseError surfaces { error, details }", () => {
+  const validCreate = { name: "x", baseUrl: "https://x", apiKey: "k", models: ["m"] } as never;
+
+  it("renders field-level Zod issues from { error, details }", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({
+        ok: false,
+        status: 400,
+        contentType: "application/json",
+        json: {
+          error: "invalid provider profile",
+          details: [{ path: ["base_url"], message: "must be a valid URL" }],
+        },
+      }),
+    );
+    await expect(api.providers.create(validCreate)).rejects.toThrow(
+      "invalid provider profile (base_url: must be a valid URL)",
+    );
+  });
+
+  it("surfaces a bare { error } (409 conflict) message", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({
+        ok: false,
+        status: 409,
+        contentType: "application/json",
+        json: { error: 'a provider named "sqz" already exists' },
+      }),
+    );
+    await expect(api.providers.create(validCreate)).rejects.toThrow('a provider named "sqz" already exists');
+  });
+
+  it("still prefers a plain { detail } string", async () => {
+    fetchMock.mockResolvedValueOnce(
+      makeResponse({ ok: false, status: 400, contentType: "application/json", json: { detail: "nope" } }),
+    );
+    await expect(api.providers.create(validCreate)).rejects.toThrow("nope");
+  });
+});

--- a/packages/web/src/utils/api.ts
+++ b/packages/web/src/utils/api.ts
@@ -66,13 +66,44 @@ function authHeaders(json = true): Record<string, string> {
   return json ? { "Content-Type": "application/json" } : {};
 }
 
+/**
+ * #206: build a readable message from a Zod issue list. The backend returns
+ * `details: parsed.error.issues` — each issue has a `path` (field) and a
+ * `message`. We render `field: message` per issue so a validation 400 tells the
+ * user *which* field is wrong (empty name, invalid url, …) instead of degrading
+ * to a generic "Request failed (400)".
+ */
+function formatIssues(details: unknown): string | null {
+  if (!Array.isArray(details) || details.length === 0) return null;
+  const parts: string[] = [];
+  for (const issue of details) {
+    if (!issue || typeof issue !== "object") continue;
+    const { path, message } = issue as { path?: unknown; message?: unknown };
+    if (typeof message !== "string" || message.length === 0) continue;
+    const field = Array.isArray(path) ? path.filter((p) => p !== "" && p != null).join(".") : "";
+    parts.push(field ? `${field}: ${message}` : message);
+  }
+  return parts.length > 0 ? parts.join("; ") : null;
+}
+
 async function parseError(res: Response): Promise<string> {
   const contentType = res.headers.get("content-type") || "";
   if (contentType.includes("application/json")) {
-    const body = (await res.json().catch(() => null)) as { detail?: unknown } | null;
-    if (typeof body?.detail === "string") {
+    // #206: the backend uses two shapes — `{ detail }` (single string) and the
+    // Zod validation shape `{ error, details }`. parseError previously read only
+    // `detail`, so every `{ error, details }` 400/409 fell through to the generic
+    // text fallback. Read all three: detail → error(+formatted details) → error.
+    const body = (await res.json().catch(() => null)) as
+      | { detail?: unknown; error?: unknown; details?: unknown }
+      | null;
+    if (typeof body?.detail === "string" && body.detail.length > 0) {
       return body.detail;
     }
+    const issues = formatIssues(body?.details);
+    if (typeof body?.error === "string" && body.error.length > 0) {
+      return issues ? `${body.error} (${issues})` : body.error;
+    }
+    if (issues) return issues;
   }
   const text = await res.text().catch(() => "");
   return text || `Request failed (${res.status})`;


### PR DESCRIPTION
## Summary

Fixes a batch of config-validation / error-feedback gaps found in the npm install + Settings setup test report (2026-06-30).

| Issue | Fix |
|-------|-----|
| **#203** | Provider `base_url` and MCP `http`/`sse` `url` are now validated as syntactic http(s) URLs (were `z.string().min(1)`, so `"not a url"` saved fine and only failed later at provider test / runtime / tool-call time). Empty/omitted `base_url` and `localhost`/`127.0.0.1` still pass. |
| **#204** | `POST /api/mcp-servers` with an existing name now returns **409** instead of silently overwriting the prior config (which could drop a token-bearing URL). Editing still goes through `PUT /mcp-servers/:name`. |
| **#205** | `POST /api/provider/profiles` rejects a duplicate name (trimmed, case-insensitive) with **409**. Enforced at the route layer only, so scaffold / `writeLocalSettings` internal callers are unaffected. |
| **#206** | Web `parseError()` now reads the backend's `{ error, details }` Zod shape (and bare `{ error }` for 409s), rendering field-level issues (e.g. `base_url: must be a valid URL`) instead of degrading every validation 400/409 to `Request failed (400)`. |

These four are intentionally grouped: #203 adds validation → #204/#205 add conflict detection (structured 400/409) → #206 makes those errors visible. Together they form the end-to-end chain "invalid/duplicate input → backend rejects → UI shows the specific reason".

## Test plan

- `npm run typecheck` ✅
- `npm test` → **626 passed** (added provider 409 / URL-schema cases; flipped the mcp "overwrite" test to expect 409)
- `packages/web` `npm test` → **146 passed** (3 new `parseError` shape tests)
- `npm run build` ✅

New/changed coverage: domain URL schema (invalid / valid / localhost / empty), provider + mcp duplicate-name 409s, `parseError` for `{detail}` / `{error,details}` / bare `{error}`.

Fixes #203
Fixes #204
Fixes #205
Fixes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)