### PR TITLE
docs: tighten README agent setup copy

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -124,27 +124,14 @@ npm run build        # 构建所有包
 npm run bp -- up     # 从源码启动（-- 用于把 flag 透传给 CLI）
 ```
 
-然后打开打印出的地址。无 Key 冒烟运行：`BP_MOCK=1 npm run bp -- up`。完整开发流程（端口、分支模型、
-测试）见 [`CONTRIBUTING.md`](CONTRIBUTING.md)。
+然后打开打印出的地址。完整开发流程（端口、分支模型、测试）见
+[`CONTRIBUTING.md`](CONTRIBUTING.md)。
 
 ### 让你的智能体替你部署
 
-已经在用 **Claude Code** 或 **OpenAI Codex**？那就不用手动跑上面的步骤了 —— 一句话把整套安装交给智能体，
-它会帮你装好 CLI、启动 BrainPilot，并把本地访问地址回给你：
+已经在用 **Claude Code** 或 **OpenAI Codex**？直接告诉你的智能体：
 
-```bash
-# Claude Code
-claude "全局安装 @brainpilot/app 这个 npm 包，然后运行 brainpilot up，并把可以打开的地址给我。"
-
-# OpenAI Codex
-codex exec "全局安装 @brainpilot/app 这个 npm 包，然后运行 brainpilot up，并把可以打开的地址给我。"
-```
-
-默认情况下，智能体在每条命令前都会停下来等你确认。几个小提示：
-
-- **无人值守跑完** —— 加上 `--dangerously-skip-permissions`（Claude Code）或 `--dangerously-bypass-approvals-and-sandbox`（Codex）。
-- **仅在你信任的目录里这么做** —— 这些 flag 会让智能体不再逐条确认就执行命令。
-- **还没有 API Key？** —— 让它*“用 mock 模式启动”*，它会以 `BP_MOCK=1` 拉起来。
+> 全局安装 `@brainpilot/app` 这个 npm 包，然后运行 `brainpilot up`，并把可以打开的地址给我。
 
 > [!TIP]
 > ### <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/openclaw.png" height="28" align="top"/> OpenClaw —— 从聊天应用里驱动 BrainPilot

--- a/README.md
+++ b/README.md
@@ -129,28 +129,14 @@ npm run build        # build all packages
 npm run bp -- up     # launch from source (the -- forwards flags to the CLI)
 ```
 
-Then open the printed URL. For a no-key smoke run: `BP_MOCK=1 npm run bp -- up`. See
-[`CONTRIBUTING.md`](CONTRIBUTING.md) for the full dev workflow (ports, branch model, tests).
+Then open the printed URL. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full dev
+workflow (ports, branch model, tests).
 
 ### Let your agent deploy it
 
-Already working inside **Claude Code** or **OpenAI Codex**? You don't have to run the steps
-above by hand — hand the whole setup to the agent in one sentence and it installs the CLI,
-launches BrainPilot, and hands you back the local URL:
+Already working inside **Claude Code** or **OpenAI Codex**? Tell your agent:
 
-```bash
-# Claude Code
-claude "Globally install the @brainpilot/app npm package, then run brainpilot up and give me the URL to open."
-
-# OpenAI Codex
-codex exec "Globally install the @brainpilot/app npm package, then run brainpilot up and give me the URL to open."
-```
-
-By default the agent pauses for approval before each command. A few tips:
-
-- **Run unattended** — add `--dangerously-skip-permissions` (Claude Code) or `--dangerously-bypass-approvals-and-sandbox` (Codex).
-- **Only in a directory you trust** — those flags let the agent run commands without asking.
-- **No API key yet?** — ask it to *"start in mock mode"* and it'll launch with `BP_MOCK=1`.
+> Globally install the `@brainpilot/app` npm package, then run `brainpilot up` and give me the URL to open.
 
 > [!TIP]
 > ### <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/openclaw.png" height="28" align="top"/> OpenClaw — drive BrainPilot from your chat app


### PR DESCRIPTION
## Summary
- shorten the README agent deployment section into a single copyable instruction
- remove the no-key smoke-run note from the source-run path
- keep Provider and MCP sections unchanged

## Checks
- git diff --check