### PR TITLE
docs: make README agent prompt copyable

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -131,7 +131,9 @@ npm run bp -- up     # 从源码启动（-- 用于把 flag 透传给 CLI）
 
 已经在用 **Claude Code** 或 **OpenAI Codex**？直接告诉你的智能体：
 
-> 全局安装 `@brainpilot/app` 这个 npm 包，然后运行 `brainpilot up`，并把可以打开的地址给我。
+```text
+全局安装 @brainpilot/app 这个 npm 包，然后运行 brainpilot up，并把可以打开的地址给我。
+```
 
 > [!TIP]
 > ### <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/openclaw.png" height="28" align="top"/> OpenClaw —— 从聊天应用里驱动 BrainPilot

--- a/README.md
+++ b/README.md
@@ -136,7 +136,9 @@ workflow (ports, branch model, tests).
 
 Already working inside **Claude Code** or **OpenAI Codex**? Tell your agent:
 
-> Globally install the `@brainpilot/app` npm package, then run `brainpilot up` and give me the URL to open.
+```text
+Globally install the @brainpilot/app npm package, then run brainpilot up and give me the URL to open.
+```
 
 > [!TIP]
 > ### <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/openclaw.png" height="28" align="top"/> OpenClaw — drive BrainPilot from your chat app


### PR DESCRIPTION
## Summary
- replace the README agent deploy blockquote with a copyable text code block
- keep all other README content unchanged

## Validation
- git diff --check