### PR TITLE
feat(runtime): surface Pi SDK compaction on AG-UI wire

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -124,27 +124,14 @@ npm run build        # 构建所有包
 npm run bp -- up     # 从源码启动（-- 用于把 flag 透传给 CLI）
 ```
 
-然后打开打印出的地址。无 Key 冒烟运行：`BP_MOCK=1 npm run bp -- up`。完整开发流程（端口、分支模型、
-测试）见 [`CONTRIBUTING.md`](CONTRIBUTING.md)。
+然后打开打印出的地址。完整开发流程（端口、分支模型、测试）见
+[`CONTRIBUTING.md`](CONTRIBUTING.md)。
 
 ### 让你的智能体替你部署
 
-已经在用 **Claude Code** 或 **OpenAI Codex**？那就不用手动跑上面的步骤了 —— 一句话把整套安装交给智能体，
-它会帮你装好 CLI、启动 BrainPilot，并把本地访问地址回给你：
+已经在用 **Claude Code** 或 **OpenAI Codex**？直接告诉你的智能体：
 
-```bash
-# Claude Code
-claude "全局安装 @brainpilot/app 这个 npm 包，然后运行 brainpilot up，并把可以打开的地址给我。"
-
-# OpenAI Codex
-codex exec "全局安装 @brainpilot/app 这个 npm 包，然后运行 brainpilot up，并把可以打开的地址给我。"
-```
-
-默认情况下，智能体在每条命令前都会停下来等你确认。几个小提示：
-
-- **无人值守跑完** —— 加上 `--dangerously-skip-permissions`（Claude Code）或 `--dangerously-bypass-approvals-and-sandbox`（Codex）。
-- **仅在你信任的目录里这么做** —— 这些 flag 会让智能体不再逐条确认就执行命令。
-- **还没有 API Key？** —— 让它*“用 mock 模式启动”*，它会以 `BP_MOCK=1` 拉起来。
+> 全局安装 `@brainpilot/app` 这个 npm 包，然后运行 `brainpilot up`，并把可以打开的地址给我。
 
 > [!TIP]
 > ### <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/openclaw.png" height="28" align="top"/> OpenClaw —— 从聊天应用里驱动 BrainPilot

--- a/README.md
+++ b/README.md
@@ -129,28 +129,14 @@ npm run build        # build all packages
 npm run bp -- up     # launch from source (the -- forwards flags to the CLI)
 ```
 
-Then open the printed URL. For a no-key smoke run: `BP_MOCK=1 npm run bp -- up`. See
-[`CONTRIBUTING.md`](CONTRIBUTING.md) for the full dev workflow (ports, branch model, tests).
+Then open the printed URL. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the full dev
+workflow (ports, branch model, tests).
 
 ### Let your agent deploy it
 
-Already working inside **Claude Code** or **OpenAI Codex**? You don't have to run the steps
-above by hand — hand the whole setup to the agent in one sentence and it installs the CLI,
-launches BrainPilot, and hands you back the local URL:
+Already working inside **Claude Code** or **OpenAI Codex**? Tell your agent:
 
-```bash
-# Claude Code
-claude "Globally install the @brainpilot/app npm package, then run brainpilot up and give me the URL to open."
-
-# OpenAI Codex
-codex exec "Globally install the @brainpilot/app npm package, then run brainpilot up and give me the URL to open."
-```
-
-By default the agent pauses for approval before each command. A few tips:
-
-- **Run unattended** — add `--dangerously-skip-permissions` (Claude Code) or `--dangerously-bypass-approvals-and-sandbox` (Codex).
-- **Only in a directory you trust** — those flags let the agent run commands without asking.
-- **No API key yet?** — ask it to *"start in mock mode"* and it'll launch with `BP_MOCK=1`.
+> Globally install the `@brainpilot/app` npm package, then run `brainpilot up` and give me the URL to open.
 
 > [!TIP]
 > ### <img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/openclaw.png" height="28" align="top"/> OpenClaw — drive BrainPilot from your chat app

--- a/packages/protocol/src/events.ts
+++ b/packages/protocol/src/events.ts
@@ -286,13 +286,58 @@ export type CustomEvent = z.infer<typeof CustomEventSchema>;
  * - `session_heartbeat` — liveness timestamp.
  * - `trace_node` — a Graph-of-Trace node was created/updated (#79); `value` is
  *   `{ op: "created" | "updated", node: TraceNode }`.
+ * - `compaction` — Pi SDK auto/manual context compaction lifecycle. `value` is
+ *   `CompactionStartValue | CompactionEndValue`. Emitted verbatim from the
+ *   Pi `compaction_start` / `compaction_end` events (mas-agent.ts) so clients
+ *   can render compaction transparently instead of a mid-run context reset.
  */
 export const CUSTOM_EVENT = {
   SESSION_STATE: "session_state",
   SESSION_TITLE: "session_title",
   SESSION_HEARTBEAT: "session_heartbeat",
   TRACE_NODE: "trace_node",
+  COMPACTION: "compaction",
 } as const;
+
+/**
+ * `CUSTOM.value` shape for `name: "compaction"` — mirrors Pi SDK's
+ * `compaction_start` / `compaction_end` fields, plus an `op` discriminator so
+ * one channel carries both edges. Kept passthrough-friendly (all optional past
+ * the required core) because Pi may add fields.
+ */
+export const CompactionReasonSchema = z.enum(["manual", "threshold", "overflow"]);
+export type CompactionReason = z.infer<typeof CompactionReasonSchema>;
+
+export const CompactionStartValueSchema = z
+  .object({
+    op: z.literal("start"),
+    reason: CompactionReasonSchema,
+  })
+  .passthrough();
+export type CompactionStartValue = z.infer<typeof CompactionStartValueSchema>;
+
+export const CompactionEndValueSchema = z
+  .object({
+    op: z.literal("end"),
+    reason: CompactionReasonSchema,
+    aborted: z.boolean(),
+    willRetry: z.boolean(),
+    errorMessage: z.string().optional(),
+    /** Provider-reported tokens before compaction (present on success). */
+    tokensBefore: z.number().optional(),
+    /** Estimated tokens after compaction (present on success). */
+    estimatedTokensAfter: z.number().optional(),
+    /** ID of the first entry kept after the compaction boundary (debug/UX). */
+    firstKeptEntryId: z.string().optional(),
+  })
+  .passthrough();
+export type CompactionEndValue = z.infer<typeof CompactionEndValueSchema>;
+
+export const CompactionCustomValueSchema = z.discriminatedUnion("op", [
+  CompactionStartValueSchema,
+  CompactionEndValueSchema,
+]);
+export type CompactionCustomValue = z.infer<typeof CompactionCustomValueSchema>;
 
 /* ------------------------------------------------------------------ *
  * agent_status_update  (§10 state authority)

--- a/packages/protocol/test/events.test.ts
+++ b/packages/protocol/test/events.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import {
   AG_UI_EVENT_TYPES,
   AgUiEventSchema,
+  CompactionCustomValueSchema,
+  CUSTOM_EVENT,
   isAgUiEvent,
   parseEvent,
   safeParseEvent,
@@ -188,6 +190,35 @@ describe("discriminated union behavior", () => {
     for (const t of AG_UI_EVENT_TYPES) {
       expect(optionTypes.has(t)).toBe(true);
     }
+  });
+
+  it("CUSTOM(name=compaction) value schema validates start + end shapes", () => {
+    const start = CompactionCustomValueSchema.parse({ op: "start", reason: "threshold" });
+    expect(start.op).toBe("start");
+
+    const end = CompactionCustomValueSchema.parse({
+      op: "end",
+      reason: "threshold",
+      aborted: false,
+      willRetry: false,
+      tokensBefore: 195000,
+      estimatedTokensAfter: 24000,
+      firstKeptEntryId: "u_42",
+    });
+    if (end.op === "end") expect(end.tokensBefore).toBe(195000);
+
+    // Wrapped as an AG-UI CUSTOM event — full-union round trip.
+    const wrapped = parseEvent({
+      type: "CUSTOM",
+      session_id: "s1",
+      name: CUSTOM_EVENT.COMPACTION,
+      value: { op: "start", reason: "overflow" },
+    });
+    expect((wrapped as { name?: string }).name).toBe("compaction");
+
+    // Rejects unknown op / reason.
+    expect(CompactionCustomValueSchema.safeParse({ op: "middle", reason: "threshold" }).success).toBe(false);
+    expect(CompactionCustomValueSchema.safeParse({ op: "start", reason: "nope" }).success).toBe(false);
   });
 
   it("passthrough keeps forward-compat extras", () => {

--- a/packages/runtime/src/__tests__/event-mapping.test.ts
+++ b/packages/runtime/src/__tests__/event-mapping.test.ts
@@ -119,6 +119,92 @@ describe("event mapping (Pi -> AG-UI via parseEvent)", () => {
     expect(agent.status).toBe("error");
   });
 
+  // Pi's compaction lifecycle used to be silently suppressed. It now surfaces on
+  // the AG-UI CUSTOM channel (name:"compaction") + a friendly system_message so
+  // clients see auto-compaction rather than a mid-run context reset.
+  describe("compaction translation", () => {
+    // Drive a MasAgent with a minimal fake Pi session that replays scripted events.
+    async function driveCompaction(events: unknown[]): Promise<AgUiEvent[]> {
+      const bus = new EventBus();
+      const captured: AgUiEvent[] = [];
+      bus.subscribe((e) => captured.push(e));
+      let listener: ((e: unknown) => void) | undefined;
+      const session = {
+        subscribe(l: (e: unknown) => void) {
+          listener = l;
+          return () => {};
+        },
+        async prompt() {
+          for (const e of events) listener?.(e);
+        },
+        async abort() {},
+        dispose() {},
+      };
+      const agent = new MasAgent({
+        sessionId: "s-compact",
+        name: "principal",
+        role: "principal",
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        session: session as any,
+        bus,
+      });
+      await agent.prompt("go");
+      for (const e of captured) expect(() => parseEvent(e)).not.toThrow();
+      return captured;
+    }
+
+    it("success path → 2 CUSTOM(name=compaction) + 2 info system_messages", async () => {
+      const captured = await driveCompaction([
+        { type: "compaction_start", reason: "threshold" },
+        {
+          type: "compaction_end",
+          reason: "threshold",
+          aborted: false,
+          willRetry: false,
+          result: { tokensBefore: 195000, estimatedTokensAfter: 24000, firstKeptEntryId: "u_42" },
+        },
+      ]);
+      const customs = captured.filter(
+        (e) => e.type === "CUSTOM" && (e as { name?: string }).name === "compaction",
+      ) as Array<{ value: Record<string, unknown> }>;
+      expect(customs).toHaveLength(2);
+      expect(customs[0].value).toMatchObject({ op: "start", reason: "threshold" });
+      expect(customs[1].value).toMatchObject({
+        op: "end",
+        reason: "threshold",
+        aborted: false,
+        willRetry: false,
+        tokensBefore: 195000,
+        estimatedTokensAfter: 24000,
+        firstKeptEntryId: "u_42",
+      });
+      const sys = captured.filter((e) => e.type === "system_message") as Array<{
+        level: string;
+        message: string;
+      }>;
+      expect(sys.some((s) => s.level === "info" && /压缩上下文/.test(s.message))).toBe(true);
+      expect(sys.some((s) => s.level === "info" && /压缩完成/.test(s.message))).toBe(true);
+    });
+
+    it("failure path → warning system_message with provider detail", async () => {
+      const captured = await driveCompaction([
+        { type: "compaction_start", reason: "overflow" },
+        {
+          type: "compaction_end",
+          reason: "overflow",
+          aborted: false,
+          willRetry: false,
+          errorMessage: "provider 429 during summarization",
+        },
+      ]);
+      const warn = captured.find(
+        (e) => e.type === "system_message" && (e as { level?: string }).level === "warning",
+      ) as { message: string; details?: string } | undefined;
+      expect(warn?.message).toMatch(/压缩失败/);
+      expect(warn?.details).toContain("provider 429");
+    });
+  });
+
   // #63: a provider/HTTP failure surfaces as a finalized assistant message with
   // stopReason "error" (Pi does NOT throw). The runtime must turn that into a
   // visible error, not an empty assistant bubble + RUN_FINISHED.

--- a/packages/runtime/src/events.ts
+++ b/packages/runtime/src/events.ts
@@ -8,7 +8,13 @@
  * `agent_name` + `_ts`; `run_id` when known.
  */
 import { randomUUID } from "node:crypto";
-import type { AgUiEvent } from "@brainpilot/protocol";
+import type {
+  AgUiEvent,
+  CompactionEndValue,
+  CompactionReason,
+  CompactionStartValue,
+} from "@brainpilot/protocol";
+import { CUSTOM_EVENT } from "@brainpilot/protocol";
 
 function ts(): string {
   return new Date().toISOString();
@@ -177,5 +183,31 @@ export const ev = {
   },
   custom(ctx: Ctx, name: string, value: unknown): AgUiEvent {
     return { type: "CUSTOM", ...envelope(ctx), name, value } as AgUiEvent;
+  },
+  /**
+   * Pi SDK auto/manual compaction — the runtime translates Pi's internal
+   * `compaction_start` / `compaction_end` events onto the AG-UI CUSTOM channel
+   * so clients can render a "context being compacted" indicator instead of
+   * silently seeing the assistant's history collapse. Wire form:
+   *   { type:"CUSTOM", name:"compaction", value: { op:"start", reason, ... } }
+   */
+  compactionStart(ctx: Ctx, reason: CompactionReason): AgUiEvent {
+    const value: CompactionStartValue = { op: "start", reason };
+    return { type: "CUSTOM", ...envelope(ctx), name: CUSTOM_EVENT.COMPACTION, value } as AgUiEvent;
+  },
+  compactionEnd(
+    ctx: Ctx,
+    v: {
+      reason: CompactionReason;
+      aborted: boolean;
+      willRetry: boolean;
+      errorMessage?: string;
+      tokensBefore?: number;
+      estimatedTokensAfter?: number;
+      firstKeptEntryId?: string;
+    },
+  ): AgUiEvent {
+    const value: CompactionEndValue = { op: "end", ...v };
+    return { type: "CUSTOM", ...envelope(ctx), name: CUSTOM_EVENT.COMPACTION, value } as AgUiEvent;
   },
 };

--- a/packages/runtime/src/mas-agent.ts
+++ b/packages/runtime/src/mas-agent.ts
@@ -245,6 +245,13 @@ export class MasAgent {
     this.setStatus("stopped");
   }
 
+  /** Emit a compaction-related system_message with the agent tag pre-filled. */
+  private emitCompactionSystemMessage(level: "info" | "warning", message: string, details?: string): void {
+    this.bus.emit(
+      ev.systemMessage(this.sessionId, level, message, { agent: this.name, details, recoverable: true }),
+    );
+  }
+
   private recordError(message: string, details?: string, raw?: string): void {
     const prev = this.lastError?.consecutiveCount ?? 0;
     this.lastError = { message, timestamp: new Date().toISOString(), consecutiveCount: prev + 1 };
@@ -269,13 +276,59 @@ export class MasAgent {
       case "agent_end":
       case "turn_start":
       case "turn_end":
-      case "compaction_start":
-      case "compaction_end":
       case "queue_update":
-        // Internal / suppressed (§6 table: turn_*, compaction_* not exposed).
+        // Internal / suppressed (§6 table: turn_*, queue_update not exposed).
         // Behavioural reactions to turn_*/agent_end now live in the Pi-native
         // trace-reminder extension, not here.
         return;
+
+      // Pi auto-compacts when context nears the model window (threshold) or an
+      // overflow error came back. Surface both edges on the AG-UI CUSTOM channel
+      // (structured, name:"compaction") plus a `system_message` so text-only UIs
+      // see them too.
+      case "compaction_start": {
+        const cs = e as Extract<PiAgentEvent, { type: "compaction_start" }>;
+        const reason = normalizeCompactionReason(cs.reason);
+        this.bus.emit(ev.compactionStart(ctx, reason));
+        this.emitCompactionSystemMessage(
+          "info",
+          `🗜️ Agent ${this.name} 正在压缩上下文 (${COMPACTION_REASON_LABEL[reason]})…`,
+        );
+        return;
+      }
+
+      case "compaction_end": {
+        const ce = e as Extract<PiAgentEvent, { type: "compaction_end" }>;
+        const reason = normalizeCompactionReason(ce.reason);
+        const { aborted, willRetry, errorMessage } = ce;
+        const r = ce.result as
+          | { tokensBefore?: number; estimatedTokensAfter?: number; firstKeptEntryId?: string }
+          | undefined;
+        this.bus.emit(
+          ev.compactionEnd(ctx, {
+            reason,
+            aborted: Boolean(aborted),
+            willRetry: Boolean(willRetry),
+            errorMessage,
+            tokensBefore: r?.tokensBefore,
+            estimatedTokensAfter: r?.estimatedTokensAfter,
+            firstKeptEntryId: r?.firstKeptEntryId,
+          }),
+        );
+        const label = COMPACTION_REASON_LABEL[reason];
+        if (errorMessage) {
+          this.emitCompactionSystemMessage("warning", `⚠️ Agent ${this.name} 上下文压缩失败 (${label})`, errorMessage);
+        } else if (aborted) {
+          this.emitCompactionSystemMessage("info", `🛑 Agent ${this.name} 上下文压缩已中止`);
+        } else {
+          const delta =
+            r?.tokensBefore !== undefined && r?.estimatedTokensAfter !== undefined
+              ? `：${r.tokensBefore.toLocaleString()} → ~${r.estimatedTokensAfter.toLocaleString()} tokens`
+              : "";
+          this.emitCompactionSystemMessage("info", `✅ Agent ${this.name} 上下文压缩完成 (${label})${delta}`);
+        }
+        return;
+      }
 
       case "message_start": {
         const msg = e as Extract<PiAgentEvent, { type: "message_start" }>;
@@ -434,6 +487,17 @@ export class MasAgent {
     }
   }
 }
+
+type CompactionReason = "manual" | "threshold" | "overflow";
+/** Coerce Pi's `reason` field to the wire enum. Defaults to "manual" on unknown. */
+function normalizeCompactionReason(r: unknown): CompactionReason {
+  return r === "threshold" || r === "overflow" ? r : "manual";
+}
+const COMPACTION_REASON_LABEL: Record<CompactionReason, string> = {
+  manual: "手动",
+  threshold: "接近上下文上限",
+  overflow: "上下文溢出",
+};
 
 function safeStringify(v: unknown): string {
   if (v === undefined || v === null) return "";

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -69,7 +69,26 @@ export type PiAgentEvent =
     }
   | { type: "auto_retry_start"; attempt: number; maxAttempts: number; delayMs: number; errorMessage: string }
   | { type: "auto_retry_end"; success: boolean; attempt: number; finalError?: string }
-  // Internal / suppressed (compaction, queue, etc.) — kept loose.
+  // Pi SDK context compaction (auto/manual). Surfaced onto the AG-UI CUSTOM
+  // channel (`name:"compaction"`) so clients can render the compaction event
+  // rather than silently seeing the history collapse. `result` mirrors Pi's
+  // `CompactionResult`; loose here because Pi may extend the shape.
+  | { type: "compaction_start"; reason: "manual" | "threshold" | "overflow" }
+  | {
+      type: "compaction_end";
+      reason: "manual" | "threshold" | "overflow";
+      aborted?: boolean;
+      willRetry?: boolean;
+      errorMessage?: string;
+      result?: {
+        summary?: string;
+        firstKeptEntryId?: string;
+        tokensBefore?: number;
+        estimatedTokensAfter?: number;
+        [k: string]: unknown;
+      };
+    }
+  // Internal / suppressed (queue, etc.) — kept loose.
   | { type: string; [k: string]: unknown };
 
 /** Pi assistant streaming sub-event (carried by `message_update`). */


### PR DESCRIPTION
## Why

Pi SDK auto-compacts context when it approaches the model window
(~contextWindow − 16k, `threshold`) or on a provider context-overflow
(`overflow`). Previously the runtime silently suppressed
`compaction_start` / `compaction_end`, so clients saw the assistant's
conversation history collapse mid-run with no indicator.

## What

Route Pi's compaction lifecycle onto the standard AG-UI wire so it is
visible to every client — no frontend change needed for baseline
visibility because the existing `system_message` bubble path already
renders 4 levels of styled inline messages.

**Two channels, one source event:**

1. Structured, for rich UIs — via the AG-UI `CUSTOM` channel:
   `{ type:"CUSTOM", name:"compaction", value: { op:"start"|"end", ... } }`
2. Human-readable, for text-only UIs — via `system_message`:
   - start → `info`: `🗜️ Agent … 正在压缩上下文 (原因)…`
   - success → `info`: `✅ … 压缩完成 (原因)：195,000 → ~24,000 tokens`
   - failure → `warning` + details from the provider error
   - aborted → `info`: `🛑 … 上下文压缩已中止`

## Wire contract additions (SSOT: `@brainpilot/protocol`)

- `CUSTOM_EVENT.COMPACTION = "compaction"` (alongside `session_state`,
  `trace_node`, etc.)
- `CompactionStartValueSchema` / `CompactionEndValueSchema` — zod
  discriminated union on `op`, mirroring Pi's `CompactionResult`:
  `reason`, `aborted`, `willRetry`, `errorMessage?`, `tokensBefore?`,
  `estimatedTokensAfter?`, `firstKeptEntryId?`.

## Compatibility

Pure addition:

- No change to existing event wire shapes.
- All CUSTOM consumers already filter by explicit `name ===` (checked
  `session_state`, `trace_node`), so `name === "compaction"` doesn't
  collide.
- `PiAgentEvent` gains explicit `compaction_start` / `compaction_end`
  variants (typing only — the union already accepted them via its
  catch-all).
- `parseEvent` / `AgUiEventSchema` union unchanged (the CUSTOM channel
  already carries `value: z.unknown()`).

## Tests

- +2 in `packages/runtime` event-mapping (success + failure paths)
- +1 in `packages/protocol` for the new zod schemas + full-union round
  trip
- All 621 non-web + 146 web tests still pass; typecheck clean.

## Not a release

Per CLAUDE.md this would normally target `development`. This PR targets
`main` at explicit request, **without** an npm publish — no version
bump, no `npm run release`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)