### PR TITLE
fix(config): migrate legacy plaintext-key settings.json to providers.json (#202)

### DIFF
--- a/packages/backend-core/src/config.ts
+++ b/packages/backend-core/src/config.ts
@@ -487,6 +487,63 @@ export async function bootstrapEnvProvider(
 }
 
 /**
+ * Strip the plaintext key from a legacy settings.json (top-level AND nested
+ * `provider` object), rewrite it at mode 0o600 so it stops sitting on disk at
+ * the old 0644. Best-effort: if the rewrite fails, at least tighten the mode.
+ */
+async function stripLegacyKey(
+  file: string,
+  parsed: Record<string, unknown> | null,
+): Promise<void> {
+  try {
+    if (parsed) {
+      for (const k of ["apiKey", "api_key"]) delete parsed[k];
+      const nested = parsed.provider;
+      if (nested && typeof nested === "object") {
+        for (const k of ["apiKey", "api_key"]) delete (nested as Record<string, unknown>)[k];
+      }
+      await fs.writeFile(file, JSON.stringify(parsed, null, 2), { encoding: "utf8", mode: 0o600 });
+    }
+    await fs.chmod(file, 0o600);
+  } catch {
+    // best-effort: a failure to sanitize the legacy file must not break startup
+  }
+}
+
+/**
+ * #202: one-time upgrade migration. Pre-rewrite versions wrote the provider —
+ * including a plaintext apiKey at mode 0644 — into bp_template/settings.json;
+ * the current SSOT is bp_template/providers.json. If providers.json is empty and
+ * the legacy settings.json carries an apiKey, fold it into a provider profile
+ * (written 0600 by createProfile, set as selected) and strip the plaintext key
+ * from the old file so it no longer lingers on disk. Idempotent: a no-op once
+ * providers.json has any profile or there's nothing to migrate.
+ */
+export async function migrateLegacySettings(
+  dataDir: string,
+): Promise<StoredProviderProfile | null> {
+  const { profiles } = await readProviders(dataDir);
+  if (profiles.length > 0) return null; // already configured — never clobber
+
+  const paths = configPaths(dataDir);
+  const legacy = await readJsonSafe(paths.bpTemplateSettings);
+  const apiKey = pickString(legacy, "apiKey", "api_key");
+  if (!apiKey) return null; // nothing to migrate
+
+  const model = pickString(legacy, "model");
+  const profile = await createProfile(dataDir, {
+    name: "Migrated",
+    apiKey, // persisted into providers.json at 0600 by createProfile
+    baseUrl: pickString(legacy, "baseUrl", "base_url") ?? "",
+    models: model ? [model] : [],
+    notes: "Migrated from legacy settings.json on upgrade (#202).",
+  });
+
+  await stripLegacyKey(paths.bpTemplateSettings, legacy);
+  return profile;
+}
+
+/**
  * Onboarding-facing view of the resolved provider config. A boolean-only key
  * presence (never the plaintext key) plus the two files a user would edit, so
  * `init`/`up` can print accurate, consistent guidance from one source.

--- a/packages/backend-core/src/index.ts
+++ b/packages/backend-core/src/index.ts
@@ -51,6 +51,7 @@ export {
   readLocalSettings,
   writeLocalSettings,
   bootstrapEnvProvider,
+  migrateLegacySettings,
   parseDotenv,
   configPaths,
   describeProviderConfig,

--- a/packages/backend-core/src/server.ts
+++ b/packages/backend-core/src/server.ts
@@ -7,7 +7,7 @@ import { pathToFileURL } from "node:url";
 import { serve, type ServerType } from "@hono/node-server";
 import { createApp, type CreateAppOptions } from "./app.js";
 import { createOrchestrator } from "./create-orchestrator.js";
-import { bootstrapEnvProvider } from "./config.js";
+import { bootstrapEnvProvider, migrateLegacySettings } from "./config.js";
 import type { Orchestrator, OrchestratorMode } from "./orchestrator.js";
 
 export interface StartServerOptions extends Partial<CreateAppOptions> {
@@ -91,12 +91,24 @@ export async function startServer(
     env: options.env,
   });
 
+  const providerDataDir = options.dataDir ?? process.env.BP_DATA_DIR ?? "./brainpilot";
+
+  // #202: migrate a legacy plaintext-key settings.json (pre-rewrite layout) into
+  // providers.json before the env fallback runs — settings.json was a user's
+  // explicit config, so it outranks env projection. No-op once providers.json
+  // has any profile. Best-effort: a failure must not block startup.
+  try {
+    await migrateLegacySettings(providerDataDir);
+  } catch {
+    // ignore — legacy migration is a convenience, not a startup gate
+  }
+
   // #51: seed a provider profile from env on first launch so an env-only
   // quick-start (ANTHROPIC_API_KEY etc.) surfaces an active provider in the Web
   // UI. No-op once providers.json has any profile. Best-effort: a failure here
   // must not block the server from starting.
   try {
-    await bootstrapEnvProvider(options.dataDir ?? process.env.BP_DATA_DIR ?? "./brainpilot", options.env);
+    await bootstrapEnvProvider(providerDataDir, options.env);
   } catch {
     // ignore — env projection is a convenience, not a startup gate
   }

--- a/packages/backend-core/test/config.test.ts
+++ b/packages/backend-core/test/config.test.ts
@@ -6,6 +6,7 @@ import {
   resolveProvider,
   writeLocalSettings,
   bootstrapEnvProvider,
+  migrateLegacySettings,
   parseDotenv,
   describeProviderConfig,
   formatProviderGuidance,
@@ -225,6 +226,89 @@ describe("providers registry (CRUD + selection)", () => {
     const dir = await tmp();
     const resolved = await resolveProvider({ dataDir: dir, env: { ANTHROPIC_API_KEY: "sk-env" } });
     expect(resolved.apiKey).toBe("sk-env");
+  });
+});
+
+describe("migrateLegacySettings (#202)", () => {
+  it("folds a legacy plaintext-key settings.json into a selected profile and strips the key", async () => {
+    const dir = await tmp();
+    const legacyPath = path.join(dir, "bp_template", "settings.json");
+    await mkdir(path.join(dir, "bp_template"), { recursive: true });
+    await writeFile(
+      legacyPath,
+      JSON.stringify({ apiKey: "sk-legacy", baseUrl: "https://old", model: "m-old", logLevel: "info" }),
+      { mode: 0o644 },
+    );
+
+    const profile = await migrateLegacySettings(dir);
+    expect(profile).not.toBeNull();
+    expect(profile?.apiKey).toBe("sk-legacy");
+    expect(profile?.baseUrl).toBe("https://old");
+    expect(profile?.models).toContain("m-old");
+
+    // providers.json now holds the key and is selected
+    const { profiles, selectedProfileId } = await readProviders(dir);
+    expect(profiles).toHaveLength(1);
+    expect(selectedProfileId).toBe(profile?.id);
+
+    // the plaintext key is gone from settings.json, other fields kept
+    const legacy = JSON.parse(await readFile(legacyPath, "utf8"));
+    expect(legacy.apiKey).toBeUndefined();
+    expect(legacy.logLevel).toBe("info");
+
+    // settings.json tightened to 0600 (POSIX only)
+    if (process.platform !== "win32") {
+      const { stat } = await import("node:fs/promises");
+      expect((await stat(legacyPath)).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it("migrates a nested provider.apiKey shape too", async () => {
+    const dir = await tmp();
+    await mkdir(path.join(dir, "bp_template"), { recursive: true });
+    await writeFile(
+      path.join(dir, "bp_template", "settings.json"),
+      JSON.stringify({ provider: { apiKey: "sk-nested", baseUrl: "https://n", model: "mn" } }),
+    );
+    const profile = await migrateLegacySettings(dir);
+    expect(profile?.apiKey).toBe("sk-nested");
+    expect(profile?.baseUrl).toBe("https://n");
+    const legacy = JSON.parse(
+      await readFile(path.join(dir, "bp_template", "settings.json"), "utf8"),
+    );
+    expect(legacy.provider.apiKey).toBeUndefined();
+  });
+
+  it("is a no-op when providers.json already has a profile", async () => {
+    const dir = await tmp();
+    await createProfile(dir, { name: "Existing", apiKey: "sk-keep", models: ["m"] });
+    await mkdir(path.join(dir, "bp_template"), { recursive: true });
+    await writeFile(
+      path.join(dir, "bp_template", "settings.json"),
+      JSON.stringify({ apiKey: "sk-legacy" }),
+    );
+    expect(await migrateLegacySettings(dir)).toBeNull();
+    const { profiles } = await readProviders(dir);
+    expect(profiles).toHaveLength(1);
+    expect(profiles[0].name).toBe("Existing");
+    // legacy file untouched
+    const legacy = JSON.parse(
+      await readFile(path.join(dir, "bp_template", "settings.json"), "utf8"),
+    );
+    expect(legacy.apiKey).toBe("sk-legacy");
+  });
+
+  it("is a no-op when there's no legacy key to migrate", async () => {
+    const dir = await tmp();
+    expect(await migrateLegacySettings(dir)).toBeNull();
+    // legacy file without a key → still no-op
+    await mkdir(path.join(dir, "bp_template"), { recursive: true });
+    await writeFile(
+      path.join(dir, "bp_template", "settings.json"),
+      JSON.stringify({ model: "m-only" }),
+    );
+    expect(await migrateLegacySettings(dir)).toBeNull();
+    expect((await readProviders(dir)).profiles).toHaveLength(0);
   });
 });
 


### PR DESCRIPTION
Fixes #202

## 问题 / Problem

从 pre-rewrite 版本(如 `0.0.4`)升级后,旧的 provider 配置被搁浅:
`bp_template/settings.json` 里存着 `0644` 权限的**明文 apiKey**,但当前的
SSOT 是 `providers.json`——backend 的 `readProviders` 和 runtime 的
`resolveSessionProvider` **都只读 providers.json**。

对"当年把 key 写进 settings.json 文件"的老用户,后果是三重的:

- **Settings → Providers 空白**(`GET /api/provider/profiles` 走 `readProviders` → `[]`),看起来配置全丢了;
- **实际用不了**:runtime `resolveSessionProvider` 读 providers.json 为空 → `undefined` → 回退 env gateway,但这类用户的 key 在文件里不在环境变量里 → **每个 session(已有的和新建的)都因无 key 失败**;
- **明文密钥裸奔**:旧 `settings.json` 以 `0644` 长期留在磁盘上,同机其他账户可读。

> 全新安装(≥ 当前版本)和 env/dotenv 用户不受影响 —— 前者没有 legacy `settings.json`,后者由 `bootstrapEnvProvider` 兜住。

## 方案 / Fix

新增 `migrateLegacySettings(dataDir)`(纯 backend-core):

1. `providers.json` 已有 profile → **直接 return**(绝不覆盖);
2. legacy `settings.json` 含 apiKey(顶层或嵌套 `provider`)→ 收编成一个 **"Migrated"** profile(由 `createProfile` 写入 `0600` 并设为 selected);
3. 从旧文件里**删除明文 key 字段**(保留其他字段),并 `chmod 0600`。

幂等:一旦有 profile / 无 key / 无文件都是 no-op,所以全新安装与 env 用户零影响。

接入点:`startServer` 中于 `bootstrapEnvProvider` **之前**调用——settings.json 是用户曾显式配置的,优先级高于 env 兜底;best-effort 包裹,失败绝不阻塞启动。

## per-session provider 说明

新架构下"每 session 独立 provider"仍然成立,但实现是「providers.json 多 profile(集中密钥,0600)+ 每个 session 只存 `{ providerId, modelId }` 引用(无 key)」。本迁移把老的单个明文 key 收编成这个池子里的第一个 profile,新建 session 默认引用它,老用户升级后无缝继续。

## 测试 / Tests

`config.test.ts` +4:
- 收编 + 删 key + 0600 权限;
- 嵌套 `provider.apiKey` 形态;
- 已有 profile 时 no-op(legacy 原样不动);
- 无 legacy key 时 no-op。

- ✅ 全部 625 个 non-web 测试通过(config 30 条)
- ✅ typecheck 干净;相关包 `tsc -b` build 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)