### PR TITLE
fix(runtime): 补 #211 trace-reminder read-only 豁免实现（修 dev CI 失败）

### DIFF
--- a/packages/runtime/src/extensions/trace-reminder.ts
+++ b/packages/runtime/src/extensions/trace-reminder.ts
@@ -87,13 +87,15 @@ export interface TraceReminderDeps {
  * substantive work and arms the delegate reminder.
  */
 const PI_ALLOWED_TOOLS = new Set([
-  // information-gathering / read-only
+  // information-gathering / read-only. These MUST be Pi's real emitted tool
+  // names, which are lowercase (see BUILTIN_TOOL_CONFIG in tools/system-tools.ts:
+  // principal = ["read","write","edit","bash","grep","find","glob","ls"]). Names
+  // are matched case-insensitively below, but keep them lowercase to match the
+  // source of truth. (The principal has no WebFetch/WebSearch tool — omitted.)
   "read",
   "grep",
   "glob",
-  "lS",
-  "webfetch",
-  "websearch",
+  "ls",
   "find",
   // management / coordination
   "create_agent",


### PR DESCRIPTION
## 问题
development CI（PR #224 dev→main）挂 1 个测试：
```
trace-reminder.test.ts > read-only tool ls + record_trace → no reminder (exempt)
AssertionError: expected [ 'delegate' ] to deeply equal []
```
651 测试里 650 过，只此 1 个。

## 根因
dev→main 合并冲突解决时，把 #211 的**测试**带进了 development，但**实现**漏了。
`PI_ALLOWED_TOOLS`（principal read-only 豁免集）在 dev 上仍是旧内容：
- `"lS"` — 大写 S 笔误，Pi 实际发的工具名是小写 `"ls"` → `ls` 永不匹配豁免 → `ls + record_trace` 仍被误判为"干实活"而提示 delegate（正是失败断言）
- 混入 `"webfetch"`/`"websearch"` — principal 根本没这俩工具

#211 已在 main 修好；本 PR 把该实现补齐到 development，与 main 对齐。

## 验证
- 本地 `trace-reminder.test.ts` 19/19 全绿
- 改后文件与 origin/main 完全一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)