### PR TITLE
Improve agent UX prompts

### DIFF
--- a/packages/runtime/src/__tests__/agent-status.test.ts
+++ b/packages/runtime/src/__tests__/agent-status.test.ts
@@ -14,33 +14,38 @@ describe("renderAgentStatusBlock", () => {
     expect(renderAgentStatusBlock([])).toBe("");
   });
 
-  it("renders a natural-language line per agent with status + unread count", () => {
+  it("returns empty string when only idle agents have no pending messages", () => {
+    expect(renderAgentStatusBlock([{ name: "principal", status: "idle", unread: 0 }])).toBe("");
+  });
+
+  it("renders an internal-only line per active or pending agent", () => {
     const lines: AgentStatusLine[] = [
       { name: "principal", status: "running", unread: 1 },
-      { name: "librarian", status: "idle", unread: 0 },
+      { name: "experimentalist", status: "idle", unread: 0 },
+      { name: "librarian", status: "idle", unread: 1 },
       { name: "engineer", status: "error", unread: 2 },
     ];
     const out = renderAgentStatusBlock(lines);
-    expect(out).toContain("<agent_status>");
-    expect(out).toContain("</agent_status>");
-    expect(out).toContain("- principal: running, 1 unread message");
-    expect(out).toContain("- librarian: idle, 0 unread messages");
-    expect(out).toContain("- engineer: error, 2 unread messages");
+    expect(out).toContain("<internal_agent_status>");
+    expect(out).toContain("</internal_agent_status>");
+    expect(out).toContain("Never mention");
+    expect(out).toContain("- principal: status=running, 1 pending message");
+    expect(out).not.toContain("experimentalist");
+    expect(out).toContain("- librarian: 1 pending message");
+    expect(out).toContain("- engineer: status=error, 2 pending messages");
   });
 
-  it("uses the singular form for exactly one unread message", () => {
+  it("uses the singular form for exactly one pending message", () => {
     const out = renderAgentStatusBlock([{ name: "x", status: "idle", unread: 1 }]);
-    expect(out).toContain("1 unread message");
-    expect(out).not.toContain("1 unread messages");
+    expect(out).toContain("1 pending message");
+    expect(out).not.toContain("1 pending messages");
   });
 
-  it("uses the plural form for zero and many", () => {
+  it("uses the plural form for many pending messages", () => {
     const out = renderAgentStatusBlock([
-      { name: "a", status: "idle", unread: 0 },
       { name: "b", status: "idle", unread: 3 },
     ]);
-    expect(out).toContain("0 unread messages");
-    expect(out).toContain("3 unread messages");
+    expect(out).toContain("3 pending messages");
   });
 });
 
@@ -49,19 +54,19 @@ describe("renderAgentStatusBlock", () => {
 describe("collectAgentStatusLines", () => {
   const unread = (counts: Record<string, number>) => (name: string) => counts[name] ?? 0;
 
-  it("includes the principal itself", () => {
+  it("includes the principal itself when active or pending", () => {
     const agents: StatusAgentLike[] = [
       { name: "principal", role: "principal", status: "running" },
       { name: "engineer", role: "expert", status: "idle" },
     ];
     const lines = collectAgentStatusLines(agents, unread({ principal: 1, engineer: 0 }));
-    expect(lines.map((l) => l.name)).toEqual(["principal", "engineer"]);
+    expect(lines.map((l) => l.name)).toEqual(["principal"]);
     expect(lines.find((l) => l.name === "principal")?.unread).toBe(1);
   });
 
   it("excludes the trace agent", () => {
     const agents: StatusAgentLike[] = [
-      { name: "principal", role: "principal", status: "idle" },
+      { name: "principal", role: "principal", status: "running" },
       { name: "trace", role: "trace", status: "running" },
     ];
     const lines = collectAgentStatusLines(agents, unread({}));
@@ -70,11 +75,20 @@ describe("collectAgentStatusLines", () => {
 
   it("excludes stopped agents", () => {
     const agents: StatusAgentLike[] = [
-      { name: "principal", role: "principal", status: "idle" },
+      { name: "principal", role: "principal", status: "running" },
       { name: "engineer", role: "expert", status: "stopped" },
     ];
     const lines = collectAgentStatusLines(agents, unread({}));
     expect(lines.map((l) => l.name)).toEqual(["principal"]);
+  });
+
+  it("excludes idle agents with no pending messages", () => {
+    const agents: StatusAgentLike[] = [
+      { name: "principal", role: "principal", status: "idle" },
+      { name: "writer", role: "expert", status: "idle" },
+    ];
+    const lines = collectAgentStatusLines(agents, unread({}));
+    expect(lines).toEqual([]);
   });
 
   it("carries the unread count from the inbox", () => {
@@ -116,7 +130,7 @@ const userMsg = (text: string): FakeMsg => ({ role: "user", content: [{ type: "t
 
 describe("makeAgentStatusExt — context hook", () => {
   it("appends a fresh status block before the LLM call", () => {
-    const block = "<agent_status>\nfresh\n</agent_status>";
+    const block = "<internal_agent_status>\nfresh\n</internal_agent_status>";
     const { pi, fire } = fakePi();
     makeAgentStatusExt({ renderStatus: () => block })(pi as never);
 
@@ -130,14 +144,16 @@ describe("makeAgentStatusExt — context hook", () => {
 
   it("strips a stale block from a previous turn and injects only the latest", () => {
     const stale = "<agent_status>\nold\n</agent_status>";
-    const fresh = "<agent_status>\nnew\n</agent_status>";
+    const fresh = "<internal_agent_status>\nnew\n</internal_agent_status>";
     const { pi, fire } = fakePi();
     makeAgentStatusExt({ renderStatus: () => fresh })(pi as never);
 
     const res = fire([userMsg("hello"), userMsg(stale)]);
     const msgs = (res as { messages: FakeMsg[] }).messages;
     // exactly one status block, and it is the fresh one
-    const blocks = msgs.filter((m) => (m.content[0].text ?? "").startsWith("<agent_status>"));
+    const blocks = msgs.filter((m) =>
+      (m.content[0].text ?? "").startsWith("<internal_agent_status>"),
+    );
     expect(blocks).toHaveLength(1);
     expect(blocks[0].content[0].text).toBe(fresh);
     // the real user message survives

--- a/packages/runtime/src/__tests__/personas.test.ts
+++ b/packages/runtime/src/__tests__/personas.test.ts
@@ -98,6 +98,17 @@ describe("personas", () => {
     expect(p.toLowerCase()).toContain("exemption");
   });
 
+  it("principal and writer personas keep internal status out of user-facing prose", () => {
+    const pi = PERSONAS.principal!;
+    const writer = PERSONAS.writer!;
+    expect(pi).toContain("User-facing communication style");
+    expect(pi).toContain("unread-message counts");
+    expect(pi).toContain("agent-status blocks");
+    expect(writer).toContain("Academic report narrative");
+    expect(writer).toContain("Purpose");
+    expect(writer).toContain("Translate them into a clean narrative");
+  });
+
   it("auditor persona constrains scope, bash, and followup count", () => {
     const a = PERSONAS.auditor!;
     // Three claim categories explicitly named

--- a/packages/runtime/src/extensions/agent-status.ts
+++ b/packages/runtime/src/extensions/agent-status.ts
@@ -19,8 +19,8 @@
  *  - `context` handler receives `{ messages }` (a safe-to-mutate copy) and may
  *    return `{ messages }` to replace what the model sees this turn.
  *  - Because the host appends a NEW block each turn, we first STRIP any block we
- *    injected on a previous turn (identified by the `<agent_status>` opener) so
- *    the model only ever sees the latest snapshot, not a pile of old ones.
+ *    injected on a previous turn (identified by the status-block opener) so the
+ *    model only ever sees the latest snapshot, not a pile of old ones.
  *
  * Only the real factory loads this — the mock has no Pi event loop, so the
  * behavioural injection is verified in real mode. The pure block renderer
@@ -38,30 +38,38 @@ export interface AgentStatusLine {
 }
 
 /** Opening tag — also the marker used to recognise a block we injected before. */
-const TAG_OPEN = "<agent_status>";
-const TAG_CLOSE = "</agent_status>";
+const TAG_OPEN = "<internal_agent_status>";
+const TAG_CLOSE = "</internal_agent_status>";
+const LEGACY_TAG_OPEN = "<agent_status>";
 
 /**
- * Build the team-status block as a natural-language list (#97, option B). The
- * wording is self-explanatory so the model needs no schema knowledge: each line
- * names an agent, its status, and how many messages are still waiting unread in
- * its inbox. Returns "" when there is nothing to report (caller skips injection).
+ * Build the team-status block as an internal coordination hint. The wording
+ * tells the model not to surface this block to the user, while still showing
+ * active work or pending agent replies that may affect coordination. Returns ""
+ * when there is nothing to report (caller skips injection).
  *
  * `lines` should already be filtered by the caller (trace agent excluded,
- * stopped agents excluded). Order is preserved.
+ * stopped agents excluded, idle agents with no pending messages excluded).
+ * Order is preserved.
  */
 export function renderAgentStatusBlock(lines: readonly AgentStatusLine[]): string {
-  if (lines.length === 0) return "";
-  const body = lines
+  const visibleLines = lines.filter((l) => l.status !== "idle" || l.unread > 0);
+  if (visibleLines.length === 0) return "";
+  const body = visibleLines
     .map((l) => {
-      const n = l.unread;
-      const msg = `${n} unread message${n === 1 ? "" : "s"}`;
-      return `- ${l.name}: ${l.status}, ${msg}`;
+      const parts: string[] = [];
+      if (l.status !== "idle") parts.push(`status=${l.status}`);
+      if (l.unread > 0) {
+        parts.push(`${l.unread} pending message${l.unread === 1 ? "" : "s"}`);
+      }
+      return `- ${l.name}: ${parts.join(", ")}`;
     })
     .join("\n");
   return (
     `${TAG_OPEN}\n` +
-    `Current agents (status, and how many messages are still waiting unread in each inbox):\n` +
+    `Internal coordination state. Use this only to decide whether to wait for pending agent work. ` +
+    `Never mention, quote, or summarize it in user-facing text.\n` +
+    `Pending or active agents:\n` +
     `${body}\n` +
     `${TAG_CLOSE}`
   );
@@ -76,10 +84,11 @@ export interface StatusAgentLike {
 
 /**
  * Collect the status lines for a team snapshot from the live agents (#97).
- * Includes every agent — INCLUDING the principal, so it sees its own backlog —
- * except the trace agent (an internal recorder) and any stopped agent
- * (destroyed; irrelevant to coordination). `unreadOf` returns the number of
- * messages still queued unread in that agent's inbox. Order follows iteration.
+ * Includes every active or pending agent — INCLUDING the principal, so it sees
+ * its own backlog — except the trace agent (an internal recorder), any stopped
+ * agent (destroyed; irrelevant to coordination), and idle agents with no unread
+ * messages. `unreadOf` returns the number of messages still queued unread in
+ * that agent's inbox. Order follows iteration.
  */
 export function collectAgentStatusLines(
   agents: Iterable<StatusAgentLike>,
@@ -89,7 +98,9 @@ export function collectAgentStatusLines(
   for (const a of agents) {
     if (a.role === "trace") continue;
     if (a.status === "stopped") continue;
-    lines.push({ name: a.name, status: a.status, unread: unreadOf(a.name) });
+    const unread = unreadOf(a.name);
+    if (a.status === "idle" && unread === 0) continue;
+    lines.push({ name: a.name, status: a.status, unread });
   }
   return lines;
 }
@@ -121,7 +132,12 @@ export interface AgentStatusDeps {
 function isStatusMessage(m: PiContextMessage): boolean {
   return (
     m.role === "user" &&
-    m.content.some((c) => c.type === "text" && (c.text ?? "").startsWith(TAG_OPEN))
+    m.content.some((c) => {
+      const text = c.text ?? "";
+      return (
+        c.type === "text" && (text.startsWith(TAG_OPEN) || text.startsWith(LEGACY_TAG_OPEN))
+      );
+    })
   );
 }
 

--- a/packages/runtime/src/personas.ts
+++ b/packages/runtime/src/personas.ts
@@ -402,11 +402,21 @@ Procedure:
 clarification, "I'll start by ...", asking the user a question), skip the audit.
 The audit is for substantive deliverables, not every turn.
 
-## Keeping the user informed
+## User-facing communication style
 
-Show progress and delegation status ("I've asked the librarian to survey X"),
-synthesized findings, decisions, and next steps. State assumptions, rationale,
-and risks for any direction you commit to. Be concise and rigorous.`;
+Keep user-facing replies concise and result-first. Use internal state only to
+decide what to do next; do not expose mailbox state, unread-message counts,
+trace reminders, tool protocol, agent-status blocks, or audit workflow unless it
+directly affects the user's decision.
+
+For progress replies, use at most one short sentence about what is being checked
+or what is ready. For final replies, lead with the answer or deliverable, then
+include only what was done, the main result, important caveats, and the next
+action if needed.
+
+Mention delegation only when it helps the user understand progress, risk, or a
+decision. Do not narrate every reminder, tool call, internal review step, or
+pending message.`;
 
 /* ------------------------------- librarian ------------------------------- */
 
@@ -640,6 +650,24 @@ logical structure, and audience awareness.
 3. **Revise** — check logical flow, verify every claim matches the evidence,
    tighten prose, enforce consistency.
 4. **Polish** — check citations, format to the venue, proofread.
+
+## Academic report narrative
+
+Default to a purpose-driven structure. Each section or paragraph should make
+clear:
+
+1. **Purpose** - what question or problem this part addresses.
+2. **Action** - what was inspected, designed, run, compared, or written.
+3. **Result** - what was found, produced, or decided.
+4. **Link** - how this result supports the user's goal and connects to the
+   previous or next part.
+
+For reports, prefer this order unless the user asks otherwise: Objective /
+Context, Approach, Results, Interpretation, Limitations, Next steps.
+
+Write in a coherent academic voice: topic sentence first, evidence after,
+interpretation last. Do not dump raw agent handoff packets, tool logs, mailbox
+state, or internal process notes. Translate them into a clean narrative.
 
 ## Skills-driven writing
 


### PR DESCRIPTION
## Summary
- tighten the PI persona so user-facing replies hide mailbox, agent-status, trace reminder, tool protocol, and audit workflow internals
- add a purpose/action/result/link report narrative guideline to the writer persona
- make agent-status injection internal-only, omit idle agents with no pending work, and keep stripping legacy status blocks

## Tests
- npm test -w @brainpilot/runtime -- src/__tests__/agent-status.test.ts src/__tests__/personas.test.ts
- npm run typecheck -w @brainpilot/runtime
- git diff --check