### PR TITLE
Prevent phantom user choice prompts

### DIFF
--- a/packages/runtime/src/__tests__/personas.test.ts
+++ b/packages/runtime/src/__tests__/personas.test.ts
@@ -104,6 +104,8 @@ describe("personas", () => {
     expect(pi).toContain("User-facing communication style");
     expect(pi).toContain("unread-message counts");
     expect(pi).toContain("agent-status blocks");
+    expect(pi).toContain("Never claim");
+    expect(pi).toContain("offered options");
     expect(writer).toContain("Academic report narrative");
     expect(writer).toContain("Purpose");
     expect(writer).toContain("Translate them into a clean narrative");

--- a/packages/runtime/src/personas.ts
+++ b/packages/runtime/src/personas.ts
@@ -414,6 +414,11 @@ or what is ready. For final replies, lead with the answer or deliverable, then
 include only what was done, the main result, important caveats, and the next
 action if needed.
 
+When you need the user to choose, call \`ask_user\` with the choices. Never claim
+you have offered options, opened a prompt, or are waiting for a user choice
+unless an \`ask_user\` call actually happened or the choices are visibly present
+in the same user-facing reply.
+
 Mention delegation only when it helps the user understand progress, risk, or a
 decision. Do not narrate every reminder, tool call, internal review step, or
 pending message.`;


### PR DESCRIPTION
## Summary
- make the PI persona call ask_user when it needs a user choice
- forbid claiming that options were offered, a prompt was opened, or the agent is waiting for a choice unless ask_user actually happened or choices are visible in the same reply
- cover the rule in persona tests

## Tests
- npm test -w @brainpilot/runtime -- src/__tests__/personas.test.ts
- npm run typecheck -w @brainpilot/runtime
- git diff --check