### PR TITLE
fix(runtime): keep persisted sessions discoverable + revivable after eviction (#223)

### DIFF
--- a/packages/runtime/src/__tests__/evict-rediscovery.test.ts
+++ b/packages/runtime/src/__tests__/evict-rediscovery.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AgUiEvent } from "@brainpilot/protocol";
+import { SessionManager } from "../session-manager.js";
+import { mockAgentFactory } from "../agent-factory.js";
+
+/**
+ * #223: a persisted session dropped by `evictSession` (idle reaper) must stay
+ * DISCOVERABLE (listSessions) and REVIVABLE (ensureLoaded → messages/state),
+ * not just history-readable (#197). Before the fix, `listSessions` returned only
+ * the in-memory map, so a refreshed sidebar lost the session entirely, and even
+ * if the id was known, `sendMessage`/`getSessionState`/SSE all 404'd.
+ */
+describe("evicted-session rediscovery + revival (#223)", () => {
+  let dataRoot: string;
+  let m: SessionManager;
+
+  beforeEach(async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), "bp-rediscover-"));
+    m = new SessionManager({ persist: true, dataRoot, agentFactory: mockAgentFactory });
+  });
+
+  afterEach(async () => {
+    // Evict every live session first so agent threads stop and their persist
+    // write-chain (mailbox/trace/usage) is flushed before we remove the dir —
+    // otherwise a background write races `rm` and throws ENOTEMPTY.
+    for (const s of await m.listSessions()) await m.evictSession(s.id);
+    await rm(dataRoot, { recursive: true, force: true });
+  });
+
+  async function runOnce(title: string): Promise<string> {
+    const s = await m.createSession({ title });
+    const events: AgUiEvent[] = [];
+    const unsub = m.subscribe(s.id, (e) => events.push(e));
+    await m.sendMessage(s.id, "hello principal");
+    await waitFor(() => events.some((e) => e.type === "RUN_FINISHED"));
+    unsub?.();
+    return s.id;
+  }
+
+  it("listSessions still includes an evicted session (disk discovery)", async () => {
+    const id = await runOnce("Discover me");
+    expect((await m.listSessions()).map((s) => s.id)).toContain(id);
+
+    await m.evictSession(id);
+    expect(m.getSession(id)).toBeUndefined();
+
+    const listed = await m.listSessions();
+    const found = listed.find((s) => s.id === id);
+    expect(found).toBeDefined();
+    expect(found!.title).toBe("Discover me");
+  });
+
+  it("listSessions dedups a live session against its disk copy", async () => {
+    const id = await runOnce("No dupes");
+    const listed = await m.listSessions();
+    expect(listed.filter((s) => s.id === id)).toHaveLength(1);
+  });
+
+  it("ensureLoaded revives an evicted session so state + messages work again", async () => {
+    const id = await runOnce("Revive me");
+    await m.evictSession(id);
+    expect(m.getSessionState(id)).toBeUndefined();
+
+    const ok = await m.ensureLoaded(id);
+    expect(ok).toBe(true);
+    expect(m.getSessionState(id)).toBeDefined();
+
+    // A revived session accepts a new message (would throw "session not found"
+    // pre-fix, since evict dropped it from the in-memory map).
+    const res = await m.sendMessage(id, "second turn");
+    expect(res.accepted).toBe(true);
+  });
+
+  it("concurrent ensureLoaded for the same id restores exactly once", async () => {
+    const id = await runOnce("Race me");
+    await m.evictSession(id);
+
+    const [a, b, c] = await Promise.all([
+      m.ensureLoaded(id),
+      m.ensureLoaded(id),
+      m.ensureLoaded(id),
+    ]);
+    expect([a, b, c]).toEqual([true, true, true]);
+    // A double restore would have duplicated the session; the map holds one.
+    expect((await m.listSessions()).filter((s) => s.id === id)).toHaveLength(1);
+  });
+
+  it("ensureLoaded returns false for an unknown session", async () => {
+    expect(await m.ensureLoaded("does-not-exist")).toBe(false);
+  });
+
+  it("non-persisting manager cannot revive (no disk backing)", async () => {
+    const mem = new SessionManager({ persist: false, agentFactory: mockAgentFactory });
+    expect(await mem.ensureLoaded("whoever")).toBe(false);
+  });
+});
+
+async function waitFor(pred: () => boolean, timeoutMs = 5000): Promise<void> {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timed out");
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}

--- a/packages/runtime/src/__tests__/restore.test.ts
+++ b/packages/runtime/src/__tests__/restore.test.ts
@@ -56,7 +56,7 @@ describe("SessionManager.restoreFromDisk", () => {
       "22222222-2222-2222-2222-222222222222",
     ]);
 
-    const sessions = m.listSessions();
+    const sessions = await m.listSessions();
     expect(sessions).toHaveLength(2);
     const a = sessions.find((s) => s.id === "11111111-1111-1111-1111-111111111111")!;
     expect(a.title).toBe("Old session A");
@@ -113,9 +113,9 @@ describe("SessionManager.restoreFromDisk", () => {
     expect(first).toHaveLength(1);
     const second = await m.restoreFromDisk();
     expect(second).toEqual([]);
-    expect(m.listSessions()).toHaveLength(1);
+    expect(await m.listSessions()).toHaveLength(1);
     // Timestamps still original after the second pass
-    expect(m.listSessions()[0]!.createdAt).toBe("2026-03-01T00:00:00.000Z");
+    expect((await m.listSessions())[0]!.createdAt).toBe("2026-03-01T00:00:00.000Z");
   });
 
   it("returns empty when .bp/ does not exist", async () => {
@@ -166,7 +166,7 @@ describe("SessionManager.restoreFromDisk", () => {
       agentFactory: mockAgentFactory,
     });
     await m.restoreFromDisk();
-    const s = m.listSessions()[0]!;
+    const s = (await m.listSessions())[0]!;
     expect(s.id).toBe("eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee");
     expect(typeof s.createdAt).toBe("string");
     expect(typeof s.updatedAt).toBe("string");

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -42,10 +42,10 @@ describe("SessionManager (mock mode)", () => {
   it("lists and deletes sessions", async () => {
     const a = await m.createSession({ title: "A" });
     const b = await m.createSession({ title: "B" });
-    expect(m.listSessions().map((s) => s.id).sort()).toEqual([a.id, b.id].sort());
+    expect((await m.listSessions()).map((s) => s.id).sort()).toEqual([a.id, b.id].sort());
     expect(await m.deleteSession(a.id)).toBe(true);
     expect(m.getSession(a.id)).toBeUndefined();
-    expect(m.listSessions()).toHaveLength(1);
+    expect(await m.listSessions()).toHaveLength(1);
   });
 
   it("auto-creates the principal on first message", async () => {

--- a/packages/runtime/src/server.ts
+++ b/packages/runtime/src/server.ts
@@ -41,10 +41,12 @@ export function createServer(opts: SessionManagerOptions & { manager?: SessionMa
     return c.json({ id: session.id, session }, 201);
   });
 
-  app.get("/sessions", (c) => c.json({ sessions: manager.listSessions() }));
+  app.get("/sessions", async (c) => c.json({ sessions: await manager.listSessions() }));
 
-  app.get("/sessions/:id", (c) => {
-    const s = manager.getSession(c.req.param("id"));
+  app.get("/sessions/:id", async (c) => {
+    const id = c.req.param("id");
+    await manager.ensureLoaded(id);
+    const s = manager.getSession(id);
     return s ? c.json(s) : c.json({ error: "not found" }, 404);
   });
 
@@ -61,13 +63,17 @@ export function createServer(opts: SessionManagerOptions & { manager?: SessionMa
     return c.json({ id, deleted }, deleted ? 200 : 404);
   });
 
-  app.get("/sessions/:id/state", (c) => {
-    const state = manager.getSessionState(c.req.param("id"));
+  app.get("/sessions/:id/state", async (c) => {
+    const id = c.req.param("id");
+    await manager.ensureLoaded(id);
+    const state = manager.getSessionState(id);
     return state ? c.json(state) : c.json({ error: "not found" }, 404);
   });
 
-  app.get("/sessions/:id/trace", (c) => {
-    const graph = manager.getTrace(c.req.param("id"));
+  app.get("/sessions/:id/trace", async (c) => {
+    const id = c.req.param("id");
+    await manager.ensureLoaded(id);
+    const graph = manager.getTrace(id);
     return graph ? c.json(graph) : c.json({ error: "not found" }, 404);
   });
 
@@ -90,6 +96,7 @@ export function createServer(opts: SessionManagerOptions & { manager?: SessionMa
     const body = await safeBody(c);
     const parsed = SendMessageRequestSchema.safeParse(body);
     if (!parsed.success) return c.json({ error: "invalid body" }, 400);
+    await manager.ensureLoaded(id);
     if (!manager.getSession(id)) return c.json({ error: "not found" }, 404);
 
     // ask_user reply branch: resolve the outstanding request.
@@ -112,11 +119,16 @@ export function createServer(opts: SessionManagerOptions & { manager?: SessionMa
     const body = await safeBody(c);
     const parsed = InterruptRequestSchema.safeParse(body);
     const agent = parsed.success ? parsed.data.agent : undefined;
+    await manager.ensureLoaded(id);
     const interrupted = await manager.interrupt(id, agent);
     return c.json({ interrupted });
   });
 
-  app.get("/sessions/:id/agents", (c) => c.json({ agents: manager.listAgents(c.req.param("id")) }));
+  app.get("/sessions/:id/agents", async (c) => {
+    const id = c.req.param("id");
+    await manager.ensureLoaded(id);
+    return c.json({ agents: manager.listAgents(id) });
+  });
 
   app.post("/sessions/:id/evict", async (c) => {
     const res = await manager.evictSession(c.req.param("id"));
@@ -188,7 +200,8 @@ export function createServer(opts: SessionManagerOptions & { manager?: SessionMa
     }
   });
 
-  const sseHandler = (id: string, c: import("hono").Context) => {
+  const sseHandler = async (id: string, c: import("hono").Context) => {
+    await manager.ensureLoaded(id);
     if (!manager.getSession(id)) return c.json({ error: "not found" }, 404);
     c.header("Content-Type", "text/event-stream");
     c.header("Cache-Control", "no-cache");

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -55,6 +55,15 @@ function makeDeferred<T>(): Deferred<T> {
   return { promise, resolve, reject };
 }
 
+/** Shape of the persisted `.bp/<id>/meta.json` (all fields optional/defensive). */
+interface SessionMeta {
+  id?: string;
+  title?: string;
+  createdAt?: string;
+  updatedAt?: string;
+  lastActivityAt?: number;
+}
+
 interface SessionEntry {
   id: string;
   title: string;
@@ -183,6 +192,12 @@ function formatBytes(n: number): string {
 
 export class SessionManager {
   private readonly sessions = new Map<string, SessionEntry>();
+  /**
+   * In-flight `restoreOne` promises, keyed by session id. Guards against a
+   * refreshed UI firing `state` + `sse` (+ `messages`) near-simultaneously and
+   * racing two `createSession` restores for the same evicted session.
+   */
+  private readonly loading = new Map<string, Promise<boolean>>();
   private readonly dataRoot: string;
   private readonly agentFactory: AgentSessionFactory;
   private readonly persist: boolean;
@@ -664,8 +679,61 @@ export class SessionManager {
     return this.toSession(e);
   }
 
-  listSessions(): Session[] {
-    return [...this.sessions.values()].map((e) => this.toSession(e));
+  /**
+   * List sessions, merging live in-memory entries with persisted-but-evicted
+   * ones discovered on disk (#223). Without this, a session dropped by
+   * `evictSession` (or an idle reaper) vanishes from the sidebar even though its
+   * `.bp/<sid>/` transcript is intact — a refresh then looks like total loss.
+   *
+   * Discovery is metadata-only: we read each `meta.json` but do NOT revive the
+   * full runtime entry (bus/mailbox/trace/agents), so listing stays cheap and
+   * eviction keeps saving memory. The session is lazily revived by
+   * `ensureLoaded` only when it's actually opened. In-memory entries win on id
+   * collision. Ordering is left to the caller (the web sorts by updatedAt).
+   */
+  async listSessions(): Promise<Session[]> {
+    const out = new Map<string, Session>();
+    for (const e of this.sessions.values()) out.set(e.id, this.toSession(e));
+    if (this.persist) {
+      const root = join(this.dataRoot, ".bp");
+      let ids: string[];
+      try {
+        ids = await readdir(root);
+      } catch {
+        ids = []; // .bp/ doesn't exist yet — only in-memory sessions
+      }
+      for (const id of ids) {
+        if (out.has(id)) continue;
+        const meta = await this.readMeta(id);
+        if (!meta) continue;
+        const sid = meta.id ?? id;
+        if (out.has(sid)) continue;
+        out.set(sid, {
+          id: sid,
+          title: meta.title ?? "Untitled session",
+          createdAt: meta.createdAt ?? "",
+          updatedAt: meta.updatedAt ?? "",
+        });
+      }
+    }
+    return [...out.values()];
+  }
+
+  /**
+   * Ensure a persisted session is live in memory, reviving it from disk if it
+   * was evicted (#223). Returns true when the session is available afterwards.
+   * Concurrent calls for the same id share one restore via `this.loading`.
+   */
+  async ensureLoaded(id: string): Promise<boolean> {
+    if (this.sessions.has(id)) return true;
+    if (!this.persist) return false;
+    const inflight = this.loading.get(id);
+    if (inflight) return inflight;
+    const p = this.restoreOne(id)
+      .then((sid) => sid !== null)
+      .finally(() => this.loading.delete(id));
+    this.loading.set(id, p);
+    return p;
   }
 
   async deleteSession(id: string): Promise<boolean> {
@@ -1688,40 +1756,56 @@ export class SessionManager {
       return restored; // .bp/ doesn't exist yet — fresh install
     }
     for (const id of ids) {
-      if (this.sessions.has(id)) continue;
-      const metaPath = join(root, id, "meta.json");
-      let raw: string;
-      try {
-        raw = await readFile(metaPath, "utf8");
-      } catch {
-        continue; // not a session dir (no meta.json) — silent skip
-      }
-      try {
-        const meta = JSON.parse(raw) as {
-          id?: string;
-          title?: string;
-          createdAt?: string;
-          updatedAt?: string;
-          lastActivityAt?: number;
-        };
-        const sid = meta.id ?? id;
-        if (this.sessions.has(sid)) continue;
-        const now = new Date().toISOString();
-        await this.createSession(
-          { id: sid, title: meta.title },
-          {
-            createdAt: meta.createdAt ?? now,
-            updatedAt: meta.updatedAt ?? now,
-            lastActivityAt:
-              typeof meta.lastActivityAt === "number" ? meta.lastActivityAt : Date.now(),
-          },
-        );
-        restored.push(sid);
-      } catch (err) {
-        // eslint-disable-next-line no-console
-        console.warn(`[runtime] skipping ${id}: ${(err as Error).message}`);
-      }
+      const sid = await this.restoreOne(id);
+      if (sid !== null) restored.push(sid);
     }
     return restored;
+  }
+
+  /**
+   * Read and parse `.bp/<id>/meta.json`. Returns null when the directory has no
+   * meta.json (not a session dir) or the file is malformed. Shared by
+   * `restoreOne`, `restoreFromDisk`, and the discovery path in `listSessions`.
+   */
+  private async readMeta(id: string): Promise<SessionMeta | null> {
+    try {
+      const raw = await readFile(join(this.dataRoot, ".bp", id, "meta.json"), "utf8");
+      return JSON.parse(raw) as SessionMeta;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Revive a single persisted session from disk into memory. Returns the
+   * restored session id only when it was **freshly** loaded this call — null
+   * when the session is already in memory (idempotent no-op) or there's no valid
+   * meta.json on disk. `restoreFromDisk` relies on this to report only newly
+   * restored ids; `ensureLoaded` layers "already loaded" on top separately.
+   * §10 策略A: agents start idle and are lazily spawned on the next message.
+   */
+  private async restoreOne(id: string): Promise<string | null> {
+    if (this.sessions.has(id)) return null;
+    const meta = await this.readMeta(id);
+    if (!meta) return null;
+    const sid = meta.id ?? id;
+    if (this.sessions.has(sid)) return null;
+    try {
+      const now = new Date().toISOString();
+      await this.createSession(
+        { id: sid, title: meta.title },
+        {
+          createdAt: meta.createdAt ?? now,
+          updatedAt: meta.updatedAt ?? now,
+          lastActivityAt:
+            typeof meta.lastActivityAt === "number" ? meta.lastActivityAt : Date.now(),
+        },
+      );
+      return sid;
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(`[runtime] skipping ${id}: ${(err as Error).message}`);
+      return null;
+    }
   }
 }

--- a/packages/web/src/__tests__/api.test.ts
+++ b/packages/web/src/__tests__/api.test.ts
@@ -183,10 +183,15 @@ describe("api.sessions.getHistory — persisted events.jsonl rehydration", () =>
     expect(url).toContain("/sessions/s1/history?limit=42");
   });
 
-  it("returns the empty envelope on a non-ok response", async () => {
+  it("returns the empty envelope on a 404 (session has no transcript)", async () => {
     fetchMock.mockResolvedValueOnce(makeResponse({ ok: false, status: 404 }));
     const out = await api.sessions.getHistory("s1");
     expect(out).toEqual({ events: [], total: 0, truncated: false });
+  });
+
+  it("throws on a non-404 failure instead of masking it as empty (#223)", async () => {
+    fetchMock.mockResolvedValueOnce(makeResponse({ ok: false, status: 500 }));
+    await expect(api.sessions.getHistory("s1")).rejects.toThrow(/history fetch failed: 500/);
   });
 
   it("returns the empty envelope when the body is null", async () => {

--- a/packages/web/src/utils/api.ts
+++ b/packages/web/src/utils/api.ts
@@ -550,7 +550,14 @@ export const api = {
         `${API_BASE}/sessions/${sessionId}/history${qs}`,
         { headers: authHeaders() },
       );
-      if (!res.ok) return { events: [], total: 0, truncated: false };
+      // A 404 means the session has no transcript on disk (genuinely empty) —
+      // return an empty history. Any OTHER non-OK status is a real failure
+      // (routing / storage / auth); surface it instead of silently rendering an
+      // empty transcript, which historically masked broken rehydrates (#223).
+      if (res.status === 404) return { events: [], total: 0, truncated: false };
+      if (!res.ok) {
+        throw new Error(`history fetch failed: ${res.status} ${res.statusText}`);
+      }
       const raw = (await res.json().catch(() => null)) as
         | { events?: unknown[]; total?: number; truncated?: boolean }
         | null;


### PR DESCRIPTION
## Summary

Fixes #223. `evictSession` drops a session from the in-memory map but keeps its `.bp/<sid>/` transcript on disk. Only `readEventHistory` had a disk fallback (#197); **every other path** (`listSessions`, messages, state, trace, agents, SSE) was memory-only, so an evicted session vanished from the sidebar and 404'd on open — a browser refresh looked like total session loss.

## Changes

**Runtime**
- `listSessions()` is now async and merges live in-memory entries with disk-discovered `meta.json`. Discovery is **metadata-only** (no full revive of bus/mailbox/trace/agents), so listing stays cheap and eviction keeps saving memory. In-memory entries win on id collision.
- New `ensureLoaded(id)` lazily revives a single evicted session from disk, with an **in-flight lock** so a refreshed UI firing `state` + `sse` (+ `messages`) near-simultaneously can't race two `createSession` restores. Wired into every interaction route in `server.ts`. The `/history` route stays a pure disk read — viewing history needs no live runtime.
- Extracted `readMeta` + `restoreOne`; `restoreFromDisk` reuses them and still reports only freshly-loaded ids (idempotent).

**Web**
- `getHistory` no longer maps *any* non-OK response to an empty history envelope: `404` → empty (genuinely no transcript on disk), any other failure → **throw**, so a broken rehydrate surfaces instead of silently rendering a blank chat (the other half of the "session conversation cannot render" report).

## Tests
- New `evict-rediscovery.test.ts`: disk discovery after evict, revival via `ensureLoaded` (state + new message), concurrent-`ensureLoaded`-restores-once, unknown/non-persist cases.
- Updated async `listSessions` callers and the `getHistory` fallback expectations (404→empty, 500→throws).

## Verification
- ✅ `npm run typecheck`
- ✅ `npm test` — 667 passed
- ✅ web vitest 160 passed + `npm run build`
- ✅ `scripts/smoke-e2e.sh` — SMOKE PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)