### PR TITLE
chore(release): bump version to 0.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainpilot",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "private": true,
   "type": "module",
   "description": "BrainPilot — multi-agent research collaboration platform (TS + Pi SDK)",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/backend-core",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "engines": {
     "node": ">=22"
   },
@@ -37,8 +37,8 @@
     "start": "node ./dist/server.js"
   },
   "dependencies": {
-    "@brainpilot/protocol": "^0.0.9",
-    "@brainpilot/runtime": "^0.0.9",
+    "@brainpilot/protocol": "^0.0.10",
+    "@brainpilot/runtime": "^0.0.10",
     "@hono/node-server": "^1.13.0",
     "hono": "^4.6.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/app",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "engines": {
     "node": ">=22"
   },
@@ -32,10 +32,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@brainpilot/backend-core": "^0.0.9",
-    "@brainpilot/protocol": "^0.0.9",
-    "@brainpilot/runtime": "^0.0.9",
-    "@brainpilot/web": "^0.0.9",
+    "@brainpilot/backend-core": "^0.0.10",
+    "@brainpilot/protocol": "^0.0.10",
+    "@brainpilot/runtime": "^0.0.10",
+    "@brainpilot/web": "^0.0.10",
     "commander": "^12.1.0",
     "picocolors": "^1.1.0"
   }

--- a/packages/client-cli/package.json
+++ b/packages/client-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/client-cli",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "private": true,
   "type": "module",
   "description": "BrainPilot headless verification client (dev/CI) — drive a session without the web UI",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/docs",
-  "version": "0.0.0",
+  "version": "0.0.10",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/protocol",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "engines": {
     "node": ">=22"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/runtime",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "engines": {
     "node": ">=22"
   },
@@ -37,8 +37,8 @@
     "start": "node ./dist/server.js"
   },
   "dependencies": {
-    "@brainpilot/protocol": "^0.0.9",
-    "@brainpilot/skills": "^0.0.9",
+    "@brainpilot/protocol": "^0.0.10",
+    "@brainpilot/skills": "^0.0.10",
     "@earendil-works/pi-coding-agent": "^0.79.0",
     "@hono/node-server": "^1.19.0",
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/skills",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "engines": {
     "node": ">=22"
   },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/web",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "engines": {
     "node": ">=22"
   },
@@ -31,7 +31,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@brainpilot/protocol": "^0.0.9",
+    "@brainpilot/protocol": "^0.0.10",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.8",
     "@types/react": "^18.3.12",


### PR DESCRIPTION
发布 0.0.10 前的版本号 bump。root version 0.0.9 → 0.0.10，version:sync 同步全部 workspace 包+内部依赖（17 字段），version:check 对齐通过。发布 6 个公开包：protocol/skills/runtime/backend-core/web/app（client-cli、docs 为 private 不发布）。合入后从 main 执行 npm publish。

🤖 Generated with [Claude Code](https://claude.com/claude-code)