### PR TITLE
fix(runtime): queue concurrent sends as follow-ups instead of erroring

### DIFF
--- a/packages/runtime/src/__tests__/concurrent-send.test.ts
+++ b/packages/runtime/src/__tests__/concurrent-send.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Concurrent send: a user message that arrives while the agent is still
+ * streaming must NOT hit the SDK's "Agent is already processing" guard. The
+ * runtime queues it as a follow-up onto the in-flight run (streamingBehavior:
+ * "followUp") — no new runId, no thrown error. See SessionManager.sendMessage
+ * + MasAgent.followUp.
+ */
+import { describe, it, expect } from "vitest";
+import { SessionManager } from "../session-manager.js";
+import type { AgentSessionFactory, IAgentSession, PiAgentEvent, PromptOptions, SystemTool } from "../types.js";
+
+interface Observed {
+  prompts: string[];
+  followUps: string[];
+}
+
+/**
+ * A factory whose session stays "streaming" (isStreaming=true) until released,
+ * so a second sendMessage lands during the streaming window. It records plain
+ * prompts vs follow-up queues so the test can assert routing. A plain prompt
+ * received while already streaming throws — mirroring the real SDK guard — so a
+ * regression (missing followUp routing) would surface as a run error.
+ */
+function gatedFactory(observe: Observed): AgentSessionFactory {
+  return async ({ sessionId }: { sessionId: string; agentName: string; systemTools: SystemTool[] }) => {
+    const listeners = new Set<(e: PiAgentEvent) => void>();
+    let streaming = false;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    const emit = (e: PiAgentEvent) => {
+      for (const l of listeners) {
+        try {
+          l(e);
+        } catch {
+          /* isolate */
+        }
+      }
+    };
+    const session: IAgentSession = {
+      sessionId,
+      get isStreaming() {
+        return streaming;
+      },
+      subscribe(listener) {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+      async prompt(text: string, opts?: PromptOptions) {
+        if (streaming) {
+          // Follow-up path: SDK accepts it while streaming when a behavior is set.
+          if (opts?.streamingBehavior) {
+            observe.followUps.push(text);
+            return;
+          }
+          // Plain prompt during streaming → mirror the real SDK guard.
+          throw new Error(
+            "Agent is already processing. Specify streamingBehavior ('steer' or 'followUp') to queue the message.",
+          );
+        }
+        observe.prompts.push(text);
+        streaming = true;
+        emit({ type: "agent_start" });
+        emit({ type: "turn_start" });
+        emit({ type: "message_start", message: { role: "assistant", content: [] } });
+        // Block inside the turn so a concurrent send arrives mid-stream.
+        await gate;
+        emit({
+          type: "message_end",
+          message: { role: "assistant", content: [{ type: "text", text: "ok" }] },
+        });
+        emit({ type: "turn_end" });
+        emit({ type: "agent_end", messages: [], willRetry: false });
+        streaming = false;
+      },
+      async abort() {
+        streaming = false;
+        release();
+      },
+      dispose() {},
+    };
+    // Expose release via a side channel keyed on the session for the test.
+    releases.set(sessionId, release);
+    return session;
+  };
+}
+
+// session id → release fn, so the test can unblock the in-flight turn.
+const releases = new Map<string, () => void>();
+
+async function waitFor(pred: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timed out");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe("concurrent send → follow-up queue", () => {
+  it("queues a second message as a follow-up instead of throwing", async () => {
+    const observe: Observed = { prompts: [], followUps: [] };
+    const m = new SessionManager({ persist: false, agentFactory: gatedFactory(observe) });
+    const s = await m.createSession();
+
+    // First message starts a run that blocks mid-turn (streaming stays true).
+    const first = await m.sendMessage(s.id, "first");
+    expect(first).toMatchObject({ accepted: true });
+    expect(first.queued).toBeFalsy();
+    await waitFor(() => observe.prompts.length === 1);
+
+    // Second message arrives while streaming → must be queued as a follow-up.
+    const second = await m.sendMessage(s.id, "second");
+    expect(second).toMatchObject({ accepted: true, queued: true });
+    // Same run id as the in-flight run (no new run opened).
+    expect(second.runId).toBe(first.runId);
+    await waitFor(() => observe.followUps.length === 1);
+    expect(observe.followUps).toEqual(["second"]);
+    // The second message never went through the plain-prompt path.
+    expect(observe.prompts).toEqual(["first"]);
+
+    // Release the gate so the run drains cleanly (no lingering timers).
+    releases.get(s.id)?.();
+  });
+
+  it("an idle send takes the normal prompt path (no queued flag)", async () => {
+    const observe: Observed = { prompts: [], followUps: [] };
+    const m = new SessionManager({ persist: false, agentFactory: gatedFactory(observe) });
+    const s = await m.createSession();
+
+    const res = await m.sendMessage(s.id, "hello");
+    expect(res).toMatchObject({ accepted: true });
+    expect(res.queued).toBeFalsy();
+    await waitFor(() => observe.prompts.length === 1);
+    expect(observe.prompts).toEqual(["hello"]);
+    expect(observe.followUps).toEqual([]);
+    releases.get(s.id)?.();
+  });
+});

--- a/packages/runtime/src/agent-factory.ts
+++ b/packages/runtime/src/agent-factory.ts
@@ -14,7 +14,7 @@
  *   - `SystemTool` is adapted to Pi's `defineTool` (params is a plain JSON
  *     schema, which `defineTool` accepts — verified empirically).
  */
-import type { AgentSessionFactory, IAgentSession, PiAgentEvent, SystemTool } from "./types.js";
+import type { AgentSessionFactory, IAgentSession, PiAgentEvent, PromptOptions, SystemTool } from "./types.js";
 import { MockAgentSession } from "./mock-agent.js";
 import { resolveGatewayModel, resolveSessionModel, type PiProviderSdk } from "./pi-provider.js";
 import { makeTraceReminderExt } from "./extensions/trace-reminder.js";
@@ -145,11 +145,14 @@ class RealAgentSession implements IAgentSession {
   get sessionId(): string {
     return this.s.sessionId;
   }
+  get isStreaming(): boolean {
+    return this.s.isStreaming;
+  }
   subscribe(listener: (e: PiAgentEvent) => void): () => void {
     return this.s.subscribe((e: unknown) => listener(e as PiAgentEvent));
   }
-  prompt(text: string): Promise<void> {
-    return this.s.prompt(text);
+  prompt(text: string, opts?: PromptOptions): Promise<void> {
+    return this.s.prompt(text, opts);
   }
   abort(): Promise<void> {
     return this.s.abort();
@@ -162,8 +165,9 @@ class RealAgentSession implements IAgentSession {
 /* ---- Minimal structural types for the Pi SDK (avoids hard type-coupling) ---- */
 interface PiSession {
   readonly sessionId: string;
+  readonly isStreaming: boolean;
   subscribe(listener: (e: unknown) => void): () => void;
-  prompt(text: string): Promise<void>;
+  prompt(text: string, opts?: { streamingBehavior?: "steer" | "followUp" }): Promise<void>;
   abort(): Promise<void>;
   dispose(): void;
 }

--- a/packages/runtime/src/mas-agent.ts
+++ b/packages/runtime/src/mas-agent.ts
@@ -178,6 +178,39 @@ export class MasAgent {
     return p;
   }
 
+  /** True while a run is streaming — a plain prompt() would be rejected. */
+  get isStreaming(): boolean {
+    return this.session.isStreaming;
+  }
+
+  /**
+   * Queue a user message onto the *in-flight* run instead of starting a new one
+   * (#: concurrent send). The SDK's agent loop drains follow-ups before it emits
+   * agent_end, so the message is handled after the current turn without a fresh
+   * RUN_STARTED/runId — the events keep flowing under the current run. Unlike
+   * `prompt()`, this does NOT open a new run lifecycle. Error-isolated: a queue
+   * failure is surfaced as a run error, never thrown to the caller.
+   *
+   * Falls back to a normal `prompt()` if the run has already drained (not
+   * streaming anymore) by the time this lands, so a race can't drop the message.
+   */
+  followUp(text: string): Promise<void> {
+    if (!this.session.isStreaming) {
+      // Race: the run finished between the caller's check and here — just start
+      // a normal run so the message isn't lost.
+      return this.prompt(text);
+    }
+    return this.session.prompt(text, { streamingBehavior: "followUp" }).catch((err) => {
+      const raw = (err as Error)?.message ?? String(err);
+      const { message, details } = normalizeAgentError(raw);
+      this.recordError(message, details, raw);
+      this.bus.emit(
+        ev.runError({ sessionId: this.sessionId, agentName: this.name, runId: this.currentRunId }, message),
+      );
+      this.setStatus("error");
+    });
+  }
+
   private async runPrompt(text: string): Promise<void> {
     this.currentRunId = newRunId();
     this.setStatus("running");

--- a/packages/runtime/src/mock-agent.ts
+++ b/packages/runtime/src/mock-agent.ts
@@ -12,7 +12,7 @@
  *     args and emits tool_execution_start/end around it.
  *   - contains "[[error]]": emits an agent-level failure (auto_retry then end).
  */
-import type { IAgentSession, PiAgentEvent, SystemTool } from "./types.js";
+import type { IAgentSession, PiAgentEvent, PromptOptions, SystemTool } from "./types.js";
 
 export interface MockSessionConfig {
   sessionId: string;
@@ -30,10 +30,15 @@ export class MockAgentSession implements IAgentSession {
   private readonly toolMap: Map<string, SystemTool>;
   private aborted = false;
   private disposed = false;
+  private processing = false;
 
   constructor(private readonly cfg: MockSessionConfig) {
     this.sessionId = cfg.sessionId;
     this.toolMap = new Map(cfg.systemTools.map((t) => [t.name, t]));
+  }
+
+  get isStreaming(): boolean {
+    return this.processing;
   }
 
   subscribe(listener: (e: PiAgentEvent) => void): () => void {
@@ -51,9 +56,21 @@ export class MockAgentSession implements IAgentSession {
     }
   }
 
-  async prompt(text: string): Promise<void> {
+  // The mock ignores streamingBehavior — it processes each prompt to completion
+  // synchronously within the await, so there is no real streaming window to
+  // queue against. The opts param keeps the IAgentSession contract.
+  async prompt(text: string, _opts?: PromptOptions): Promise<void> {
     if (this.disposed) return;
     this.aborted = false;
+    this.processing = true;
+    try {
+      await this.runPrompt(text);
+    } finally {
+      this.processing = false;
+    }
+  }
+
+  private async runPrompt(text: string): Promise<void> {
     this.emit({ type: "agent_start" });
     this.emit({ type: "turn_start" });
 

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -710,7 +710,7 @@ export class SessionManager {
     content: string,
     agentName = "principal",
     opts: { uuid?: string } = {},
-  ): Promise<{ accepted: boolean; runId?: string }> {
+  ): Promise<{ accepted: boolean; runId?: string; queued?: boolean }> {
     const entry = this.sessions.get(sessionId);
     if (!entry) throw new Error(`session not found: ${sessionId}`);
     this.touch(entry);
@@ -730,6 +730,22 @@ export class SessionManager {
     // session's workspace (the agent's cwd) before it runs, so it can read the
     // file the user just attached. No-op when nothing was staged.
     await this.drainLocalUploads(sessionId);
+
+    // Concurrent send: the target agent is still streaming its previous run.
+    // A plain prompt() would hit the SDK's "already processing" guard. Queue
+    // the message as a follow-up onto the current run instead — no new runId,
+    // no new run bookkeeping; the SDK loop drains it before agent_end and the
+    // events keep flowing under the in-flight run. The user prompt is still
+    // broadcast (so SSE replay stays complete) correlated to the CURRENT run.
+    if (agent.isStreaming) {
+      const runId = entry.activeRunId ?? undefined;
+      entry.bus.emit(
+        ev.textMessageChunk({ sessionId, agentName, runId }, opts.uuid ?? randomUUID(), content, "user"),
+      );
+      void agent.followUp(content);
+      return { accepted: true, runId, queued: true };
+    }
+
     entry.runActive = true;
     entry.activeRunId = `run_${randomUUID()}`;
     const runId = entry.activeRunId;

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -17,12 +17,30 @@ export type AgentRole = "principal" | "expert" | "trace";
  * stream. Both speak the SAME Pi event vocabulary so the translator (§6) is
  * exercised identically in tests and production.
  */
+/** How a prompt sent while the agent is already streaming should be queued. */
+export type StreamingBehavior = "steer" | "followUp";
+
+export interface PromptOptions {
+  /**
+   * When the agent is already streaming, the underlying SDK refuses a plain
+   * prompt and requires a queueing mode: "steer" interrupts the current turn,
+   * "followUp" waits for it to finish then continues. Ignored when idle.
+   */
+  streamingBehavior?: StreamingBehavior;
+}
+
 export interface IAgentSession {
   readonly sessionId: string;
+  /**
+   * True while a run is in flight (the SDK is streaming). A plain `prompt()`
+   * during this window throws in the real SDK; callers must pass
+   * `streamingBehavior` to queue the message instead.
+   */
+  readonly isStreaming: boolean;
   /** Subscribe to Pi events. Returns an unsubscribe fn. */
   subscribe(listener: (event: PiAgentEvent) => void): () => void;
   /** Send a prompt. Resolves when the run completes (or is aborted). */
-  prompt(text: string): Promise<void>;
+  prompt(text: string, opts?: PromptOptions): Promise<void>;
   /**
    * Hard-abort the active run. For the real Pi session this aborts the provider
    * stream AND awaits the agent returning to idle (SDK `AgentSession.abort()`


### PR DESCRIPTION
## 现象
Agent 还在处理时用户再发消息 → 系统错误:
`⚠️ Agent principal 遇到错误: Agent is already processing. Specify streamingBehavior ('steer' or 'followUp') to queue the message.`

## 根因(跨层)
底层 SDK 规定 streaming 中调 `prompt()` 必须带 `streamingBehavior`(steer/followUp),否则抛错。runtime `sendMessage` 无条件调 `agent.prompt()`、不传 behavior、不查是否在忙 → 第二条消息撞 SDK 守卫,被 catch 成 systemMessage error。前端 `canSend` 也没查 run 是否进行中。

## 修法(排队 followUp)
run 进行中发的第二条消息 → 排队到当前 run,等这一轮结束后 agent 接着处理,不打断:
- **types**:`IAgentSession` 加 `isStreaming` + `prompt(text, {streamingBehavior})`
- **agent-factory** `RealAgentSession` + `PiSession` 结构类型透传
- **mock-agent**:`processing` 标志驱动 `isStreaming`;忽略 behavior(mock 同步跑完每条 prompt)
- **mas-agent**:`isStreaming` getter + `followUp()`(error-isolated;若 run 已结束回落成普通 prompt 防竞态丢消息)
- **session-manager.sendMessage**:检测在忙 → 走 followUp、复用当前 runId、不开新 run、返回 `queued:true`
- idle 发送保持原 prompt 路径不变

## 验证
- 全量 `tsc -b` ✅ / **runtime 286 测试**(+2 新 concurrent-send) / **web 159 测试** ✅
- **真实网关端到端**:发第一条 → 立刻发第二条 → 第二条返回 `queued:true` 且 runId 与第一条相同;事件流仅 1 个 RUN_STARTED/RUN_FINISHED、2 条用户消息、零 already-processing 错误。已部署 :9000 验证。

🤖 Generated with [Claude Code](https://claude.com/claude-code)