### PR TITLE
fix(web): re-tokenize KB panel after #236 (dark-mode safe)

### DIFF
--- a/packages/web/src/components/settings/KnowledgeBasePanel.tsx
+++ b/packages/web/src/components/settings/KnowledgeBasePanel.tsx
@@ -70,41 +70,18 @@ function SetupProgressRow({
   label: string;
   state: SetupState;
 }) {
-  const barColor =
-    state.status === "done" ? "#22c55e"
-    : state.status === "error" ? "#ef4444"
-    : "#3b82f6";
   const pct = Math.max(0, Math.min(100, state.percent));
   return (
-    <div>
-      <div style={{ display: "flex", justifyContent: "space-between", fontSize: 12, marginBottom: 3 }}>
-        <span style={{ fontWeight: 500 }}>{label}</span>
-        <span style={{ color: "#64748b" }}>
-          {state.status === "done" ? "✓ 100%" : `${pct}%`}
-        </span>
+    <div className="kb-setup-row">
+      <div className="kb-setup-row__head">
+        <span className="kb-setup-row__label">{label}</span>
+        <span className="kb-setup-row__pct">{state.status === "done" ? "✓ 100%" : `${pct}%`}</span>
       </div>
-      <div style={{
-        height: 6,
-        background: "#e2e8f0",
-        borderRadius: 3,
-        overflow: "hidden",
-      }}>
-        <div style={{
-          width: `${pct}%`,
-          height: "100%",
-          background: barColor,
-          transition: "width 250ms ease-out",
-        }} />
+      <div className="kb-setup-row__track" aria-hidden="true">
+        <span className={`kb-setup-row__fill kb-setup-row__fill--${state.status}`} style={{ width: `${pct}%` }} />
       </div>
       {state.msg ? (
-        <div style={{
-          fontSize: 11,
-          color: state.status === "error" ? "#b91c1c" : "#64748b",
-          marginTop: 2,
-          overflow: "hidden",
-          textOverflow: "ellipsis",
-          whiteSpace: "nowrap",
-        }}>
+        <div className={`kb-setup-row__msg ${state.status === "error" ? "kb-setup-row__msg--error" : ""}`}>
           {state.msg}
         </div>
       ) : null}
@@ -544,36 +521,22 @@ export function KnowledgeBasePanel() {
                   disabled={envBusy || modelBusy || activeJob !== null}
                   title={t("settings.kb.env.setupFullHint")}
                 >
-                  <Wrench size={14} style={{ marginRight: 4 }} aria-hidden />
+                  <Wrench size={14} aria-hidden />
                   {t("settings.kb.env.setupFullButton")}
                 </button>
-                {envBusy || modelBusy ? <Loader2 size={14} className="animate-spin" aria-hidden /> : null}
+                {envBusy || modelBusy ? <Loader2 size={14} className="spin" aria-hidden /> : null}
               </div>
-              <details style={{ marginTop: 6 }}>
-                <summary style={{ cursor: "pointer", color: "#64748b" }}>
-                  {t("settings.kb.env.cliFallback")}
-                </summary>
-                <pre
-                  style={{
-                    marginTop: 4,
-                    padding: 8,
-                    background: "#0f172a",
-                    color: "#e2e8f0",
-                    borderRadius: 4,
-                    overflowX: "auto",
-                    fontSize: 12,
-                  }}
-                >
+              <details className="kb-env__fallback">
+                <summary>{t("settings.kb.env.cliFallback")}</summary>
+                <pre className="kb-code">
                   {`bash ${env.kbRoot}/scripts/setup_env.sh
 ${env.kbRoot}/.venv/bin/python ${env.kbRoot}/scripts/setup_models.py`}
                 </pre>
-                <div style={{ color: "#64748b", marginTop: 4 }}>
-                  {t("settings.kb.env.venvHint")}
-                </div>
+                <p className="kb-env__note">{t("settings.kb.env.venvHint")}</p>
               </details>
             </div>
           ) : (
-            <div style={{ marginTop: 8, display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+            <div className="kb-env__buttons">
               <button
                 type="button"
                 className="settings-button settings-button--ghost"
@@ -590,7 +553,7 @@ ${env.kbRoot}/.venv/bin/python ${env.kbRoot}/scripts/setup_models.py`}
 
           {/* Setup progress rows: shown any time either job is/was active. */}
           {(envProgress.status !== "pending" || modelProgress.status !== "pending") ? (
-            <div style={{ marginTop: 12, display: "flex", flexDirection: "column", gap: 8 }}>
+            <div className="kb-setup-rows">
               <SetupProgressRow
                 label={t("settings.kb.env.venvProgressLabel")}
                 state={envProgress}
@@ -608,25 +571,15 @@ ${env.kbRoot}/.venv/bin/python ${env.kbRoot}/scripts/setup_models.py`}
         <label className="settings-field">
           <span>{t("settings.kb.ocrKey")}</span>
           {ocrKeySaved && !ocrKeyEditing ? (
-            <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-              <div style={{
-                flex: 1,
-                padding: "6px 10px",
-                background: "#f0fdf4",
-                border: "1px solid #bbf7d0",
-                borderRadius: 4,
-                fontSize: 13,
-                fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
-                color: "#166534",
-              }}>
+            <div className="kb-key-saved-row">
+              <div className="kb-key-saved">
                 {t("settings.kb.ocrKeySaved")} {ocrKeyPreview}
               </div>
               <button
                 type="button"
-                className="settings-button"
+                className="settings-button settings-button--ghost"
                 onClick={() => setOcrKeyEditing(true)}
                 disabled={active || skip.ocr}
-                style={{ background: "transparent", border: "1px solid #cbd5e1", color: "#334155" }}
               >
                 {t("settings.kb.ocrKeyChange")}
               </button>
@@ -705,11 +658,11 @@ ${env.kbRoot}/.venv/bin/python ${env.kbRoot}/scripts/setup_models.py`}
           />
           <span>{t("settings.kb.useHfMirror")}</span>
         </label>
-        <p style={{ margin: "-4px 0 8px 24px", fontSize: 12, opacity: 0.7 }}>
+        <p className="kb-field-hint">
           {t("settings.kb.useHfMirrorHint")}
         </p>
 
-        <fieldset className="settings-field" style={{ border: "none", padding: 0 }}>
+        <fieldset className="kb-stages">
           <legend>{t("settings.kb.stages")}</legend>
           <div className="kb-stages__row">
             {STAGES.map((s) => (

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -5876,6 +5876,102 @@ button {
   color: var(--color-accent);
 }
 
+/* #236 KB hardening surfaces, re-tokenized (dark-mode safe). */
+
+/* Setup progress rows (venv + model download) in the env card. */
+.kb-setup-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 12px;
+}
+
+.kb-setup-row__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.kb-setup-row__label {
+  color: var(--color-text);
+  font-size: 12px;
+  font-weight: 560;
+}
+
+.kb-setup-row__pct {
+  color: var(--color-text-muted);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.kb-setup-row__track {
+  height: 6px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--color-surface-soft);
+}
+
+.kb-setup-row__fill {
+  display: block;
+  height: 100%;
+  border-radius: 999px;
+  background: var(--color-accent);
+  transition: width 250ms var(--ease-out);
+}
+
+.kb-setup-row__fill--done {
+  background: var(--color-success);
+}
+
+.kb-setup-row__fill--error {
+  background: var(--color-danger);
+}
+
+.kb-setup-row__msg {
+  margin-top: 3px;
+  overflow: hidden;
+  color: var(--color-text-subtle);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.kb-setup-row__msg--error {
+  color: var(--color-danger);
+}
+
+/* Persisted OCR key: masked-preview box + Change button. */
+.kb-key-saved-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.kb-key-saved {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--color-success-soft);
+  border-radius: var(--radius-sm);
+  background: var(--color-success-soft);
+  color: var(--color-success);
+  padding: 6px 10px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Inline field hint (e.g. HF mirror explanation). */
+.kb-field-hint {
+  margin: -4px 0 8px 24px;
+  color: var(--color-text-muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
 @media (max-width: 860px) {
   .search-dialog {
     width: calc(100vw - 28px);


### PR DESCRIPTION
## 背景
#236(KB hardening)加了新面板元素——双 setup 进度条、OCR key 持久化 saved 框、HF mirror 开关、一键 full setup——但用了**硬编码色值 + 内联 style**,还把 #235 已 token 化的 3 处回退了(CLI fallback 块、reinstall 按钮容器),并混入未定义的 `.animate-spin`。结果:**KnowledgeBasePanel 深色模式渲染是花的**。

## 改动(纯展示层,保留 #236 全部功能)
把面板所有硬编码/内联 style 重新指向设计 token:
- `SetupProgressRow` → `.kb-setup-row*`(accent/success/danger token),仅动态 width 保留内联
- OCR-saved 框 → `.kb-key-saved`(success-soft token)+ `.settings-button--ghost`
- CLI fallback → 复用 #235 的 `.kb-env__fallback` / `.kb-code` / `.kb-env__note`
- reinstall 容器 → `.kb-env__buttons`;stages fieldset → `.kb-stages`;HF mirror 提示 → `.kb-field-hint`;`.animate-spin` → `.spin`

**功能零改动**,后端/KB 逻辑不碰。

## 验证
- tsc + build + web 167 测试全绿;面板内硬编码 hex=0(除动态 width)、animate-spin=0
- 本地 :9000 浅/深色都切过,深色不再花;full setup/reinstall/OCR saved-change/HF mirror/阶段勾选功能正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)