### PR TITLE
feat(runtime): throttle concurrent provider calls + coalesce retry warnings (#167)

### DIFF
--- a/packages/runtime/src/__tests__/concurrency-throttle.test.ts
+++ b/packages/runtime/src/__tests__/concurrency-throttle.test.ts
@@ -1,0 +1,137 @@
+/**
+ * #167: per-session provider concurrency cap. A wide delegation fan-out must
+ * not fire more than `maxConcurrentAgents` provider calls at once (excess calls
+ * queue, they don't fail), so a multi-agent turn can't self-inflict 429s.
+ */
+import { describe, it, expect } from "vitest";
+import { SessionManager } from "../session-manager.js";
+import type { AgentSessionFactory, IAgentSession, PiAgentEvent, PromptOptions, SystemTool } from "../types.js";
+
+/**
+ * A factory whose sessions block inside prompt() on a shared gate, and record
+ * the peak number of simultaneously-in-flight prompts. `release()` lets them
+ * all finish. Each expert also emits a delegation on its first (principal) turn
+ * so the test can fan out to N experts from one user message.
+ */
+function trackingFactory(peak: { current: number; max: number }, gate: { release?: () => void }) {
+  const inflight = { n: 0 };
+  const factory: AgentSessionFactory = async ({ sessionId, agentName, systemTools }) => {
+    const toolMap = new Map<string, SystemTool>(systemTools.map((t) => [t.name, t]));
+    const listeners = new Set<(e: PiAgentEvent) => void>();
+    const emit = (e: PiAgentEvent) => {
+      for (const l of listeners) {
+        try {
+          l(e);
+        } catch {
+          /* isolate */
+        }
+      }
+    };
+    const session: IAgentSession = {
+      sessionId,
+      get isStreaming() {
+        return false;
+      },
+      subscribe(listener) {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
+      async prompt(text: string, _opts?: PromptOptions) {
+        inflight.n++;
+        peak.current = inflight.n;
+        peak.max = Math.max(peak.max, inflight.n);
+        emit({ type: "agent_start" });
+        emit({ type: "turn_start" });
+        emit({ type: "message_start", message: { role: "assistant", content: [] } });
+        try {
+          // The principal delegates to 5 experts, then all block on the gate.
+          if (agentName === "principal" && text.includes("GO")) {
+            for (const name of ["a1", "a2", "a3", "a4", "a5"]) {
+              const tool = toolMap.get("send_message");
+              if (tool) {
+                await tool.execute({ to: name, content: "work" });
+              }
+            }
+          } else {
+            // Expert turns block so their provider calls overlap in time.
+            await new Promise<void>((r) => {
+              gate.release = () => {
+                inflight.n = Math.max(0, inflight.n - 1);
+                r();
+              };
+            });
+          }
+        } finally {
+          emit({
+            type: "message_end",
+            message: { role: "assistant", content: [{ type: "text", text: "ok" }] },
+          });
+          emit({ type: "turn_end" });
+          emit({ type: "agent_end", messages: [], willRetry: false });
+          if (agentName === "principal") inflight.n = Math.max(0, inflight.n - 1);
+        }
+      },
+      async abort() {
+        gate.release?.();
+      },
+      dispose() {},
+    };
+    return session;
+  };
+  return factory;
+}
+
+async function waitFor(pred: () => boolean, timeoutMs = 3000): Promise<void> {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timed out");
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe("#167 per-session provider concurrency cap", () => {
+  it("never runs more than maxConcurrentAgents prompts at once", async () => {
+    const peak = { current: 0, max: 0 };
+    const gate: { release?: () => void } = {};
+    const m = new SessionManager({
+      persist: false,
+      agentFactory: trackingFactory(peak, gate),
+      maxConcurrentAgents: 2,
+    });
+    const s = await m.createSession();
+
+    // One user message that fans out to 5 experts.
+    await m.sendMessage(s.id, "GO delegate to everyone");
+
+    // Let the experts pile up against the gate; peak must stay ≤ 2.
+    await waitFor(() => peak.max >= 2, 3000).catch(() => {});
+    // Give any (incorrectly) unthrottled calls a chance to overshoot.
+    await new Promise((r) => setTimeout(r, 100));
+    expect(peak.max).toBeLessThanOrEqual(2);
+
+    // Drain: release gated experts a few times so the run can settle.
+    for (let i = 0; i < 8; i++) {
+      gate.release?.();
+      await new Promise((r) => setTimeout(r, 10));
+    }
+  });
+
+  it("disables throttling when maxConcurrentAgents <= 0", async () => {
+    const peak = { current: 0, max: 0 };
+    const gate: { release?: () => void } = {};
+    const m = new SessionManager({
+      persist: false,
+      agentFactory: trackingFactory(peak, gate),
+      maxConcurrentAgents: 0,
+    });
+    const s = await m.createSession();
+    await m.sendMessage(s.id, "GO delegate to everyone");
+    // With no cap, more than 2 experts should overlap.
+    await waitFor(() => peak.max > 2, 3000).catch(() => {});
+    expect(peak.max).toBeGreaterThan(2);
+    for (let i = 0; i < 8; i++) {
+      gate.release?.();
+      await new Promise((r) => setTimeout(r, 10));
+    }
+  });
+});

--- a/packages/runtime/src/events.ts
+++ b/packages/runtime/src/events.ts
@@ -168,11 +168,14 @@ export const ev = {
     sessionId: string,
     level: "info" | "warning" | "error" | "fatal",
     message: string,
-    opts?: { agent?: string; details?: string; recoverable?: boolean },
+    opts?: { agent?: string; details?: string; recoverable?: boolean; id?: string },
   ): AgUiEvent {
     return {
       type: "system_message",
       session_id: sessionId,
+      // #167: optional stable id lets the client coalesce repeated messages
+      // (e.g. retry warnings) into one updating bubble instead of appending.
+      ...(opts?.id ? { id: opts.id } : {}),
       agent: opts?.agent,
       level,
       message,

--- a/packages/runtime/src/mas-agent.ts
+++ b/packages/runtime/src/mas-agent.ts
@@ -442,6 +442,11 @@ export class MasAgent {
       }
 
       case "auto_retry_start": {
+        // #167: coalesce retry warnings. Instead of a fresh bubble per attempt
+        // (which stacked into N messages during a rate-limit window), emit the
+        // warning with a STABLE id keyed on (agent, run) + an incrementing
+        // attempt count. The web reducer updates the existing bubble in place,
+        // so the user sees one live "retrying (n/N)" line that ticks up.
         const r = e as Extract<PiAgentEvent, { type: "auto_retry_start" }>;
         this.bus.emit(
           ev.systemMessage(
@@ -450,7 +455,11 @@ export class MasAgent {
             `⏳ Agent ${this.name} 遇到 API 错误，正在自动重试 (${r.attempt}/${r.maxAttempts})，${
               r.delayMs / 1000
             }秒后重试...`,
-            { agent: this.name, recoverable: true },
+            {
+              agent: this.name,
+              recoverable: true,
+              id: `retry-${this.name}-${this.currentRunId ?? "run"}`,
+            },
           ),
         );
         return;

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -55,6 +55,62 @@ function makeDeferred<T>(): Deferred<T> {
   return { promise, resolve, reject };
 }
 
+/** #167 default concurrent-provider-calls cap when nothing is configured. */
+const DEFAULT_MAX_CONCURRENT_AGENTS = 4;
+
+/**
+ * Resolve the per-session provider concurrency cap: explicit option wins, else
+ * `BP_MAX_CONCURRENT_AGENTS`, else the default. Non-integer / empty env falls
+ * back to the default; 0 or negative is honored as "throttling disabled".
+ */
+function resolveMaxConcurrentAgents(opt?: number): number {
+  if (typeof opt === "number" && Number.isFinite(opt)) return Math.trunc(opt);
+  const env = process.env.BP_MAX_CONCURRENT_AGENTS?.trim();
+  if (env !== undefined && env !== "") {
+    const n = Number(env);
+    if (Number.isFinite(n)) return Math.trunc(n);
+  }
+  return DEFAULT_MAX_CONCURRENT_AGENTS;
+}
+
+/**
+ * A minimal FIFO counting semaphore. `acquire()` resolves with a `release` fn
+ * once a slot is free; excess acquirers queue in order. Used per-session to
+ * bound concurrent provider calls (#167). Not reentrant; callers must release
+ * exactly once (we do so in a `finally`).
+ */
+class ProviderSemaphore {
+  private available: number;
+  private readonly waiters: Array<() => void> = [];
+
+  constructor(limit: number) {
+    this.available = Math.max(1, limit);
+  }
+
+  acquire(): Promise<() => void> {
+    return new Promise<() => void>((resolve) => {
+      const grant = () => {
+        let released = false;
+        resolve(() => {
+          if (released) return;
+          released = true;
+          const next = this.waiters.shift();
+          if (next) next();
+          else this.available++;
+        });
+      };
+      if (this.available > 0) {
+        this.available--;
+        grant();
+      } else {
+        // Queue: when a slot frees, this waiter is handed the slot directly
+        // (available stays decremented — ownership transfers, no double count).
+        this.waiters.push(grant);
+      }
+    });
+  }
+}
+
 interface SessionEntry {
   id: string;
   title: string;
@@ -137,6 +193,13 @@ export interface SessionManagerOptions {
    * Env override: BP_MAX_TOOL_RESULT_TOKENS.
    */
   maxToolResultTokens?: number;
+  /**
+   * #167: max concurrent provider calls per session (throttle to avoid
+   * self-inflicted 429s on a wide multi-agent fan-out). Default 4; env override
+   * `BP_MAX_CONCURRENT_AGENTS` (intended range ~2–6). 0 or negative disables
+   * throttling. Tests inject this directly.
+   */
+  maxConcurrentAgents?: number;
 }
 
 /** Roles inferred from agent name. */
@@ -217,6 +280,15 @@ export class SessionManager {
   // Tool result truncation (issue #80). 0 = disabled.
   private readonly maxToolResultTokens: number;
 
+  // #167: per-session cap on concurrent provider calls. Each agent's delivery
+  // loop is already serial, but distinct experts run independently, so a wide
+  // delegation fan-out can fire N provider requests at once and self-inflict
+  // 429s. A per-session semaphore bounds in-flight `prompt()`s; excess calls
+  // queue (they don't fail). Default 4, tunable via BP_MAX_CONCURRENT_AGENTS
+  // (intended range ~2–6 for shared/rate-limited gateways).
+  private readonly maxConcurrentAgents: number;
+  private readonly providerSlots = new Map<string, ProviderSemaphore>();
+
   constructor(opts: SessionManagerOptions = {}) {
     this.dataRoot = opts.dataRoot ?? process.env.BP_DATA_DIR ?? join(process.cwd(), ".bp-data");
     this.agentFactory = opts.agentFactory ?? selectFactory();
@@ -239,6 +311,8 @@ export class SessionManager {
     // format; `skill_search` reads from here, Pi never sees it.
     this.routerSkillsDir =
       opts.routerSkillsDir ?? join(this.dataRoot, "bp_template", "skills-router");
+
+    this.maxConcurrentAgents = resolveMaxConcurrentAgents(opts.maxConcurrentAgents);
 
     const limitBytes = opts.memLimitBytes ?? parseMemLimitMb(process.env);
     this.memWatchdog =
@@ -674,6 +748,7 @@ export class SessionManager {
     for (const a of e.agents.values()) a.stop();
     e.bus.clear();
     this.sessions.delete(id);
+    this.providerSlots.delete(id);
     if (this.persist) {
       await rm(this.bpDir(id), { recursive: true, force: true }).catch(() => {});
       await rm(this.workspaceDir(id), { recursive: true, force: true }).catch(() => {});
@@ -699,6 +774,7 @@ export class SessionManager {
       e.pendingInputs.delete(id2);
     }
     this.sessions.delete(id);
+    this.providerSlots.delete(id);
     return { evicted: true, agentsKilled: killed };
   }
 
@@ -764,8 +840,8 @@ export class SessionManager {
       ev.textMessageChunk({ sessionId, agentName, runId }, opts.uuid ?? randomUUID(), content, "user"),
     );
     // Fire-and-track: don't block the HTTP response on the full run.
-    void agent
-      .prompt(content)
+    // #167: the principal's own turn also counts against the session provider cap.
+    void this.withProviderSlot(sessionId, () => agent.prompt(content))
       .catch((err) => {
         entry.bus.emit(
           ev.systemMessage(sessionId, "error", `发送消息失败: ${(err as Error).message}`, { agent: agentName }),
@@ -1161,6 +1237,26 @@ export class SessionManager {
     entry.agents.delete(name); // history on disk is kept (§5).
   }
 
+  /**
+   * #167: run `fn` (an `agent.prompt(...)` call) under the session's provider
+   * concurrency cap. `agent.prompt` is error-isolated (never throws), so the
+   * slot is always released. A cap of 0/negative disables throttling.
+   */
+  private async withProviderSlot<T>(sessionId: string, fn: () => Promise<T>): Promise<T> {
+    if (this.maxConcurrentAgents <= 0) return fn();
+    let sem = this.providerSlots.get(sessionId);
+    if (!sem) {
+      sem = new ProviderSemaphore(this.maxConcurrentAgents);
+      this.providerSlots.set(sessionId, sem);
+    }
+    const release = await sem.acquire();
+    try {
+      return await fn();
+    } finally {
+      release();
+    }
+  }
+
   /* ------------------------- mailbox delivery (#76) ------------------------- */
 
   /**
@@ -1217,7 +1313,8 @@ export class SessionManager {
       this.touch(entry);
       // Surface the delegated run immediately (derived active flag, agent list).
       this.emitSessionState(entry);
-      await agent.prompt(this.renderEnvelopes(msgs, name));
+      // #167: cap concurrent provider calls across experts in this session.
+      await this.withProviderSlot(sessionId, () => agent.prompt(this.renderEnvelopes(msgs, name)));
 
       // #97 error path. A delegated run that ended in `error` is handled here
       // (the trace-reminder extension bails on an errored run, leaving the host

--- a/packages/web/src/__tests__/newUiEvents.test.ts
+++ b/packages/web/src/__tests__/newUiEvents.test.ts
@@ -56,6 +56,38 @@ describe("system_message mapping", () => {
     expect(out[0].systemMessage?.level).toBe("warning");
     expect(out[0].content).toBe("watch out");
   });
+
+  it("#167: coalesces repeated system_messages sharing a stable id (retry ticks)", () => {
+    const mk = (attempt: number) =>
+      ({
+        type: "system_message",
+        id: "retry-librarian-run_1",
+        level: "warning",
+        message: `retrying (${attempt}/3)`,
+        agent: "librarian",
+      }) as WebSocketEvent;
+    let msgs = reduceMessagesForEvent([], mk(1));
+    msgs = reduceMessagesForEvent(msgs, mk(2));
+    msgs = reduceMessagesForEvent(msgs, mk(3));
+    // One bubble, updated in place to the latest attempt.
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].id).toBe("retry-librarian-run_1");
+    expect(msgs[0].content).toBe("retrying (3/3)");
+  });
+
+  it("#167: system_messages without a stable id still append", () => {
+    let msgs = reduceMessagesForEvent([], {
+      type: "system_message",
+      level: "warning",
+      message: "one",
+    } as WebSocketEvent);
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "system_message",
+      level: "warning",
+      message: "two",
+    } as WebSocketEvent);
+    expect(msgs).toHaveLength(2);
+  });
 });
 
 describe("ask_user mapping + submit + reducer round-trip", () => {

--- a/packages/web/src/contexts/messageReducer.ts
+++ b/packages/web/src/contexts/messageReducer.ts
@@ -338,7 +338,17 @@ export function reduceMessagesForEvent(existing: ChatMessage[], event: WebSocket
 
     // 修正6 — system_message: 4-level styled bubble in the conversation stream.
     case "system_message": {
-      return [...existing, systemMessageToChatMessage(event)];
+      const msg = systemMessageToChatMessage(event);
+      // #167: coalesce by stable id — a repeated system_message carrying an id
+      // that already exists (e.g. an agent's retry warning ticking n/N) updates
+      // the existing bubble in place instead of stacking a new one. Messages
+      // without a stable id (random-id path) always append, as before.
+      const e = event as Record<string, unknown>;
+      const hasStableId = typeof (e.id ?? e.messageId) === "string";
+      if (hasStableId && existing.some((m) => m.id === msg.id)) {
+        return existing.map((m) => (m.id === msg.id ? msg : m));
+      }
+      return [...existing, msg];
     }
 
     // 修正6 — user_input_request (ask_user): interactive card. Keyed by


### PR DESCRIPTION
Addresses #167 (subset A + B; Retry-After / SDK retry knobs left to discussion).

## 问题
多 agent 任务里,多个专家的 delivery loop 独立并发 → 同时 N 个 provider 调用 → 自造 429;且每次重试都新弹一条 warning 气泡,限流窗口刷屏。

## 改动
**A. 每-session 并发限流器**
- FIFO 信号量限制每 session 同时在飞的 `agent.prompt()` 数(超出排队,不失败)。
- 默认 4,env `BP_MAX_CONCURRENT_AGENTS`(意图范围 ~2–6),0/负数关闭。
- 包住 delivery-loop prompt + principal 自身 turn;`finally` 释放;delete/evict 清理。

**B. 重试警告合并**
- `auto_retry_start` 的 system_message 带稳定 id(`retry-<agent>-<runId>`);web reducer 对已存在同 id 的消息**原地更新**而非追加 → 用户看到一条会跳动的「retrying (n/N)」而不是 N 条。
- 无稳定 id 的 system_message 仍照常追加(不影响其他警告)。

## 不在本 PR(留 #167 讨论)
honor провайдер `Retry-After` 头 + 暴露 SDK retry 旋钮 —— 需 SDK 支持/属独立议题。

## 验证
- 全量 `tsc -b`;**runtime 288 测试**(+2 并发上限:cap 生效 ≤2 / cap≤0 关闭时溢出)+ **web 169**(+2 合并:同 id 原地更新 / 无 id 追加)
- **真实网关端到端**:`BP_MAX_CONCURRENT_AGENTS=2` 起,发一个委派给 3 个专家并行的任务,40 次采样非-trace running agent **始终 ≤2**(第三个专家排队,槽位释放后才跑),证明限流真生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)