### PR TITLE
fix(runtime): reset process-level /metrics.lastActivityAt to now on restore (#242)

### DIFF
--- a/packages/runtime/src/__tests__/restore.test.ts
+++ b/packages/runtime/src/__tests__/restore.test.ts
@@ -171,4 +171,32 @@ describe("SessionManager.restoreFromDisk", () => {
     expect(typeof s.createdAt).toBe("string");
     expect(typeof s.updatedAt).toBe("string");
   });
+
+  // #242: restoring an old session must NOT freeze the process-level liveness
+  // metric at the session's stale on-disk time — otherwise a hosted reaper doing
+  // `now - metrics.lastActivityAt` mis-kills a freshly-restarted container.
+  it("resets process-level /metrics.lastActivityAt to ~now on restore (not stale disk time)", async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), "bp-restore-"));
+    const staleMs = Date.parse("2020-01-01T00:00:00.000Z"); // years ago
+    await writeMeta(dataRoot, "ffffffff-ffff-ffff-ffff-ffffffffffff", {
+      id: "ffffffff-ffff-ffff-ffff-ffffffffffff",
+      title: "Stale session",
+      createdAt: "2020-01-01T00:00:00.000Z",
+      updatedAt: "2020-01-01T00:00:00.000Z",
+      lastActivityAt: staleMs,
+    });
+    const before = Date.now();
+    const m = new SessionManager({ dataRoot, persist: true, agentFactory: mockAgentFactory });
+    await m.restoreFromDisk();
+
+    // Process-level liveness anchor reflects "this process is freshly alive".
+    const metricTs = Date.parse(m.metrics().lastActivityAt!);
+    expect(metricTs).toBeGreaterThanOrEqual(before);
+    expect(metricTs).toBeGreaterThan(staleMs);
+
+    // Per-session historical timestamps are still preserved (UI/history intact).
+    const s = m.listSessions().find((x) => x.id === "ffffffff-ffff-ffff-ffff-ffffffffffff")!;
+    expect(s.createdAt).toBe("2020-01-01T00:00:00.000Z");
+    expect(s.updatedAt).toBe("2020-01-01T00:00:00.000Z");
+  });
 });

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -698,8 +698,20 @@ export class SessionManager {
       tokenUsage: { total: emptyTokenUsage(), byAgent: {} },
     };
     this.sessions.set(id, entry);
-    if (!_restore) this.touch(entry);
-    else this.lastActivityAt = entry.lastActivityAt;
+    if (!_restore) {
+      this.touch(entry);
+    } else {
+      // #242: a restored session keeps its OLD per-session `entry.lastActivityAt`
+      // (historical "last active" for UI/history), but the PROCESS-level liveness
+      // anchor must reflect activity since THIS process/container started — not a
+      // timestamp frozen on disk days ago. Otherwise a hosted reaper computing
+      // `now - metrics.lastActivityAt` sees a huge idle for a freshly-restarted
+      // container and kills it immediately (start → reaped → start death spiral).
+      // Take the newest activity the process has seen so multi-session restore
+      // stays monotonic. Per-session `entry.lastActivityAt` is intentionally
+      // untouched here.
+      this.lastActivityAt = Math.max(this.lastActivityAt, Date.now());
+    }
 
     if (this.persist) {
       await mkdir(join(this.bpDir(id), "history"), { recursive: true });


### PR DESCRIPTION
Closes #242.

## 问题
runtime 开机从磁盘 restore 会话时,进程级 liveness 锚 `this.lastActivityAt`(即 `/metrics.lastActivityAt`)被设成**被恢复会话的旧磁盘时间戳**。托管层用 `now - metrics.lastActivityAt` 判容器空闲 → 刚重启的容器算出巨大 idle → 立刻误杀 → start→秒杀→start 死亡螺旋。

## 根因(`packages/runtime/src/session-manager.ts`)
`createSession` restore 分支:`else this.lastActivityAt = entry.lastActivityAt` —— 把进程级锚冻结到旧会话时间。`metrics()` 输出的就是它。

## 修法(issue 的 minimal option)
restore 时:
- **保留** per-session 历史 `entry.lastActivityAt`(UI/history 正确,"这个会话上次活跃于")
- 进程级锚改为 `this.lastActivityAt = Math.max(this.lastActivityAt, Date.now())` —— 反映"本进程/容器刚启动、活着",多会话 restore 单调稳健。
- **不改契约**:`/metrics.lastActivityAt` 仍是同一 top-level string,只修 restore 路径语义(未采用 issue Option 2 的加字段方案,避免契约扩展)。

## 验证
- runtime `tsc -b` + **289 单测**(restore.test +1:旧磁盘会话 restore 后 metrics.lastActivityAt ≈ now,而 per-session createdAt/updatedAt 仍保留旧值)
- web 不受影响(它读 per-session `state.lastActivityTs`,非 `/metrics`)
- testbed M14(evict → lastActivityAt sticky 非 null)不受影响(evict 路径未动)

进 0.0.11。

🤖 Generated with [Claude Code](https://claude.com/claude-code)