### PR TITLE
chore(release): v0.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainpilot",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "private": true,
   "type": "module",
   "description": "BrainPilot — multi-agent research collaboration platform (TS + Pi SDK)",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/backend-core",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "engines": {
     "node": ">=22"
   },
@@ -37,8 +37,8 @@
     "start": "node ./dist/server.js"
   },
   "dependencies": {
-    "@brainpilot/protocol": "^0.0.11",
-    "@brainpilot/runtime": "^0.0.11",
+    "@brainpilot/protocol": "^0.0.12",
+    "@brainpilot/runtime": "^0.0.12",
     "@hono/node-server": "^1.13.0",
     "hono": "^4.6.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/app",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "engines": {
     "node": ">=22"
   },
@@ -32,10 +32,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@brainpilot/backend-core": "^0.0.11",
-    "@brainpilot/protocol": "^0.0.11",
-    "@brainpilot/runtime": "^0.0.11",
-    "@brainpilot/web": "^0.0.11",
+    "@brainpilot/backend-core": "^0.0.12",
+    "@brainpilot/protocol": "^0.0.12",
+    "@brainpilot/runtime": "^0.0.12",
+    "@brainpilot/web": "^0.0.12",
     "commander": "^12.1.0",
     "picocolors": "^1.1.0"
   }

--- a/packages/client-cli/package.json
+++ b/packages/client-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/client-cli",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "private": true,
   "type": "module",
   "description": "BrainPilot headless verification client (dev/CI) — drive a session without the web UI",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/docs",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/protocol",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "engines": {
     "node": ">=22"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/runtime",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "engines": {
     "node": ">=22"
   },
@@ -37,8 +37,8 @@
     "start": "node ./dist/server.js"
   },
   "dependencies": {
-    "@brainpilot/protocol": "^0.0.11",
-    "@brainpilot/skills": "^0.0.11",
+    "@brainpilot/protocol": "^0.0.12",
+    "@brainpilot/skills": "^0.0.12",
     "@earendil-works/pi-coding-agent": "^0.79.0",
     "@hono/node-server": "^1.19.0",
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/skills",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "engines": {
     "node": ">=22"
   },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/web",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "engines": {
     "node": ">=22"
   },
@@ -31,7 +31,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@brainpilot/protocol": "^0.0.11",
+    "@brainpilot/protocol": "^0.0.12",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.8",
     "@types/react": "^18.3.12",


### PR DESCRIPTION
Release **v0.0.12** — bumps every workspace package `0.0.11 → 0.0.12` (via `npm run version:sync`).

### Features
- **files:** differentiate the three file tiers — attachments / workspace / data (#263)
- **runtime:** agent-accessible cross-session persistent root (#257, #259)
- **upload:** raw streaming upload + configurable size cap (#256, #258)
- **skills:** rework catalog — add science / network-neuro skills, drop NeuroClaw + EthoClaw (#260)
- **kb:** OCR provider abstraction, live-progress SSE, spawn-log secret hygiene (#251)
- **kb:** panel completeness probes, per-stage warnings, inventory card, mirror/token controls (#249)

### Fixes
- **runtime:** broaden auditor to open-ended scientific-reliability review (#270)
- **skill-router:** accept only comma-string keywords + array fallback (#260)
- **mcp:** raise per-call timeout to 5 min + reset on progress
- **web:** grow GoT trace "Next tasks" bubbles to fit wrapped titles (#268)
- **web:** return-home entry in sidebar for hosted subpath deploys (#250, #254)
- **web:** clear `hasPanned` on mouseup so trace-graph node clicks survive a pan (#253)

### Docs
- **web:** document disk-quota UI as a hosted trust-front hook (#262, #267)
