### PR TITLE
feat(skills): add fmriprep skill to 06_fMRI_Neuroimaging

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -179,7 +179,7 @@ npm run bp -- up     # 从源码启动（-- 用于把 flag 透传给 CLI）
 | `03_Cognitive_Psychology` | 范式、评分、DDM、SDT |
 | `04_Psycholinguistics` | 阅读时、SPR、刺激常模 |
 | `05_EEG_ERP` | EEG 预处理、ERP 分析、MNE-Python |
-| `06_fMRI_Neuroimaging` | fMRI 预处理、GLM、pycortex、解码 |
+| `06_fMRI_Neuroimaging` | fMRI 预处理（含 fMRIPrep BIDS-App）、GLM、pycortex、解码 |
 | `07_Computational_Modeling` | ACT-R、贝叶斯建模、参数恢复 |
 | `08_Computational_Neuroscience` | 神经群体分析、脉冲网络 |
 | `09_Cellular_Molecular_Neuroscience` | 钙成像、光遗传学 |

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Existing categories under `packages/skills/skills/`:
 | `03_Cognitive_Psychology` | Paradigms, scoring, DDM, SDT |
 | `04_Psycholinguistics` | Reading time, SPR, stimulus norming |
 | `05_EEG_ERP` | EEG preprocessing, ERP analysis, MNE-Python |
-| `06_fMRI_Neuroimaging` | fMRI preprocessing, GLM, pycortex, decoding |
+| `06_fMRI_Neuroimaging` | fMRI preprocessing (incl. fMRIPrep BIDS-App), GLM, pycortex, decoding |
 | `07_Computational_Modeling` | ACT-R, Bayesian modelling, parameter recovery |
 | `08_Computational_Neuroscience` | Neural population analysis, spiking networks |
 | `09_Cellular_Molecular_Neuroscience` | Calcium imaging, optogenetics |

--- a/packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/SKILL.md
+++ b/packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: "fmriprep"
+description: "Preprocess task-based or resting-state fMRI data with fMRIPrep — a robust, BIDS-App preprocessing pipeline built on FSL, ANTs, FreeSurfer, AFNI, and Nilearn. Use this skill whenever the user asks to preprocess fMRI/BOLD data, run fMRIPrep on a BIDS dataset, set up Docker/Singularity/Apptainer containers for fMRIPrep, choose output spaces (MNI152NLin2009cAsym, fsaverage, fsLR/CIFTI), configure susceptibility distortion correction (SDC), extract or interpret the confounds table, resample to surface/grayordinates, cite fMRIPrep and its dependencies, or debug fMRIPrep crashes and hangs."
+domain: "fmri-neuroimaging"
+version: "1.0.0"
+authors:
+  - "Claude (AI-assisted)"
+review_status: "ai-generated"
+---
+
+# fMRIPrep: Robust fMRI Preprocessing Pipeline
+
+## Purpose
+
+This skill encodes complete operational knowledge of **fMRIPrep** — the NiPreps
+BIDS-App for preprocessing task and resting-state fMRI. It covers installation
+(Docker/Apptainer/pip), the full CLI, workflow internals, output layout, the
+confounds table, output spaces / TemplateFlow, susceptibility distortion
+correction, BIDS filters, troubleshooting, and how to cite. It is derived from
+the fMRIPrep 25.2.x (LTS) source tree (https://github.com/nipreps/fmriprep).
+
+## When to Use This Skill
+
+Activate when the user:
+
+- Wants to run fMRIPrep on a BIDS dataset (Docker, Singularity/Apptainer, pip)
+- Asks how to install fMRIPrep or set up dependencies (FreeSurfer license, TemplateFlow)
+- Needs help choosing `--output-spaces`, `--cifti-output`, or surface targets (fsaverage, fsLR)
+- Needs help with SDC / fieldmap issues (`--use-syn-sdc`, `--force syn-sdc`, `IntendedFor`, `B0FieldIdentifier`)
+- Asks about the confounds file (`~_desc-confounds_timeseries.tsv`), aCompCor/tCompCor, motion parameters
+- Debugs a crashing/hanging fMRIPrep run, FreeSurfer `IsRunning` errors, or race conditions
+- Wants to reuse pre-computed derivatives (`--derivatives`), an existing FreeSurfer subject dir, or a partial run
+- Needs a BIDS filter file (`--bids-filter-file`) or wants to select tasks/sessions/echoes
+- Needs a citation/boilerplate for a paper or grant proposal
+- Wants to interpret the HTML visual report
+
+## Reference Files (Progressive Disclosure)
+
+| Topic | File | When to Read |
+|-------|------|--------------|
+| Installation (Docker, Apptainer, pip, wrapper, FreeSurfer license) | `references/installation.md` | User asks how to install/set up fMRIPrep, or hits license/permission errors |
+| Complete CLI reference (every flag, defaults, choices) | `references/cli-reference.md` | User asks "what does flag X do?" or needs the full option table |
+| Practical invocation examples (single subject, batch, HPC SLURM, Docker) | `references/usage-examples.md` | User asks "how do I actually run it on my data?" |
+| Workflow internals (anat + BOLD stages, HMC, BBR, SDC, surface, CIFTI) | `references/workflows.md` | User asks what fMRIPrep does under the hood, or wants a step-by-step methods section |
+| Output layout and derivatives naming | `references/outputs.md` | User asks what files fMRIPrep produces, or how to find a specific derivative |
+| Confounds table (aCompCor, tCompCor, motion, FD, DVARS, spike regressors) | `references/confounds.md` | User asks which columns of the confounds TSV to use for denoising |
+| Output spaces / TemplateFlow (MNI152NLin2009cAsym, fsLR, fsaverage, custom) | `references/spaces.md` | User asks how to specify `--output-spaces`, use custom templates, or pre-fetch templates |
+| Susceptibility distortion correction (fieldmaps, PEPOLAR, phase-diff, SyN) | `references/sdc-fieldmaps.md` | User has fieldmaps, wants fieldmap-less SDC, or SDC-related errors |
+| BIDS filter file syntax + PyBIDS queries | `references/bids-filter.md` | User needs to select specific sessions/tasks or non-BIDS entities |
+| FAQ, troubleshooting, hangs, HPC, TemplateFlow offline | `references/troubleshooting-faq.md` | User's run is crashing/hanging or they're on an HPC without Internet |
+| Citation boilerplate, DOIs, BibTeX, dependency papers | `references/citation.md` | User writes a paper or grant that uses fMRIPrep |
+| Pinned dependency versions (25.2.x LTS) | `references/versions-dependencies.md` | User asks which version of FreeSurfer/ANTs/FSL/AFNI ships with fMRIPrep |
+
+## What fMRIPrep Is
+
+fMRIPrep is a **BIDS-App**: a container that consumes a `BIDS`-organized
+dataset and emits a BIDS-Derivatives dataset plus a per-subject HTML report.
+It performs *minimal preprocessing* — motion correction, field unwarping,
+normalization, bias-field correction, brain extraction, coregistration, and
+optional surface resampling — and deliberately **does not smooth or denoise**.
+Downstream denoising is enabled by the confounds table.
+
+- **Homepage**: https://fmriprep.org
+- **Repo**: https://github.com/nipreps/fmriprep
+- **Container image**: `nipreps/fmriprep:<version>` on Docker Hub
+- **Latest release** (of this snapshot): **25.2.5** (2026-03-10) — 25.2.x is the **LTS** track, supported through **October 2029**
+- **License**: Apache-2.0 (since 21.0.x)
+- **RRID**: SCR_016216
+
+## Command-Line Structure (BIDS-App)
+
+```
+fmriprep <bids_dir> <output_dir> <analysis_level> [OPTIONS]
+```
+
+- `bids_dir` — root of the BIDS dataset (contains `sub-*/` folders and `dataset_description.json`)
+- `output_dir` — where derivatives + reports go (must NOT be inside `bids_dir`)
+- `analysis_level` — only `participant` is supported
+
+Same structure applies to the container form:
+
+```
+docker run --rm -it <mounts> nipreps/fmriprep:<version> <bids_dir> <output_dir> participant [OPTIONS]
+```
+
+## Pipeline Overview
+
+```
+                       ┌──────────────────────────────────────┐
+                       │  BIDS Dataset (T1w/T2w + BOLD + fmap)│
+                       └──────────────────┬───────────────────┘
+                                          │
+                    ┌─────────────────────┼─────────────────────┐
+                    ▼                     ▼                     ▼
+        ┌───────────────────┐   ┌───────────────────┐   ┌───────────────────┐
+        │  Anatomical WF    │   │  Fieldmap WF      │   │  BOLD WF (per run)│
+        │  (smriprep)       │   │  (SDCFlows)       │   │  (fmriprep)       │
+        │  ───────────────  │   │  ───────────────  │   │  ─────────────    │
+        │  • Conform T1w    │   │  • PEPOLAR/TOPUP  │   │  • Reference img  │
+        │  • N4 bias corr   │   │  • Phase-diff     │   │  • HMC (mcflirt)  │
+        │  • Skull-strip    │   │  • Phase encoding │   │  • STC (3dTShift) │
+        │    (antsBrainExt) │   │  • SyN-SDC (t1w)  │   │  • SDC apply      │
+        │  • FAST segment   │   │                   │   │  • BBR to T1w     │
+        │  • antsRegistrat  │   │                   │   │  • Multi-echo T2* │
+        │    → MNI templates│   │                   │   │  • Resample to    │
+        │  • recon-all      │   │                   │   │    output spaces  │
+        │  • MSM-Sulc       │   │                   │   │  • Surface + CIFTI│
+        │  • Curv/Sulc/Thick│   │                   │   │  • Confounds      │
+        └─────────┬─────────┘   └──────────┬────────┘   └──────────┬────────┘
+                  │                        │                       │
+                  └────────────────────────┴───────────────────────┘
+                                          │
+                                          ▼
+                     ┌────────────────────────────────────────┐
+                     │  BIDS-Derivatives + sub-XX.html report │
+                     └────────────────────────────────────────┘
+```
+
+Read `references/workflows.md` for the full method description and node names.
+
+## Quick Start
+
+The **fastest path** for a new user with Docker:
+
+```bash
+# 1. Install the wrapper (Python 3.10+)
+python -m pip install --user fmriprep-docker
+
+# 2. Get a FreeSurfer license (free): https://surfer.nmr.mgh.harvard.edu/registration.html
+#    Save the file, e.g. as ~/.licenses/freesurfer/license.txt
+export FS_LICENSE=$HOME/.licenses/freesurfer/license.txt
+
+# 3. Pre-fetch TemplateFlow templates (avoids network needs mid-run)
+python -m pip install --user templateflow
+python -c "from templateflow.api import get; \
+  get(['MNI152NLin2009cAsym','MNI152NLin6Asym','OASIS30ANTs','fsaverage','fsLR'])"
+
+# 4. Run — replace paths with yours
+fmriprep-docker /path/to/bids /path/to/derivatives participant \
+    --participant-label 01 \
+    --output-spaces MNI152NLin2009cAsym:res-2 fsaverage:den-10k \
+    --nthreads 8 --omp-nthreads 4 --mem 12000 \
+    -w /path/to/work
+```
+
+Equivalent bare Docker invocation (what the wrapper produces):
+
+```bash
+docker run --rm -it \
+    -v /path/to/bids:/data:ro \
+    -v /path/to/derivatives:/out \
+    -v /path/to/work:/scratch \
+    -v $FS_LICENSE:/opt/freesurfer/license.txt:ro \
+    -v $HOME/.cache/templateflow:/home/fmriprep/.cache/templateflow \
+    nipreps/fmriprep:25.2.5 \
+    /data /out participant \
+    --participant-label 01 \
+    --output-spaces MNI152NLin2009cAsym:res-2 fsaverage:den-10k \
+    --nthreads 8 --omp-nthreads 4 --mem 12000 \
+    -w /scratch
+```
+
+Equivalent Apptainer/Singularity invocation:
+
+```bash
+apptainer run --cleanenv \
+    -B /path/to/bids:/data:ro \
+    -B /path/to/derivatives:/out \
+    -B /path/to/work:/work \
+    -B $FS_LICENSE:/opt/freesurfer/license.txt:ro \
+    -B $HOME/.cache/templateflow:/opt/templateflow \
+    --env TEMPLATEFLOW_HOME=/opt/templateflow \
+    fmriprep-25.2.5.sif \
+    /data /out participant \
+    --participant-label 01 \
+    --fs-license-file /opt/freesurfer/license.txt \
+    -w /work
+```
+
+## Key Concepts (cheat-sheet)
+
+| Concept | Meaning |
+|---------|---------|
+| **BIDS-App** | Container/exec with fixed 3-positional CLI (`bids_dir output_dir participant`). fMRIPrep only supports `participant`. |
+| **BIDS Derivatives** | Output format — sub-folders per subject, sidecar JSON per NIfTI, standardized entity keys (`space-`, `desc-`, `hemi-`, `from-`, `to-`). |
+| **NiPreps** | The umbrella (www.nipreps.org). fMRIPrep depends on sister packages: `smriprep` (anat), `sdcflows` (SDC), `niworkflows` (utilities), `nireports` (reports), `templateflow` (templates). |
+| **TemplateFlow** | Registry of standard neuroimaging templates fetched on demand. Home dir: `$TEMPLATEFLOW_HOME` (default `~/.cache/templateflow`). |
+| **Working directory** (`-w`) | Nipype's scratch space. Enables resume-on-crash. Not inside `bids_dir`. |
+| **`--output-spaces`** | Which coordinate systems to resample BOLD/T1w to. Space `KEY[:cohort-X][:res-Y][:den-Z]`. Default: `MNI152NLin2009cAsym:res-native`. Read `references/spaces.md`. |
+| **`--level`** | `minimal` (transforms only), `resampling` (adds mid-way NIfTIs), `full` (default — every derivative). |
+| **`--ignore`** | Skip preprocessing aspects. Choices: `fieldmaps`, `slicetiming`, `sbref`, `t2w`, `flair`, `fmap-jacobian`. |
+| **`--force`** | Override auto-choices. Choices: `bbr`, `no-bbr`, `syn-sdc`, `fmap-jacobian`. |
+| **`--derivatives`** | Reuse precomputed derivatives from another package (BIDS-Derivatives-compliant); replaces the older `--anat-derivatives`. |
+| **`--use-syn-sdc`** | Fieldmap-less SDC using anatomical prior; if no fmap and unable → `error` (default) or `warn`. |
+| **`--cifti-output`** | Enable grayordinate output. Choices: `91k` (2 mm, 91282 grayordinates), `170k` (1.6 mm, 170494). Implies `MNI152NLin6Asym`. |
+| **`--fs-no-reconall`** | Skip FreeSurfer surface reconstruction. Disables surface/CIFTI outputs. |
+| **`--fs-license-file`** | Path to your FreeSurfer license (required even if `recon-all` is not run — some FS binaries need it). |
+| **Confounds** | Nuisance regressors written to `~_desc-confounds_timeseries.tsv`. Read `references/confounds.md` before including in a design matrix. |
+| **HMC** | Head-Motion Correction (FSL `mcflirt`). Reference-image based. |
+| **STC** | Slice-Timing Correction (AFNI `3dTShift`). Runs only if `SliceTiming` present in metadata and ≥5 usable volumes. |
+| **BBR** | Boundary-Based Registration (FreeSurfer `bbregister` when recon-all is on, else FSL `flirt --schedule=bbr.sch`). |
+| **CompCor** | Component-based noise correction. Anatomical (aCompCor) uses eroded WM/CSF/combined masks; temporal (tCompCor) uses top-variance voxels. |
+| **Boilerplate** | Auto-generated methods paragraph in the report — copy verbatim into papers (public-domain, CC0). |
+
+## Sensible Defaults
+
+fMRIPrep is designed so a bare invocation "just works". If you have no strong
+preferences, this is the recommended starting point:
+
+- `--output-spaces MNI152NLin2009cAsym:res-2 fsaverage:den-10k anat` — one volumetric standard space, a light surface space, and native anatomical
+- `--nthreads = number of CPU cores allocated to the container`
+- `--omp-nthreads ≤ nthreads` (typically `nthreads / 2` when running multiple subjects; single subject: 8 is a common cap)
+- `--mem-mb` at least 8000 (Docker wrapper warns below 8 GB); 16 GB is comfortable
+- Keep the FS license mounted; keep `TEMPLATEFLOW_HOME` mounted; keep `-w` on a **fast local disk** (not NFS if avoidable)
+- Process **one subject per container instance** (see FAQ)
+
+## Common Pitfalls
+
+1. **Output dir == input dir**: fMRIPrep will refuse to run. Put derivatives in a separate path (e.g. `bids/derivatives/fmriprep-25.2.5/`).
+2. **Working directory inside `bids_dir`**: also refused. Put `-w /scratch/work` outside the input.
+3. **`--output-spaces MNI152NLin6Asym:res-2` ≠ 2 mm always** — `res-` is a TemplateFlow *index*, not millimeters. Verify with the template JSON.
+4. **Race conditions on parallel subjects**: never share the same `-w` across subjects. Give each subject its own working directory, or launch each subject in its own container.
+5. **FreeSurfer `IsRunning.lh+rh` error** after a crash: delete `IsRunning.*` files in `<output>/sourcedata/freesurfer/sub-XX/scripts/` and re-run.
+6. **Slice-timing correction is referenced to the middle slice by default** (`--slice-time-ref 0.5`), which shifts effective volume onsets by 0.5 TR — adjust your GLM accordingly, or set `--slice-time-ref 0` to disable the shift.
+7. **Never include all confounds columns** in a design matrix — pick a strategy (24P+aCompCor, ICA-AROMA, scrubbing) and use the corresponding subset.
+8. **No skull-stripped T1w inputs** — fMRIPrep expects raw T1w. If skull-stripped, use `--skull-strip-t1w skip` (understand the risks) or revert to originals.
+9. **Version pinning**: process an entire study with the *same* fMRIPrep version+container build. Do not upgrade mid-study.
+10. **Datasets with lesions**: place `sub-XX/anat/sub-XX_label-lesion_roi.nii.gz` and add `*lesion_roi.nii.gz` to `.bidsignore` — enables lesion cost-function masking during registration.
+11. **Apple Silicon Docker**: run under `--platform linux/amd64` (or `DOCKER_DEFAULT_PLATFORM=linux/amd64` when using `fmriprep-docker`); the container is only built for `linux-64`.
+12. **Multi-echo two-echo data**: rejected since 25.2.4 — fMRIPrep requires ≥3 echoes for tedana T2* estimation.
+13. **`--use-syn-sdc` requires anatomical space templates** to be present locally (`MNI152NLin2009cAsym`); pre-fetch or allow Internet.
+14. **HPC + Singularity**: the FS license *and* a writeable `TEMPLATEFLOW_HOME` must be bind-mounted; login-node fetches templates before batch submission (compute nodes are usually offline).
+
+## What This Skill Does Not Cover
+
+- **Group-level statistics** — fMRIPrep is participant-level only. Use FitLins, Nilearn, SPM, FSL FEAT, etc. downstream.
+- **Denoising strategy selection** — see [Ciric 2017](https://doi.org/10.1016/j.neuroimage.2017.03.020) and [Parkes 2018](https://doi.org/10.1016/j.neuroimage.2017.12.073); fMRIPrep only supplies regressors.
+- **DWI, MEG, EEG** — different NiPreps apps (`dMRIPrep`, `MEGPrep`, planned).
+- **Custom Nipype workflow edits** — for extension, read the API docs at https://fmriprep.readthedocs.io/en/latest/api.html.
+
+## Where to Get Help
+
+- Community Q&A: https://neurostars.org/tag/fmriprep (canonical support channel)
+- Bug reports: https://github.com/nipreps/fmriprep/issues
+- Full docs: https://fmriprep.org / https://fmriprep.readthedocs.io
+- Sample HTML report: https://fmriprep.org/en/latest/_static/SampleReport/sample_report.html
+
+## Verify Installation
+
+```bash
+fmriprep --version                    # bare-metal
+docker run --rm nipreps/fmriprep:25.2.5 --version   # Docker
+apptainer run fmriprep-25.2.5.sif --version         # Apptainer
+```
+
+Expected output form: `fMRIPrep vXX.Y.Z`.

--- a/packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/references/bids-filter.md
+++ b/packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/references/bids-filter.md
@@ -1,0 +1,287 @@
+# BIDS Filter File Reference
+
+`--bids-filter-file FILE` lets you pass fMRIPrep a JSON file with custom
+PyBIDS queries — the way to select input data on any BIDS entity that isn't
+covered by `--participant-label`, `--session-label`, `--task-id`, or
+`--echo-idx`.
+
+## Table of Contents
+1. [Syntax overview](#syntax-overview)
+2. [Default filters (what fMRIPrep queries by default)](#default-filters-what-fmriprep-queries-by-default)
+3. [Filter entity reference](#filter-entity-reference)
+4. [Special values: `null` and `"*"`](#special-values-null-and-)
+5. [Worked examples](#worked-examples)
+6. [Combining with other flags](#combining-with-other-flags)
+7. [Validating your filter](#validating-your-filter)
+
+---
+
+## Syntax overview
+
+A single JSON object with a well-known set of top-level keys (the "query
+names") — each maps to an entity-value dict. Only entries whose top-level
+key matches a fMRIPrep query take effect.
+
+```json
+{
+    "<query_name>": {
+        "<bids_entity>": "<filter_value>",
+        ...
+    },
+    ...
+}
+```
+
+Common `query_name`s: `t1w`, `t2w`, `bold`, `flair`, `fmap`, `sbref`, `roi`.
+
+Entity keys are PyBIDS entity names: `datatype`, `suffix`, `session`,
+`acquisition`, `run`, `direction`, `reconstruction`, `subject`, `task`,
+`echo`, `part`, etc. See the PyBIDS config:
+https://github.com/bids-standard/pybids/blob/main/src/bids/layout/config/bids.json
+
+---
+
+## Default filters (what fMRIPrep queries by default)
+
+If you don't pass a filter file, these are the built-in queries used by
+fMRIPrep (from the official FAQ):
+
+```json
+{
+    "fmap":  {"datatype": "fmap"},
+    "bold":  {"datatype": "func", "suffix": "bold"},
+    "sbref": {"datatype": "func", "suffix": "sbref"},
+    "flair": {"datatype": "anat", "suffix": "FLAIR"},
+    "t2w":   {"datatype": "anat", "suffix": "T2w"},
+    "t1w":   {"datatype": "anat", "suffix": "T1w"},
+    "roi":   {"datatype": "anat", "suffix": "roi"}
+}
+```
+
+Note: fMRIPrep delegates data collection to
+`niworkflows.utils.bids.collect_data`, which in current niworkflows versions
+adds `"part": ["mag", None]` to `t1w`/`t2w`/`bold`/`sbref`/`flair` so complex
+`part-phase` images are excluded automatically. If you need to keep `part-phase`
+data (rare), override the query explicitly with your own filter file.
+
+Any query you include in your file OVERRIDES the matching default entirely
+(the merge is per-query, not per-entity). Only the queries you override change
+— unspecified queries keep their defaults.
+
+---
+
+## Filter entity reference
+
+Values are compared to file entity values (all strings). Supports:
+
+| Value | Meaning |
+|-------|---------|
+| `"01"`, `"rest"`, `"AP"`, ... | Literal string match |
+| `["01", "02"]` | Match any of these values |
+| `null` | Match files that have NO value for this entity |
+| `"*"` | Match files with ANY non-empty value for this entity |
+
+---
+
+## Special values: `null` and `"*"`
+
+`null` → PyBIDS `Query.NONE`: matches files without that entity in their name/metadata.
+
+Use case: select the T1w that has no `acquisition-` tag when the dataset has
+both `acq-original` and `acq-clean` variants.
+
+```json
+{"t1w": {"datatype": "anat", "suffix": "T1w", "acquisition": null}}
+```
+
+`"*"` → PyBIDS `Query.ANY`: matches files where the entity is present with any value.
+
+Use case: only include BOLD runs that have an explicit `run-` entity.
+
+```json
+{"bold": {"datatype": "func", "suffix": "bold", "run": "*"}}
+```
+
+---
+
+## Worked examples
+
+### Session 02 T1w, session 02 BOLD (from the fMRIPrep docs FAQ)
+
+```json
+{
+    "t1w": {
+        "datatype": "anat",
+        "session": "02",
+        "acquisition": null,
+        "suffix": "T1w"
+    },
+    "bold": {
+        "datatype": "func",
+        "session": "02",
+        "suffix": "bold"
+    }
+}
+```
+
+Note: `--session-label 02` is a simpler equivalent for the same result when
+you don't need entity-level nuances.
+
+### Only rest-task BOLD runs
+
+```json
+{
+    "bold": {"datatype": "func", "suffix": "bold", "task": "rest"}
+}
+```
+
+Equivalent to `--task-id rest`.
+
+### Multiple acquisitions, but not "hurried"
+
+```json
+{
+    "bold": {
+        "datatype": "func",
+        "suffix": "bold",
+        "acquisition": ["mb4", "mb8"]
+    }
+}
+```
+
+Or exclude a specific value — PyBIDS doesn't have a "not equal" match; use
+`--force-index`/`--ignore` or `.bidsignore` for exclusion patterns.
+
+### Preferred T1w by reconstruction
+
+Dataset has `rec-defaced` and `rec-original` T1w — pick original:
+
+```json
+{
+    "t1w": {
+        "datatype": "anat",
+        "suffix": "T1w",
+        "reconstruction": "original"
+    }
+}
+```
+
+### AP-direction PEPOLAR EPIs only (both dirs would confuse SDC selection)
+
+```json
+{
+    "fmap": {"datatype": "fmap", "direction": "AP"}
+}
+```
+
+### Multi-echo dataset, restrict to echo 2 for tests
+
+```json
+{
+    "bold": {"datatype": "func", "suffix": "bold", "echo": "2"}
+}
+```
+
+(Or use `--echo-idx 2`.)
+
+### Only runs with a matching sbref
+
+Two-query filter: require BOTH BOLD and its sbref to have `run` entity.
+
+```json
+{
+    "bold":  {"datatype": "func", "suffix": "bold",  "run": "*"},
+    "sbref": {"datatype": "func", "suffix": "sbref", "run": "*"}
+}
+```
+
+### Only session that DOESN'T have `acq-` tag on the T1w
+
+```json
+{
+    "t1w": {
+        "datatype": "anat",
+        "suffix": "T1w",
+        "acquisition": null
+    }
+}
+```
+
+---
+
+## Combining with other flags
+
+The filter file is applied on top of `--participant-label` / `--session-label`
+/ `--task-id` / `--echo-idx`. Order of operations:
+
+1. `--participant-label` restricts the subjects that get processed.
+2. Within each subject, PyBIDS queries (default OR overridden by your filter)
+   run against the subject's files.
+3. `--task-id`, `--session-label`, `--echo-idx` further filter the BOLD query
+   *after* the filter file is applied.
+
+So `--task-id rest --bids-filter-file f.json` with a filter of
+`{"bold": {"acquisition": "mb4"}}` yields BOLD files with
+`task-rest AND acq-mb4`.
+
+Also consider:
+
+- `--bids-database-dir /path/to/db` — pre-computed PyBIDS SQLite index.
+  Speeds up filtering for large datasets. Create with:
+  ```bash
+  pybids layout <bids_root> <db_dir> --no-validate --index-metadata
+  ```
+- `--ignore` (fMRIPrep-level, disables aspects of processing) or
+  `.bidsignore` at the dataset root (excludes files from PyBIDS/bids-validator
+  altogether) — for finer control over what files reach the pipeline. Note:
+  the `--force-index` PyBIDS flag is *not* exposed by fMRIPrep's CLI despite
+  older docs referencing it; use `.bidsignore` instead.
+
+---
+
+## Validating your filter
+
+Before running fMRIPrep, test the filter with PyBIDS in Python:
+
+```python
+from bids import BIDSLayout
+from bids.layout import Query
+import json
+
+layout = BIDSLayout("/data/bids", validate=False)
+
+with open("my_filter.json") as f:
+    filters = json.load(f)
+
+# Replace None → Query.NONE, "*" → Query.ANY
+def clean(d):
+    return {k: (Query.NONE if v is None else Query.ANY if v == "*" else v)
+            for k, v in d.items()}
+
+for query_name, query in filters.items():
+    print(f"\n=== {query_name} ===")
+    files = layout.get(**clean(query))
+    for f in files[:5]:
+        print(f.path)
+    print(f"... ({len(files)} total)")
+```
+
+Iterate on your filter until the file lists look right, THEN pass it to fMRIPrep.
+
+---
+
+## Common pitfalls
+
+1. **Wrong query key** — a top-level key that isn't in `{t1w, t2w, bold, flair, fmap, sbref, roi}` is silently ignored. Watch spelling.
+2. **`suffix` vs `datatype`** — `suffix` is the final `_bold`/`_T1w` label; `datatype` is the folder (`func`/`anat`/`fmap`). Provide both when overriding.
+3. **PyBIDS entity vs metadata key** — `session`, `acquisition`, etc. are entities (folder/filename); metadata (e.g., `RepetitionTime`) is NOT filterable via `--bids-filter-file` — use `--force-index`/`--ignore` or `.bidsignore`.
+4. **JSON quoting** — `null` is unquoted; `"*"` is a quoted string.
+5. **Path separator** — On Windows, use forward slashes in your JSON paths.
+
+---
+
+## Reference
+
+- fMRIPrep FAQ on filter files: https://fmriprep.readthedocs.io/en/latest/faq.html#how-do-I-select-only-certain-files-to-be-input-to-fMRIPrep
+- PyBIDS entity dictionary: https://github.com/bids-standard/pybids/blob/main/src/bids/layout/config/bids.json
+- BIDS entity table: https://bids-specification.readthedocs.io/en/stable/appendices/entity-table.html

--- a/packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/references/citation.md
+++ b/packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/references/citation.md
@@ -1,0 +1,284 @@
+# Citation Reference
+
+fMRIPrep sits on top of many other tools. Cite them all — the official
+citation strategy is **use the auto-generated boilerplate** from your run's
+visual report, verbatim.
+
+## Table of Contents
+1. [The citation boilerplate mechanism](#the-citation-boilerplate-mechanism)
+2. [Primary papers](#primary-papers)
+3. [Software DOI (Zenodo)](#software-doi-zenodo)
+4. [BibTeX for the primary papers](#bibtex-for-the-primary-papers)
+5. [Dependency papers](#dependency-papers)
+6. [Plagiarism disclaimer](#plagiarism-disclaimer)
+7. [Where boilerplate lives in your outputs](#where-boilerplate-lives-in-your-outputs)
+
+---
+
+## The citation boilerplate mechanism
+
+Every fMRIPrep run auto-generates a methods paragraph tailored to what the
+pipeline actually did (which SDC estimator, which templates, which
+CompCor variant, etc.). It's written to `<output>/logs/CITATION.{md,html,tex}`
+and embedded in the per-subject HTML report.
+
+Copy that paragraph **verbatim** into your paper's Methods section. It is:
+- **CC0-licensed** public domain — no attribution required, no relicensing.
+- Version-specific — every citation and dependency version matches what ran.
+- Peer-endorsed — the NiPreps team maintains the wording to be accurate and
+  reviewer-defensible.
+
+Full rationale: https://www.nipreps.org/intro/transparency/#citation-boilerplates
+
+Generate only the boilerplate, without doing the preprocessing:
+
+```bash
+fmriprep /data/bids /data/derivatives participant \
+    --participant-label 01 \
+    --boilerplate-only
+```
+
+Output lands in `/data/derivatives/logs/CITATION.md` (and `.html`, `.tex`).
+
+If you want to skip the pandoc conversion (Markdown only):
+
+```bash
+--md-only-boilerplate
+```
+
+---
+
+## Primary papers
+
+Cite both when publishing:
+
+### Esteban et al., 2019 — the main fMRIPrep paper
+
+> Esteban, O., Markiewicz, C. J., Blair, R. W., Moodie, C. A., Isik, A. I.,
+> Erramuzpe, A., Kent, J. D., Goncalves, M., DuPre, E., Snyder, M., Oya, H.,
+> Ghosh, S. S., Wright, J., Durnez, J., Poldrack, R. A., & Gorgolewski, K. J.
+> (2019). **fMRIPrep: a robust preprocessing pipeline for functional MRI.**
+> *Nature Methods, 16*, 111–116.
+> https://doi.org/10.1038/s41592-018-0235-4
+> [Preprint](https://doi.org/10.1101/306951)
+
+### Esteban et al., 2020 — the Nature Protocols companion
+
+> Esteban, O., Ciric, R., Finc, K., Blair, R. W., Markiewicz, C. J., Moodie,
+> C. A., Kent, J. D., Goncalves, M., DuPre, E., Gomez, D. E. P., Ye, Z.,
+> Salo, T., Valabregue, R., Amlien, I. K., Liem, F., Jacoby, N., Stojić, H.,
+> Cieslak, M., Urchs, S., … Gorgolewski, K. J. (2020).
+> **Analysis of task-based functional MRI data preprocessed with fMRIPrep.**
+> *Nature Protocols, 15*, 2186–2202.
+> https://doi.org/10.1038/s41596-020-0327-3
+> [Preprint](https://doi.org/10.1101/694364)
+
+---
+
+## Software DOI (Zenodo)
+
+Cite the exact software version:
+
+> fMRIPrep — Software DOI: https://doi.org/10.5281/zenodo.852659
+
+The Zenodo DOI resolves to the latest version; for version-specific DOIs, see
+the version tree on Zenodo.
+
+Also cite the RRID for reproducibility:
+
+- **RRID: SCR_016216**
+
+---
+
+## BibTeX for the primary papers
+
+```bibtex
+@article{esteban2019fmriprep,
+  title   = {fMRIPrep: a robust preprocessing pipeline for functional MRI},
+  author  = {Esteban, Oscar and Markiewicz, Christopher J and Blair, Ross W
+             and Moodie, Craig A and Isik, A Ilkay and Erramuzpe, Asier
+             and Kent, James D and Goncalves, Mathias and DuPre, Elizabeth
+             and Snyder, Madeleine and Oya, Hiroyuki and Ghosh, Satrajit S
+             and Wright, Jessey and Durnez, Joke and Poldrack, Russell A
+             and Gorgolewski, Krzysztof J},
+  journal = {Nature Methods},
+  volume  = {16},
+  number  = {1},
+  pages   = {111--116},
+  year    = {2019},
+  doi     = {10.1038/s41592-018-0235-4}
+}
+
+@article{esteban2020analysis,
+  title   = {Analysis of task-based functional {MRI} data preprocessed with
+             fMRIPrep},
+  author  = {Esteban, Oscar and Ciric, Rastko and Finc, Karolina and
+             Blair, Ross W and Markiewicz, Christopher J and Moodie, Craig A
+             and Kent, James D and Goncalves, Mathias and DuPre, Elizabeth
+             and Gomez, Daniel E P and Ye, Zhifang and Salo, Taylor and
+             Valabregue, Romain and Amlien, Inge K and Liem, Franz and
+             Jacoby, Nir and Stoji{\'c}, Hrvoje and Cieslak, Matthew and
+             Urchs, Sebastian and Halchenko, Yaroslav O and Ghosh, Satrajit S
+             and De La Vega, Alejandro and Yarkoni, Tal and Wright, Jessey
+             and Thompson, William H and Poldrack, Russell A and
+             Gorgolewski, Krzysztof J},
+  journal = {Nature Protocols},
+  volume  = {15},
+  number  = {7},
+  pages   = {2186--2202},
+  year    = {2020},
+  doi     = {10.1038/s41596-020-0327-3}
+}
+
+@software{fmriprep_zenodo,
+  author       = {The NiPreps Developers},
+  title        = {{fMRIPrep}: robust preprocessing pipeline for fMRI},
+  publisher    = {Zenodo},
+  doi          = {10.5281/zenodo.852659},
+  url          = {https://doi.org/10.5281/zenodo.852659}
+}
+```
+
+Replace the Zenodo DOI with the version-specific DOI (from the version tree
+on Zenodo) when possible.
+
+---
+
+## Dependency papers
+
+The boilerplate handles these for you, but here's the master list (from
+`REFERENCES.md` in the repo). Cite each tool your run actually used
+(the boilerplate is aware).
+
+### Registration / anatomical
+
+- **FreeSurfer** — https://github.com/freesurfer/freesurfer
+- **recon-all** — Dale AM, Fischl B, Sereno MI (1999). Cortical surface-based
+  analysis. https://doi.org/10.1006/nimg.1998.0395
+- **bbregister & BBR** — Greve DN, Fischl B (2009).
+  https://doi.org/10.1016/j.neuroimage.2009.06.060
+- **mri_robust_template** — Reuter M, Rosas HD, Fischl B (2012).
+  https://doi.org/10.1016/j.neuroimage.2012.02.084
+- **mri_robust_register** — Reuter M, Rosas HD, Fischl B (2010).
+  https://doi.org/10.1016/j.neuroimage.2010.07.020
+
+- **ANTs** — Avants BB et al. (2015).
+  https://doi.org/10.3389/fninf.2015.00005
+- **antsRegistration (SyN)** — Avants BB et al. (2008).
+  https://doi.org/10.1016/j.media.2007.06.004
+- **N4BiasFieldCorrection** — Tustison NJ et al. (2010).
+  https://doi.org/10.1109/TMI.2010.2046908
+- **antsBrainExtraction** — Avants BB et al. (2015).
+  https://doi.org/10.1038/sdata.2015.3
+
+- **FSL** — Jenkinson M et al. (2012). NeuroImage.
+  https://doi.org/10.1016/j.neuroimage.2011.09.015
+- **FAST** — Zhang Y et al. (2001).
+  https://doi.org/10.1109/42.906424
+- **BET** — Smith SM (2002).
+  https://doi.org/10.1002/hbm.10062
+- **FLIRT** — Jenkinson M et al. (2002).
+  https://doi.org/10.1006/nimg.2002.1132
+- **MCFLIRT** — Jenkinson M (2002).
+  https://doi.org/10.1006/nimg.2002.1132
+
+- **AFNI** — Cox RW (1996).
+  https://doi.org/10.1006/cbmr.1996.0014
+
+- **Connectome Workbench** — https://humanconnectome.org/software/connectome-workbench
+- **MSM (Multimodal Surface Matching)** — Robinson EC et al. (2014, 2018).
+
+### Confounds / motion
+
+- **DVARS / Framewise Displacement** (Power et al. 2012, 2014):
+  https://doi.org/10.1016/j.neuroimage.2011.10.018
+- **DVARS improvements** — Afyouni & Nichols (2018):
+  https://arxiv.org/abs/1704.01469
+- **RMSD** — Jenkinson M et al. (2002):
+  https://doi.org/10.1006/nimg.2002.1132
+- **a/tCompCor** — Behzadi Y et al. (2007):
+  https://doi.org/10.1016/j.neuroimage.2007.04.042
+- **aCompCor refinement (WM/CSF split)** — Muschelli J et al. (2014):
+  https://doi.org/10.1016/j.neuroimage.2014.03.028
+- **Motion parameter expansion** — Satterthwaite TD et al. (2013):
+  https://doi.org/10.1016/j.neuroimage.2012.08.052
+- **Crown / brain-edge PCA** — Provins C et al. (2022):
+  https://doi.org/10.31219/osf.io/hz52v; Patriat R et al. (2017):
+  https://doi.org/10.1016/j.neuroimage.2016.08.051
+
+### Analysis frameworks
+
+- **Nipype** — Gorgolewski KJ et al. (2011):
+  https://doi.org/10.3389/fninf.2011.00013 +
+  https://doi.org/10.5281/zenodo.581704
+- **Nilearn** — Abraham A et al. (2014):
+  https://doi.org/10.3389/fninf.2014.00014
+- **NiBabel** — Brett M et al.:
+  https://doi.org/10.5281/zenodo.60808
+
+### Templates / grayordinates
+
+- **HCP fsLR / grayordinates** — Glasser MF et al. (2016):
+  https://doi.org/10.1038/nature18933
+
+### fMRIPrep-specific method notes
+
+- **Slice-timing referenced middle of TR + Power motion recommendation** —
+  Power JD et al. (2017):
+  https://doi.org/10.1371/journal.pone.0182939
+- **Lesion cost-function masking** — Brett M et al. (2001):
+  https://doi.org/10.1006/nimg.2001.0845
+- **Carpetplot QA** — Power JD (2016):
+  https://doi.org/10.1016/j.neuroimage.2016.08.009
+
+### Denoising strategy references (not cited by boilerplate but critical
+for choosing confound strategy)
+
+- **Ciric R et al. (2017)** — Benchmarking confound-regression strategies:
+  https://doi.org/10.1016/j.neuroimage.2017.03.020
+- **Parkes L et al. (2018)** — Evaluation of motion correction strategies:
+  https://doi.org/10.1016/j.neuroimage.2017.12.073
+- **Greve DN et al. (2013)** — Sources of noise in fMRI:
+  https://doi.org/10.1007/s11336-013-9344-2
+
+---
+
+## Plagiarism disclaimer
+
+Some journals' plagiarism detectors flag the auto-generated boilerplate
+because it appears (verbatim) in many other papers. This is intentional and
+recommended. If flagged, reply with a link to the transparency page:
+
+> The methods text is the auto-generated fMRIPrep citation boilerplate,
+> distributed as CC0 public-domain and intended to be used verbatim. See
+> https://www.nipreps.org/intro/transparency/#citation-boilerplates.
+
+---
+
+## Where boilerplate lives in your outputs
+
+```
+<output_dir>/
+    logs/
+        CITATION.md          # Markdown — the canonical source
+        CITATION.html        # Rendered HTML (embedded in the visual report)
+        CITATION.tex         # LaTeX with proper citation commands
+```
+
+Also visible at the bottom of the visual report `sub-XX.html`.
+
+The Markdown and LaTeX include full BibTeX-ready reference entries — copy
+those into your bibliography manager.
+
+---
+
+## Funding acknowledgements (from the repo README)
+
+If you rely on fMRIPrep, consider adding a funding acknowledgement to your
+paper — this helps the maintainers secure continued support:
+
+> This work uses the *fMRIPrep* preprocessing pipeline, which is steered and
+> maintained by the NiPreps Community and supported by the Laura and John
+> Arnold Foundation, the NIH (NBIB R01EB020740, PI: Ghosh; R24MH114705,
+> R24MH117179, R01MH121867, PI: Poldrack), and CZI's Essential Open Source
+> Software for Science.

--- a/packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/references/cli-reference.md
+++ b/packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/references/cli-reference.md
@@ -1,0 +1,260 @@
+# Complete CLI Reference
+
+Source of truth: `fmriprep/cli/parser.py` in the source tree (25.2.x).
+Every flag below is verified against that parser. Defaults shown are the parser
+defaults; some (marked *"auto"*) are set later during workflow construction.
+
+Command form:
+
+```
+fmriprep <bids_dir> <output_dir> <analysis_level> [OPTIONS]
+```
+
+## Table of Contents
+1. [Positional arguments](#positional-arguments)
+2. [BIDS filtering options](#bids-filtering-options)
+3. [Performance options](#performance-options)
+4. [Subset-of-workflow options](#subset-of-workflow-options)
+5. [Workflow configuration](#workflow-configuration)
+6. [Output modulation](#output-modulation)
+7. [Confounds options](#confounds-options)
+8. [ANTs (skull-strip) options](#ants-skull-strip-options)
+9. [Fieldmap options](#fieldmap-options)
+10. [SyN-SDC options](#syn-sdc-options)
+11. [FreeSurfer options](#freesurfer-options)
+12. [Carbon tracking](#carbon-tracking)
+13. [Other options](#other-options)
+14. [Deprecated flags](#deprecated-flags)
+
+---
+
+## Positional arguments
+
+| Argument | Type | Description |
+|----------|------|-------------|
+| `bids_dir` | existing dir | Root of a valid BIDS dataset (contains `sub-*/` folders) |
+| `output_dir` | dir path | Where derivatives + visual reports go. **Must not equal or contain `bids_dir`**. |
+| `analysis_level` | `participant` (only choice) | BIDS-App analysis level. fMRIPrep does not support group-level. |
+
+---
+
+## BIDS filtering options
+*Group: "Options for filtering BIDS queries"*
+
+| Flag | Type / Default | Description |
+|------|----------------|-------------|
+| `--skip_bids_validation`, `--skip-bids-validation` | flag / `False` | Assume dataset is BIDS-valid; skip the built-in validator. |
+| `--participant-label`, `--participant_label` | space-list of labels | Restrict processing to these subjects. `sub-` prefix is stripped automatically. |
+| `--session-label` | space-list of labels | Restrict to these sessions. `ses-` prefix stripped. (Requires 25.2.0+.) |
+| `-t`, `--task-id` | string | Restrict to a single task. |
+| `--echo-idx` | int | Restrict to a specific echo in multi-echo data. |
+| `--subject-anatomical-reference` | `first-lex` (default) / `unbiased` / `sessionwise` | How to combine T1w images across sessions. `first-lex` = align to first (lexical); `unbiased` = build unbiased template (replaces old `--longitudinal`); `sessionwise` = independent per session. |
+| `--track-sessions` / `--no-track-sessions` | flag / `True` | Whether to append session IDs to FreeSurfer subject IDs. Restores pre-25.2 behavior when disabled. |
+| `--bids-filter-file` | JSON path | Custom PyBIDS queries — see `references/bids-filter.md`. |
+| `-d`, `--derivatives` | `PACKAGE=PATH ...` | Search paths for pre-computed BIDS-Derivatives (replaces old `--anat-derivatives`). |
+| `--bids-database-dir` | dir path | Pre-indexed PyBIDS SQLite database (created if missing). Speeds up large datasets. |
+
+---
+
+## Performance options
+*Group: "Options to handle performance"*
+
+| Flag | Type / Default | Description |
+|------|----------------|-------------|
+| `--nprocs`, `--nthreads`, `--n_cpus`, `--n-cpus` | int (≥1) / auto | Maximum threads across all processes. |
+| `--omp-nthreads` | int (≥1) / auto | Maximum threads per process. Default: `min(nprocs-1, 8)`. |
+| `--mem`, `--mem_mb`, `--mem-mb` | int MB or K/M/G/T suffix | Upper memory bound. Docker wrapper warns below 8000. |
+| `--low-mem` | flag / `False` | Trade disk for RAM: use uncompressed intermediates and other tricks. |
+| `--use-plugin`, `--nipype-plugin-file` | YAML file | Custom Nipype plugin config (e.g. for SGE, PBS). |
+| `--sloppy` | flag / `False` | **TESTING ONLY** — coarser tools for faster CI. Do not use on real data. |
+
+---
+
+## Subset-of-workflow options
+*Group: "Options for performing only a subset of the workflow"*
+
+| Flag | Type / Default | Description |
+|------|----------------|-------------|
+| `--anat-only` | flag / `False` | Only run anatomical workflows (smriprep). |
+| `--level` | `minimal` / `resampling` / `full` (default) | Depth of derivatives generation. `minimal` = transforms only; `resampling` = adds intermediates useful for third-party resampling; `full` = every derivative. |
+| `--boilerplate-only`, `--boilerplate_only` | flag / `False` | Emit only the citation boilerplate and exit. |
+| `--reports-only` | flag / `False` | Regenerate reports from cached reportlets without re-running workflows. |
+
+---
+
+## Workflow configuration
+*Group: "Workflow configuration"*
+
+| Flag | Type / Default | Description |
+|------|----------------|-------------|
+| `--ignore` | space-list of `fieldmaps` / `slicetiming` / `sbref` / `t2w` / `flair` / `fmap-jacobian` | Disable a pipeline aspect. Ex: `--ignore slicetiming fieldmaps`. |
+| `--force` | space-list of `bbr` / `no-bbr` / `syn-sdc` / `fmap-jacobian` | Override auto-choices. `bbr`+`no-bbr` conflict. `syn-sdc` **adds** SyN to any existing fieldmaps. |
+| `--output-spaces` | space-list of `SPACE[:cohort-X][:res-Y][:den-Z]` | Where to resample outputs. Empty (`--output-spaces` alone) = no BOLD resampling. Default when omitted: `MNI152NLin2009cAsym:res-native`. See `references/spaces.md`. |
+| `--bold2anat-init` | `auto` (default) / `t1w` / `t2w` / `header` | Initial BOLD-to-anatomical alignment. `auto` uses T2w if available, else T1w; `header` skips initial reg and uses the BOLD header. |
+| `--bold2anat-dof` | `6` (default) / `9` / `12` | DOF of BOLD-to-anat registration. `6` = rigid; `9` adds scaling; `12` = full affine. |
+| `--slice-time-ref` | 0..1 or `start` (=0) / `middle` (=0.5, default) | Target time of each TR to correct slices to. `0.5` → volume onsets shift by 0.5 TR; downstream GLM must account for this. |
+| `--dummy-scans` | int | Manually set the number of non-steady-state volumes (overrides auto-detection). |
+| `--fallback-total-readout-time` | number or `"estimated"` | Fallback TRT when metadata is missing. |
+| `--random-seed` | int | Seed the workflow's RNG. Combined with `--omp-nthreads 1` and `--skull-strip-fixed-seed` for reproducibility. |
+| `--me-t2s-fit-method` | `curvefit` (default) / `loglin` | T2*/S0 estimation for multi-echo. `curvefit` = nonlinear regression (slower, more accurate); `loglin` = log-linear (faster, less accurate). |
+| `--project-goodvoxels` | flag / `False` | Exclude voxels with locally-high coefficient of variation during surface resampling (HCP "goodvoxels" masking). Only affects fsaverage / fsnative GIFTI output. |
+
+---
+
+## Output modulation
+*Group: "Options for modulating outputs"*
+
+| Flag | Type / Default | Description |
+|------|----------------|-------------|
+| `--output-layout` | `bids` (default) / `legacy` | `bids` places fMRIPrep derivatives at `output_dir/` and FreeSurfer at `output_dir/sourcedata/freesurfer`. `legacy` uses pre-21.0 layout with `fmriprep/` and `freesurfer/` subfolders. |
+| `--me-output-echos` | flag / `False` | For multi-echo: also save per-echo time series after STC/HMC/SDC. Feeds downstream tedana processing. |
+| `--aggregate-session-reports` | int / `4` | Max sessions per subject's report before splitting into multi-file reports. |
+| `--medial-surface-nan` | flag / `False` | Replace medial-wall values with NaN in functional GIFTI (fsnative/fsaverage). |
+| `--md-only-boilerplate` | flag / `False` | Emit Markdown boilerplate only; skip pandoc HTML/LaTeX conversion. |
+| `--cifti-output` | flag with optional value `91k` (default) / `170k` | Enable CIFTI grayordinate output. `91k` = 91,282 grayordinates @ 2 mm; `170k` = 170,494 @ 1.6 mm. Implies `MNI152NLin6Asym` in output spaces. |
+| `--msm` / `--no-msm` | flag / `True` | Enable/disable Multimodal Surface Matching (MSMSulc) surface registration. |
+
+---
+
+## Confounds options
+*Group: "Options relating to confounds"*
+
+| Flag | Type / Default | Description |
+|------|----------------|-------------|
+| `--return-all-components` | flag / `False` | Include *all* CompCor components in the confounds TSV (default keeps only enough to explain 50% variance in each ROI). |
+| `--fd-spike-threshold` | float / `0.5` | Framewise-displacement threshold (mm) for spike-regressor generation. |
+| `--dvars-spike-threshold` | float / `1.5` | Standardized-DVARS threshold for spike-regressor generation. |
+
+See `references/confounds.md` for the full column dictionary.
+
+---
+
+## ANTs (skull-strip) options
+*Group: "Specific options for ANTs registrations"*
+
+| Flag | Type / Default | Description |
+|------|----------------|-------------|
+| `--skull-strip-template` | Reference string / `OASIS30ANTs` | Template used by `antsBrainExtraction`. |
+| `--skull-strip-fixed-seed` | flag / `False` | Use a fixed random seed (needed for exact reproducibility). |
+| `--skull-strip-t1w` | `auto` / `skip` / `force` (default) | Heuristic-guided (`auto`) or forced skull-stripping. Use `skip` only when T1w is already brain-extracted. |
+
+---
+
+## Fieldmap options
+*Group: "Specific options for handling fieldmaps"*
+
+| Flag | Type / Default | Description |
+|------|----------------|-------------|
+| `--fmap-bspline` | flag / `False` | Fit a B-Spline field via least-squares (experimental). |
+| `--fmap-no-demean` | flag / `True` (i.e., demean IS done by default) | Do NOT remove the within-mask median from the fieldmap. Passing this flag disables demeaning. |
+
+---
+
+## SyN-SDC options
+*Group: "Specific options for SyN distortion correction"*
+
+| Flag | Type / Default | Description |
+|------|----------------|-------------|
+| `--use-syn-sdc` | optional value `warn` / `error` (default) | Enable fieldmap-less SDC using an anatomical prior. Argument specifies behavior when unable to compute: `error` (default) or `warn`. |
+| `--force syn-sdc` | (via `--force`) | *Add* SyN-SDC even when other fieldmaps are present. |
+
+---
+
+## FreeSurfer options
+*Group: "Specific options for FreeSurfer preprocessing"*
+
+| Flag | Type / Default | Description |
+|------|----------------|-------------|
+| `--fs-license-file` | file path | Path to FreeSurfer license.txt. Register free at https://surfer.nmr.mgh.harvard.edu/registration.html |
+| `--fs-subjects-dir` | dir path | Existing FreeSurfer subjects dir to reuse. Default: `<output-dir>/sourcedata/freesurfer` (bids layout) or `<output-dir>/freesurfer` (legacy). |
+| `--submm-recon` / `--no-submm-recon` | flag / `True` | Enable/disable sub-mm high-resolution recon. Auto-triggers when T1w voxels <1 mm. |
+| `--fs-no-reconall` | flag | **Disable FreeSurfer surface preprocessing entirely.** Skips surface/CIFTI outputs. |
+| `--fs-no-resume` | flag / `False` | EXPERT: import a pre-computed recon without resuming. User must ensure completeness. |
+
+---
+
+## Carbon tracking
+*Group: "Options for carbon usage tracking"*
+
+| Flag | Type / Default | Description |
+|------|----------------|-------------|
+| `--track-carbon` | flag / `False` | Track power draw via CodeCarbon. |
+| `--country-code` | ISO / `CAN` | Country code for carbon calculations. |
+
+---
+
+## Other options
+*Group: "Other options"*
+
+| Flag | Type / Default | Description |
+|------|----------------|-------------|
+| `--version` | flag | Show `fMRIPrep vX.Y.Z` and exit. |
+| `-v`, `--verbose` | count / `0` | Repeat for more log detail. `-vvv` = DEBUG. |
+| `-w`, `--work-dir` | dir path | Nipype scratch directory. Default `./work/`. Must NOT be inside `bids_dir`. |
+| `--clean-workdir` | flag / `False` | Wipe the working dir before running. **Do not use with concurrent runs.** |
+| `--resource-monitor` | flag / `False` | Enable Nipype resource-monitor sampling (memory/CPU). |
+| `--config-file` | file path | Load a pre-generated fMRIPrep TOML config. CLI args override config values. |
+| `--write-graph` | flag / `False` | Save the Nipype workflow graph. |
+| `--stop-on-first-crash` | flag / `False` | Stop immediately on the first error, even if `-w` is set. |
+| `--notrack` | flag / `False` | Opt out of telemetry. |
+| `--debug` | space-list of `compcor` / `fieldmaps` / `pdb` / `all` | Enable a debug mode (`pdb` drops into the debugger on crash). |
+| `-h`, `--help` | flag | Show help. |
+
+---
+
+## Deprecated flags
+
+Deprecated in 25.x (removed in the version noted):
+
+| Old flag | Replacement | Removed in |
+|----------|-------------|------------|
+| `--force-bbr` | `--force bbr` | 26.0.0 |
+| `--force-no-bbr` | `--force no-bbr` | 26.0.0 |
+| `--force-syn` | `--force syn-sdc` | 26.0.0 |
+| `--longitudinal` | `--subject-anatomical-reference unbiased` | 26.1.0 |
+| `--anat-derivatives` | `--derivatives smriprep=/path` | Removed (use `-d`) |
+
+---
+
+## `fmriprep-docker` wrapper flags
+
+The wrapper reproduces the fmriprep CLI. Its own flags:
+
+| Flag | Purpose |
+|------|---------|
+| `-i`, `--image IMG` | Docker image (default `nipreps/fmriprep:<wrapper_version>`) |
+| `-e`, `--env VAR val` | Pass env var into container (repeatable) |
+| `-u`, `--user UID[:GID]` | Run as another user |
+| `--network none|bridge|host|...` | Docker network driver |
+| `--shell` | Drop to shell in the image |
+| `--patch PACKAGE=PATH` | Bind-mount a dev checkout over an installed package |
+| `--config PATH` | Custom `nipype.cfg` |
+| `--no-tty` | Skip `-it` (CI-safe) |
+
+The wrapper automatically bind-mounts: `bids_dir → /data:ro`,
+`output_dir → /out`, `work_dir → /scratch`, `fs_license_file → /opt/freesurfer/license.txt:ro`,
+`fs_subjects_dir → /opt/subjects`, `config_file → /tmp/config.toml`,
+`derivatives → /deriv/<name>:ro`, `use_plugin → /tmp/plugin.yml:ro`,
+`bids_database_dir → /tmp/bids_db`, `bids_filter_file → /tmp/bids_filter.json`.
+
+Custom output-space templates (not in the built-in TemplateFlow set) can be
+passed as `--output-spaces /path/to/tpl-MyCustom` — the wrapper bind-mounts
+them into `/home/fmriprep/.cache/templateflow/tpl-MyCustom`.
+
+---
+
+## Consistency validations enforced by the parser
+
+fMRIPrep will refuse to run if:
+
+- `output_dir == bids_dir` — suggests `bids_dir/derivatives/fmriprep-<ver>` instead
+- `work_dir` is inside `bids_dir`
+- `--force bbr` and `--force no-bbr` both set
+- `--force fmap-jacobian` and `--ignore fmap-jacobian` both set
+
+Warnings printed when:
+
+- `--omp-nthreads > --nthreads`
+- `--skull-strip-t1w auto` (heuristic risks are noted)
+- Telemetry is disabled because `sentry_sdk` is missing
+- Your version is in the flagged list (`.versions.json`); check before publishing

--- a/packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/references/confounds.md
+++ b/packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/references/confounds.md
@@ -1,0 +1,344 @@
+# Confounds Reference
+
+fMRIPrep does not smooth or denoise BOLD data. Instead it emits a **rich table
+of nuisance regressors** per run — your downstream tool (Nilearn, FitLins, FSL
+FEAT, SPM) is responsible for including them in a design matrix or regressing
+them out.
+
+File: `sub-<label>_[specifiers]_desc-confounds_timeseries.tsv` (+ `.json`).
+
+Row = one BOLD timepoint (kept for every volume in the raw series; leading
+non-steady-state rows typically have `n/a` in framewise-derivative columns).
+
+⚠️ **Never dump every column into a design matrix**. Pick a strategy and
+include only its subset. See [strategy recipes](#recommended-denoising-strategies) at the bottom.
+
+## Table of Contents
+1. [Column reference](#column-reference)
+2. [aCompCor and tCompCor](#acompcor-and-tcompcor)
+3. [DCT cosine regressors](#dct-cosine-regressors)
+4. [Spike/outlier regressors](#spikeoutlier-regressors)
+5. [Crown / brain-edge PCA](#crown--brain-edge-pca)
+6. [JSON metadata schema](#json-metadata-schema)
+7. [Recommended denoising strategies](#recommended-denoising-strategies)
+8. [Programmatic loading](#programmatic-loading)
+9. [Interpreting the report's carpetplot](#interpreting-the-reports-carpetplot)
+
+---
+
+## Column reference
+
+### Motion parameters (6 base + expansions → up to 24)
+
+| Column | Meaning |
+|--------|---------|
+| `trans_x`, `trans_y`, `trans_z` | Rigid-body translations (mm) w.r.t. reference volume |
+| `rot_x`, `rot_y`, `rot_z` | Rigid-body rotations (radians) |
+| `trans_{x,y,z}_derivative1` | 1st temporal derivative of each translation |
+| `rot_{x,y,z}_derivative1` | 1st temporal derivative of each rotation |
+| `trans_{x,y,z}_power2` | Quadratic term of each translation |
+| `rot_{x,y,z}_power2` | Quadratic term of each rotation |
+| `trans_{x,y,z}_derivative1_power2` | Squared derivative |
+| `rot_{x,y,z}_derivative1_power2` | Squared derivative |
+
+Choose 6 = base, 12 = base + derivatives (Friston), 24 = base + derivatives +
+squares (Satterthwaite).
+
+### Global signals
+
+| Column | Meaning |
+|--------|---------|
+| `csf` | Mean signal in eroded CSF mask (anatomical) |
+| `white_matter` | Mean signal in eroded WM mask (anatomical) |
+| `global_signal` | Mean signal in brain mask |
+| `csf_derivative1`, `csf_power2`, `csf_derivative1_power2` | expansions |
+| `white_matter_derivative1`, `white_matter_power2`, `white_matter_derivative1_power2` | expansions |
+| `global_signal_derivative1`, `global_signal_power2`, `global_signal_derivative1_power2` | expansions |
+
+Combined with the 24 motion params → **36-parameter Satterthwaite** strategy.
+
+### Motion metrics
+
+| Column | Meaning | Notes |
+|--------|---------|-------|
+| `framewise_displacement` | FD (mm) per Power 2012 | `n/a` for first volume |
+| `rmsd` | Relative frame-to-frame head motion (Jenkinson 2002) | |
+| `dvars` | Derivative of RMS voxel variance (Power 2012) | `n/a` for first volume |
+| `std_dvars` | Standardized DVARS | For thresholding |
+
+### Non-steady-state outliers
+
+`non_steady_state_outlier00`, `non_steady_state_outlier01`, ... — one column
+per detected dummy volume, with `1` at that timepoint and `0` elsewhere.
+Detected automatically or set by `--dummy-scans N`.
+
+### Motion spike regressors
+
+`motion_outlier00`, `motion_outlier01`, ... — one column per timepoint flagged
+by (FD > `--fd-spike-threshold`) OR (std_dvars > `--dvars-spike-threshold`).
+Defaults: FD > 0.5 mm, std_dvars > 1.5.
+
+These are **one-hot** regressors — including them censors those volumes when
+regressed. Alternatively use them to build a scrub mask and drop volumes.
+
+---
+
+## aCompCor and tCompCor
+
+**aCompCor** (anatomical, Behzadi 2007 / Muschelli 2014): PCA of BOLD signals
+inside three noise ROIs derived from tissue segmentation. Each ROI's
+components are written to a **distinct column prefix** — no need to consult
+the JSON `Mask` field to disambiguate:
+
+| ROI | Column prefix | JSON `Mask` |
+|-----|---------------|-------------|
+| Combined WM ∪ CSF (Behzadi original) | `a_comp_cor_00`, `a_comp_cor_01`, ... | `combined` |
+| CSF alone (Muschelli) | `c_comp_cor_00`, `c_comp_cor_01`, ... | `CSF` |
+| WM alone (Muschelli) | `w_comp_cor_00`, `w_comp_cor_01`, ... | `WM` |
+
+All three sets carry `Method: aCompCor` in the JSON. Retained-vs-dropped
+status, singular value, and cumulative variance explained are in the JSON
+sidecar per component.
+
+**tCompCor** (temporal, Behzadi 2007): PCA on top-variance voxels
+(temporally). Columns: `t_comp_cor_00`, `t_comp_cor_01`, ...
+JSON `Method: tCompCor`.
+
+**Retention policy**: by default fMRIPrep keeps components that cumulatively
+explain the top 50% variance of each ROI's decomposition. Dropped components
+are kept in the JSON with the `dropped_XX` prefix. Use `--return-all-components`
+to include every component in the TSV.
+
+**Selection tips**:
+- The three anatomical CompCor variants are now distinguishable by column
+  prefix (`a_`, `c_`, `w_`) — no need to filter the JSON `Mask` field to
+  separate combined / CSF-only / WM-only families.
+- Common choices: first 5–6 components; first N to explain 50% / 70% / 90%
+  cumulative variance; number chosen by elbow / broken stick.
+- Behzadi original: use `a_comp_cor_*` (combined-mask components).
+- Muschelli refinement: use `w_comp_cor_*` and `c_comp_cor_*` separately.
+- Do **not** combine WM/CSF CompCor with the plain `white_matter` / `csf`
+  global signal (redundant / collinear).
+- Combining `global_signal` **with** CompCor is beneficial (Parkes 2018).
+
+### High-pass filtering caveat
+
+fMRIPrep applies a temporal high-pass filter *before* CompCor decomposition.
+When you use CompCor regressors, you MUST include the corresponding
+`cosine_XX` regressors in the same design matrix — otherwise you'll re-alias
+low-frequency drift back into your model.
+
+---
+
+## DCT cosine regressors
+
+`cosine_00`, `cosine_01`, ..., `cosine_NN` — DCT basis functions modeling
+low-frequency drift.
+
+- Number of regressors depends on effective series length (excluding detected
+  non-steady-state volumes) and TR.
+- Cutoff is set internally to match the CompCor high-pass.
+- Two datasets with the same TR and effective length produce identical cosine
+  regressors.
+- **Do not combine with your own high-pass filter.**
+
+---
+
+## Spike/outlier regressors
+
+Categories (each is a set of one-hot columns):
+
+| Prefix | Trigger | Threshold flag |
+|--------|---------|----------------|
+| `non_steady_state_outlier` | Detected T1-saturation / dummy scans | `--dummy-scans` |
+| `motion_outlier` | Frame with FD > threshold OR std_dvars > threshold | `--fd-spike-threshold`, `--dvars-spike-threshold` |
+
+Common practice:
+- **Regress-out**: include as regressors → those timepoints are effectively censored.
+- **Scrub**: use as a mask to drop volumes prior to GLM (rebuilds series length).
+- **Report**: track the fraction of flagged volumes per subject — a common
+  quality-control exclusion criterion (e.g. exclude subject if >20%).
+
+---
+
+## Crown / brain-edge PCA
+
+24 PCA components extracted from voxels on the outer brain edge ("crown"):
+signal here is dominated by motion / physiological artifacts, not neural
+activity. Introduced in Patriat 2017 and formalized for fMRIPrep in
+Provins 2022.
+
+Columns: `edge_comp_00`, `edge_comp_01`, ..., `edge_comp_23` (24 components).
+JSON `Method: EdgeRegressor` (not `aCompCor` or `tCompCor`, though the
+implementation reuses aCompCor plumbing on the "crown" mask). Useful as an
+aggressive nuisance model when a lot of motion is expected.
+
+---
+
+## JSON metadata schema
+
+Each TSV has a paired JSON. Example entry for one component:
+
+```json
+{
+  "a_comp_cor_00": {
+    "CumulativeVarianceExplained": 0.1082,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 25.827,
+    "VarianceExplained": 0.1082
+  },
+  "dropped_0": {
+    "CumulativeVarianceExplained": 0.5966,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 20.796,
+    "VarianceExplained": 0.0701
+  }
+}
+```
+
+Fields:
+- `Method` — `aCompCor` or `tCompCor`.
+- `Mask` — for aCompCor: `CSF`, `WM`, `combined`.
+- `SingularValue` — component's singular value.
+- `VarianceExplained` — this component's share of ROI variance.
+- `CumulativeVarianceExplained` — running total up through this component.
+- `Retained` — whether saved in the TSV (`true`) or listed only in JSON (`false`, i.e. `dropped_XX`).
+
+---
+
+## Recommended denoising strategies
+
+Pick ONE (or a small orthogonal set) — don't mix redundant families.
+
+### Minimal (6-parameter)
+
+```
+trans_x, trans_y, trans_z, rot_x, rot_y, rot_z
++ framewise_displacement (optional group-level covariate)
+```
+
+Simplest; only motion. Poor for high-motion cohorts.
+
+### 24-parameter Friston-24 (aka Volterra)
+
+```
+Base 6 + 6 derivatives + 6 squares + 6 squared derivatives
+```
+
+Column pattern: `(trans|rot)_[xyz](_derivative1)?(_power2)?`
+
+### 36-parameter Satterthwaite (aka aCompCor+GSR expansion)
+
+24-parameter motion + 12 tissue signals (csf, white_matter, global_signal,
+each with derivative + squares).
+
+### aCompCor (Behzadi original)
+
+```
+6 motion + first N aCompCor components with Mask=="combined" + cosine_XX
+```
+
+### aCompCor (Muschelli refinement)
+
+```
+6 motion + first N w_comp_cor_* (WM mask) + first N c_comp_cor_* (CSF mask) + cosine_XX
+```
+
+(No need to filter by JSON `Mask` — the column prefixes already partition
+combined/WM/CSF.)
+
+### Scrubbing / censoring
+
+Use `motion_outlier_XX` as a design regressor OR drop those volumes entirely
+(rebuild series). Common threshold: FD>0.5 mm (default) or stricter (0.2 mm)
+for resting-state connectivity.
+
+### AROMA (via post-processor)
+
+fMRIPrep 21+ dropped built-in AROMA. Use the community-maintained
+`fmripost-aroma` BIDS-App downstream — it consumes fMRIPrep outputs.
+
+---
+
+## Programmatic loading
+
+Python (Nilearn / pandas):
+
+```python
+from pathlib import Path
+import pandas as pd
+import json
+
+conf = Path("derivatives/sub-01/func/"
+            "sub-01_task-rest_desc-confounds_timeseries.tsv")
+
+df = pd.read_csv(conf, sep="\t")
+
+# Metadata (used to pick components by variance / retention if desired)
+with open(conf.with_suffix(".json")) as f:
+    meta = json.load(f)
+
+# Extract aCompCor combined-mask, top 6 — columns are prefixed a_/c_/w_ to
+# denote combined/CSF/WM masks respectively, so filtering by prefix suffices.
+combined_cols = [c for c in df.columns if c.startswith("a_comp_cor_")][:6]
+
+# Motion basic 6
+motion6 = ["trans_x", "trans_y", "trans_z", "rot_x", "rot_y", "rot_z"]
+
+# High-pass cosines
+cosines = [c for c in df.columns if c.startswith("cosine")]
+
+# Motion outliers
+outliers = [c for c in df.columns if c.startswith("motion_outlier")]
+
+design = df[motion6 + combined_cols + cosines + outliers].fillna(0.0)
+```
+
+Nilearn convenience:
+
+```python
+from nilearn.interfaces.fmriprep import load_confounds
+
+confounds, sample_mask = load_confounds(
+    "sub-01_task-rest_space-MNI152NLin2009cAsym_desc-preproc_bold.nii.gz",
+    strategy=["motion", "high_pass", "wm_csf", "scrub"],
+    motion="basic",
+    wm_csf="basic",
+    scrub=5,
+    fd_threshold=0.5,
+    std_dvars_threshold=1.5,
+)
+```
+
+`load_confounds` supports `strategy=[...]` values: `motion`, `high_pass`,
+`wm_csf`, `global_signal`, `compcor`, `ica_aroma`, `scrub`, `non_steady_state`.
+
+---
+
+## Interpreting the report's carpetplot
+
+The visual report's per-run carpetplot (Power 2016; Provins 2022 extension)
+plots BOLD time × voxels as a heatmap, with above-the-carpet:
+- `GS`, `CSF`, `WM` — global / tissue signals
+- `FD` — framewise displacement
+- `DVARS` — derivative of variance
+
+Rows are grouped: cortical GM, deep GM, WM, CSF, cerebellum, edge/crown.
+
+Diagnostic patterns:
+- **Vertical bright/dark stripes** — motion or physiological events;
+  correlates with FD/DVARS spikes.
+- **Slow drift** — scanner drift; ensure cosine regressors or high-pass.
+- **Correlated stripes across all rows** — global signal contamination;
+  consider including `global_signal` regressor.
+- **Row-specific bright bands** — issue localized to that tissue class (e.g.,
+  vascular near-edge).
+
+The report also shows:
+- **CompCor cumulative-variance curves** — helps choose N components.
+- **Confound correlation heatmap** — spot collinearity in your chosen model.
+- **Confound-vs-global-signal bar plot** — flag partial-volume effects.

--- a/packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/references/installation.md
+++ b/packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/references/installation.md
@@ -1,0 +1,346 @@
+# Installation Reference
+
+## Table of Contents
+1. [Container installations (recommended)](#container-installations-recommended)
+   - 1.1 [Docker](#11-docker)
+   - 1.2 [`fmriprep-docker` wrapper](#12-fmriprep-docker-wrapper)
+   - 1.3 [Apptainer / Singularity](#13-apptainer--singularity)
+2. [Bare-metal (pip) installation](#bare-metal-pip-installation)
+3. [External binary dependencies (bare-metal only)](#external-binary-dependencies-bare-metal-only)
+4. [FreeSurfer license](#freesurfer-license)
+5. [TemplateFlow setup](#templateflow-setup)
+6. [Environment variables](#environment-variables)
+7. [Verifying the installation](#verifying-the-installation)
+
+---
+
+## Container installations (recommended)
+
+fMRIPrep is a **BIDS-App**. Containers are the officially supported deployment
+path — they package every neuroimaging binary (FreeSurfer, FSL, ANTs, AFNI,
+Connectome-Workbench, MSM) at exact tested versions, avoiding the pain of a
+manual environment.
+
+### 1.1 Docker
+
+Pull an official image from Docker Hub:
+
+```bash
+docker pull nipreps/fmriprep:25.2.5      # replace with the desired version
+docker pull nipreps/fmriprep:latest      # bleeding edge (not recommended for research)
+```
+
+Image sizes are ~10 GB compressed / ~25 GB extracted.
+
+Minimal bare-Docker invocation:
+
+```bash
+docker run --rm -it \
+    -v /path/to/bids:/data:ro \
+    -v /path/to/derivatives:/out \
+    -v /path/to/work:/scratch \
+    -v /path/to/freesurfer/license.txt:/opt/freesurfer/license.txt:ro \
+    nipreps/fmriprep:25.2.5 \
+    /data /out participant \
+    -w /scratch
+```
+
+Docker Hub tags: https://hub.docker.com/r/nipreps/fmriprep/tags/
+
+### 1.2 `fmriprep-docker` wrapper
+
+A Python wrapper that constructs the `docker run` command for you. It shares
+the CLI of `fmriprep` (paths are automatically bind-mounted).
+
+Install:
+
+```bash
+python -m pip install --user fmriprep-docker
+```
+
+Use exactly like `fmriprep`:
+
+```bash
+fmriprep-docker /path/to/bids /path/to/derivatives participant \
+    --fs-license-file $HOME/.licenses/freesurfer/license.txt \
+    --output-spaces MNI152NLin2009cAsym:res-2 fsaverage \
+    -w /path/to/work
+```
+
+Wrapper-specific options (translate to `docker run` flags):
+
+| Wrapper flag | Purpose |
+|--------------|---------|
+| `-i / --image IMG` | Pick a specific image (default: `nipreps/fmriprep:<wrapper_version>`) |
+| `-e / --env VAR val` | Inject an env var (repeatable) |
+| `-u / --user UID[:GID]` | Run container as another user |
+| `--network none` | Simulate offline mode |
+| `--shell` | Drop into a bash shell inside the container |
+| `--patch PACKAGE=PATH` | Bind-mount a dev checkout over the installed package |
+| `--no-tty` | Omit `-it` (useful for CI / batch) |
+| `--config PATH` | Custom `nipype.cfg` |
+
+The wrapper auto-detects `$FS_LICENSE` and bind-mounts it. It also warns if
+Docker has <8 GB of RAM available.
+
+The wrapper source lives at `wrapper/src/fmriprep_docker/__main__.py`; expected
+Docker image path convention: `/app/.pixi/envs/fmriprep/lib/python3.12/site-packages`.
+
+### 1.3 Apptainer / Singularity
+
+Build an image from Docker Hub (typical HPC workflow):
+
+```bash
+# On a machine with internet + apptainer/singularity
+apptainer build fmriprep-25.2.5.sif docker://nipreps/fmriprep:25.2.5
+```
+
+Run:
+
+```bash
+apptainer run --cleanenv \
+    -B /path/to/bids:/data:ro \
+    -B /path/to/derivatives:/out \
+    -B /path/to/work:/work \
+    -B $FS_LICENSE:/opt/freesurfer/license.txt:ro \
+    -B $HOME/.cache/templateflow:/opt/templateflow \
+    --env TEMPLATEFLOW_HOME=/opt/templateflow \
+    fmriprep-25.2.5.sif \
+    /data /out participant \
+    --fs-license-file /opt/freesurfer/license.txt \
+    -w /work --nthreads 8 --omp-nthreads 4 --mem 16000
+```
+
+Notes:
+- `--cleanenv` prevents host env from leaking in (recommended). If `$FS_LICENSE`
+  is set on the host and you use `--cleanenv`, you must pass
+  `--fs-license-file` explicitly (as above).
+- Recent Apptainer (≥1.0) is a drop-in replacement for Singularity 3.x.
+- Under Singularity 2.x, use `singularity exec` and add `-w` explicitly.
+
+Extended HPC / TemplateFlow docs:
+https://www.nipreps.org/apps/singularity/
+
+---
+
+## Bare-metal (pip) installation
+
+> ⚠️ **Not recommended** — the container is the tested reference; bare-metal
+> installs commonly break when a system library version drifts. Use only when
+> containers are impossible.
+
+Requirements:
+- Python **3.10+** (3.11–3.13 also supported)
+- All [External Dependencies](#external-binary-dependencies-bare-metal-only) present on `$PATH`
+
+Install fMRIPrep from PyPI:
+
+```bash
+python -m pip install fmriprep
+```
+
+To pin a specific version:
+
+```bash
+python -m pip install fmriprep==25.2.5
+```
+
+Development install from GitHub:
+
+```bash
+git clone https://github.com/nipreps/fmriprep.git
+cd fmriprep
+python -m pip install -e ".[all]"
+```
+
+Optional feature groups (via pip extras):
+
+| Extra | Adds |
+|-------|------|
+| `[doc]` / `[docs]` | Sphinx + docs deps |
+| `[dev]` | ruff, pre-commit |
+| `[test]` / `[tests]` | pytest, coverage |
+| `[telemetry]` | migas + sentry-sdk |
+| `[container]` | Extras baked into container (datalad, git-annex) |
+| `[duecredit]` | duecredit citation tracking |
+| `[maint]` | maintenance tools |
+| `[all]` | Everything |
+
+Python dependencies (auto-installed):
+`acres`, `looseversion`, `nibabel≥5.1.1`, `nipype≥1.9.0`, `nireports≥24.1.0`,
+`nitime≥0.9`, `nitransforms≥25.0.1`, `niworkflows≥1.14.4`, `numpy≥2.0`,
+`packaging≥24`, `pandas≥2.2`, `psutil≥5.4`, `pybids≥0.16`, `requests≥2.27`,
+`sdcflows≥2.15.0`, `smriprep≥0.19.2`, `tedana≥25.1.0`, `templateflow≥24.2.2`,
+`transforms3d≥0.4.2`, `toml≥0.10`, `codecarbon≥2`, `APScheduler≥3.10`.
+
+---
+
+## External binary dependencies (bare-metal only)
+
+Containers include these. For bare-metal, install these versions (from fMRIPrep
+25.2.x lockfiles / Dockerfile):
+
+| Tool | Version (25.2.x) | Notes |
+|------|------------------|-------|
+| FreeSurfer | **7.3.2** | Get from Harvard, requires license.txt |
+| FSL | **6.0.7.7** (via fsl-{bet2, flirt, fast4, fugue, mcflirt, miscmaths, topup} conda pkgs) | Only the components fMRIPrep uses |
+| ANTs | **2.5.1** (2.6.* in pixi env) | `antsRegistration`, `N4BiasFieldCorrection`, `antsBrainExtraction.sh` |
+| AFNI | **25.2.09** | Only `3dvolreg`, `3dTshift`, `3dUnifize`, `3dAutomask` are used |
+| Connectome Workbench | **1.5.0+** (2.0.* in container, Qt6 build) | CIFTI + surface I/O |
+| MSM | **HOCR (Nov 2019)** | Multimodal Surface Matching |
+| bids-validator | **1.14.10** | Input dataset validation |
+| NodeJS | **20.x** | For bids-validator, svgo |
+| svgo | **^3.2.0** | Report SVG optimization |
+| Python | **3.12** | Container uses 3.12 |
+
+Use `references/versions-dependencies.md` for the exact pin table.
+
+Verify each tool is on PATH:
+
+```bash
+which recon-all antsRegistration flirt 3dvolreg wb_command
+```
+
+---
+
+## FreeSurfer license
+
+fMRIPrep uses FreeSurfer tools even when `--fs-no-reconall` is set (some
+utilities need it). **You must supply a license file.**
+
+Register (free): https://surfer.nmr.mgh.harvard.edu/registration.html
+
+You receive a `license.txt` (small text file with 4 lines). Recommended location:
+`$HOME/.licenses/freesurfer/license.txt`.
+
+fMRIPrep resolves the license path in this order:
+1. `--fs-license-file /path/to/license.txt` argument
+2. `$FS_LICENSE` environment variable (fMRIPrep sets this in-process)
+3. `$FREESURFER_HOME/license.txt` (bare-metal fallback)
+
+### Passing the license into containers
+
+**Docker (raw):**
+```bash
+-v $FS_LICENSE:/opt/freesurfer/license.txt:ro
+```
+
+**Docker (wrapper) — auto-detected from `$FS_LICENSE`:**
+```bash
+export FS_LICENSE=$HOME/.licenses/freesurfer/license.txt
+fmriprep-docker /data /out participant
+```
+
+**Apptainer with `--cleanenv`:** must pass `--fs-license-file` explicitly, e.g.:
+```bash
+apptainer run --cleanenv \
+    -B $HOME/.licenses/freesurfer/license.txt:/opt/freesurfer/license.txt:ro \
+    fmriprep-25.2.5.sif /data /out participant \
+    --fs-license-file /opt/freesurfer/license.txt
+```
+
+---
+
+## TemplateFlow setup
+
+TemplateFlow is the registry that provides `MNI152NLin2009cAsym`, `fsLR`,
+`OASIS30ANTs`, etc. Templates are downloaded on first use.
+
+Default cache path: `$HOME/.cache/templateflow`. Override with:
+```bash
+export TEMPLATEFLOW_HOME=/path/to/templateflow
+```
+
+**Pre-fetch templates** (recommended for HPC, air-gapped or slow-network setups):
+
+```bash
+python -m pip install templateflow
+python -c "from templateflow.api import get; \
+  get(['MNI152NLin2009cAsym', 'MNI152NLin6Asym', 'OASIS30ANTs', \
+       'MNIPediatricAsym', 'MNIInfant', 'fsaverage', 'fsLR'])"
+```
+
+Templates that **must** be present for common workflows:
+
+| Template | Needed when |
+|----------|-------------|
+| `MNI152NLin2009cAsym` | Always (default output space + internal reference) |
+| `OASIS30ANTs` | Skull-stripping default (`--skull-strip-template`) |
+| `MNI152NLin6Asym` | `--cifti-output` |
+| `fsaverage` / `fsLR` | Surface / CIFTI output |
+| `MNIPediatricAsym` / `MNIInfant` | Pediatric / infant cohorts |
+
+The helper script bundled in the repo (`scripts/fetch_templates.py`) pulls all
+common templates:
+
+```bash
+wget https://raw.githubusercontent.com/nipreps/fmriprep/master/scripts/fetch_templates.py
+python fetch_templates.py --tf-dir /path/to/templateflow
+```
+
+The container image includes a pre-populated TemplateFlow mirror in
+`/home/fmriprep/.cache/templateflow` — you don't strictly need to bind-mount
+your host cache when using Docker/Apptainer, but doing so avoids re-downloads
+if you delete the container.
+
+Apptainer + TemplateFlow guide:
+https://www.nipreps.org/apps/singularity/#templateflow-and-singularity
+
+---
+
+## Environment variables
+
+| Variable | Effect |
+|----------|--------|
+| `FS_LICENSE` | Path to FreeSurfer license (auto-picked up by fMRIPrep and the wrapper) |
+| `FREESURFER_HOME` | FreeSurfer install root (bare-metal); used as fallback license search location |
+| `SUBJECTS_DIR` | FreeSurfer subjects directory (bare-metal) |
+| `TEMPLATEFLOW_HOME` | TemplateFlow cache root (default `~/.cache/templateflow`) |
+| `FMRIPREP_DEV` | Set to `1` to enable dev warnings (normally suppressed) |
+| `FMRIPREP_WARNINGS` | Force warnings even in production builds (dev use) |
+| `NIPYPE_NO_ET` / `NO_ET` | Disable Nipype telemetry ping (fMRIPrep force-sets these) |
+| `PYTHONHASHSEED` | Set to `0` for reproducible runs (container sets automatically) |
+| `MKL_NUM_THREADS` / `OMP_NUM_THREADS` | Set to `1` in container so Nipype controls parallelism |
+| `FSLDIR` | FSL install root (bare-metal); container sets to pixi env |
+| `FSLOUTPUTTYPE` | `NIFTI_GZ` in container |
+| `IS_DOCKER_8395080871` | Set inside the container; fMRIPrep uses it to detect containerized execution |
+| `DOCKER_VERSION_8395080871` | Set by the Docker wrapper; distinguishes `docker` from `fmriprep-docker` runs |
+
+---
+
+## Verifying the installation
+
+Print the version — every install path should respond:
+
+```bash
+# bare-metal
+fmriprep --version
+
+# Docker
+docker run --rm nipreps/fmriprep:25.2.5 --version
+
+# Docker wrapper
+fmriprep-docker --version
+
+# Apptainer
+apptainer run fmriprep-25.2.5.sif --version
+```
+
+Expected: `fMRIPrep v25.2.5` (or your installed release).
+
+Dry-run to verify a BIDS dataset without doing work:
+
+```bash
+fmriprep /path/to/bids /path/to/derivatives participant \
+    --participant-label 01 \
+    --boilerplate-only        # emit only the methods paragraph and exit
+```
+
+Or generate reports without redoing computation (uses cached working dir):
+
+```bash
+fmriprep /path/to/bids /path/to/derivatives participant \
+    --participant-label 01 \
+    --reports-only \
+    -w /path/to/work
+```

--- a/packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/references/outputs.md
+++ b/packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/references/outputs.md
@@ -1,0 +1,369 @@
+# Outputs Reference
+
+fMRIPrep emits three broad classes of output:
+1. **Visual QA reports** — one HTML per subject (`sub-XX.html`).
+2. **Derivatives** — preprocessed NIfTI/GIFTI/CIFTI + JSON sidecars.
+3. **Confounds** — nuisance regressor TSVs (with JSON metadata).
+
+Everything follows the [BIDS-Derivatives](https://bids-specification.readthedocs.io/en/stable/05-derivatives/01-introduction.html)
+spec (plus BEP-011/012 for functional/structural extensions).
+
+## Table of Contents
+1. [Top-level layout](#top-level-layout)
+2. [Anatomical derivatives (per subject)](#anatomical-derivatives-per-subject)
+3. [FreeSurfer derivatives](#freesurfer-derivatives)
+4. [Functional derivatives (per BOLD run)](#functional-derivatives-per-bold-run)
+5. [Motion / coregistration / fieldmap transforms](#motion--coregistration--fieldmap-transforms)
+6. [Confounds files](#confounds-files)
+7. [Multi-echo derivatives](#multi-echo-derivatives)
+8. [Surface / GIFTI derivatives](#surface--gifti-derivatives)
+9. [CIFTI grayordinate derivatives](#cifti-grayordinate-derivatives)
+10. [Reports and boilerplate](#reports-and-boilerplate)
+11. [Filename entities cheat-sheet](#filename-entities-cheat-sheet)
+12. [Legacy layout (pre-21.0)](#legacy-layout-pre-210)
+
+---
+
+## Top-level layout
+
+Default (`--output-layout bids`, since 21.0.x):
+
+```
+<output_dir>/
+    dataset_description.json      # BIDS-Derivatives metadata; PipelineDescription = "fMRIPrep"
+    .bidsignore
+    logs/
+        CITATION.md               # Boilerplate for methods sections
+        CITATION.html
+        CITATION.tex
+        (Nipype crash files if any)
+    sub-<label>/
+        anat/
+        func/
+        (figures/)                # HTML reportlets
+    sub-<label>.html              # Per-subject visual report
+    sourcedata/
+        freesurfer/               # If reconstructor ran or was reused
+```
+
+- Output dir is itself a valid BIDS derivative dataset — can be nested with other BIDS-Derivatives (smriprep, MRIQC, etc.).
+- `sub-<label>.html` is the visual QA report — open in any browser.
+
+---
+
+## Anatomical derivatives (per subject)
+
+Under `sub-<label>/anat/`:
+
+```
+sub-<label>[_space-<space>]_desc-preproc_T1w.nii.gz
+sub-<label>[_space-<space>]_desc-preproc_T2w.nii.gz         # if T2w + FS enabled
+sub-<label>[_space-<space>]_desc-brain_mask.nii.gz
+sub-<label>[_space-<space>]_dseg.nii.gz                     # discrete seg (CSF/GM/WM)
+sub-<label>[_space-<space>]_label-CSF_probseg.nii.gz
+sub-<label>[_space-<space>]_label-GM_probseg.nii.gz
+sub-<label>[_space-<space>]_label-WM_probseg.nii.gz
+```
+
+- Absence of `space-` = native T1w space.
+- Common `space-*`: `MNI152NLin2009cAsym`, `MNI152NLin6Asym`, ...
+
+**T1w↔MNI transforms** (composite HDF5, both directions):
+
+```
+sub-<label>_from-MNI152NLin2009cAsym_to-T1w_mode-image_xfm.h5
+sub-<label>_from-T1w_to-MNI152NLin2009cAsym_mode-image_xfm.h5
+```
+
+**Surface files** (if FreeSurfer enabled):
+
+```
+sub-<label>_hemi-[LR]_white.surf.gii
+sub-<label>_hemi-[LR]_midthickness.surf.gii
+sub-<label>_hemi-[LR]_pial.surf.gii
+sub-<label>_hemi-[LR]_desc-reg_sphere.surf.gii              # fsaverage reg sphere
+sub-<label>_hemi-[LR]_space-fsLR_desc-reg_sphere.surf.gii
+sub-<label>_hemi-[LR]_space-fsLR_desc-msmsulc_sphere.surf.gii   # if MSMSulc enabled
+sub-<label>_hemi-[LR]_desc-cortex_mask.label.gii
+```
+
+**T1w ↔ fsnative** transforms (affine):
+
+```
+sub-<label>_from-fsnative_to-T1w_mode-image_xfm.txt
+sub-<label>_from-T1w_to-fsnative_mode-image_xfm.txt
+```
+
+**Shape metrics** (per hemisphere GIFTI + fsLR-32k CIFTI dscalar):
+
+```
+sub-<label>_hemi-[LR]_thickness.shape.gii
+sub-<label>_hemi-[LR]_curv.shape.gii
+sub-<label>_hemi-[LR]_sulc.shape.gii
+sub-<label>_space-fsLR_den-32k_thickness.dscalar.nii
+sub-<label>_space-fsLR_den-32k_curv.dscalar.nii
+sub-<label>_space-fsLR_den-32k_sulc.dscalar.nii
+```
+
+⚠️ HCP inverts curv/sulc signs vs FreeSurfer; fMRIPrep follows HCP conventions
+in CIFTI dscalars and masks the medial wall.
+
+---
+
+## FreeSurfer derivatives
+
+Full FreeSurfer subjects tree (uncompressed, ~600 MB per subject):
+
+```
+<output_dir>/
+    sourcedata/
+        freesurfer/
+            fsaverage/           # copies as needed
+            fsaverage5/
+            fsaverage6/
+            sub-<label>/
+                mri/  surf/  label/  stats/  scripts/  touch/ ...
+    desc-aparc_dseg.tsv          # aparc label ↔ integer lookup
+    desc-aparcaseg_dseg.tsv      # aparc+aseg label ↔ integer lookup
+```
+
+Placement:
+- Default (`--output-layout bids`): `sourcedata/freesurfer/`.
+- Legacy (`--output-layout legacy`): `<output>/freesurfer/`.
+- Override with `--fs-subjects-dir /custom/path` (path is created if missing).
+
+The `sourcedata/` prefix marks FreeSurfer outputs as an *input* to fMRIPrep
+(they are re-consumable across runs). If reused across runs, keep the same
+`--fs-subjects-dir`.
+
+---
+
+## Functional derivatives (per BOLD run)
+
+Common entities per BOLD run: `task-<task>[_run-<idx>][_ses-<ses>][_dir-<dir>][_acq-<acq>][_echo-<n>]`.
+Denoted `[specifiers]` below.
+
+Under `sub-<label>/func/`:
+
+**Volumetric BOLD** (one file per `--output-spaces` volumetric target, at `--level full`):
+
+```
+sub-<label>_[specifiers]_space-<space>_desc-preproc_bold.nii.gz    # main preprocessed BOLD
+sub-<label>_[specifiers]_space-<space>_desc-brain_mask.nii.gz      # matching mask (minimal level)
+sub-<label>_[specifiers]_space-<space>_boldref.nii.gz              # reference in same space
+```
+
+**FreeSurfer segmentations in BOLD space** (if FS enabled, `--level full`):
+
+```
+sub-<label>_[specifiers]_space-T1w_desc-aparcaseg_dseg.nii.gz
+sub-<label>_[specifiers]_space-T1w_desc-aseg_dseg.nii.gz
+```
+
+**Fieldmap-corrected reference** (if a fieldmap was used):
+
+```
+sub-<label>_[specifiers]_space-<space>_desc-fmapref_bold.nii.gz
+```
+
+---
+
+## Motion / coregistration / fieldmap transforms
+
+Available at every `--level` (part of "minimal"):
+
+**HMC** — reference image and per-volume rigid transform (ITK txt format,
+`from-orig` = raw BOLD grid, `to-boldref` = HMC target reference):
+
+```
+sub-<label>_[specifiers]_desc-hmc_boldref.nii.gz
+sub-<label>_[specifiers]_from-orig_to_boldref_mode-image_desc-hmc_xfm.txt
+```
+
+**Coregistration** — BOLD ref → T1w affine:
+
+```
+sub-<label>_[specifiers]_desc-coreg_boldref.nii.gz
+sub-<label>_[specifiers]_from-boldref_to-T1w_mode-image_desc-coreg_xfm.txt
+```
+
+**Fieldmap registration** — if SDC ran:
+
+```
+# If fieldmap is B0Identifier=TOPUP:
+sub-<label>_[specifiers]_from-boldref_to-TOPUP_mode-image_xfm.txt
+
+# If fieldmap is found via IntendedFor (auto-generated ID):
+sub-<label>_[specifiers]_from-boldref_to-auto000XX_mode-image_xfm.txt
+```
+
+These transforms let downstream tools reproduce the exact preprocessing chain.
+
+---
+
+## Confounds files
+
+For every BOLD run:
+
+```
+sub-<label>_[specifiers]_desc-confounds_timeseries.tsv
+sub-<label>_[specifiers]_desc-confounds_timeseries.json      # column metadata
+```
+
+Row = timepoint (in the original series length; nonsteady-state and dummy rows
+often have `n/a` for framewise-derived measures). See `references/confounds.md`
+for the full column reference and typical denoising strategies.
+
+Excerpt of a typical TSV (columns truncated):
+
+```
+csf   white_matter  global_signal  std_dvars  dvars   framewise_displacement  t_comp_cor_00  ...  a_comp_cor_00  ...  non_steady_state_outlier00  trans_x  trans_y  trans_z  rot_x  rot_y  rot_z
+682.7 0.0           491.6          n/a        n/a     n/a                     0.0            ...  0.0            ...  1                            0.0      0.0      0.0      -1e-4  0      0
+669.1 0.0           489.4          1.168      17.58   0.0721                  -0.451         ...  -0.032         ...  0                            0.021    0.046    0.0003   0      0      0
+```
+
+---
+
+## Multi-echo derivatives
+
+For inputs `sub-01_task-rest_echo-{1,2,3}_bold.nii.gz`:
+
+Base outputs (from the optimally combined series):
+
+```
+sub-01_task-rest_boldref.nii.gz
+sub-01_task-rest_desc-brain_mask.nii.gz
+sub-01_task-rest_T2starmap.nii.gz                                  # tedana T2* estimate
+sub-01_task-rest_space-<space>_desc-preproc_bold.nii.gz            # combined + preprocessed
+```
+
+If `--me-output-echos` (or `--level resampling`), per-echo preprocessed series:
+
+```
+sub-01_task-rest_echo-1_desc-preproc_bold.nii.gz
+sub-01_task-rest_echo-2_desc-preproc_bold.nii.gz
+sub-01_task-rest_echo-3_desc-preproc_bold.nii.gz
+```
+
+Feed these to `tedana` for downstream denoising.
+
+---
+
+## Surface / GIFTI derivatives
+
+When `fsnative` / `fsaverage*` is in `--output-spaces`:
+
+```
+sub-<label>_[specifiers]_hemi-[LR]_space-<surface_space>_bold.func.gii
+```
+
+- `<surface_space>`: `fsnative` (full-density subject mesh), `fsaverage`
+  (164k), `fsaverage6` (41k), `fsaverage5` (10k, default when `fsaverage` given
+  without density modifier).
+- One file per hemisphere per run per space.
+- If `--medial-surface-nan`, medial-wall vertices contain NaN.
+
+---
+
+## CIFTI grayordinate derivatives
+
+When `--cifti-output` is set (91k default; 170k available):
+
+```
+sub-<label>_[specifiers]_space-fsLR_den-91k_bold.dtseries.nii
+sub-<label>_[specifiers]_space-fsLR_den-91k_bold.json
+```
+
+Structure:
+- Cortical grayordinates on the fsLR mesh (32k-per-hemisphere for 91k output,
+  164k-per-hemisphere for 170k; medial wall is masked out).
+- Subcortical grayordinates on a MNI152NLin6Asym volumetric grid at 2 mm
+  (91k output) or 1.6 mm (170k output).
+- Total: 91,282 grayordinates for 91k output; 170,494 for 170k output.
+- Compatible with HCP Pipelines and Connectome Workbench.
+
+---
+
+## Reports and boilerplate
+
+**Visual QA report**: `<output_dir>/sub-<label>.html`
+- Standalone HTML — embedded SVG reportlets. Open in any modern browser.
+- If sessions exceed `--aggregate-session-reports N` (default 4), splits into
+  `sub-<label>_ses-<ses>.html` files.
+
+**Reportlets** live under `sub-<label>/figures/` (SVG + small HTML fragments).
+They are the pieces the report is assembled from — usable independently in
+supplementary materials.
+
+**Boilerplate citations** in `<output_dir>/logs/`:
+
+```
+CITATION.md      # Markdown - authoritative source
+CITATION.html    # Rendered HTML
+CITATION.tex     # LaTeX
+```
+
+Copy the boilerplate verbatim into your methods section — it's CC0-licensed
+public domain, drafted specifically to cite every tool used with the exact
+versions from this run. See `references/citation.md`.
+
+---
+
+## Filename entities cheat-sheet
+
+BIDS-Derivatives filename entities in fMRIPrep output, in canonical order:
+
+| Entity | Meaning | Example |
+|--------|---------|---------|
+| `sub-` | Subject | `sub-01` |
+| `ses-` | Session | `ses-01` |
+| `task-` | Task | `task-rest` |
+| `acq-` | Acquisition variant | `acq-mb4` |
+| `ce-` | Contrast agent | `ce-gadolinium` |
+| `rec-` | Reconstruction | `rec-magnitude` |
+| `dir-` | Phase-encoding dir | `dir-AP` |
+| `run-` | Run index | `run-01` |
+| `mod-` | Modality label | `mod-T1w` |
+| `echo-` | Echo index | `echo-1` |
+| `part-` | Complex-data part | `part-mag`, `part-phase` |
+| `hemi-` | Hemisphere | `hemi-L`, `hemi-R` |
+| `space-` | Spatial reference | `space-MNI152NLin2009cAsym` |
+| `atlas-` | Atlas | `atlas-HCP` |
+| `res-` | Resolution index | `res-2` |
+| `den-` | Surface density | `den-32k` |
+| `label-` | Anatomical label | `label-GM` |
+| `desc-` | Free-form descriptor | `desc-preproc`, `desc-brain`, `desc-confounds` |
+| `from-` / `to-` / `mode-` | Transform meta | `from-T1w_to-MNI152NLin2009cAsym_mode-image` |
+| `_suffix` | Modality/data type | `_bold`, `_T1w`, `_dseg`, `_probseg`, `_mask`, `_xfm`, `_timeseries`, `_boldref` |
+
+Extensions:
+- `.nii.gz` — volumes
+- `.surf.gii` — surface meshes
+- `.func.gii` / `.shape.gii` / `.label.gii` — data on surfaces
+- `.dtseries.nii` / `.dscalar.nii` — CIFTI-2
+- `.h5` — ANTs composite transforms
+- `.txt` — ITK affine transforms (or `.mat`)
+- `.tsv` + `.json` — tables + sidecars
+
+Filename entity dictionary:
+https://bids-specification.readthedocs.io/en/stable/appendices/entity-table.html
+
+---
+
+## Legacy layout (pre-21.0)
+
+Enable with `--output-layout legacy`:
+
+```
+<output_dir>/
+    fmriprep/               # fMRIPrep derivatives (as if `<output>/` in bids layout)
+    freesurfer/             # FreeSurfer subjects (instead of sourcedata/freesurfer)
+```
+
+Identical contents to the bids layout — only the folder wrapping differs. Can
+be reproduced from a bids-layout run by pointing subsequent tools to
+`<output>/` and `<output>/sourcedata/freesurfer/` respectively.
+
+The bids layout is preferred because the output directory is itself a valid
+BIDS-Derivatives dataset (needed by BIDS-Derivatives-consuming tools like
+XCP-D, fmripost-*, and Nilearn's dataset loaders).

--- a/packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/references/sdc-fieldmaps.md
+++ b/packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/references/sdc-fieldmaps.md
@@ -1,0 +1,306 @@
+# Susceptibility Distortion Correction (SDC) & Fieldmaps
+
+Echo-planar imaging (EPI) suffers from spatial distortion caused by B0 field
+inhomogeneity, most visible near air-tissue boundaries (orbitofrontal, temporal
+lobes). fMRIPrep applies SDC automatically when it can identify a compatible
+fieldmap, or on request (fieldmap-less SyN) when it cannot.
+
+SDC in fMRIPrep is delegated to the **SDCFlows** package. Full theoretical
+reference: https://www.nipreps.org/sdcflows/master/api/sdcflows.workflows.fit.fieldmap.html
+
+## Table of Contents
+1. [Supported fieldmap types](#supported-fieldmap-types)
+2. [How fMRIPrep pairs a fieldmap to a BOLD run](#how-fmriprep-pairs-a-fieldmap-to-a-bold-run)
+3. [Estimator selection order](#estimator-selection-order)
+4. [Fieldmap-less SDC (SyN)](#fieldmap-less-sdc-syn)
+5. [Relevant CLI flags](#relevant-cli-flags)
+6. [BIDS fieldmap examples](#bids-fieldmap-examples)
+7. [Troubleshooting](#troubleshooting)
+8. [Outputs related to SDC](#outputs-related-to-sdc)
+
+---
+
+## Supported fieldmap types
+
+| Type | BIDS `suffix` | Estimator | Notes |
+|------|----------------|-----------|-------|
+| **PEPOLAR** | `epi` (opposite phase-encoding EPI) | FSL `topup` | Preferred when available; robust, no phase-unwrapping issues |
+| **Phase difference + magnitude** | `phasediff` + `magnitude1` (+ optional `magnitude2`) | FSL `prelude` → `fugue` | Requires `EchoTime1` and `EchoTime2` in JSON |
+| **Two-phase + magnitude** | `phase1` + `phase2` + `magnitude1` + `magnitude2` | FSL `prelude` → `fugue` | Older Siemens variant |
+| **Direct fieldmap** | `fieldmap` + `magnitude` | FSL `fugue` | User-supplied Hz fieldmap |
+| **Fieldmap-less** | none — anatomical prior | ANTs SyN vs T1w | Enable with `--use-syn-sdc` or `--force syn-sdc` |
+
+BIDS fieldmap spec:
+https://bids-specification.readthedocs.io/en/stable/04-modality-specific-files/01-magnetic-resonance-imaging-data.html#types-of-fieldmaps
+
+---
+
+## How fMRIPrep pairs a fieldmap to a BOLD run
+
+Two mechanisms — **SDCFlows prefers `B0FieldIdentifier` and IGNORES `IntendedFor` if present anywhere in the dataset.**
+
+### 1. `B0FieldIdentifier` / `B0FieldSource` (preferred, BIDS ≥1.6)
+
+Add to the fieldmap JSON:
+
+```json
+{
+  "B0FieldIdentifier": "TOPUP_AP_PA"
+}
+```
+
+Add to every BOLD JSON it applies to:
+
+```json
+{
+  "B0FieldSource": "TOPUP_AP_PA"
+}
+```
+
+Any string ID works — pick one per session/acquisition.
+
+### 2. `IntendedFor` (legacy)
+
+Add to the fieldmap JSON — a list of BIDS-relative paths to BOLD runs it corrects:
+
+```json
+{
+  "IntendedFor": [
+    "ses-01/func/sub-01_ses-01_task-rest_run-01_bold.nii.gz",
+    "ses-01/func/sub-01_ses-01_task-task_run-01_bold.nii.gz"
+  ]
+}
+```
+
+Paths are relative to the subject folder. Use forward slashes.
+
+⚠️ **Mixing is dangerous**: if ANY fieldmap in the dataset has
+`B0FieldIdentifier`, `IntendedFor` is ignored EVERYWHERE. Choose one strategy
+per dataset.
+
+---
+
+## Estimator selection order
+
+When multiple compatible fieldmaps are present, SDCFlows picks by priority
+(higher is preferred):
+
+1. PEPOLAR (`epi` suffix pair, opposite `PhaseEncodingDirection`) — most robust.
+2. Phase-difference (`phasediff` + `magnitude1`).
+3. Two-phase (`phase1` + `phase2` + magnitudes).
+4. Direct fieldmap (`fieldmap` + `magnitude`).
+
+If none matches AND `--use-syn-sdc` / `--force syn-sdc` is set → SyN fallback.
+
+---
+
+## Fieldmap-less SDC (SyN)
+
+Uses ANTs SyN to nonlinearly register the *distorted* BOLD reference to the
+*undistorted* T1w, allowing displacements only in the phase-encoding
+direction. Requires the T1w-space template (`MNI152NLin2009cAsym`) to be
+available locally.
+
+### `--use-syn-sdc [warn|error]`
+
+Enable SyN **only when no other fieldmap is available**. If SyN cannot run
+(e.g., missing PE direction metadata), the argument controls the fallback:
+
+- `warn` — log a warning, skip SDC, continue.
+- `error` (default when flag is used) — fail hard.
+
+Example:
+
+```bash
+--use-syn-sdc error   # crash if SyN fails
+--use-syn-sdc warn    # limp along without SDC
+```
+
+### `--force syn-sdc`
+
+**In addition to** any fieldmap already present. Useful for method comparison
+or robustness checks.
+
+```bash
+--force syn-sdc
+```
+
+Requirements for SyN to work:
+- `PhaseEncodingDirection` must be present in the BOLD JSON (e.g. `"j-"`).
+- The anatomical must be adequately preprocessed (fMRIPrep does this).
+
+---
+
+## Relevant CLI flags
+
+| Flag | Effect |
+|------|--------|
+| `--ignore fieldmaps` | Skip SDC entirely. Only use to test if a fieldmap is the source of an issue. |
+| `--use-syn-sdc [warn|error]` | Enable SyN fallback when no fieldmap present. |
+| `--force syn-sdc` | Add SyN in addition to fieldmap-based SDC. |
+| `--fmap-bspline` | Fit fieldmap as a B-Spline field (experimental). Improves SNR on noisy fieldmaps. |
+| `--fmap-no-demean` | Do NOT subtract the within-mask median from the fieldmap (default is to demean). |
+| `--ignore fmap-jacobian` | Don't apply Jacobian modulation of BOLD after SDC. |
+| `--force fmap-jacobian` | Force Jacobian modulation (defaults are auto per fieldmap type). |
+| `--fallback-total-readout-time` | Fallback TRT if metadata is missing. Number of seconds, or the string `"estimated"`. |
+
+---
+
+## BIDS fieldmap examples
+
+### PEPOLAR (recommended for new acquisitions)
+
+```
+sub-01/
+    ses-01/
+        fmap/
+            sub-01_ses-01_dir-AP_epi.nii.gz
+            sub-01_ses-01_dir-AP_epi.json
+            sub-01_ses-01_dir-PA_epi.nii.gz
+            sub-01_ses-01_dir-PA_epi.json
+```
+
+`sub-01_ses-01_dir-AP_epi.json`:
+```json
+{
+  "PhaseEncodingDirection": "j-",
+  "TotalReadoutTime": 0.03,
+  "B0FieldIdentifier": "TOPUP_PA_AP"
+}
+```
+
+`sub-01_ses-01_dir-PA_epi.json`:
+```json
+{
+  "PhaseEncodingDirection": "j",
+  "TotalReadoutTime": 0.03,
+  "B0FieldIdentifier": "TOPUP_PA_AP"
+}
+```
+
+Then every BOLD JSON in that session:
+```json
+{
+  "PhaseEncodingDirection": "j-",
+  "TotalReadoutTime": 0.03,
+  "B0FieldSource": "TOPUP_PA_AP",
+  "TaskName": "rest",
+  "RepetitionTime": 2.0
+}
+```
+
+### Phase-difference
+
+```
+sub-01/
+    ses-01/
+        fmap/
+            sub-01_ses-01_magnitude1.nii.gz
+            sub-01_ses-01_magnitude2.nii.gz
+            sub-01_ses-01_phasediff.nii.gz
+            sub-01_ses-01_phasediff.json
+```
+
+`sub-01_ses-01_phasediff.json`:
+```json
+{
+  "EchoTime1": 0.00492,
+  "EchoTime2": 0.00738,
+  "B0FieldIdentifier": "PHASE_DIFF"
+}
+```
+
+### Direct fieldmap in Hz
+
+```
+sub-01/fmap/
+    sub-01_fieldmap.nii.gz          # in Hz
+    sub-01_fieldmap.json            # includes Units:"Hz"
+    sub-01_magnitude.nii.gz
+```
+
+---
+
+## Troubleshooting
+
+### "SDCFlows could not compute a fieldmap"
+
+Common causes:
+- Missing `PhaseEncodingDirection` or `TotalReadoutTime` in BOLD or fieldmap
+  JSON. Add them — they're required by BIDS and by SDCFlows.
+- Both `B0FieldIdentifier` and `IntendedFor` are set inconsistently — pick
+  one strategy.
+- Phase-diff data is missing `EchoTime1`/`EchoTime2`.
+
+### "IntendedFor works standalone but stops working after adding another fieldmap"
+
+That other fieldmap almost certainly has a `B0FieldIdentifier` — SDCFlows
+switches to the new-style mechanism the moment *any* B0 identifier is present.
+Add `B0FieldIdentifier`/`B0FieldSource` everywhere, or remove them everywhere.
+
+### "TOPUP fails / bad output"
+
+- Confirm the two `dir-` EPIs are truly opposite (e.g., `AP` and `PA`).
+- Confirm both have the same acquisition parameters (matrix, resolution, TR).
+- Try `--fmap-bspline` if the field is noisy.
+
+### "SyN-SDC unwarping looks wrong"
+
+- Check `PhaseEncodingDirection` — is `j-` correct, or should it be `j`?
+  Flipping causes exactly-wrong displacement.
+- Check the SDC overlay in the visual report — it should look better, not
+  worse, than the uncorrected image.
+
+### "Fieldmap looks correct but BOLD is still distorted"
+
+- Confirm the fieldmap is actually paired to the BOLD (report should show the
+  fmap→BOLDref transform).
+- Try `--ignore fieldmaps` to confirm it's a fmap issue vs. something else.
+
+### `--ignore fieldmaps` — when to use
+
+Only for diagnosis. Never publish results from a run that ignored a fieldmap
+if a fieldmap was acquired — that's uncorrected geometric distortion.
+
+---
+
+## Outputs related to SDC
+
+**Estimated fieldmap** (if computed):
+- Stored in the working directory (not by default in derivatives).
+- Add `--debug fieldmaps` to expose intermediate fieldmap files.
+
+**BOLDref → fieldmap transform** (in `sub-XX/func/`):
+
+```
+# B0FieldIdentifier-based:
+sub-<label>_[specifiers]_from-boldref_to-TOPUP_PA_AP_mode-image_xfm.txt
+
+# IntendedFor-based (auto-generated ID):
+sub-<label>_[specifiers]_from-boldref_to-auto00001_mode-image_xfm.txt
+```
+
+**Corrected BOLD reference** (part of `--level minimal`):
+
+```
+sub-<label>_[specifiers]_desc-hmc_boldref.nii.gz
+sub-<label>_[specifiers]_desc-coreg_boldref.nii.gz    # after SDC + BBR
+```
+
+**Visual reportlet** — the SDC animation swipes before/after unwarping,
+overlaid on the target anatomical. Inspect for every run.
+
+---
+
+## Reading the report's SDC panel
+
+The per-run SDC panel shows:
+
+- **Before/after animation** — the corrected BOLD reference should match
+  anatomical structures better than the pre-corrected one, especially in
+  the OFC / temporal lobes.
+- **Fieldmap magnitude overlay** — verify the estimated field is smooth and
+  bounded (typical: ±100 Hz peak).
+- **Method identifier** — indicates which estimator ran (`TOPUP`, `PhaseDiff`,
+  `SyN`, etc.). If you expected `TOPUP` but got `SyN`, your fieldmap wasn't
+  paired correctly.

--- a/packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/references/spaces.md
+++ b/packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/references/spaces.md
@@ -1,0 +1,334 @@
+# Output Spaces & TemplateFlow
+
+`--output-spaces` controls where fMRIPrep resamples anatomical + BOLD
+derivatives. It accepts a **space-separated list** of tokens. Each token is:
+
+```
+<SPACE>[:cohort-<label>][:res-<idx>][:den-<idx>][:...]
+```
+
+## Table of Contents
+1. [Default behavior](#default-behavior)
+2. [Standard spaces (TemplateFlow)](#standard-spaces-templateflow)
+3. [Modifiers: `res-`, `cohort-`, `den-`, `atlas-`](#modifiers-res--cohort--den--atlas-)
+4. [Nonstandard spaces (`T1w`, `anat`, `fsnative`, `func`, ...)](#nonstandard-spaces-t1w-anat-fsnative-func-)
+5. [Surface spaces](#surface-spaces)
+6. [Custom templates](#custom-templates)
+7. [Implicit spaces required by other flags](#implicit-spaces-required-by-other-flags)
+8. [Pre-fetching templates (offline / HPC)](#pre-fetching-templates-offline--hpc)
+9. [Common recipes](#common-recipes)
+
+---
+
+## Default behavior
+
+If `--output-spaces` is omitted:
+
+```
+--output-spaces MNI152NLin2009cAsym:res-native
+```
+
+- `MNI152NLin2009cAsym` = MNI non-linear 2009c asymmetric — fMRIPrep's
+  internal reference.
+- `res-native` = keep the original BOLD grid rather than resample to a
+  template resolution.
+
+The bare invocation `--output-spaces` (no tokens) is meaningful: it disables
+BOLD resampling entirely. Only anatomical + transforms are written.
+
+Whatever you list, fMRIPrep also keeps at least the *internal* reference
+(`MNI152NLin2009cAsym`) even if it's not in the list — but that reference is
+NOT saved to derivatives unless you include it.
+
+---
+
+## Standard spaces (TemplateFlow)
+
+Bundled with the container (or fetched on demand). Common IDs:
+
+| Space | Description | Notes |
+|-------|-------------|-------|
+| `MNI152NLin2009cAsym` | MNI152 non-linear 2009c asymmetric — **fMRIPrep default** | Res 1 = 1 mm, res 2 = 2 mm |
+| `MNI152NLin6Asym` | FSL's MNI152 non-linear 6-generation asymmetric | Required for CIFTI output |
+| `MNI152NLin6Sym` | Symmetric version | Rare |
+| `MNI152Lin` | Linear MNI152 (SPM) | Legacy |
+| `OASIS30ANTs` | ANTs' Oxford Aging Study 30 | Skull-strip default |
+| `NKI` | Enhanced Nathan Kline Institute template | |
+| `PNC` | Philadelphia Neurodevelopmental Cohort | |
+| `MNIPediatricAsym` | Pediatric MNI, multi-cohort by age | Use `cohort-N` (see below) |
+| `MNIInfant` | Infant template, multi-cohort | Use `cohort-N` |
+| `UNCInfant` | UNC infant | Use `cohort-N` |
+| `fsLR` | HCP-style fsLR mesh (32k or 164k) | Surface only |
+| `fsaverage` | FreeSurfer average | Surface only (default den-10k = fsaverage5) |
+| `fsaverage5` | 10k mesh (legacy alias for `fsaverage:den-10k`) | Surface |
+| `fsaverage6` | 41k mesh (legacy alias for `fsaverage:den-41k`) | Surface |
+
+Full template catalog: https://www.templateflow.org
+
+Wrapper's built-in whitelist (`TF_TEMPLATES` in `wrapper/src/fmriprep_docker/__main__.py`):
+`MNI152Lin`, `MNI152NLin2009cAsym`, `MNI152NLin6Asym`, `MNI152NLin6Sym`,
+`MNIInfant`, `MNIPediatricAsym`, `NKI`, `OASIS30ANTs`, `PNC`, `UNCInfant`,
+`fsLR`, `fsaverage`, `fsaverage5`, `fsaverage6`.
+
+Anything outside this list is treated as a custom template by the wrapper — it
+must live in `$TEMPLATEFLOW_HOME` or be pointed to as a filesystem path (which
+the wrapper bind-mounts).
+
+---
+
+## Modifiers: `res-`, `cohort-`, `den-`, `atlas-`
+
+Colon-separated modifiers control which template variant / resolution is used
+for that entry. Modifiers may be combinatorial (multiple `res-`, multiple `cohort-`).
+
+### `res-<idx>`
+
+**Resolution INDEX in TemplateFlow — NOT millimeters.** Look up what each
+index means in the template's `template_description.json`.
+
+Common:
+- `MNI152NLin2009cAsym:res-1` → 1 mm
+- `MNI152NLin2009cAsym:res-2` → 2 mm
+- `MNI152NLin6Asym:res-2` → 2 mm
+- `MNI152NLin6Asym:res-3` → **0.5 mm** (not 3 mm!) — always verify
+
+Aliases:
+- `res-native` — keep the original BOLD grid (no template resampling).
+- `res-*` combined with another (e.g. `MNIPediatricAsym:res-native:res-1`) generates BOTH.
+
+### `cohort-<label>`
+
+Used by multi-cohort templates (pediatric, infant). Example:
+
+```
+--output-spaces MNIPediatricAsym:cohort-2:res-1
+```
+
+`cohort-2` for MNIPediatricAsym = prepuberty phase (4.5–8.5 y). See the
+template description JSON at
+https://github.com/templateflow/tpl-MNIPediatricAsym.
+
+Combinatorial: `MNIPediatricAsym:cohort-1:cohort-2:res-native:res-1` →
+4 variants (2 cohorts × 2 resolutions).
+
+### `den-<idx>` (surfaces only)
+
+Surface density. Common:
+
+- `fsaverage:den-10k` = fsaverage5 (10,242 vertices/hemi)
+- `fsaverage:den-41k` = fsaverage6 (40,962 vertices/hemi)
+- `fsaverage:den-164k` = full fsaverage (163,842 vertices/hemi)
+- `fsLR:den-32k` = HCP 32k mesh (default for CIFTI 91k output)
+- `fsLR:den-164k` = HCP 164k mesh
+
+Prefer the `den-` form over the legacy `fsaverageN` names.
+
+### `atlas-<label>` and others
+
+Some template variants come with an atlas modifier (e.g., HCP atlas). Rarely
+needed by end users.
+
+---
+
+## Nonstandard spaces (`T1w`, `anat`, `fsnative`, `func`, ...)
+
+Non-template outputs; **modifiers are NOT allowed** on these:
+
+| Token | Meaning | Output surface/volume? |
+|-------|---------|-----------------------|
+| `T1w` / `anat` | Subject's native anatomical (T1w) reference | Volume |
+| `fsnative` | FreeSurfer's subject-specific cortical mesh | Surface |
+| `func` / `bold` / `run` / `boldref` / `sbref` | Original BOLD grid, after STC/HMC/SDC | Volume (**experimental** — expected to change) |
+
+`T1w` and `anat` are aliases in current versions. `func` and friends are for
+downstream tools that want the corrected native-BOLD-grid data.
+
+---
+
+## Surface spaces
+
+- **`fsnative`** — subject's original cortical mesh (varies per subject).
+- **`fsaverage[:den-10k|41k|164k]`** — FreeSurfer's standard template.
+- **`fsLR[:den-32k|164k]`** — HCP-style mesh with aligned L/R hemispheres.
+
+CIFTI output requires `fsLR:den-32k` (91k) or `fsLR:den-91k`-equivalent (170k)
+internally; it's added automatically when `--cifti-output` is set.
+
+---
+
+## Custom templates
+
+### Via TemplateFlow home
+
+Put a directory named `tpl-<Name>/` under `$TEMPLATEFLOW_HOME`:
+
+```
+$TEMPLATEFLOW_HOME/
+    tpl-MyCustom/
+        template_description.json
+        tpl-MyCustom_res-1_T1w.nii.gz
+        tpl-MyCustom_res-1_desc-brain_mask.nii.gz
+        tpl-MyCustom_res-2_T1w.nii.gz
+        tpl-MyCustom_res-2_desc-brain_mask.nii.gz
+```
+
+Then reference it in `--output-spaces MyCustom:res-1`.
+
+Minimum required files:
+- `template_description.json` (identifies the template)
+- `tpl-<Name>_res-<idx>_T1w.nii.gz` (one per resolution)
+- `tpl-<Name>_res-<idx>_desc-brain_mask.nii.gz` (one per resolution)
+
+Full guide: https://www.templateflow.org/python-client/tutorials.html
+
+### Via filesystem path (wrapper only)
+
+```bash
+fmriprep-docker /data /out participant \
+    --output-spaces /home/me/tpl-MyCustom:res-1 \
+    -w /work
+```
+
+The wrapper bind-mounts `/home/me/tpl-MyCustom` into
+`/home/fmriprep/.cache/templateflow/tpl-MyCustom` inside the container and
+strips the `tpl-` prefix when passing the flag on.
+
+**Restriction**: custom template folders must be prefixed `tpl-` for the
+wrapper to accept them.
+
+---
+
+## Implicit spaces required by other flags
+
+Even if you don't list them, fMRIPrep will add these internally when needed:
+
+| Flag | Implicit space |
+|------|----------------|
+| Always | `MNI152NLin2009cAsym` (skull-strip fallback + reference frame) |
+| No `--skull-strip-template` override | `OASIS30ANTs` |
+| `--cifti-output` | `MNI152NLin6Asym` (for the CIFTI subcortical grid) |
+| `--use-syn-sdc` / `--force syn-sdc` | `MNI152NLin2009cAsym` (SyN prior) |
+
+Templates added implicitly are **not** saved to derivatives — you have to list
+them in `--output-spaces` to get outputs.
+
+---
+
+## Pre-fetching templates (offline / HPC)
+
+Compute nodes are often offline. TemplateFlow downloads templates on demand,
+so pre-populate the cache from a login node:
+
+```bash
+# One-time on a network-connected host
+export TEMPLATEFLOW_HOME=$HOME/.cache/templateflow
+python -m pip install --user templateflow
+
+python <<'EOF'
+from templateflow.api import get
+for tpl in [
+    "MNI152NLin2009cAsym",
+    "MNI152NLin6Asym",
+    "OASIS30ANTs",
+    "MNIPediatricAsym",
+    "MNIInfant",
+    "fsaverage",
+    "fsLR",
+]:
+    get(tpl)
+EOF
+```
+
+Or use the helper script bundled in the fMRIPrep repo:
+
+```bash
+wget https://raw.githubusercontent.com/nipreps/fmriprep/master/scripts/fetch_templates.py
+python fetch_templates.py --tf-dir /shared/templateflow
+```
+
+`fetch_templates.py` pulls:
+- `MNI152NLin2009cAsym` (T1w, T2w, brain mask, carpet dseg, fMRIPrep boldref, brain probseg — res 1 and 2)
+- `MNI152NLin6Asym` (T1w, brain mask, HCP atlas dseg — res 1 and 2)
+- `OASIS30ANTs` (T1w, WM/BS/brain probseg, brain mask, BrainCerebellumExtraction mask)
+- `fsaverage` (164k sphere, midthickness, sulc)
+- `fsLR` (32k density — sphere, midthickness, dparc, etc.)
+
+Then bind-mount into the container:
+
+```bash
+# Docker
+-v $HOME/.cache/templateflow:/home/fmriprep/.cache/templateflow
+
+# Apptainer
+-B $HOME/.cache/templateflow:/opt/templateflow --env TEMPLATEFLOW_HOME=/opt/templateflow
+```
+
+---
+
+## Common recipes
+
+### Only MNI, ready for group analysis in SPM/FSL
+
+```
+--output-spaces MNI152NLin2009cAsym:res-2
+```
+
+### Volumetric MNI + native anat for QC
+
+```
+--output-spaces MNI152NLin2009cAsym:res-2 anat
+```
+
+### Both MNI152NLin2009c (default) AND MNI152NLin6 (FSL/HCP compatible)
+
+```
+--output-spaces MNI152NLin2009cAsym:res-2 MNI152NLin6Asym:res-2
+```
+
+### HCP-style: surface + CIFTI
+
+```
+--output-spaces MNI152NLin6Asym:res-2 fsLR fsaverage:den-10k
+--cifti-output 91k
+```
+
+### Multi-resolution for method comparisons
+
+```
+--output-spaces \
+    MNI152NLin2009cAsym:res-1 MNI152NLin2009cAsym:res-2 MNI152NLin2009cAsym:res-native
+```
+
+### Pediatric study, multiple cohorts
+
+```
+--output-spaces MNIPediatricAsym:cohort-1:res-1 MNIPediatricAsym:cohort-2:res-1
+```
+
+### Infant study
+
+```
+--output-spaces MNIInfant:cohort-1:res-2 UNCInfant:cohort-1:res-2
+```
+
+### Surface-only (skip volumetric BOLD)
+
+```
+--output-spaces fsaverage:den-10k fsnative
+```
+
+### Absolutely no BOLD resampling (transforms and reports only)
+
+```
+--output-spaces
+```
+
+(pass the flag with no arguments — only anatomical outputs and transforms are saved)
+
+### Custom template alongside standard
+
+```
+--output-spaces MNI152NLin2009cAsym:res-2 MyLabTemplate:res-1
+```
+
+(with `MyLabTemplate` prepared under `$TEMPLATEFLOW_HOME/tpl-MyLabTemplate/`)

--- a/packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/references/troubleshooting-faq.md
+++ b/packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/references/troubleshooting-faq.md
@@ -1,0 +1,419 @@
+# FAQ & Troubleshooting
+
+Curated from the official fMRIPrep FAQ (`docs/faq.rst` in the repo) plus
+recurring issues on NeuroStars. Every entry is a specific symptom → fix.
+
+## Table of Contents
+1. [Should I QC my data before running fMRIPrep?](#should-i-qc-my-data-before-running-fmriprep)
+2. [Skull-stripped T1w input](#skull-stripped-t1w-input)
+3. [Hangs / `BrokenProcessPool` / OOM kills](#hangs--brokenprocesspool--oom-kills)
+4. [Reusing an existing `recon-all` output](#reusing-an-existing-recon-all-output)
+5. [`ERROR: it appears that recon-all is already running`](#error-it-appears-that-recon-all-is-already-running)
+6. [Race conditions running subjects in parallel](#race-conditions-running-subjects-in-parallel)
+7. [How much CPU / RAM to allocate?](#how-much-cpu--ram-to-allocate)
+8. [When to upgrade — and the "flagged versions" list](#when-to-upgrade--and-the-flagged-versions-list)
+9. [Apptainer / Singularity troubleshooting](#apptainer--singularity-troubleshooting)
+10. [What is TemplateFlow — and offline / HPC use](#what-is-templateflow--and-offline--hpc-use)
+11. [Selecting subsets of files with `--bids-filter-file`](#selecting-subsets-of-files-with---bids-filter-file)
+12. [Resume after a crash](#resume-after-a-crash)
+13. [Longitudinal / multi-session studies](#longitudinal--multi-session-studies)
+14. [Speed up large datasets](#speed-up-large-datasets)
+15. [`insufficient length of BOLD data after discarding nonsteady-states`](#insufficient-length-of-bold-data-after-discarding-nonsteady-states)
+16. [Container permission / user ID errors](#container-permission--user-id-errors)
+17. [Apple Silicon (arm64) Docker](#apple-silicon-arm64-docker)
+18. [The FreeSurfer license](#the-freesurfer-license)
+19. [Slice-timing shift in first-level modeling](#slice-timing-shift-in-first-level-modeling)
+20. [When to file a bug](#when-to-file-a-bug)
+
+---
+
+## Should I QC my data before running fMRIPrep?
+
+**Yes**, before any processing. Bad acquisitions (severe motion, wrap, ghosts,
+missing slices) waste hours of pipeline time and can crash fMRIPrep. Use
+**MRIQC** (also a NiPreps app) for automated per-subject QC of raw data:
+
+```bash
+docker run --rm -it -v /data:/data:ro -v /out:/out \
+    nipreps/mriqc:latest /data /out participant
+```
+
+Pre-specify exclusion criteria before looking at data (open-science hygiene).
+
+---
+
+## Skull-stripped T1w input
+
+If your dataset ships with already-brain-extracted T1w (some public datasets
+do), fMRIPrep will either fail at brain extraction or produce garbage
+downstream because it doesn't know what preprocessing was already applied.
+
+Options:
+- **Preferred**: revert to the original, defaced T1w.
+- If you must use pre-stripped data: `--skull-strip-t1w skip`. Document this
+  clearly in your methods — cross-subject preprocessing consistency is broken.
+- `--skull-strip-t1w auto` applies a heuristic. If it misfires either way,
+  fall back to `skip` or `force`.
+
+Related issues:
+[nipreps/smriprep#12](https://github.com/nipreps/smriprep/issues/12),
+[nipreps/fmriprep#939](https://github.com/nipreps/fmriprep/issues/939).
+
+---
+
+## Hangs / `BrokenProcessPool` / OOM kills
+
+Symptom: fMRIPrep hangs indefinitely, or crashes with `BrokenProcessPool`.
+
+Root cause: a Python bug in some Linux configurations triggers the OOM killer
+when the process pool exceeds available memory. Depending on what gets killed,
+the pool either crashes visibly or wedges.
+
+Fixes:
+1. **Allocate more RAM** — 16 GB is a comfortable single-subject baseline.
+2. **`--low-mem`** — trades RAM for disk in `-w`.
+3. **Reduce parallelism** — lower `--nthreads` and/or `--omp-nthreads`.
+4. **One subject per container** — never share `-w` across concurrent subjects.
+
+NeuroStars threads:
+- https://neurostars.org/t/memory-issue-when-processing-large-amount-of-data/2562
+- https://neurostars.org/t/how-much-ram-cpus-is-reasonable-to-run-pipelines-like-fmriprep/1086
+- https://neurostars.org/t/memory-allocation-issues-with-fmriprep-singularity-and-hpc/2759
+- https://neurostars.org/t/fmriprep-v1-0-12-hanging/1661
+
+---
+
+## Reusing an existing `recon-all` output
+
+Yes, if FreeSurfer ≥ 6.0.0 was used originally.
+
+**Option A** — put subjects in the default location:
+
+```
+<output_dir>/sourcedata/freesurfer/sub-01/    # bids layout
+<output_dir>/freesurfer/sub-01/                # legacy layout
+```
+
+fMRIPrep auto-detects and reuses; missing steps are completed.
+
+**Option B** — external subjects dir:
+
+```bash
+--fs-subjects-dir /shared/freesurfer_subjects
+```
+
+If your recon is complete (no need to resume), use `--fs-no-resume` (EXPERT).
+
+---
+
+## `ERROR: it appears that recon-all is already running`
+
+Symptom: FreeSurfer refuses to run because `IsRunning.lh+rh` or
+`IsRunning.{lh,rh}` files exist under
+`<output_dir>/sourcedata/freesurfer/sub-XX/scripts/`.
+
+Cause: previous `recon-all` was killed / died before it could clean up.
+
+Fix — after confirming no `recon-all` is actually running:
+
+```bash
+rm -f <output_dir>/sourcedata/freesurfer/sub-XX/scripts/IsRunning.*
+# then rerun fMRIPrep
+```
+
+Or add `-no-isrunning` to a manual `recon-all` invocation (fMRIPrep doesn't
+expose this, but you can pre-clean).
+
+Full FreeSurfer explanation:
+https://surfer.nmr.mgh.harvard.edu/fswiki/RunningFreeSurferInParallel
+
+---
+
+## Race conditions running subjects in parallel
+
+Symptom: `FileNotFoundError: [...]/logs/CITATION.md` or similar when running
+multiple subjects concurrently in **the same working dir**.
+
+Cause: multiple fMRIPrep processes writing to the same shared paths (usually
+the citations logs directory).
+
+Fix — **one working directory per subject, or one container per subject**.
+Recommended pattern (works on any cluster):
+
+```bash
+for sub in $(cat subject_list.txt); do
+    sbatch --export=ALL,SUBJECT=$sub run_fmriprep.sh
+done
+```
+
+with `run_fmriprep.sh` using `-w /scratch/$USER/work/sub-${SUBJECT}` and
+`--participant-label $SUBJECT`.
+
+Detailed workaround:
+https://neurostars.org/t/updated-fmriprep-workaround-for-running-subjects-in-parallel/6677
+
+---
+
+## How much CPU / RAM to allocate?
+
+Typical single-subject run (no FreeSurfer):
+- ~2 hours with 4 CPUs
+- ~1 hour with 16 CPUs
+- >16 CPUs shows *no further speedup* per subject
+
+RAM: **at least 8 GB**, 16 GB is comfortable. FreeSurfer recon adds ~4 GB.
+
+When running many subjects in parallel: `--omp-nthreads ≈ nCPU_per_subject`,
+and give each subject its own container.
+
+Reference benchmarks (Intel E5-2683 v4, 64 GB):
+`docs/_static/fmriprep_benchmark.svg`. Two subjects × 8 CPUs finishes about
+as fast as one subject × 16 CPUs but is easier to schedule on a cluster.
+
+---
+
+## When to upgrade — and the "flagged versions" list
+
+Rule: **process a whole study with the same fMRIPrep version + container
+build**. Don't upgrade mid-study.
+
+But: check `.versions.json` in the repo — flagged versions have known severe
+bugs (e.g., phase-difference fieldmap bug, fsLR resampling bug in 20.0.x,
+functional outputs orientation bug in 20.1.x/20.2.0/20.2.1). If your version
+is flagged, upgrade to a non-flagged patch release and reprocess.
+
+Live list:
+https://github.com/nipreps/fmriprep/blob/master/.versions.json
+
+Current LTS track: **25.2.x**, supported through October 2029. Prefer 25.2.x
+for new studies.
+
+---
+
+## Apptainer / Singularity troubleshooting
+
+Common issues:
+
+- **TemplateFlow can't write to cache** → point `TEMPLATEFLOW_HOME` at a
+  writeable path and bind-mount it:
+  `-B $HOME/.cache/templateflow:/opt/templateflow --env TEMPLATEFLOW_HOME=/opt/templateflow`
+- **FreeSurfer complains about license** with `--cleanenv` → pass
+  `--fs-license-file` explicitly, don't rely on `$FS_LICENSE`.
+- **"container immutable"** → run outside `--writable-tmpfs` needs; if you
+  see mount errors, add `--writable-tmpfs`.
+- **Slow first run** → templates being fetched. Pre-populate the cache.
+
+Full guide: https://www.nipreps.org/apps/singularity/
+
+---
+
+## What is TemplateFlow — and offline / HPC use
+
+TemplateFlow is the template registry (MNI152, fsLR, OASIS30ANTs, ...).
+Templates are fetched over HTTP on first use. On HPC compute nodes without
+Internet:
+
+```bash
+# On login node (with Internet):
+export TEMPLATEFLOW_HOME=$HOME/.cache/templateflow
+python -m pip install --user templateflow
+python -c "from templateflow.api import get; \
+  get(['MNI152NLin2009cAsym', 'MNI152NLin6Asym', 'OASIS30ANTs', \
+       'MNIPediatricAsym', 'MNIInfant'])"
+```
+
+Then bind-mount it in every job. Even Docker/Apptainer's baked-in cache is
+overridden by bind-mounts, ensuring you know exactly what template files are
+being used.
+
+The container ships with a pre-fetched cache at
+`/home/fmriprep/.cache/templateflow` — but relying on it only means you can't
+audit template versions unless you mount your own.
+
+Extra note: `--cifti-output` requires `MNI152NLin6Asym`; `--use-syn-sdc`
+requires `MNI152NLin2009cAsym`; default skull-strip requires `OASIS30ANTs`.
+
+---
+
+## Selecting subsets of files with `--bids-filter-file`
+
+See `references/bids-filter.md`. Quick note: metadata-based filtering (e.g.,
+"only runs with TR=2s") requires a `.bidsignore` file or a wrapper script —
+`--bids-filter-file` filters on **entities**, not on metadata content.
+
+---
+
+## Resume after a crash
+
+Yes — fMRIPrep is built on Nipype, which persists workflow state in the
+working directory. Point `-w` at the same path (default `./work/`) and re-run
+with the same arguments. Some nodes rerun unconditionally, but expensive
+steps (recon-all, ANTs registration) are cached.
+
+```bash
+# Original run crashed at 60%; just re-run:
+fmriprep-docker /data /out participant --participant-label 01 -w /data/work
+```
+
+Never wipe `-w` unless you want a clean rerun. If disk is tight, use
+`--clean-workdir` OR narrow scope with `--participant-label`.
+
+---
+
+## Longitudinal / multi-session studies
+
+Guiding assumption: fMRIPrep assumes no substantial anatomical change across
+sessions.
+
+- **Same-brain assumption OK** (adult, short study): use defaults
+  (`--subject-anatomical-reference first-lex`) or `unbiased` for
+  reg-quality-sensitive analyses.
+- **Post-surgery**: use ONLY pre-op sessions as anatomical inputs — filter with
+  `--bids-filter-file` to restrict `t1w` to specific sessions.
+- **Developing / elderly cohorts** (substantial atrophy): use
+  `--subject-anatomical-reference sessionwise` — each session gets its own
+  anat reference and FreeSurfer subject.
+
+NeuroStars long thread on the "anatomical fast-track" pattern:
+https://neurostars.org/t/fmriprep-how-to-reuse-longitudinal-and-pre-run-freesurfer/4585/15
+
+---
+
+## Speed up large datasets
+
+Options:
+
+1. **Pre-index the BIDS layout**:
+   ```bash
+   pybids layout /data/bids /data/bids_db --no-validate --index-metadata
+   ```
+   Then pass `--bids-database-dir /data/bids_db` — huge speedup for datasets
+   with thousands of files.
+
+2. **`--ignore`** — disable aspects of processing (fieldmaps, slicetiming,
+   sbref, t2w, flair, fmap-jacobian) at fMRIPrep level. Use `.bidsignore` at
+   the dataset root to exclude files from PyBIDS/bids-validator entirely.
+
+3. **`--level minimal`** — skip resampled outputs.
+
+4. **`--anat-only`** first, then per-session BOLD with `-d fmriprep=...`.
+
+5. **`--skip-bids-validation`** — only after you've validated once with
+   `bids-validator`.
+
+---
+
+## `insufficient length of BOLD data after discarding nonsteady-states`
+
+Symptom: AFNI `3dTShift` (STC) crashes because <5 volumes remain after
+non-steady-state removal.
+
+Root causes:
+- Very short BOLD run (fewer than ~8 volumes total).
+- Auto-detected non-steady-state count is unusually high (should be 0–5).
+
+Fixes:
+- `--dummy-scans N` — set explicitly (usually 0 or 4). Overrides auto-detection.
+- `--ignore slicetiming` — skip STC entirely if the series is really that short.
+
+Both settings apply to ALL runs in the invocation; use `--task-id` / `--session-label`
+/ `--bids-filter-file` to isolate the affected run if needed.
+
+---
+
+## Container permission / user ID errors
+
+Symptom on Linux: derivatives owned by `root:root` from Docker runs.
+
+Fix: run as your own UID/GID.
+
+```bash
+docker run --user "$(id -u):$(id -g)" ...
+# or with the wrapper:
+fmriprep-docker --user "$(id -u):$(id -g)" ...
+```
+
+Downside: the container's internal user (`fmriprep`) doesn't match, so `$HOME`
+inside is undefined. Bind-mount a writeable dir:
+
+```bash
+-v /some/writeable/dir:/home/fmriprep
+```
+
+Or use Apptainer, which runs as the invoking user by default.
+
+---
+
+## Apple Silicon (arm64) Docker
+
+The container is built only for `linux-64`. On M1/M2/M3 Macs run under Rosetta:
+
+```bash
+docker run --platform linux/amd64 --rm -it ... nipreps/fmriprep:25.2.5 ...
+```
+
+`fmriprep-docker` (the Python wrapper) does not expose a `--platform` flag.
+To force x86 emulation with the wrapper, set the Docker CLI's daemon-wide
+default platform beforehand:
+
+```bash
+export DOCKER_DEFAULT_PLATFORM=linux/amd64
+fmriprep-docker /data /out participant ...
+```
+
+Expect ~30% slowdown; some numerical steps may differ trivially due to x86
+emulation.
+
+---
+
+## The FreeSurfer license
+
+Register (free): https://surfer.nmr.mgh.harvard.edu/registration.html
+
+fMRIPrep looks for the license in this order:
+1. `--fs-license-file /path/to/license.txt`
+2. `$FS_LICENSE` env var
+3. `$FREESURFER_HOME/license.txt` (bare-metal fallback)
+
+**Even with `--fs-no-reconall`, you need the license** — some FreeSurfer
+utilities (mri_convert, mri_binarize) are used regardless.
+
+For Docker wrapper: `export FS_LICENSE=/path/to/license.txt` — auto-detected.
+For raw Docker: `-v /path/to/license.txt:/opt/freesurfer/license.txt:ro`.
+For Apptainer with `--cleanenv`: pass `--fs-license-file` explicitly.
+
+---
+
+## Slice-timing shift in first-level modeling
+
+Default `--slice-time-ref 0.5` shifts effective volume onsets by 0.5 TR.
+For TR=2s: original onsets [0, 2, 4, ...] → effective [1, 3, 5, ...].
+
+Options in first-level GLM:
+- Configure model to expect middle-slice reference (most packages support this).
+- Manually shift volume onsets forward by 0.5 TR, OR event onsets backward by
+  0.5 TR.
+- Set `--slice-time-ref 0` in fMRIPrep to keep original onsets (STC still runs,
+  but shifts everything to the START of TR).
+
+Deep dive:
+https://reproducibility.stanford.edu/slice-timing-correction-in-fmriprep-and-linear-modeling/
+
+---
+
+## When to file a bug
+
+Before opening an issue on GitHub:
+1. Update to the latest patch of the same minor version (e.g. 25.2.x).
+2. Check the flagged versions list (`.versions.json`).
+3. Search NeuroStars: https://neurostars.org/tag/fmriprep
+4. Check open + closed GitHub issues: https://github.com/nipreps/fmriprep/issues
+
+When filing:
+- fMRIPrep version + exec env (Docker, Apptainer, bare-metal, container tag).
+- Exact command line (redact PII).
+- Relevant log excerpts (stderr, `<output>/logs/`, crash files under `<output>/sub-XX/log/`).
+- A minimal reproducer if possible (subset of the dataset).
+
+Issue tracker: https://github.com/nipreps/fmriprep/issues
+Support forum (preferred for usage questions): https://neurostars.org/tag/fmriprep

--- a/packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/references/usage-examples.md
+++ b/packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/references/usage-examples.md
@@ -1,0 +1,465 @@
+# Usage Examples
+
+Copy-pasteable, real-world invocations. Every example assumes the current
+25.2.x LTS release; replace the version tag as needed.
+
+## Table of Contents
+1. [Minimal single-subject (Docker wrapper)](#1-minimal-single-subject-docker-wrapper)
+2. [Full-featured single-subject (bare Docker)](#2-full-featured-single-subject-bare-docker)
+3. [Apptainer / Singularity on HPC](#3-apptainer--singularity-on-hpc)
+4. [Batch: one job per subject with SLURM](#4-batch-one-job-per-subject-with-slurm)
+5. [Anatomical only (fast prep for later runs)](#5-anatomical-only-fast-prep-for-later-runs)
+6. [CIFTI / grayordinate output (HCP-style)](#6-cifti--grayordinate-output-hcp-style)
+7. [Multi-echo BOLD](#7-multi-echo-bold)
+8. [Fieldmap-less SDC (SyN)](#8-fieldmap-less-sdc-syn)
+9. [Reuse existing FreeSurfer recon](#9-reuse-existing-freesurfer-recon)
+10. [Reuse BIDS-Derivatives (partial reruns / meta-pipelines)](#10-reuse-bids-derivatives-partial-reruns--meta-pipelines)
+11. [Longitudinal / multi-session with unbiased template](#11-longitudinal--multi-session-with-unbiased-template)
+12. [Sessionwise processing (long developmental studies)](#12-sessionwise-processing-long-developmental-studies)
+13. [Select specific task/session/echo/subjects](#13-select-specific-tasksessionechosubjects)
+14. [Boilerplate-only run (methods paragraph)](#14-boilerplate-only-run-methods-paragraph)
+15. [Reports-only re-run](#15-reports-only-re-run)
+16. [Minimal-level output for large datasets](#16-minimal-level-output-for-large-datasets)
+17. [Debug / crash-on-first-error](#17-debug--crash-on-first-error)
+18. [Custom template via `--output-spaces`](#18-custom-template-via---output-spaces)
+19. [Pediatric / Infant cohorts](#19-pediatric--infant-cohorts)
+20. [Lesion cost-function masking (stroke / tumor)](#20-lesion-cost-function-masking-stroke--tumor)
+
+---
+
+## 1. Minimal single-subject (Docker wrapper)
+
+```bash
+export FS_LICENSE=$HOME/.licenses/freesurfer/license.txt
+
+fmriprep-docker /data/bids /data/derivatives participant \
+    --participant-label 01 \
+    -w /data/work
+```
+
+Everything else takes defaults: `MNI152NLin2009cAsym:res-native`, full-level
+outputs, auto CPU/thread selection, FS recon enabled.
+
+---
+
+## 2. Full-featured single-subject (bare Docker)
+
+```bash
+docker run --rm -it \
+    -v /data/bids:/data:ro \
+    -v /data/derivatives:/out \
+    -v /data/work:/scratch \
+    -v $HOME/.licenses/freesurfer/license.txt:/opt/freesurfer/license.txt:ro \
+    -v $HOME/.cache/templateflow:/home/fmriprep/.cache/templateflow \
+    --user "$(id -u):$(id -g)" \
+    nipreps/fmriprep:25.2.5 \
+    /data /out participant \
+    --participant-label 01 \
+    --output-spaces MNI152NLin2009cAsym:res-2 MNI152NLin6Asym:res-2 fsaverage:den-10k anat \
+    --cifti-output 91k \
+    --nthreads 16 --omp-nthreads 4 --mem 32000 \
+    --use-syn-sdc warn \
+    --fd-spike-threshold 0.5 --dvars-spike-threshold 1.5 \
+    --write-graph --stop-on-first-crash \
+    -w /scratch \
+    --skip-bids-validation
+```
+
+Notes: `--user` avoids root-owned files on Linux. Add `--platform linux/amd64`
+on Apple Silicon. `--skip-bids-validation` is fine only after you've validated
+the dataset once with `bids-validator`.
+
+---
+
+## 3. Apptainer / Singularity on HPC
+
+```bash
+# One-time: build .sif on a network-connected node
+apptainer build fmriprep-25.2.5.sif docker://nipreps/fmriprep:25.2.5
+
+# One-time: pre-fetch TemplateFlow on a login node
+python -m pip install --user templateflow
+python -c "from templateflow.api import get; \
+  get(['MNI152NLin2009cAsym','MNI152NLin6Asym','OASIS30ANTs','fsaverage','fsLR'])"
+```
+
+Then on a compute node:
+
+```bash
+apptainer run --cleanenv \
+    -B /scratch/user/bids:/data:ro \
+    -B /scratch/user/derivatives:/out \
+    -B /scratch/user/work:/work \
+    -B $HOME/.licenses/freesurfer/license.txt:/opt/freesurfer/license.txt:ro \
+    -B $HOME/.cache/templateflow:/opt/templateflow \
+    --env TEMPLATEFLOW_HOME=/opt/templateflow \
+    /shared/containers/fmriprep-25.2.5.sif \
+    /data /out participant \
+    --participant-label 01 \
+    --fs-license-file /opt/freesurfer/license.txt \
+    --output-spaces MNI152NLin2009cAsym:res-2 fsaverage:den-10k \
+    -w /work --nthreads 16 --omp-nthreads 4 --mem 32000
+```
+
+---
+
+## 4. Batch: one job per subject with SLURM
+
+This is the recommended parallelism pattern — one container per subject, each
+with its own `-w`. Multiple concurrent subjects in ONE container instance
+causes race conditions (see FAQ).
+
+`sbatch_fmriprep.slurm`:
+
+```bash
+#!/bin/bash
+#SBATCH --job-name=fmriprep
+#SBATCH --output=logs/fmriprep-%A_%a.out
+#SBATCH --error=logs/fmriprep-%A_%a.err
+#SBATCH --time=24:00:00
+#SBATCH --mem=32G
+#SBATCH --cpus-per-task=16
+#SBATCH --array=1-40                   # one array task per subject
+
+set -euo pipefail
+
+# List of subjects (no sub- prefix)
+SUBJECTS=($(cat subject_list.txt))
+SUBJECT=${SUBJECTS[$SLURM_ARRAY_TASK_ID-1]}
+
+BIDS=/scratch/user/bids
+OUT=/scratch/user/derivatives
+WORK=/scratch/user/work/sub-${SUBJECT}
+SIF=/shared/containers/fmriprep-25.2.5.sif
+FS_LICENSE=$HOME/.licenses/freesurfer/license.txt
+
+mkdir -p "$WORK"
+
+apptainer run --cleanenv \
+    -B "$BIDS":/data:ro \
+    -B "$OUT":/out \
+    -B "$WORK":/work \
+    -B "$FS_LICENSE":/opt/freesurfer/license.txt:ro \
+    -B $HOME/.cache/templateflow:/opt/templateflow \
+    --env TEMPLATEFLOW_HOME=/opt/templateflow \
+    "$SIF" \
+    /data /out participant \
+    --participant-label $SUBJECT \
+    --fs-license-file /opt/freesurfer/license.txt \
+    --output-spaces MNI152NLin2009cAsym:res-2 fsaverage:den-10k \
+    -w /work \
+    --nthreads ${SLURM_CPUS_PER_TASK} \
+    --omp-nthreads 4 \
+    --mem $((SLURM_MEM_PER_NODE - 2000))    # leave 2 GB headroom
+```
+
+Submit with `sbatch sbatch_fmriprep.slurm`.
+
+A canonical SLURM template also ships in the repo at `docs/_static/sbatch.slurm`.
+
+---
+
+## 5. Anatomical only (fast prep for later runs)
+
+```bash
+fmriprep /data/bids /data/derivatives participant \
+    --participant-label 01 \
+    --anat-only \
+    -w /data/work
+```
+
+Produces T1w-space brain mask, tissue seg, FreeSurfer recon, and MNI transforms
+— everything you need to re-run BOLD later with `--derivatives fmriprep=/data/derivatives`.
+
+---
+
+## 6. CIFTI / grayordinate output (HCP-style)
+
+```bash
+fmriprep-docker /data/bids /data/derivatives participant \
+    --participant-label 01 \
+    --output-spaces MNI152NLin6Asym:res-2 fsLR fsaverage:den-10k \
+    --cifti-output 91k \
+    --project-goodvoxels \
+    --medial-surface-nan \
+    -w /data/work
+```
+
+- `--cifti-output 91k` implies `MNI152NLin6Asym` internally (2 mm subcortical grid + fsLR 32k cortical mesh).
+- `--project-goodvoxels` masks voxels with locally high CoV during surface sampling.
+- `--medial-surface-nan` sets medial-wall vertices to NaN.
+
+Outputs include `sub-XX_task-XX_bold.dtseries.nii` (CIFTI-2 dense timeseries).
+
+---
+
+## 7. Multi-echo BOLD
+
+If your BIDS dataset has `sub-XX_task-YY_echo-1_bold.nii.gz`, `echo-2_bold.nii.gz`,
+etc. (≥3 echoes required as of 25.2.4):
+
+```bash
+fmriprep-docker /data/bids /data/derivatives participant \
+    --participant-label 01 \
+    --me-t2s-fit-method curvefit \
+    --me-output-echos \
+    --output-spaces MNI152NLin2009cAsym:res-2 \
+    -w /data/work
+```
+
+Effect:
+- `tedana` T2* map + optimally combined BOLD are produced automatically.
+- `--me-output-echos` also saves per-echo STC/HMC/SDC-corrected series for
+  downstream tedana denoising.
+- `--echo-idx N` (rarely used) restricts to a single echo.
+
+---
+
+## 8. Fieldmap-less SDC (SyN)
+
+When no fieldmap is available, ask fMRIPrep to compute SDC from the anatomical:
+
+```bash
+fmriprep-docker /data/bids /data/derivatives participant \
+    --participant-label 01 \
+    --use-syn-sdc error \
+    -w /data/work
+```
+
+- `--use-syn-sdc error` (default when the flag is present without arg) — fail if SyN cannot run.
+- `--use-syn-sdc warn` — proceed without SDC but log a warning.
+
+To ADD SyN-SDC on top of existing fieldmaps (for comparison / robustness):
+
+```bash
+--force syn-sdc
+```
+
+---
+
+## 9. Reuse existing FreeSurfer recon
+
+If `recon-all` was already run (FreeSurfer 6.0.0+ required):
+
+```bash
+# Option A: put subjects at the default location
+mkdir -p /data/derivatives/sourcedata/freesurfer
+cp -r /existing/fs_subjects/sub-01 /data/derivatives/sourcedata/freesurfer/
+
+fmriprep-docker /data/bids /data/derivatives participant \
+    --participant-label 01 \
+    -w /data/work
+
+# Option B: point to an external subjects dir
+fmriprep-docker /data/bids /data/derivatives participant \
+    --participant-label 01 \
+    --fs-subjects-dir /existing/fs_subjects \
+    -w /data/work
+```
+
+fMRIPrep completes any missing `recon-all` steps and skips completed ones.
+
+---
+
+## 10. Reuse BIDS-Derivatives (partial reruns / meta-pipelines)
+
+Since 23.2.0, `--derivatives` (or `-d`) lets fMRIPrep reuse any prior
+BIDS-Derivatives-compliant output. Useful for:
+- Running functional after a prior `--anat-only` run
+- Substituting a custom brain mask/segmentation
+- Splitting a huge dataset across multiple jobs
+
+```bash
+# Prior anat-only run at /data/derivatives_anat
+# Now run BOLD reusing it:
+fmriprep-docker /data/bids /data/derivatives_bold participant \
+    --participant-label 01 \
+    -d fmriprep=/data/derivatives_anat \
+    -w /data/work_bold
+```
+
+Multiple `-d` entries are allowed. Names are conventional (`smriprep`,
+`fmriprep`); the path is what matters.
+
+---
+
+## 11. Longitudinal / multi-session with unbiased template
+
+For 2 sessions where a shared anatomical reference is desired:
+
+```bash
+fmriprep-docker /data/bids /data/derivatives participant \
+    --participant-label 01 \
+    --subject-anatomical-reference unbiased \
+    --output-spaces MNI152NLin2009cAsym:res-2 anat \
+    -w /data/work
+```
+
+`unbiased` builds a mid-point T1w template across sessions; equivalent to the
+retired `--longitudinal` flag.
+
+---
+
+## 12. Sessionwise processing (long developmental studies)
+
+When brain morphometry evolves session-to-session (infant, adolescent, elderly):
+
+```bash
+fmriprep-docker /data/bids /data/derivatives participant \
+    --participant-label 01 \
+    --subject-anatomical-reference sessionwise \
+    -w /data/work
+```
+
+Each session gets its own anatomical reference and FreeSurfer subject.
+
+---
+
+## 13. Select specific task/session/echo/subjects
+
+Restrict scope for testing or batching:
+
+```bash
+fmriprep-docker /data/bids /data/derivatives participant \
+    --participant-label 01 02 05 \
+    --session-label baseline followup \
+    --task-id rest \
+    --echo-idx 2 \
+    -w /data/work
+```
+
+For anything finer — filtering on `acq-`, `run-`, `dir-`, `reconstruction-` —
+use `--bids-filter-file`; see `references/bids-filter.md`.
+
+---
+
+## 14. Boilerplate-only run (methods paragraph)
+
+Emit the auto-generated methods text without running any workflow steps:
+
+```bash
+fmriprep /data/bids /data/derivatives participant \
+    --participant-label 01 \
+    --boilerplate-only
+```
+
+Result lands in `output_dir/logs/CITATION.{md,html,tex}`.
+
+---
+
+## 15. Reports-only re-run
+
+After a completed (or partial) run, regenerate the HTML report without redoing
+computation. Requires the same `-w` from the original run.
+
+```bash
+fmriprep /data/bids /data/derivatives participant \
+    --participant-label 01 \
+    --reports-only \
+    -w /data/work
+```
+
+---
+
+## 16. Minimal-level output for large datasets
+
+Save disk by generating only essentials (transforms + reports).
+
+```bash
+fmriprep-docker /data/bids /data/derivatives participant \
+    --participant-label 01 \
+    --level minimal \
+    -w /data/work
+```
+
+Then later resample where needed with `--level resampling` or `--level full`
+plus `-d fmriprep=/data/derivatives`.
+
+---
+
+## 17. Debug / crash-on-first-error
+
+For CI or triage:
+
+```bash
+fmriprep-docker /data/bids /data/derivatives participant \
+    --participant-label 01 \
+    --stop-on-first-crash \
+    -vvv \
+    --debug all \
+    --resource-monitor \
+    -w /data/work
+```
+
+`--debug pdb` drops into pdb on the first crash (only useful bare-metal or with
+an interactive container).
+
+---
+
+## 18. Custom template via `--output-spaces`
+
+Put your template folder in `$TEMPLATEFLOW_HOME`:
+
+```
+$TEMPLATEFLOW_HOME/tpl-MyCustom/
+    template_description.json
+    tpl-MyCustom_res-1_T1w.nii.gz
+    tpl-MyCustom_res-1_desc-brain_mask.nii.gz
+```
+
+Then reference it:
+
+```bash
+fmriprep-docker /data/bids /data/derivatives participant \
+    --output-spaces MyCustom:res-1 \
+    -w /data/work
+```
+
+With the wrapper you can also pass a filesystem path (the wrapper bind-mounts
+it into the TemplateFlow cache):
+
+```bash
+fmriprep-docker /data/bids /data/derivatives participant \
+    --output-spaces /path/to/tpl-MyCustom:res-1 \
+    -w /data/work
+```
+
+---
+
+## 19. Pediatric / Infant cohorts
+
+Use a cohort-aware template:
+
+```bash
+# Prepubertal children (4.5–8.5 y)
+--output-spaces MNIPediatricAsym:cohort-2:res-1
+
+# Infant
+--output-spaces MNIInfant:cohort-1:res-2
+```
+
+Full cohort tables: https://github.com/templateflow/tpl-MNIPediatricAsym /
+https://github.com/templateflow/tpl-MNIInfant
+
+Cohorts are combinatorial: `--output-spaces MNIPediatricAsym:cohort-1:cohort-2:res-native:res-1`
+produces four variants (2 cohorts × 2 resolutions).
+
+---
+
+## 20. Lesion cost-function masking (stroke / tumor)
+
+1. Place a binary mask in `sub-XX/anat/sub-XX_label-lesion_roi.nii.gz`
+   (1 = lesion, 0 = healthy, same grid as T1w).
+2. Add `*lesion_roi.nii.gz` to `.bidsignore` in the dataset root
+   (until BIDS accepts the entity natively).
+3. Run fMRIPrep normally — spatial normalization automatically uses the mask
+   to avoid warping healthy tissue into the lesion.
+
+```bash
+fmriprep-docker /data/bids /data/derivatives participant \
+    --participant-label 01 \
+    -w /data/work
+```
+
+The BIDS-Derivatives-recommended location (`manual_masks/sub-01/anat/sub-01_desc-tumor_mask.nii.gz`)
+will be honored in an upcoming version.

--- a/packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/references/versions-dependencies.md
+++ b/packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/references/versions-dependencies.md
@@ -1,0 +1,228 @@
+# Version & Dependency Reference
+
+Verified against the 25.2.x LTS source tree (`pyproject.toml`, `Dockerfile`,
+`Dockerfile.base`, `.versions.json`, `pixi.lock`).
+
+## Table of Contents
+1. [Current release status](#current-release-status)
+2. [Neuroimaging binary dependencies (container pins)](#neuroimaging-binary-dependencies-container-pins)
+3. [Python runtime dependencies](#python-runtime-dependencies)
+4. [Optional Python dependencies (pip extras)](#optional-python-dependencies-pip-extras)
+5. [Base OS + toolchain](#base-os--toolchain)
+6. [Container base image](#container-base-image)
+7. [Flagged / broken versions to AVOID](#flagged--broken-versions-to-avoid)
+8. [Release cadence & LTS policy](#release-cadence--lts-policy)
+
+---
+
+## Current release status
+
+- **Latest release (this snapshot)**: **25.2.5** (2026-03-10)
+- **Support track**: **25.2.x — LTS** through **October 2029** (announced with 25.2.0 on 2025-10-01).
+- **License**: Apache-2.0 (since 21.0.x pre-release; pre-21.0 was BSD-3-Clause).
+- **RRID**: SCR_016216
+- **Python required**: 3.10 – 3.13 (container uses **3.12**)
+- **Version scheme**: `nipreps-calver` (calendar-based; `YY.M.PATCH`).
+- **Repo**: https://github.com/nipreps/fmriprep
+
+Recent releases (from `CHANGES.rst`):
+
+| Version | Date | Type |
+|---------|------|------|
+| 25.2.5 | 2026-03-10 | Bug-fix (restores `--no-track-sessions` compatibility) |
+| 25.2.4 | 2026-01-14 | Bug-fix (multi-echo + multi-session fixes; rejects 2-echo data) |
+| 25.2.3 | 2025-10-17 | Bug-fix (PyBIDS/universal-pathlib compat) |
+| 25.2.2 | 2025-10-06 | Bug-fix (Perl install in container) |
+| 25.2.1 | 2025-10-03 | Bug-fix (multi-anat session summary) |
+| 25.2.0 | 2025-10-01 | **LTS entry release**; per-session processing; grid-constant interpolation default |
+| 25.1.x | 2025 | Prior stable series |
+| 24.1.x | 2024 | Prior LTS series (support ended) |
+| 23.2.0 | ~2024 | Introduced `--level` and `--derivatives` |
+| 21.0.x | 2022 | Switch to Apache-2.0; BIDS-Derivatives output layout default; dropped ICA-AROMA |
+
+---
+
+## Neuroimaging binary dependencies (container pins)
+
+The container is the authoritative reference; bare-metal users should try to
+match these pins.
+
+| Tool | Version (25.2.x container) | Purpose |
+|------|-----------------------------|---------|
+| **FreeSurfer** | **7.3.2** | Surface reconstruction, `bbregister`, `mri_robust_template`, `aseg`, etc. |
+| **FSL** | **6.0.7.7** (via `fsl-{bet2 2111.8.*, flirt 2111.4.*, fast4 2111.3.*, fugue 2201.5.*, mcflirt 2111.0.*, miscmaths 2412.4.*, topup 2203.5.*}` conda packages from fslconda) | HMC (mcflirt), tissue seg (FAST), fieldmap unwarping (fugue/topup), BBR fallback (flirt) |
+| **ANTs** | **2.5.1** documented; container installs **2.6.* via conda** | Registration, N4 bias correction, `antsBrainExtraction.sh` |
+| **AFNI** | **25.2.09** (only `3dvolreg`, `3dTshift`, `3dUnifize`, `3dAutomask` shipped) | Slice-timing (3dTShift) and reference-image tools |
+| **Connectome Workbench (`wb_command`)** | **≥1.5.0** documented; container uses **2.0.\* qt6\*** | CIFTI I/O, surface resampling to fsLR |
+| **MSM (HOCR)** | Nov 19, 2019 release | Multimodal Surface Matching for fsLR alignment |
+| **bids-validator** | **1.14.10** | Input dataset validation |
+| **Python** | **3.12.\*** | Runtime |
+| **Node.js** | **20.\*** | Required by bids-validator + svgo |
+| **svgo** | **≥3.2.0** | Report SVG optimization |
+| **pandoc** | **3.7.\*** | Citation boilerplate rendering |
+| **graphviz** | **12.2.\*** | Workflow graph rendering (`--write-graph`) |
+| **MKL** | **2024.2.2.\*** + mkl-service 2.4.2.\* | Numerical linear algebra |
+
+Scientific Python stack pins (container):
+
+- `numpy 2.2.*` (dependency overrides to ≥2.2)
+- `scipy 1.15.*`
+- `matplotlib 3.10.*`
+- `pandas 2.2.*`
+- `h5py 3.13.*`
+- `nitime 0.11.*`
+- `scikit-image 0.25.*`
+- `scikit-learn 1.6.*`
+
+---
+
+## Python runtime dependencies
+
+From `pyproject.toml` — required to install fMRIPrep:
+
+| Package | Minimum version |
+|---------|-----------------|
+| `acres` | ≥0.2.0 |
+| `looseversion` | ≥1.3 |
+| `nibabel` | ≥5.1.1 |
+| `nipype` | ≥1.9.0 |
+| `nireports` | ≥24.1.0 |
+| `nitime` | ≥0.9 |
+| `nitransforms` | ≥25.0.1 |
+| `niworkflows` | ≥1.14.4 |
+| `numpy` | ≥2.0 |
+| `packaging` | ≥24 |
+| `pandas` | ≥2.2 |
+| `psutil` | ≥5.4 |
+| `pybids` | ≥0.16 |
+| `requests` | ≥2.27 |
+| `sdcflows` | ≥2.15.0 |
+| `smriprep` | ≥0.19.2 |
+| `tedana` | ≥25.1.0 |
+| `templateflow` | ≥24.2.2 |
+| `transforms3d` | ≥0.4.2 |
+| `toml` | ≥0.10 |
+| `codecarbon` | ≥2 |
+| `APScheduler` | ≥3.10 |
+
+### NiPreps sibling packages (developed together)
+
+| Package | Role | Repo |
+|---------|------|------|
+| `niworkflows` | Shared Nipype interfaces and utility workflows | https://github.com/nipreps/niworkflows |
+| `smriprep` | Anatomical (T1w/T2w) preprocessing sub-workflow | https://github.com/nipreps/smriprep |
+| `sdcflows` | Susceptibility-distortion correction | https://github.com/nipreps/sdcflows |
+| `nireports` | HTML report generation + reportlets | https://github.com/nipreps/nireports |
+| `nitransforms` | ITK/ANTs/FreeSurfer transform I/O and application | https://github.com/nipreps/nitransforms |
+| `templateflow` | Template registry / fetcher | https://github.com/templateflow/templateflow |
+| `tedana` | Multi-echo T2* fitting + denoising | https://github.com/ME-ICA/tedana |
+
+Updating any of these can change fMRIPrep behavior — pin all NiPreps
+dependencies to the versions the fMRIPrep release constraints (or use the
+container).
+
+---
+
+## Optional Python dependencies (pip extras)
+
+Install with `pip install "fmriprep[<extra>]"`:
+
+| Extra | Adds | Use |
+|-------|------|-----|
+| `doc` / `docs` | `pydot`, `sphinx≥5`, `sphinx-argparse`, `sphinx_rtd_theme` | Building the docs |
+| `dev` | `ruff`, `pre-commit` | Development |
+| `test` / `tests` | `coverage`, `pytest≥8.1`, `pytest-cov`, `pytest-env`, `pytest-xdist` | Test suite |
+| `duecredit` | `duecredit` | Citation tracking |
+| `resmon` | (marker) | Resource-monitor extras |
+| `container` | `datalad`, `datalad-osf` (+ `[telemetry]`) | Extras bundled in container |
+| `telemetry` | `migas≥0.4.0`, `sentry-sdk≥1.3` | Crash reporting |
+| `maint` | `fuzzywuzzy`, `python-Levenshtein` | Maintenance tools |
+| `all` | `[doc,maint,telemetry,test]` | Everything |
+
+---
+
+## Base OS + toolchain
+
+- **Base OS**: Ubuntu 22.04 LTS (`ubuntu:jammy-20250730`)
+- **Container backend**: `ghcr.io/prefix-dev/pixi:0.53.0` for dependency resolution
+- **Environment manager**: `pixi` with conda-forge + fslconda channels
+- **Base image build date** (BASE_IMAGE tag): `ghcr.io/nipreps/fmriprep-base:20251006`
+- **Templates**: pre-populated `TEMPLATEFLOW_HOME=/templateflow` (see `scripts/fetch_templates.py`)
+
+Key env vars set inside the container:
+- `PATH="/app/.pixi/envs/fmriprep/bin:$PATH"`
+- `FSLDIR="/app/.pixi/envs/fmriprep"`
+- `FSLOUTPUTTYPE="NIFTI_GZ"`
+- `FREESURFER_HOME="/opt/freesurfer"`
+- `SUBJECTS_DIR="$FREESURFER_HOME/subjects"`
+- `MKL_NUM_THREADS=1`, `OMP_NUM_THREADS=1` (Nipype handles parallelism)
+- `IS_DOCKER_8395080871=1` (marker for detecting containerized execution)
+- `PYTHONNOUSERSITE=1`
+- `ENTRYPOINT ["/app/.pixi/envs/fmriprep/bin/fmriprep"]`
+
+---
+
+## Container base image
+
+- **Registry**: `nipreps/fmriprep` on Docker Hub
+- **Tags**: `nipreps/fmriprep:25.2.5`, `nipreps/fmriprep:latest`, plus historical release tags
+- **Signed & CI-built**: via GitHub Actions from tagged releases
+- **Base image**: `ghcr.io/nipreps/fmriprep-base:<date>` (rebuilt when neuroimaging deps change)
+- **Includes** at container build time:
+  - FreeSurfer 7.3.2 (excludes non-x86 subdirs via `docker/files/freesurfer7.3.2-exclude.txt`)
+  - MSM HOCR (Nov 2019 GitHub release)
+  - AFNI binaries copied from `afni/afni_make_build:AFNI_25.2.09`
+
+Image extraction reference:
+
+```bash
+docker create --name tmp nipreps/fmriprep:25.2.5
+docker cp tmp:/opt/freesurfer/VERSION -   # confirm FS version
+docker rm tmp
+```
+
+Or peek inside:
+
+```bash
+docker run --rm --entrypoint bash nipreps/fmriprep:25.2.5 -c \
+    'cat /opt/freesurfer/VERSION; flirt -version; antsRegistration --version; wb_command -version'
+```
+
+---
+
+## Flagged / broken versions to AVOID
+
+The following versions have known severe bugs (from `.versions.json`). Do NOT
+publish results processed with them; upgrade to a non-flagged patch.
+
+| Version range | Bug |
+|---------------|-----|
+| 1.0.0 | Deprecated / too old |
+| 1.0.1 – 20.0.5 (many) | Phase-difference fieldmap bug (some also had Nipype instability at 1.5.x) |
+| 20.0.0rc1 – 20.0.2 | fsLR resampling error when `--cifti-output` was used |
+| 20.1.0 – 20.2.1 | Functional outputs in standard space can be wrong depending on orientation headers (see [issue #2307](https://github.com/nipreps/fmriprep/issues/2307)) |
+
+Live authoritative list:
+https://github.com/nipreps/fmriprep/blob/master/.versions.json
+
+fMRIPrep prints a warning at run start if the running version is flagged.
+
+---
+
+## Release cadence & LTS policy
+
+- **Major/minor releases** on the NiPreps calendar (CalVer `YY.M`), roughly
+  a few per year.
+- **Patch releases** for bug fixes, targeted at each active minor.
+- **LTS releases** (announced explicitly) get **4 years** of bug-fix support.
+  - Current LTS: **25.2.x** (through Oct 2029).
+  - Previous LTS: 24.1.x (support ended per 25.2.x announcement).
+
+**For a study**: pick an LTS at the start; do not upgrade mid-study.
+
+**For method comparison studies**: pin the exact container tag *and* the
+`TEMPLATEFLOW_HOME` snapshot — even minor template updates can change results
+subtly.
+
+Release notes for every version live in `CHANGES.rst` in the repo and on
+https://fmriprep.readthedocs.io/en/latest/changes.html.

--- a/packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/references/workflows.md
+++ b/packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/references/workflows.md
@@ -1,0 +1,392 @@
+# Workflow Internals
+
+The fMRIPrep pipeline is a Nipype workflow graph. This reference maps each
+stage to its Python entry point (so you can read the source) and describes
+the algorithms in enough depth to write a methods section or troubleshoot a
+node failure.
+
+Source root: `fmriprep/workflows/` — `base.py` (top-level), `bold/` (BOLD
+per-run subworkflows). Anatomical workflows live in `smriprep` (sister package),
+distortion-correction in `sdcflows`, common utilities in `niworkflows`.
+
+## Table of Contents
+1. [Top-level flow](#1-top-level-flow)
+2. [Anatomical pipeline](#2-anatomical-pipeline)
+3. [BOLD pipeline overview (fit vs apply)](#3-bold-pipeline-overview-fit-vs-apply)
+4. [BOLD reference-image estimation](#4-bold-reference-image-estimation)
+5. [Head-motion correction (HMC)](#5-head-motion-correction-hmc)
+6. [Slice-timing correction (STC)](#6-slice-timing-correction-stc)
+7. [Susceptibility distortion correction (SDC)](#7-susceptibility-distortion-correction-sdc)
+8. [Pre-processed BOLD in native space](#8-pre-processed-bold-in-native-space)
+9. [EPI-to-T1w registration (BBR)](#9-epi-to-t1w-registration-bbr)
+10. [Resampling to standard/native volumetric spaces](#10-resampling-to-standardnative-volumetric-spaces)
+11. [Surface sampling (FreeSurfer)](#11-surface-sampling-freesurfer)
+12. [HCP grayordinates / CIFTI-2](#12-hcp-grayordinates--cifti-2)
+13. [T2*-driven multi-echo combination](#13-t2-driven-multi-echo-combination)
+14. [Confounds estimation](#14-confounds-estimation)
+15. [Reports (nireports)](#15-reports-nireports)
+16. [Processing levels (`--level`)](#16-processing-levels---level)
+
+---
+
+## 1. Top-level flow
+
+```
+init_fmriprep_wf                    (per-run entry)
+ └─ init_single_subject_wf          (fmriprep/workflows/base.py)
+     ├─ init_anat_preproc_wf        (smriprep.workflows.anatomical)
+     ├─ init_bold_wf                (fmriprep/workflows/bold/base.py)  ── one per BOLD run
+     │   ├─ init_bold_fit_wf        (fmriprep/workflows/bold/fit.py)
+     │   ├─ init_bold_native_wf     (fmriprep/workflows/bold/fit.py)
+     │   ├─ init_bold_volumetric_resample_wf   (fmriprep/workflows/bold/apply.py)
+     │   ├─ init_bold_surf_wf                  (fmriprep/workflows/bold/resampling.py)
+     │   ├─ init_bold_fsLR_resampling_wf       (fmriprep/workflows/bold/resampling.py)
+     │   └─ init_bold_confs_wf                 (fmriprep/workflows/bold/confounds.py)
+     └─ ds_report_* nodes → visual report reportlets
+```
+
+Workflow naming conventions:
+- Names end in `_wf`, built by `init_<name>_wf` functions.
+- `inputnode` / `outputnode` = workflow "arguments"/"returns".
+- `ds_*` nodes write to `<output_dir>/`; `ds_report_*` write reportlets.
+- Node/label paths in the graph include `(module)` markers referencing where the
+  interface is defined (e.g. `about (reports)`).
+
+---
+
+## 2. Anatomical pipeline
+*Entry: `smriprep.workflows.anatomical.init_anat_preproc_wf`*
+
+Steps (in order):
+
+1. **Conform + average T1w** — reorient to RAS, resample to common voxel size,
+   optionally average (or unbiased-template) multiple T1w runs.
+   - `--subject-anatomical-reference first-lex` (default): register to first (lex) image.
+   - `--subject-anatomical-reference unbiased`: `mri_robust_template` unbiased template.
+   - `--subject-anatomical-reference sessionwise`: independent per session.
+
+2. **T2w merge/coregistration** — if T2w available, aligned to T1w space. Used
+   downstream by FreeSurfer for pial refinement.
+
+3. **N4 bias-field correction** — ANTs `N4BiasFieldCorrection`.
+
+4. **Skull-stripping** — Nipype implementation of `antsBrainExtraction.sh` on
+   OASIS30ANTs template (or `--skull-strip-template ...`).
+   - `--skull-strip-t1w force` (default) always strips.
+   - `--skull-strip-t1w auto` uses a heuristic to detect pre-stripped inputs.
+   - `--skull-strip-t1w skip` bypasses stripping entirely.
+
+5. **Tissue segmentation** — FSL `FAST` produces 3-class (CSF/GM/WM) probability
+   maps and a discrete segmentation.
+
+6. **Spatial normalization** — ANTs `antsRegistration` multi-scale mutual-info
+   nonlinear registration to every requested standard space
+   (`--output-spaces MNI152NLin2009cAsym`, etc.). Produces `.h5` composite
+   transforms both directions.
+
+7. **Optional lesion cost-function masking** — if
+   `sub-XX/anat/sub-XX_label-lesion_roi.nii.gz` exists, ANTs uses it to avoid
+   warping healthy tissue into damage (Brett et al. 2001).
+
+8. **Surface reconstruction** — FreeSurfer `recon-all`, three phases:
+   - Phase 1: `autorecon1 -noskullstrip` — brain mask from step 4 is injected.
+   - Phase 2: import brainmask.
+   - Phase 3: resume, using T2w/FLAIR for pial refinement when available.
+   - Submillimeter recon triggered automatically if voxels <1 mm, unless
+     `--no-submm-recon`. Disable entirely with `--fs-no-reconall`.
+   - Reused if outputs already exist in `<output>/sourcedata/freesurfer/sub-XX`.
+
+9. **MSMSulc surface registration** — Multimodal Surface Matching (MSM) using
+   sulcal depth to register subject spheres to `fsLR` (HCP convention).
+   Disable with `--no-msm`.
+
+10. **Brain-mask refinement** — When FreeSurfer runs, replace the ANTs-derived
+    mask with one derived from `mri/aseg.mgz` (better inclusion of deep-brain
+    structures).
+
+11. **Cortical thickness / curvature / sulcal-depth conversion** — GIFTI shape
+    files plus fsLR-32k CIFTI dscalar summaries.
+
+12. **Outputs** — see `references/outputs.md` for the full naming schema.
+
+---
+
+## 3. BOLD pipeline overview (fit vs apply)
+*Entry: `fmriprep/workflows/bold/base.py :: init_bold_wf`*
+
+Since 23.2.0 the BOLD workflow is split for clarity and to enable `--level`
+partial runs:
+
+```
+BOLD series ──▶ init_bold_fit_wf ──▶ init_bold_native_wf ──▶ init_bold_volumetric_resample_wf
+                                                          └▶ init_bold_surf_wf
+                                                          └▶ init_bold_fsLR_resampling_wf
+                                                          └▶ init_bold_confs_wf
+```
+
+- **`bold_fit_wf`** (`fit.py`) — resolves all transforms without saving heavy
+  intermediate BOLD data. Outputs reference images, HMC transforms, BBR transform,
+  and (when applicable) the fieldmap→BOLDref transform.
+- **`bold_native_wf`** (`fit.py`) — applies STC and HMC/SDC in native BOLD space.
+  This is the input to all downstream resamplers.
+- **`bold_volumetric_resample_wf`** (`apply.py`) — resamples native BOLD into
+  each `--output-spaces` template space.
+- **`bold_surf_wf`** / **`bold_fsLR_resampling_wf`** — surface / CIFTI paths.
+- **`bold_confs_wf`** (`confounds.py`) — confounds table.
+
+At `--level minimal`, only transforms and refs are saved; the resamplers still
+run internally when needed for QC plots but their outputs are discarded.
+
+---
+
+## 4. BOLD reference-image estimation
+*Entry: `fmriprep/workflows/bold/reference.py :: init_raw_boldref_wf`*
+
+Chooses a per-run reference volume:
+
+- If T1-saturation "dummy scans" are detected (non-steady-state), they are
+  averaged (superior tissue contrast).
+- Otherwise, median of a motion-corrected volume subset.
+
+For BBR registration a distinct reference is used:
+- Prefers a single-band reference (`sbref`) if the dataset provides one.
+- Contrast-enhanced and skull-stripped via
+  `niworkflows.func.util.init_enhance_and_skullstrip_bold_wf`.
+- If fieldmaps present, the stripped reference is SDC-corrected before BBR.
+
+Number of non-steady-state volumes: auto-detected unless `--dummy-scans N`
+forces it.
+
+---
+
+## 5. Head-motion correction (HMC)
+*Entry: `fmriprep/workflows/bold/hmc.py :: init_bold_hmc_wf`*
+
+- Tool: FSL `mcflirt`.
+- Reference: BOLD reference from §4.
+- Motion **parameters are estimated on the raw (un-STC) BOLD** so that
+  slice-timing interpolation does not alias motion into the estimates
+  (Power 2017 recommendation). The motion transforms are then applied jointly
+  with STC and SDC downstream (single-interpolation resampling).
+- Emits:
+  - 6-parameter rigid transforms per volume (`trans_x/y/z`, `rot_x/y/z`).
+  - `framewise_displacement`, `rmsd` — pushed to the confounds workflow.
+  - `hmc_boldref` (aligned template) — pushed to BBR.
+
+---
+
+## 6. Slice-timing correction (STC)
+*Entry: `fmriprep/workflows/bold/stc.py :: init_bold_stc_wf`*
+
+- Tool: AFNI `3dTShift`.
+- **Only runs** if `SliceTiming` metadata is present AND ≥5 usable (post-dummy)
+  volumes exist.
+- Reference slice controlled by `--slice-time-ref` (default `0.5` = middle):
+  - `0` / `start` — TR onset (matches raw acquisition; no volume onset shift)
+  - `0.5` / `middle` — middle of TR (default; shifts volume onsets by 0.5 TR
+    — remember to adjust your first-level model)
+  - `1` — end of TR
+- Disable with `--ignore slicetiming`.
+
+STC is applied to the raw (validated) BOLD *before* HMC/SDC transforms are
+applied — HMC/SDC transforms are then composed and applied together in a
+single interpolation step (see §8 / §10). This ordering (STC on raw data →
+HMC/SDC on STC-corrected data) is why HMC motion *parameters* are estimated
+on the un-STC data in §5.
+
+---
+
+## 7. Susceptibility distortion correction (SDC)
+*Delegated to the `sdcflows` package (`sdcflows.workflows.*`).*
+See `references/sdc-fieldmaps.md` for user-facing SDC guidance.
+
+Supported estimators (auto-selected from BIDS metadata):
+
+| BIDS fieldmap type | Estimator | Notes |
+|--------------------|-----------|-------|
+| **PEPOLAR** (opposite phase-encoding EPI) | TOPUP-based | Preferred when available |
+| **Phase-difference + magnitude** (`phasediff` or `phase1/phase2`) | PRELUDE→FUGUE | Requires 2 echo times in JSON |
+| **Precomputed fieldmap** (`fieldmap` suffix) | FUGUE | User-supplied |
+| **Fieldmap-less (SyN)** | ANTs SyN vs anatomical | Enabled by `--use-syn-sdc`, `--force syn-sdc` |
+
+Fieldmap association (SDCFlows preference order):
+1. `B0FieldIdentifier` / `B0FieldSource` metadata (BIDS ≥1.6). **If present anywhere in the dataset, `IntendedFor` is ignored.**
+2. `IntendedFor` metadata on the fieldmap JSON.
+
+Fieldmap Jacobian modulation is applied by default; disable with
+`--ignore fmap-jacobian` (or force with `--force fmap-jacobian`).
+
+---
+
+## 8. Pre-processed BOLD in native space
+*Entry: `fmriprep/workflows/bold/fit.py :: init_bold_native_wf`*
+
+Applies HMC + (if any) SDC in **one interpolation step**, concatenating the
+composed transforms to minimize resampling blur. The volumetric resampler is
+`fmriprep.interfaces.resampling.ResampleSeries` (built on `nitransforms`),
+default order-3 **cubic B-spline** interpolation with `grid-constant` boundary
+mode (the default since 25.2.0). Output stays in the original BOLD grid.
+
+Note: Lanczos-windowed sinc interpolation is used by fMRIPrep in some
+non-volumetric places (e.g. `outputs.py` ANTs `ApplyTransforms` calls for
+resampling anat images to output spaces) but the BOLD series itself is
+resampled with cubic B-spline.
+
+---
+
+## 9. EPI-to-T1w registration (BBR)
+*Entry: `fmriprep/workflows/bold/registration.py :: init_bbreg_wf` (FS on) or `init_fsl_bbr_wf` (FS off).*
+
+With FreeSurfer enabled:
+- `bbregister` aligns BOLD reference to the `?h.white` surfaces using
+  boundary-based registration.
+- `--bold2anat-init` picks the initial reference: `auto` (T2w if available,
+  else T1w — default), `t1w`, `t2w`, or `header` (skip init reg).
+- `--bold2anat-dof` picks DOF: 6 (rigid, default), 9, or 12.
+
+Without FreeSurfer:
+- FSL `flirt` with the BBR cost function (`bbr.sch`, ships in `fmriprep/data/flirtsch/`)
+  and the FAST WM segmentation as boundary.
+
+**Fallback**: The BBR result is compared to the initial affine; excessive
+deviation rejects BBR and uses the initial affine instead. Override with
+`--force bbr` or `--force no-bbr`.
+
+---
+
+## 10. Resampling to standard/native volumetric spaces
+*Entry: `fmriprep/workflows/bold/apply.py :: init_bold_volumetric_resample_wf`*
+
+Concatenates: HMC ∘ SDC ∘ BBR ∘ T1w-to-standard, applied in a **single
+cubic B-spline** interpolation (nitransforms `ResampleSeries`, order-3,
+`grid-constant` boundary mode) for each `--output-spaces` entry. The boilerplate
+records this as: "Gridded (volumetric) resamplings were performed using
+nitransforms, configured with cubic B-spline interpolation."
+
+`res-*` and other modifiers on `--output-spaces` control resampling grid; see
+`references/spaces.md`.
+
+Also produces the T1w brain mask resampled to each target space (using
+ANTs `ApplyTransforms` with `MultiLabel` interpolation to preserve label integrity).
+
+---
+
+## 11. Surface sampling (FreeSurfer)
+*Entry: `fmriprep/workflows/bold/resampling.py :: init_bold_surf_wf`*
+
+Only runs when FreeSurfer is enabled and `fsnative`/`fsaverage*` is in
+`--output-spaces` (or when `--cifti-output` is set).
+
+- Samples cortical ribbon at 6 intervals normal to the white surface, extending
+  to the pial surface, and averages — one value per vertex per timepoint.
+- Emits GIFTI (`.func.gii`) for both hemispheres.
+- Native subject-mesh (`fsnative`), plus `fsaverage` and downsampled
+  `fsaverage6` (41k) / `fsaverage5` (10k, default).
+- `--medial-surface-nan` replaces medial-wall vertices with NaN.
+- `--project-goodvoxels` masks locally high-CoV voxels ("goodvoxels" heuristic).
+
+---
+
+## 12. HCP grayordinates / CIFTI-2
+*Entry: `fmriprep/workflows/bold/resampling.py :: init_bold_fsLR_resampling_wf`*
+
+When `--cifti-output` is set:
+1. Native BOLD → subject-native surface via §11.
+2. Dilate to fill sampling holes.
+3. Resample to `fsLR` mesh using Connectome Workbench (aligned L/R).
+4. Combine with volumetric subcortical time series (resampled to a
+   MNI152NLin6Asym grid) into a CIFTI-2 dense time series.
+
+Resolutions:
+- `--cifti-output 91k` — 91,282 grayordinates, 2 mm subcortical (default).
+- `--cifti-output 170k` — 170,494 grayordinates, 1.6 mm subcortical.
+
+Uses `wb_command` from Connectome Workbench (v1.5.0+).
+
+---
+
+## 13. T2*-driven multi-echo combination
+*Entry: `fmriprep/workflows/bold/t2s.py :: init_bold_t2s_wf`*
+
+For datasets with ≥3 echoes (`echo-N_bold`):
+- Uses `tedana`'s `t2smap_workflow` to estimate adaptive T2* and S0 maps.
+- Produces an **optimally combined** BOLD series that replaces the per-echo
+  data for all downstream steps.
+- Method controlled by `--me-t2s-fit-method`:
+  - `curvefit` (default) — nonlinear regression; slower, more accurate.
+  - `loglin` — log-linear regression; faster.
+- `--me-output-echos` also saves per-echo STC/HMC/SDC-corrected series for
+  downstream tedana denoising.
+
+Two-echo data is **rejected** since 25.2.4 (tedana requires ≥3 echoes to fit T2*).
+
+---
+
+## 14. Confounds estimation
+*Entry: `fmriprep/workflows/bold/confounds.py :: init_bold_confs_wf`*
+
+Given motion-corrected BOLD, brain mask, HMC parameters, and tissue seg,
+computes per-timepoint nuisance signals. See `references/confounds.md` for the
+full column dictionary. Highlights:
+
+- **Motion**: 6 rigid params (+ derivatives + squares → 24-parameter model).
+- **Global signals**: `csf`, `white_matter`, `global_signal` (+ derivatives + squares).
+- **Framewise displacement** (Power 2012), **RMSD** (Jenkinson 2002).
+- **DVARS** / **std_dvars** (Power 2012).
+- **CompCor**:
+  - `a_comp_cor_XX` — anatomical, **combined** WM ∪ CSF mask (Behzadi original).
+  - `c_comp_cor_XX` — anatomical, **CSF-only** mask (Muschelli refinement).
+  - `w_comp_cor_XX` — anatomical, **WM-only** mask (Muschelli refinement).
+  - `t_comp_cor_XX` — temporal, top-variance voxels.
+  - High-pass filter applied before decomposition; corresponding
+    `cosine_XX` DCT regressors are output — include them in your GLM if using
+    CompCor.
+- **Non-steady-state outliers**: `non_steady_state_outlier_XX` (one column per detected outlier).
+- **Motion spike regressors**: `motion_outlier_XX`, flagged when
+  FD > `--fd-spike-threshold` OR std-DVARS > `--dvars-spike-threshold`.
+- **Edge / crown PCA**: `edge_comp_XX` — 24 components from an "outer brain
+  edge" (crown) mask, tagged in the JSON with `Method: EdgeRegressor`
+  (Patriat 2017 / Provins 2022).
+
+By default, only components explaining the top 50% of ROI variance are
+retained; `--return-all-components` keeps all (dropped ones are still tracked
+in the JSON metadata).
+
+---
+
+## 15. Reports (nireports)
+
+Each subject gets `<output>/sub-XX.html` (or split across sessions if
+`--aggregate-session-reports` is exceeded).
+
+Report structure defined by:
+- `fmriprep/data/reports-spec.yml` (top-level)
+- `fmriprep/data/reports-spec-anat.yml` (anatomical section)
+- `fmriprep/data/reports-spec-func.yml` (per-run functional section)
+
+Reportlets included (per subject / per BOLD run):
+- Summary tables + BIDS validation warnings
+- Anatomical conformation, skull-strip, tissue segmentation, MNI normalization animations
+- FreeSurfer recon overlay
+- Per-run BOLD validation, BBR alignment overlay, SDC before/after (if applicable)
+- Carpetplot with FD/DVARS/GS strips (Power 2016)
+- ROI overlay (tCompCor blue, aCompCor magenta)
+- CompCor cumulative-variance curves
+- Confound correlation matrix + global-signal correlation
+- Multi-echo: T2*/S0 map, per-echo histogram, ICA_AROMA plot (legacy)
+- Boilerplate citations (`CITATION.md/html/tex`)
+
+Sample report: https://fmriprep.org/en/latest/_static/SampleReport/sample_report.html
+
+---
+
+## 16. Processing levels (`--level`)
+
+| Level | What's saved | Use case |
+|-------|--------------|----------|
+| `minimal` | Transforms, references, brain masks. No resampled BOLD in outputs. All QC-relevant reportlets except carpetplot / confounds are still generated. | Large datasets, disk-constrained; also anatomical-only-adjacent flows. |
+| `resampling` | + intermediate NIfTIs helpful for third-party resampling. If multi-echo, individual echos are saved after STC/HMC/SDC (like `--me-output-echos`). | You plan to do your own resampling downstream. |
+| `full` (default) | + resampled BOLD in every `--output-spaces` target; CIFTI (if enabled); all confounds artifacts and carpetplots. | Standard use. |
+
+Combine `--level minimal` with `--derivatives fmriprep=<path>` in a later run
+to add outputs on demand.


### PR DESCRIPTION
## 目标

将 fMRIPrep（NiPreps 官方 BIDS-App，最广泛使用的 fMRI 预处理管道）作为一个 skill 加入 router 库，供 engineer / experimentalist / auditor 等 agent 通过 \`skill_search\` 查阅并驱动实际的预处理工作流。

## 落地位置

\`packages/skills/skills/06_fMRI_Neuroimaging/fmriprep/\` —— 与已有的 \`fmri-preprocessing-pipeline-guide\`（方法学层面）并列，fmriprep 侧重具体工具的完整操作知识。

## 内容

- **SKILL.md**（255 行，符合 <500 行规范）
  - 关键词丰富的 \`description\`（589 字符，覆盖预处理 / BIDS-App / Docker / Apptainer / 输出空间 / SDC / confounds / 引用等触发场景）
  - frontmatter 补齐 \`domain: "fmri-neuroimaging"\`（与同目录其他 skill 对齐）
- **12 个 references**（progressive disclosure）：
  - \`installation.md\` — Docker / Apptainer / pip / wrapper / FreeSurfer license / TemplateFlow
  - \`cli-reference.md\` — 完整 CLI 参数
  - \`usage-examples.md\` — 单被试、批量、HPC SLURM
  - \`workflows.md\` — 内部 anat + BOLD 流水线细节
  - \`outputs.md\` — derivatives 命名与目录结构
  - \`confounds.md\` — aCompCor / tCompCor / motion / FD / DVARS
  - \`spaces.md\` — MNI152NLin2009cAsym / fsLR / fsaverage / TemplateFlow
  - \`sdc-fieldmaps.md\` — 磁敏感失真矫正（fieldmaps / SyN）
  - \`bids-filter.md\` — filter file + PyBIDS 语法
  - \`troubleshooting-faq.md\` — 常见崩溃 / hang / HPC 离线
  - \`citation.md\` — DOI / BibTeX / 依赖论文
  - \`versions-dependencies.md\` — 25.2.x LTS 各依赖版本

## README 更新

中英文 README 里 \`06_fMRI_Neuroimaging\` 一行都追加了 "(incl. fMRIPrep BIDS-App)" / "（含 fMRIPrep BIDS-App）"。

## 生效方式

零代码改动。skill 会被 \`materializeSkills\` 管道识别为 router 侧内容：
- 部署时自动拷贝到 \`<dataDir>/bp_template/skills-router/06_fMRI_Neuroimaging/fmriprep/\`
- agent 通过 \`skill_search(mode="query", keywords="fmriprep, preprocessing, bids")\` 触发
- 已验证：\`materialize-skills.test.ts\` / \`skill-search.test.ts\` / \`two-skill-paths.test.ts\` 全绿（39/39 tests pass）

## 变更行数

+4292 / -2，15 files（1 SKILL.md + 12 references + 2 README）

## 显式非目标

- 不在 persona 里显式提及 fMRIPrep —— 通过 skill_search 的通用发现机制即可，避免在系统提示里堆积具体工具名
- 不加 \`scripts/\` 目录 —— fMRIPrep 的调用形态因 Docker/Apptainer/HPC 不同差异大，交给 agent 按用户环境即时生成命令
- 不修改 \`AGENT_TOOL_CONFIG\` —— 现有 engineer/experimentalist/auditor/writer/_default 均已可用 skill_search

🤖 Generated with [Claude Code](https://claude.com/claude-code)