### PR TITLE
fix(cli): gate scaffold's bundled-skill copy behind BP_SKIP_SKILL_COPY (#284)

### DIFF
--- a/packages/cli/src/scaffold.test.ts
+++ b/packages/cli/src/scaffold.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mkdtemp, rm, readFile, stat, writeFile, readdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { scaffold, isScaffolded } from "./scaffold.js";
+import { scaffold, isScaffolded, shouldSkipSkillCopy } from "./scaffold.js";
 import { EXAMPLE_MODEL } from "@brainpilot/protocol";
 
 let dir: string;
@@ -118,5 +118,50 @@ describe("scaffold", () => {
       await readFile(join(paths.bpTemplate, "providers.example.json"), "utf8"),
     );
     expect(example.profiles[0].models).toEqual([EXAMPLE_MODEL]);
+  });
+});
+
+// #284: the bundled-skill copy is the single most expensive thing scaffold does
+// (hundreds of files, growing with the skill catalogue). It is gated so the CLI
+// test suite doesn't pay it on every scaffold. These tests pin the gate.
+//
+// The gate's on-disk marker is the materialised category tree
+// `bp_template/skills/<ALWAYS_ON_CATEGORY>/` — scaffold's own default writes only
+// put README.md/example.md directly in `bp_template/skills/`, so a materialised
+// category dir appears iff `materializeSkills` actually ran.
+describe("shouldSkipSkillCopy (#284)", () => {
+  it("reads BP_SKIP_SKILL_COPY (1/true on, anything else off)", () => {
+    expect(shouldSkipSkillCopy({ BP_SKIP_SKILL_COPY: "1" })).toBe(true);
+    expect(shouldSkipSkillCopy({ BP_SKIP_SKILL_COPY: "true" })).toBe(true);
+    expect(shouldSkipSkillCopy({ BP_SKIP_SKILL_COPY: "0" })).toBe(false);
+    expect(shouldSkipSkillCopy({ BP_SKIP_SKILL_COPY: "" })).toBe(false);
+    expect(shouldSkipSkillCopy({})).toBe(false);
+  });
+});
+
+describe("scaffold — skill copy gate (#284)", () => {
+  // The materialised always-on category (01_Meta-Skills) — present only when
+  // the recursive copy actually ran.
+  const materialisedMarker = (root: string) =>
+    join(root, "bp_template", "skills", "01_Meta-Skills");
+
+  it("skips the bundled-skill copy when skipSkillCopy is set", async () => {
+    const root = join(dir, "skip");
+    const { created } = await scaffold(root, { skipSkillCopy: true });
+    // The skeleton + default files are still written…
+    expect(await exists(join(root, "bp_template", "skills", "README.md"))).toBe(true);
+    expect(await isScaffolded(root)).toBe(true);
+    // …but the heavy category copy did not run.
+    expect(await exists(materialisedMarker(root))).toBe(false);
+    expect(created.some((c) => c.includes("skill files"))).toBe(false);
+  });
+
+  it("still copies the bundled skills when the gate is off (skipSkillCopy: false)", async () => {
+    const root = join(dir, "copy");
+    // Explicit override so this test is independent of the suite-wide
+    // BP_SKIP_SKILL_COPY set in vitest.setup.ts — it proves the copy path is a
+    // real, reachable gate, not dead code.
+    await scaffold(root, { skipSkillCopy: false });
+    expect(await exists(materialisedMarker(root))).toBe(true);
   });
 });

--- a/packages/cli/src/scaffold.ts
+++ b/packages/cli/src/scaffold.ts
@@ -209,6 +209,35 @@ export interface ScaffoldOptions {
   port?: number;
   /** Default provider name baked into brainpilot.config.json. */
   provider?: string;
+  /**
+   * Skip the bundled-skill copy (`materializeSkills`). Defaults to reading
+   * `BP_SKIP_SKILL_COPY` from the environment. See {@link shouldSkipSkillCopy}.
+   * The directory skeleton and all default files are still written — only the
+   * ~600-file recursive copy is elided. The runtime server materialises skills
+   * itself on startup (`ensureSkillsMaterialized`), so a real launch is never
+   * left without them; this flag only matters for tests and dry scaffolds.
+   */
+  skipSkillCopy?: boolean;
+}
+
+/**
+ * Whether `scaffold` should skip the expensive `materializeSkills` copy.
+ *
+ * Set `BP_SKIP_SKILL_COPY=1` (or `true`) to elide it. This exists for the test
+ * suite (#284): every CLI test that calls `up`/`scaffold`/`init` otherwise
+ * triggers a full recursive copy of the bundled `@brainpilot/skills` tree
+ * (hundreds of files and growing). On a contended CI runner that disk IO — not
+ * the code under test — dominates wall-clock and flakily blows the per-test
+ * timeout. Skipping it makes CLI test time flat with respect to skill count.
+ *
+ * NOT for production: real launches leave the flag unset, and even if a user
+ * sets it, the runtime server re-materialises skills on startup, so agents
+ * still get them.
+ */
+export function shouldSkipSkillCopy(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return env.BP_SKIP_SKILL_COPY === "1" || env.BP_SKIP_SKILL_COPY === "true";
 }
 
 export interface ScaffoldResult {
@@ -273,11 +302,16 @@ export async function scaffold(
   //    bp_template/skills/ for Pi's native skill pipeline. Skip-if-exists at the
   //    file level, so user edits and the README/example above are preserved.
   //    Best-effort: a missing skills package never fails the scaffold.
-  try {
-    const res = await materializeSkills(p.dataDir);
-    if (res.copied > 0) created.push(`${p.bpTemplateSkills} (+${res.copied} skill files)`);
-  } catch {
-    /* skills are a convenience — never block scaffolding on them */
+  //    Skippable via BP_SKIP_SKILL_COPY (#284) — the hundreds-of-files copy is
+  //    what makes the CLI test suite flaky/slow; the runtime server also
+  //    materialises skills on startup, so skipping here never strands a real run.
+  if (!(options.skipSkillCopy ?? shouldSkipSkillCopy())) {
+    try {
+      const res = await materializeSkills(p.dataDir);
+      if (res.copied > 0) created.push(`${p.bpTemplateSkills} (+${res.copied} skill files)`);
+    } catch {
+      /* skills are a convenience — never block scaffolding on them */
+    }
   }
 
   return { paths: p, created };

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,15 @@
+/// <reference types="vitest" />
+import { defineConfig } from "vitest/config";
+
+// Test-only config for the CLI package. The build uses tsc (`tsc -b`); this
+// only affects `vitest`. The sole reason it exists is `setupFiles` (#284): the
+// setup file sets BP_SKIP_SKILL_COPY so no CLI test pays the cost of copying the
+// full bundled skills tree on every scaffold. Everything else stays on vitest's
+// Node defaults, matching the other non-web packages in the workspace.
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+    setupFiles: ["./vitest.setup.ts"],
+  },
+});

--- a/packages/cli/vitest.setup.ts
+++ b/packages/cli/vitest.setup.ts
@@ -1,0 +1,20 @@
+/**
+ * vitest.setup.ts — global setup for the @brainpilot/app (CLI) test suite.
+ *
+ * #284: nearly every CLI test calls `up`/`scaffold`/`init`, each of which
+ * scaffolds a fresh temp data dir and — before this switch — recursively copied
+ * the entire bundled `@brainpilot/skills` tree (hundreds of files, growing with
+ * every added skill). That copy is pure disk IO unrelated to the code under
+ * test; on a contended 2-core CI runner it dominates wall-clock and flakily
+ * blew the per-test timeout (e.g. up.test.ts port-precheck cases).
+ *
+ * Setting BP_SKIP_SKILL_COPY here makes `scaffold` skip the copy for the whole
+ * CLI suite, so test time is flat with respect to skill-directory size. The
+ * real skill copy is still exercised directly by the runtime's
+ * materialize-skills tests, and a production launch (which never sets this flag)
+ * still materialises skills — both via `scaffold` and again on server startup.
+ *
+ * Tests that need to assert the copy behaviour can override this per-call by
+ * passing `{ skipSkillCopy: false }` to `scaffold` (see scaffold.test.ts).
+ */
+process.env.BP_SKIP_SKILL_COPY = "1";


### PR DESCRIPTION
Closes #284.

## Problem

`packages/cli/src/commands/up.test.ts` flakily times out in CI (5000ms) while passing locally in ~100ms. Root cause is **structural, not random**: nearly every CLI test calls `up`/`scaffold`/`init`, and each scaffolds a fresh temp data dir that recursively copies the *entire* bundled `@brainpilot/skills` tree — **~600 files today and growing with every added skill** (357 when the issue was filed; #280 fmriprep added 13; spikeinterface added more). On a contended 2-core GitHub runner that disk IO — not the code under test — dominates wall-clock and eventually blows the per-test timeout. Every added skill slows all 29 `up.test.ts` cases a little; it's a trend that only worsens.

## Fix (issue's recommended option 1)

- `scaffold()` skips `materializeSkills()` when `BP_SKIP_SKILL_COPY=1|true` (or `ScaffoldOptions.skipSkillCopy`). The directory skeleton and all default files (README, example, providers, mcp_servers, config) are still written — **only the heavy recursive copy is elided**.
- New `packages/cli/vitest.{config,setup}.ts` sets the flag for the whole CLI suite, so every current *and future* CLI test benefits with zero per-test change.
- Regression tests pin the gate: it skips when set, and still copies with `skipSkillCopy: false` (proving it's a live path, not dead code).

**Safety**: production never sets the flag, and even if it did, the runtime server re-materialises skills on startup (`ensureSkillsMaterialized`) — a real launch is never stranded. The runtime's own `materialize-skills` tests call `materializeSkills` directly (bypassing the CLI gate), so real-copy coverage is untouched.

## Results

| | before | after |
|---|---|---|
| `up.test.ts` (29 cases) | 1579ms | 45ms |
| `up.test.ts` +200 fake skills | scales up | 42ms (flat) |

- Full workspace: **614 tests green** (59 files).
- Runtime `materialize-skills` / `two-skill-paths` (real copy): still green.
- Typecheck clean.

## Acceptance criteria

- [x] `up.test.ts` wall-clock no longer scales with skills dir size
- [x] Adding a new skill leaves `up.test.ts` time basically unchanged (verified with +200 files)
- [x] `scaffold`/`init`/`template` tests no longer trigger the full skill copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)