### PR TITLE
refactor(runtime): flatten persistent library to data/ (#287)

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -105,6 +105,10 @@ brainpilot down          # 停止后台后端
 默认情况下，BrainPilot 会把数据放在当前目录下的 `./brainpilot`。可以用 `--dir <path>` 或
 `BP_DATA_DIR` 覆盖。
 
+跨 session 复用的文件直接位于 `<BP_DATA_DIR>/data/`，仅属于单个 session 的工作文件位于
+`workspaces/<sessionId>/`。每个 runtime 只管理一个单用户数据根；托管多用户部署必须为每位
+用户提供独立的 `BP_DATA_DIR`/volume，而不是在 `data/` 内增加用户目录。
+
 > **信任边界。** 在本地（非 Docker）模式下 **没有容器隔离** —— 智能体直接在你的机器上读写，路径
 > 为 `brainpilot/workspaces/<sessionId>/`。该模式下 UI 会隐藏 *Sandbox* 控件，因为没有可挂载的
 > Docker 沙箱。如需隔离，请使用 [Docker 部署](#-docker-部署)，它会把智能体跑在沙箱容器内。

--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ brainpilot down          # stop the detached backend
 By default, BrainPilot stores data under `./brainpilot` in the current directory. Override it
 with `--dir <path>` or `BP_DATA_DIR`.
 
+Reusable files shared across sessions live directly under `<BP_DATA_DIR>/data/`; session-only
+work stays under `workspaces/<sessionId>/`. A runtime owns one single-user data root. Hosted
+multi-user deployments must give each user a separate `BP_DATA_DIR`/volume rather than adding
+a user-id directory inside `data/`.
+
 > **Trust boundary.** In local (non-Docker) mode there is **no container isolation** —
 > agents read and write directly on your machine, under
 > `brainpilot/workspaces/<sessionId>/`. The UI hides the *Sandbox* control in this mode

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,10 +30,11 @@ services:
       - BP_MOCK=${BP_MOCK:-}
     volumes:
       # The whole data root is persisted here. Besides per-session
-      # `workspaces/<sid>/`, this holds the #257 cross-session persistent root
-      # `data/<BP_USER_ID>/` (default user `local`) — uploads/datasets placed
-      # there stay reusable across sessions. No extra mount needed; set
-      # BP_USER_ID per-user in multi-tenant hosting.
+      # `workspaces/<sid>/`, this holds the cross-session persistent library
+      # at `data/` (#257, flattened by #287) — uploads/datasets placed there
+      # stay reusable across sessions. The runtime is single-user by contract;
+      # multi-user hosting gives each user their own dataRoot / bind mount
+      # (BP_USER_ID is no longer used for path resolution).
       - ${BP_DATA_DIR:-./brainpilot}:/root/.bp-root:rw
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${BP_SANDBOX_PORT:-8081}/health"]

--- a/packages/protocol/src/http.ts
+++ b/packages/protocol/src/http.ts
@@ -273,8 +273,8 @@ export const RUNTIME_ROUTES = {
    * Workspace files. `?path=` addresses one of several roots by prefix:
    *  - `/workspace[/...]` (or a bare relative path) → per-session workspace
    *    `workspaces/:id/` (the agent's cwd);
-   *  - `/data[/...]` → the shared per-user persistent root `data/<userId>/`,
-   *    reusable across sessions (#257);
+   *  - `/data[/...]` → the runtime's single-user persistent root `data/`,
+   *    reusable across sessions (#257/#287);
    *  - `/shared[/...]` → the cross-user READ-ONLY shared root (#261), when the
    *    deployment configures one (`BP_SHARED_DIR`); writes/deletes are rejected.
    * Each root is traversal-guarded independently.

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -19,6 +19,19 @@ byte-passthrough) and, in hosted deployments, by the platform layer.
 
 All wire types come from `@brainpilot/protocol` (the zod SSOT).
 
+## Persistent storage contract
+
+The runtime is single-user: reusable cross-session files live directly under
+`<BP_DATA_DIR>/data/`, while session workspaces live under
+`<BP_DATA_DIR>/workspaces/<sessionId>/`. `/data/...` is the stable logical API
+prefix. A hosted multi-user deployment must isolate users with separate data
+roots/volumes; `BP_USER_ID` no longer selects a nested storage root.
+
+On upgrade from the former `data/<userId>/` layout, startup migrates only the
+known legacy directory (`BP_USER_ID`, or `local` when unset) and records the v2
+layout outside the user-visible `data/` tree. Ambiguous mixed layouts fail
+readiness without moving files so an operator can resolve them safely.
+
 ## Liveness contract (R-3)
 
 The runtime imposes **no fixed wall-clock cap on a single agent turn.** A

--- a/packages/runtime/src/__tests__/server.test.ts
+++ b/packages/runtime/src/__tests__/server.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createServer, startServer } from "../server.js";
 import { SessionManager } from "../session-manager.js";
+import { PERSISTENT_LAYOUT_MARKER } from "../persistent-layout.js";
 import { mockAgentFactory } from "../agent-factory.js";
 
 /**
@@ -463,6 +464,10 @@ describe("startServer boot-time restore", () => {
       agentFactory: mockAgentFactory,
     });
     try {
+      const layout = JSON.parse(
+        await readFile(join(dataRoot, PERSISTENT_LAYOUT_MARKER), "utf8"),
+      );
+      expect(layout).toMatchObject({ version: 2, status: "ready" });
       const res = await fetch(`http://127.0.0.1:${handle.port}/sessions`);
       expect(res.status).toBe(200);
       const body = (await res.json()) as { sessions: Array<{ id: string; createdAt: string }> };

--- a/packages/runtime/src/__tests__/server.test.ts
+++ b/packages/runtime/src/__tests__/server.test.ts
@@ -373,8 +373,8 @@ describe("workspace file routes", () => {
     expect(read.status).toBe(200);
     expect((await read.json()) as { content: string }).toMatchObject({ content: "reusable dataset" });
 
-    // On disk it lives under data/local/, not workspaces/.
-    const onDisk = await readFile(join(dataRoot, "data", "local", "lib", "set.csv"), "utf8");
+    // On disk it lives flat under data/ (#287 removed the per-user subdir).
+    const onDisk = await readFile(join(dataRoot, "data", "lib", "set.csv"), "utf8");
     expect(onDisk).toBe("reusable dataset");
   });
 

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -1,21 +1,19 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { mkdtemp, mkdir, writeFile, readFile, readdir, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, writeFile, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parseEvent, type AgUiEvent } from "@brainpilot/protocol";
 import { SessionManager, warnOnDeprecatedPersistentUserId, resolveSharedDir } from "../session-manager.js";
+import {
+  PERSISTENT_LAYOUT_MARKER,
+  PERSISTENT_LAYOUT_STAGING,
+} from "../persistent-layout.js";
 import { mockAgentFactory } from "../agent-factory.js";
 import { PERSONAS } from "../personas.js";
 
 function mgr(): SessionManager {
   // persist:false keeps tests hermetic; mock factory => no Pi SDK / API.
   return new SessionManager({ persist: false, agentFactory: mockAgentFactory });
-}
-
-/** Sorted names in a directory (dotfiles included), for migration assertions. */
-async function readdirNames(dir: string): Promise<string[]> {
-  const entries = await readdir(dir, { withFileTypes: true });
-  return entries.map((e) => e.name).sort();
 }
 
 describe("SessionManager (mock mode)", () => {
@@ -367,7 +365,7 @@ describe("warnOnDeprecatedPersistentUserId (#287)", () => {
     expect(warnOnDeprecatedPersistentUserId(undefined, { BP_USER_ID: "bob" }, (m) => msgs.push(m))).toBe(true);
     expect(msgs).toHaveLength(1);
     expect(msgs[0]).toMatch(/BP_USER_ID env \("bob"\)/);
-    expect(msgs[0]).toMatch(/ignored since #287/);
+    expect(msgs[0]).toMatch(/no longer controls path resolution since #287/);
   });
   it("warns (mentioning the option source) when only persistentUserId is passed", () => {
     const msgs: string[] = [];
@@ -387,102 +385,98 @@ describe("SessionManager legacy `data/<userId>/` migration (#287)", () => {
     root = await mkdtemp(join(tmpdir(), "bp-mig-"));
   });
 
-  it("flattens a single legacy user subdir into data/ and drops a sentinel", async () => {
-    // Seed the legacy layout on disk BEFORE constructing the manager.
+  it("migrates only the known default data/local directory", async () => {
     await mkdir(join(root, "data", "local"), { recursive: true });
     await writeFile(join(root, "data", "local", "dataset.csv"), "cols\n1,2\n", "utf8");
     await mkdir(join(root, "data", "local", "subdir"), { recursive: true });
     await writeFile(join(root, "data", "local", "subdir", "notes.md"), "kept together", "utf8");
 
     const m = new SessionManager({ dataRoot: root, persist: false, agentFactory: mockAgentFactory });
-    await m.createSession({ title: "S" }); // triggers migration
+    await m.ensurePersistentLayout();
 
-    // Files are now flat under data/.
     expect(await readFile(join(root, "data", "dataset.csv"), "utf8")).toBe("cols\n1,2\n");
     expect(await readFile(join(root, "data", "subdir", "notes.md"), "utf8")).toBe("kept together");
-    // Legacy subdir is gone (empty → rmdir'd).
     await expect(readFile(join(root, "data", "local", "dataset.csv"), "utf8")).rejects.toThrow();
-    // Sentinel is present and names the source.
-    const sentinelBody = await readFile(join(root, "data", ".bp-migrated-from-local"), "utf8");
-    expect(sentinelBody).toMatch(/data\/local\//);
+    const marker = JSON.parse(await readFile(join(root, PERSISTENT_LAYOUT_MARKER), "utf8"));
+    expect(marker).toMatchObject({ version: 2, status: "ready", migratedFrom: "data/local" });
   });
 
-  it("is idempotent across manager restarts (sentinel short-circuits)", async () => {
-    await mkdir(join(root, "data", "local"), { recursive: true });
-    await writeFile(join(root, "data", "local", "a.txt"), "one", "utf8");
-    const m1 = new SessionManager({ dataRoot: root, persist: false, agentFactory: mockAgentFactory });
-    await m1.createSession({ title: "S1" });
-    expect(await readFile(join(root, "data", "a.txt"), "utf8")).toBe("one");
-
-    // Simulate an agent later creating a directory named identically to a
-    // former user — this must NOT re-trigger migration once the sentinel is
-    // in place. The stray dir stays put; a.txt is untouched.
-    await mkdir(join(root, "data", "local"), { recursive: true });
-    await writeFile(join(root, "data", "local", "should_stay_here.txt"), "x", "utf8");
-
-    const m2 = new SessionManager({ dataRoot: root, persist: false, agentFactory: mockAgentFactory });
-    await m2.createSession({ title: "S2" });
-    // The stray file was NOT flattened (would've overwritten nothing but
-    // still: the guard is "sentinel present → no-op").
-    expect(await readFile(join(root, "data", "local", "should_stay_here.txt"), "utf8")).toBe("x");
-    expect(await readFile(join(root, "data", "a.txt"), "utf8")).toBe("one");
-  });
-
-  it("refuses to migrate when data/ has ≥2 subdirs (unknown state → leave alone)", async () => {
+  it("uses BP_USER_ID only as a legacy migration hint", async () => {
     await mkdir(join(root, "data", "alice"), { recursive: true });
-    await mkdir(join(root, "data", "bob"), { recursive: true });
     await writeFile(join(root, "data", "alice", "a.txt"), "alice", "utf8");
-    await writeFile(join(root, "data", "bob", "b.txt"), "bob", "utf8");
-
-    const m = new SessionManager({ dataRoot: root, persist: false, agentFactory: mockAgentFactory });
-    await m.createSession({ title: "S" });
-
-    // Nothing was touched.
-    expect(await readFile(join(root, "data", "alice", "a.txt"), "utf8")).toBe("alice");
-    expect(await readFile(join(root, "data", "bob", "b.txt"), "utf8")).toBe("bob");
-    // And no sentinel was written (migration bailed BEFORE writing it).
-    const rootEntries = await readdirNames(join(root, "data"));
-    expect(rootEntries.filter((n) => n.startsWith(".bp-migrated-from-"))).toEqual([]);
+    const previous = process.env.BP_USER_ID;
+    process.env.BP_USER_ID = "alice";
+    try {
+      const m = new SessionManager({ dataRoot: root, persist: false, agentFactory: mockAgentFactory });
+      await m.ensurePersistentLayout();
+      expect(await readFile(join(root, "data", "a.txt"), "utf8")).toBe("alice");
+    } finally {
+      if (previous === undefined) delete process.env.BP_USER_ID;
+      else process.env.BP_USER_ID = previous;
+    }
   });
 
-  it("ignores dotted helper entries at data/ root (e.g. a stray .tmp)", async () => {
-    // A hidden dotfile at data/ (say, .tmp from a prior interrupted op) should
-    // not count as "already-flat" — those dotted entries are filtered so a
-    // real legacy subdir alongside them still migrates. This exercises the
-    // `!e.name.startsWith(".")` filter on the dirs list; files at the root
-    // still count, but a dotted file is rare and we let it count as
-    // "already-flat" via the `files.length > 0` guard (safe default).
-    await mkdir(join(root, "data", ".tmp"), { recursive: true }); // dotted subdir
+  it("does not flatten a valid v2 tree containing only data/project/", async () => {
+    await mkdir(join(root, "data", "project"), { recursive: true });
+    await writeFile(join(root, "data", "project", "dataset.csv"), "kept", "utf8");
+
+    const m1 = new SessionManager({ dataRoot: root, persist: false, agentFactory: mockAgentFactory });
+    await m1.ensurePersistentLayout();
+    const m2 = new SessionManager({ dataRoot: root, persist: false, agentFactory: mockAgentFactory });
+    await m2.ensurePersistentLayout();
+
+    expect(await readFile(join(root, "data", "project", "dataset.csv"), "utf8")).toBe("kept");
+    await expect(readFile(join(root, "data", "dataset.csv"), "utf8")).rejects.toThrow();
+  });
+
+  it("refuses a mixed v1/v2 tree without moving either side", async () => {
     await mkdir(join(root, "data", "local"), { recursive: true });
-    await writeFile(join(root, "data", "local", "x.txt"), "moved", "utf8");
+    await writeFile(join(root, "data", "local", "old.txt"), "old", "utf8");
+    await writeFile(join(root, "data", "new.txt"), "new", "utf8");
 
     const m = new SessionManager({ dataRoot: root, persist: false, agentFactory: mockAgentFactory });
-    await m.createSession({ title: "S" });
-
-    // Legacy content flattened, .tmp dir left in place.
-    expect(await readFile(join(root, "data", "x.txt"), "utf8")).toBe("moved");
-    const rootEntries = await readdirNames(join(root, "data"));
-    expect(rootEntries).toContain(".tmp");
-    expect(rootEntries).toContain(".bp-migrated-from-local");
+    await expect(m.ensurePersistentLayout()).rejects.toThrow(/cannot migrate/);
+    expect(await readFile(join(root, "data", "local", "old.txt"), "utf8")).toBe("old");
+    expect(await readFile(join(root, "data", "new.txt"), "utf8")).toBe("new");
   });
 
-  it("is a no-op when data/ already contains files at the root (new layout)", async () => {
-    // Someone (or a prior migration) already flattened data/ but no sentinel:
-    // presence of any regular file at the root proves the new layout is live
-    // and we should NOT try to migrate anything.
+  it("single-flights migration before concurrent /data writes with no session", async () => {
+    await mkdir(join(root, "data", "local"), { recursive: true });
+    await writeFile(join(root, "data", "local", "old.txt"), "old", "utf8");
+    const m = new SessionManager({ dataRoot: root, persist: false, agentFactory: mockAgentFactory });
+
+    await Promise.all([
+      m.writeSessionFile("not-created", "/data/new.txt", Buffer.from("new").toString("base64")),
+      m.writeSessionFile("not-created", "/data/other.txt", Buffer.from("other").toString("base64")),
+    ]);
+
+    expect(await readFile(join(root, "data", "old.txt"), "utf8")).toBe("old");
+    expect(await readFile(join(root, "data", "new.txt"), "utf8")).toBe("new");
+    expect(await readFile(join(root, "data", "other.txt"), "utf8")).toBe("other");
+  });
+
+  it("resumes a staged whole-directory migration after interruption", async () => {
+    await mkdir(join(root, PERSISTENT_LAYOUT_STAGING), { recursive: true });
+    await writeFile(join(root, PERSISTENT_LAYOUT_STAGING, "old.txt"), "old", "utf8");
     await mkdir(join(root, "data"), { recursive: true });
-    await writeFile(join(root, "data", "already-flat.txt"), "hi", "utf8");
-    await mkdir(join(root, "data", "sub"), { recursive: true }); // a legit subdir
-    await writeFile(join(root, "data", "sub", "leave-alone.txt"), "sub", "utf8");
+    await writeFile(
+      join(root, PERSISTENT_LAYOUT_MARKER),
+      JSON.stringify({
+        version: 2,
+        status: "migrating",
+        phase: "staged",
+        legacyUserId: "local",
+        startedAt: new Date().toISOString(),
+      }),
+      "utf8",
+    );
 
     const m = new SessionManager({ dataRoot: root, persist: false, agentFactory: mockAgentFactory });
-    await m.createSession({ title: "S" });
+    await m.ensurePersistentLayout();
 
-    // Untouched.
-    expect(await readFile(join(root, "data", "sub", "leave-alone.txt"), "utf8")).toBe("sub");
-    // No sentinel (nothing to migrate).
-    const rootEntries = await readdirNames(join(root, "data"));
-    expect(rootEntries.filter((n) => n.startsWith(".bp-migrated-from-"))).toEqual([]);
+    expect(await readFile(join(root, "data", "old.txt"), "utf8")).toBe("old");
+    const marker = JSON.parse(await readFile(join(root, PERSISTENT_LAYOUT_MARKER), "utf8"));
+    expect(marker).toMatchObject({ status: "ready", migratedFrom: "data/local" });
   });
 });
 

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -1,15 +1,21 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { mkdtemp, mkdir, writeFile, readFile, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, writeFile, readFile, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parseEvent, type AgUiEvent } from "@brainpilot/protocol";
-import { SessionManager, resolvePersistentUserId, resolveSharedDir } from "../session-manager.js";
+import { SessionManager, warnOnDeprecatedPersistentUserId, resolveSharedDir } from "../session-manager.js";
 import { mockAgentFactory } from "../agent-factory.js";
 import { PERSONAS } from "../personas.js";
 
 function mgr(): SessionManager {
   // persist:false keeps tests hermetic; mock factory => no Pi SDK / API.
   return new SessionManager({ persist: false, agentFactory: mockAgentFactory });
+}
+
+/** Sorted names in a directory (dotfiles included), for migration assertions. */
+async function readdirNames(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  return entries.map((e) => e.name).sort();
 }
 
 describe("SessionManager (mock mode)", () => {
@@ -262,8 +268,9 @@ describe("SessionManager persistent cross-session root (#257)", () => {
     const read = await m.readSessionFile(b.id, "/data/dataset.csv");
     expect(read.content).toBe("shared,data");
 
-    // On disk it lives under data/<userId>/, NOT workspaces/<sid>/.
-    const onDisk = await readFile(join(root, "data", "local", "dataset.csv"), "utf8");
+    // On disk it lives flat under data/, NOT workspaces/<sid>/ (#287 removed
+    // the per-user subdir; the runtime is single-user by contract).
+    const onDisk = await readFile(join(root, "data", "dataset.csv"), "utf8");
     expect(onDisk).toBe("shared,data");
   });
 
@@ -286,17 +293,21 @@ describe("SessionManager persistent cross-session root (#257)", () => {
     await expect(m.readSessionFile(s.id, "/data/../../etc/passwd")).rejects.toThrow(/escapes/);
   });
 
-  it("honors a custom persistentUserId in the on-disk layout", async () => {
+  it("ignores the deprecated persistentUserId option and lands flat under data/ (#287)", async () => {
     const m = new SessionManager({
       dataRoot: root,
       persist: false,
       agentFactory: mockAgentFactory,
+      // #287: this option is now ignored; the write must NOT land under
+      // data/alice/ but flat in data/, mirroring the single-user contract.
       persistentUserId: "alice",
     });
     const s = await m.createSession({ title: "S" });
     await m.writeSessionFile(s.id, "/data/lib.txt", b64("hi"));
-    const onDisk = await readFile(join(root, "data", "alice", "lib.txt"), "utf8");
+    const onDisk = await readFile(join(root, "data", "lib.txt"), "utf8");
     expect(onDisk).toBe("hi");
+    // The legacy layout must not have been created.
+    await expect(readFile(join(root, "data", "alice", "lib.txt"), "utf8")).rejects.toThrow();
   });
 });
 
@@ -344,26 +355,134 @@ describe("SessionManager conversation attachments (.attachments/)", () => {
   });
 });
 
-describe("resolvePersistentUserId (#257)", () => {
-  it("defaults to `local` when unset", () => {
-    expect(resolvePersistentUserId(undefined, {})).toBe("local");
-    expect(resolvePersistentUserId("   ", {})).toBe("local");
+describe("warnOnDeprecatedPersistentUserId (#287)", () => {
+  it("is silent when neither the option nor the env is set", () => {
+    const msgs: string[] = [];
+    expect(warnOnDeprecatedPersistentUserId(undefined, {}, (m) => msgs.push(m))).toBe(false);
+    expect(warnOnDeprecatedPersistentUserId("   ", { BP_USER_ID: "" }, (m) => msgs.push(m))).toBe(false);
+    expect(msgs).toEqual([]);
   });
-  it("reads BP_USER_ID from env when no explicit option", () => {
-    expect(resolvePersistentUserId(undefined, { BP_USER_ID: "bob" })).toBe("bob");
+  it("warns (once, mentioning the env source) when only BP_USER_ID is set", () => {
+    const msgs: string[] = [];
+    expect(warnOnDeprecatedPersistentUserId(undefined, { BP_USER_ID: "bob" }, (m) => msgs.push(m))).toBe(true);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]).toMatch(/BP_USER_ID env \("bob"\)/);
+    expect(msgs[0]).toMatch(/ignored since #287/);
   });
-  it("explicit option wins over env", () => {
-    expect(resolvePersistentUserId("carol", { BP_USER_ID: "bob" })).toBe("carol");
+  it("warns (mentioning the option source) when only persistentUserId is passed", () => {
+    const msgs: string[] = [];
+    expect(warnOnDeprecatedPersistentUserId("alice", {}, (m) => msgs.push(m))).toBe(true);
+    expect(msgs[0]).toMatch(/persistentUserId option \("alice"\)/);
   });
-  it("sanitizes separators and traversal to a single safe segment", () => {
-    // Whatever the input, the result is a single segment with no separators or
-    // `..` (so the "persistent root" can never escape `data/`).
-    for (const bad of ["../../etc", "a/b", "..", "x/../y", "..\\..\\z"]) {
-      const out = resolvePersistentUserId(bad, {});
-      expect(out).not.toContain("..");
-      expect(out).not.toMatch(/[\\/]/);
-    }
-    expect(resolvePersistentUserId("a/b", {})).toBe("a_b");
+  it("names BOTH sources when they are both set", () => {
+    const msgs: string[] = [];
+    warnOnDeprecatedPersistentUserId("alice", { BP_USER_ID: "bob" }, (m) => msgs.push(m));
+    expect(msgs[0]).toMatch(/persistentUserId option \("alice"\).*BP_USER_ID env \("bob"\)/);
+  });
+});
+
+describe("SessionManager legacy `data/<userId>/` migration (#287)", () => {
+  let root: string;
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), "bp-mig-"));
+  });
+
+  it("flattens a single legacy user subdir into data/ and drops a sentinel", async () => {
+    // Seed the legacy layout on disk BEFORE constructing the manager.
+    await mkdir(join(root, "data", "local"), { recursive: true });
+    await writeFile(join(root, "data", "local", "dataset.csv"), "cols\n1,2\n", "utf8");
+    await mkdir(join(root, "data", "local", "subdir"), { recursive: true });
+    await writeFile(join(root, "data", "local", "subdir", "notes.md"), "kept together", "utf8");
+
+    const m = new SessionManager({ dataRoot: root, persist: false, agentFactory: mockAgentFactory });
+    await m.createSession({ title: "S" }); // triggers migration
+
+    // Files are now flat under data/.
+    expect(await readFile(join(root, "data", "dataset.csv"), "utf8")).toBe("cols\n1,2\n");
+    expect(await readFile(join(root, "data", "subdir", "notes.md"), "utf8")).toBe("kept together");
+    // Legacy subdir is gone (empty → rmdir'd).
+    await expect(readFile(join(root, "data", "local", "dataset.csv"), "utf8")).rejects.toThrow();
+    // Sentinel is present and names the source.
+    const sentinelBody = await readFile(join(root, "data", ".bp-migrated-from-local"), "utf8");
+    expect(sentinelBody).toMatch(/data\/local\//);
+  });
+
+  it("is idempotent across manager restarts (sentinel short-circuits)", async () => {
+    await mkdir(join(root, "data", "local"), { recursive: true });
+    await writeFile(join(root, "data", "local", "a.txt"), "one", "utf8");
+    const m1 = new SessionManager({ dataRoot: root, persist: false, agentFactory: mockAgentFactory });
+    await m1.createSession({ title: "S1" });
+    expect(await readFile(join(root, "data", "a.txt"), "utf8")).toBe("one");
+
+    // Simulate an agent later creating a directory named identically to a
+    // former user — this must NOT re-trigger migration once the sentinel is
+    // in place. The stray dir stays put; a.txt is untouched.
+    await mkdir(join(root, "data", "local"), { recursive: true });
+    await writeFile(join(root, "data", "local", "should_stay_here.txt"), "x", "utf8");
+
+    const m2 = new SessionManager({ dataRoot: root, persist: false, agentFactory: mockAgentFactory });
+    await m2.createSession({ title: "S2" });
+    // The stray file was NOT flattened (would've overwritten nothing but
+    // still: the guard is "sentinel present → no-op").
+    expect(await readFile(join(root, "data", "local", "should_stay_here.txt"), "utf8")).toBe("x");
+    expect(await readFile(join(root, "data", "a.txt"), "utf8")).toBe("one");
+  });
+
+  it("refuses to migrate when data/ has ≥2 subdirs (unknown state → leave alone)", async () => {
+    await mkdir(join(root, "data", "alice"), { recursive: true });
+    await mkdir(join(root, "data", "bob"), { recursive: true });
+    await writeFile(join(root, "data", "alice", "a.txt"), "alice", "utf8");
+    await writeFile(join(root, "data", "bob", "b.txt"), "bob", "utf8");
+
+    const m = new SessionManager({ dataRoot: root, persist: false, agentFactory: mockAgentFactory });
+    await m.createSession({ title: "S" });
+
+    // Nothing was touched.
+    expect(await readFile(join(root, "data", "alice", "a.txt"), "utf8")).toBe("alice");
+    expect(await readFile(join(root, "data", "bob", "b.txt"), "utf8")).toBe("bob");
+    // And no sentinel was written (migration bailed BEFORE writing it).
+    const rootEntries = await readdirNames(join(root, "data"));
+    expect(rootEntries.filter((n) => n.startsWith(".bp-migrated-from-"))).toEqual([]);
+  });
+
+  it("ignores dotted helper entries at data/ root (e.g. a stray .tmp)", async () => {
+    // A hidden dotfile at data/ (say, .tmp from a prior interrupted op) should
+    // not count as "already-flat" — those dotted entries are filtered so a
+    // real legacy subdir alongside them still migrates. This exercises the
+    // `!e.name.startsWith(".")` filter on the dirs list; files at the root
+    // still count, but a dotted file is rare and we let it count as
+    // "already-flat" via the `files.length > 0` guard (safe default).
+    await mkdir(join(root, "data", ".tmp"), { recursive: true }); // dotted subdir
+    await mkdir(join(root, "data", "local"), { recursive: true });
+    await writeFile(join(root, "data", "local", "x.txt"), "moved", "utf8");
+
+    const m = new SessionManager({ dataRoot: root, persist: false, agentFactory: mockAgentFactory });
+    await m.createSession({ title: "S" });
+
+    // Legacy content flattened, .tmp dir left in place.
+    expect(await readFile(join(root, "data", "x.txt"), "utf8")).toBe("moved");
+    const rootEntries = await readdirNames(join(root, "data"));
+    expect(rootEntries).toContain(".tmp");
+    expect(rootEntries).toContain(".bp-migrated-from-local");
+  });
+
+  it("is a no-op when data/ already contains files at the root (new layout)", async () => {
+    // Someone (or a prior migration) already flattened data/ but no sentinel:
+    // presence of any regular file at the root proves the new layout is live
+    // and we should NOT try to migrate anything.
+    await mkdir(join(root, "data"), { recursive: true });
+    await writeFile(join(root, "data", "already-flat.txt"), "hi", "utf8");
+    await mkdir(join(root, "data", "sub"), { recursive: true }); // a legit subdir
+    await writeFile(join(root, "data", "sub", "leave-alone.txt"), "sub", "utf8");
+
+    const m = new SessionManager({ dataRoot: root, persist: false, agentFactory: mockAgentFactory });
+    await m.createSession({ title: "S" });
+
+    // Untouched.
+    expect(await readFile(join(root, "data", "sub", "leave-alone.txt"), "utf8")).toBe("sub");
+    // No sentinel (nothing to migrate).
+    const rootEntries = await readdirNames(join(root, "data"));
+    expect(rootEntries.filter((n) => n.startsWith(".bp-migrated-from-"))).toEqual([]);
   });
 });
 

--- a/packages/runtime/src/persistent-layout.ts
+++ b/packages/runtime/src/persistent-layout.ts
@@ -1,0 +1,227 @@
+/**
+ * Persistent-library layout initialization and v1 -> v2 migration (#287).
+ *
+ * v1: <dataRoot>/data/<legacyUserId>/...
+ * v2: <dataRoot>/data/...
+ *
+ * The marker deliberately lives outside data/: data/ is user-visible and a
+ * directory-count heuristic cannot distinguish a v1 user id from a perfectly
+ * valid v2 directory such as data/project/.
+ */
+import { mkdir, readFile, readdir, rename, rmdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const LAYOUT_VERSION = 2;
+export const PERSISTENT_LAYOUT_MARKER = ".bp-persistent-layout.json";
+export const PERSISTENT_LAYOUT_STAGING = ".bp-persistent-data-v1-migration";
+
+type LayoutMarker =
+  | { version: 2; status: "ready"; migratedFrom?: string; completedAt: string }
+  | {
+      version: 2;
+      status: "migrating";
+      phase: "prepared" | "staged";
+      legacyUserId: string;
+      startedAt: string;
+    };
+
+/** Reproduce the old resolver exactly, but only to locate a v1 directory. */
+export function resolveLegacyPersistentUserId(
+  opt?: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const raw = (opt ?? env.BP_USER_ID ?? "").trim();
+  const candidate = raw === "" ? "local" : raw;
+  const safe = candidate.replace(/[\\/]/g, "_").replace(/\.\.+/g, "_");
+  return safe === "" || safe === "." ? "local" : safe;
+}
+
+async function readMarker(path: string): Promise<LayoutMarker | null> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+
+  let marker: Partial<LayoutMarker>;
+  try {
+    marker = JSON.parse(raw) as Partial<LayoutMarker>;
+  } catch {
+    throw new Error(`invalid persistent-layout marker at ${path}`);
+  }
+  if (
+    marker.version !== LAYOUT_VERSION ||
+    (marker.status !== "ready" && marker.status !== "migrating")
+  ) {
+    throw new Error(`unsupported persistent-layout marker at ${path}`);
+  }
+  if (
+    marker.status === "migrating" &&
+    (typeof marker.legacyUserId !== "string" ||
+      (marker.phase !== "prepared" && marker.phase !== "staged"))
+  ) {
+    throw new Error(`invalid in-progress persistent-layout marker at ${path}`);
+  }
+  return marker as LayoutMarker;
+}
+
+async function writeMarker(path: string, marker: LayoutMarker): Promise<void> {
+  const temp = `${path}.tmp`;
+  await writeFile(temp, `${JSON.stringify(marker, null, 2)}\n`, "utf8");
+  await rename(temp, path);
+}
+
+async function readDirOrNull(path: string) {
+  try {
+    return await readdir(path, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+}
+
+function layoutConflict(dataDir: string, legacyUserId: string, entries: string[]): Error {
+  return new Error(
+    `[persistent-data] cannot migrate ${dataDir}/${legacyUserId}: data/ also contains ` +
+      `${entries.join(", ")}. Move either the flat-layout entries or the legacy directory ` +
+      `out of data/, then restart; no files were changed.`,
+  );
+}
+
+async function finishStagedMigration(
+  dataDir: string,
+  stagingDir: string,
+  markerPath: string,
+  marker: Extract<LayoutMarker, { status: "migrating" }>,
+): Promise<void> {
+  const stagingEntries = await readDirOrNull(stagingDir);
+  if (stagingEntries === null) {
+    // phase=staged with no staging dir means the final rename completed and
+    // the process stopped before it could write the ready marker.
+    const dataEntries = await readDirOrNull(dataDir);
+    if (dataEntries === null) {
+      throw new Error(`[persistent-data] migration state is incomplete: both ${dataDir} and ${stagingDir} are missing`);
+    }
+  } else {
+    const dataEntries = await readDirOrNull(dataDir);
+    if (dataEntries !== null && dataEntries.length > 0) {
+      throw new Error(
+        `[persistent-data] cannot resume migration: ${dataDir} is non-empty while ${stagingDir} exists`,
+      );
+    }
+    if (dataEntries !== null) await rmdir(dataDir);
+    await rename(stagingDir, dataDir);
+  }
+
+  await writeMarker(markerPath, {
+    version: LAYOUT_VERSION,
+    status: "ready",
+    migratedFrom: `data/${marker.legacyUserId}`,
+    completedAt: new Date().toISOString(),
+  });
+}
+
+async function runOrResumeMigration(
+  dataRoot: string,
+  markerPath: string,
+  marker: Extract<LayoutMarker, { status: "migrating" }>,
+): Promise<void> {
+  const dataDir = join(dataRoot, "data");
+  const stagingDir = join(dataRoot, PERSISTENT_LAYOUT_STAGING);
+
+  if (marker.phase === "prepared") {
+    const stagingEntries = await readDirOrNull(stagingDir);
+    if (stagingEntries === null) {
+      const entries = await readDirOrNull(dataDir);
+      if (entries === null) {
+        throw new Error(`[persistent-data] migration source is missing: ${dataDir}`);
+      }
+      const others = entries.filter((entry) => entry.name !== marker.legacyUserId);
+      const legacy = entries.find((entry) => entry.name === marker.legacyUserId);
+      if (!legacy?.isDirectory() || others.length > 0) {
+        throw layoutConflict(dataDir, marker.legacyUserId, others.map((entry) => entry.name));
+      }
+      await rename(join(dataDir, marker.legacyUserId), stagingDir);
+    }
+    marker = { ...marker, phase: "staged" };
+    await writeMarker(markerPath, marker);
+  }
+
+  await finishStagedMigration(dataDir, stagingDir, markerPath, marker);
+}
+
+/**
+ * Ensure v2 is ready before any /data access. Unexpected or ambiguous states
+ * reject instead of serving a split library. The caller supplies a single
+ * legacy id resolved with the old rules; directory counts are never used to
+ * guess identity.
+ */
+export async function ensurePersistentLayout(
+  dataRoot: string,
+  legacyUserId: string,
+): Promise<void> {
+  await mkdir(dataRoot, { recursive: true });
+  const markerPath = join(dataRoot, PERSISTENT_LAYOUT_MARKER);
+  const stagingDir = join(dataRoot, PERSISTENT_LAYOUT_STAGING);
+  const marker = await readMarker(markerPath);
+
+  if (marker?.status === "ready") return;
+  if (marker?.status === "migrating") {
+    await runOrResumeMigration(dataRoot, markerPath, marker);
+    return;
+  }
+
+  // A staging directory without its journal is not safe to infer or discard.
+  if ((await readDirOrNull(stagingDir)) !== null) {
+    throw new Error(
+      `[persistent-data] found unjournaled migration staging directory at ${stagingDir}; ` +
+        `restore its marker or resolve it manually before restart`,
+    );
+  }
+
+  const dataDir = join(dataRoot, "data");
+  const entries = await readDirOrNull(dataDir);
+  if (entries === null || entries.length === 0) {
+    await mkdir(dataDir, { recursive: true });
+    await writeMarker(markerPath, {
+      version: LAYOUT_VERSION,
+      status: "ready",
+      completedAt: new Date().toISOString(),
+    });
+    return;
+  }
+
+  const legacy = entries.find((entry) => entry.name === legacyUserId);
+  if (legacy === undefined) {
+    // Existing content that does not use the one known legacy id is already
+    // v2. In particular, data/project/ must remain data/project/.
+    await writeMarker(markerPath, {
+      version: LAYOUT_VERSION,
+      status: "ready",
+      completedAt: new Date().toISOString(),
+    });
+    return;
+  }
+  if (!legacy.isDirectory()) {
+    throw new Error(
+      `[persistent-data] expected legacy path ${join(dataDir, legacyUserId)} to be a directory; no files were changed`,
+    );
+  }
+
+  const others = entries.filter((entry) => entry.name !== legacyUserId);
+  if (others.length > 0) {
+    throw layoutConflict(dataDir, legacyUserId, others.map((entry) => entry.name));
+  }
+
+  const migrating: LayoutMarker = {
+    version: LAYOUT_VERSION,
+    status: "migrating",
+    phase: "prepared",
+    legacyUserId,
+    startedAt: new Date().toISOString(),
+  };
+  await writeMarker(markerPath, migrating);
+  await runOrResumeMigration(dataRoot, markerPath, migrating);
+}

--- a/packages/runtime/src/personas.ts
+++ b/packages/runtime/src/personas.ts
@@ -68,13 +68,13 @@ export function withLanguageDirective(persona: string): string {
 }
 
 /**
- * Persistent cross-session storage directive (#257). Your working directory is
- * the per-session workspace — anything there is scoped to THIS session. A
- * separate persistent root, given here as an absolute path, is SHARED across all
- * of the user's sessions: files there (uploaded datasets, reference documents,
- * reusable models) remain available in future sessions. `${absPath}` is
- * interpolated at load time with the deployment's real path so the agent can
- * `read`/`write`/`bash` it directly.
+ * Persistent cross-session storage directive (#257; flattened by #287). Your
+ * working directory is the per-session workspace — anything there is scoped to
+ * THIS session. A separate persistent root, given here as an absolute path, is
+ * SHARED across all sessions of this runtime: files there (uploaded datasets,
+ * reference documents, reusable models) remain available in future sessions.
+ * `${absPath}` is interpolated at load time with the deployment's real path so
+ * the agent can `read`/`write`/`bash` it directly.
  */
 export function persistentRootDirective(absPath: string): string {
   return `## Persistent cross-session storage

--- a/packages/runtime/src/server.ts
+++ b/packages/runtime/src/server.ts
@@ -279,6 +279,12 @@ export async function startServer(opts: StartServerOptions = {}): Promise<{
 }> {
   const { app, manager } = createServer(opts);
 
+  // #287: complete or recover the persistent-library layout migration before
+  // restoring sessions or accepting requests. Unlike session restore, this is
+  // a readiness gate: serving a half-migrated /data tree could split or hide
+  // user data, so initialization failures intentionally abort startup.
+  await manager.ensurePersistentLayout();
+
   // Restore sessions persisted under `<dataRoot>/.bp/*/meta.json` before we
   // accept the first HTTP request, so `GET /sessions` reflects history on
   // boot instead of an empty list. Persist defaults to true on the manager

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -46,6 +46,10 @@ import { materializeSkills } from "./materialize-skills.js";
 import { resolveSessionProvider, type SessionProviderRef } from "./provider-config.js";
 import { MemWatchdog, parseMemLimitMb } from "./mem-watchdog.js";
 import { isWindows } from "./platform.js";
+import {
+  ensurePersistentLayout as initializePersistentLayout,
+  resolveLegacyPersistentUserId,
+} from "./persistent-layout.js";
 import type { AgentRole, AgentSessionFactory, EventListener, SystemTool, SystemToolResult } from "./types.js";
 
 interface Deferred<T> {
@@ -105,23 +109,11 @@ function resolveMaxConcurrentAgents(opt?: number): number {
 }
 
 /**
- * #287: name of the one-shot migration sentinel written under `<dataRoot>/data/`
- * once the legacy `data/<legacyUserId>/` layout has been flattened. Its
- * presence is what makes `maybeMigrateLegacyPersistentLayout` idempotent — a
- * second boot sees the sentinel and takes no action, even if a new
- * subdirectory named identically to a former user id is later created by an
- * agent.
- */
-const MIGRATION_SENTINEL_PREFIX = ".bp-migrated-from-";
-
-/**
  * #287 (former #257 hook): the runtime is now single-user by contract, so
- * `BP_USER_ID` no longer influences on-disk layout. We keep reading the env
- * only to print a one-shot deprecation notice — a hosted deployment that still
- * exports it should learn quickly that the value is ignored, without a hard
- * error that would break rollout. `opt` is likewise ignored (kept in the
- * SessionManagerOptions surface for API compatibility) but a non-empty value
- * still triggers the same warning so integrators notice.
+ * `BP_USER_ID` no longer influences the active on-disk root. A separate
+ * migration helper may use its old value once to locate data/<legacyUserId>;
+ * this warning tells hosted deployments that it can be removed after rollout.
+ * `opt` is likewise retained only for API/migration compatibility.
  * Returns true when a warning was printed, purely so tests can assert on it.
  */
 export function warnOnDeprecatedPersistentUserId(
@@ -139,9 +131,10 @@ export function warnOnDeprecatedPersistentUserId(
         ? `persistentUserId option ("${optVal}")`
         : `BP_USER_ID env ("${envVal}")`;
   log(
-    `[persistent-data] ${source} is ignored since #287: the runtime is single-user ` +
-      `and stores its persistent library flat under <dataRoot>/data/. Multi-user ` +
-      `isolation is the deployment layer's job (one dataRoot per user).`,
+    `[persistent-data] ${source} no longer controls path resolution since #287; ` +
+      `it is used only to locate a legacy directory during one-shot migration. ` +
+      `The runtime stores its library flat under <dataRoot>/data/; multi-user ` +
+      `isolation requires one dataRoot per user.`,
   );
   return true;
 }
@@ -305,10 +298,11 @@ export interface SessionManagerOptions {
   /**
    * @deprecated since #287. The runtime is single-user by contract and the
    * persistent library lives flat under `<dataRoot>/data/`. This field (and
-   * the `BP_USER_ID` env var) are IGNORED for path resolution — supplying
-   * either only produces a one-shot deprecation warning so old integrations
-   * find out quickly. Multi-user isolation belongs to the deployment layer:
-   * give each user their own `dataRoot` (bind mount / container / volume).
+   * the `BP_USER_ID` env var) are IGNORED for active path resolution. During
+   * upgrade only, the old value identifies the one legacy directory eligible
+   * for migration; it also produces a deprecation warning. Multi-user
+   * isolation belongs to the deployment layer: give each user their own
+   * `dataRoot` (bind mount / container / volume).
    */
   persistentUserId?: string;
   /**
@@ -430,12 +424,10 @@ export class SessionManager {
   // so hosted deployments can accept large files; default 20 MiB.
   private readonly uploadMaxBytes: number;
 
-  // #287: legacy `data/<userId>/` was flattened to `data/`. `BP_USER_ID` / the
-  // `persistentUserId` option are ignored (with a one-shot deprecation warning
-  // in the ctor). Multi-user isolation is delegated to the deployment layer
-  // (one dataRoot per user). See `maybeMigrateLegacyPersistentLayout` for the
-  // one-shot on-disk migration.
-  private migrationChecked = false;
+  // #287: active addressing is always flat data/. The deprecated value is
+  // retained only as a v1 migration hint; it never changes the v2 root.
+  private readonly legacyPersistentUserId: string;
+  private persistentLayoutReady?: Promise<void>;
 
   // Per-tool on/off overrides. Populated by `ensureToolToggles()` on the
   // first agent creation and cached for the process lifetime; a restart is
@@ -476,9 +468,10 @@ export class SessionManager {
 
     this.maxConcurrentAgents = resolveMaxConcurrentAgents(opts.maxConcurrentAgents);
     this.uploadMaxBytes = resolveUploadMaxBytes(opts.uploadMaxBytes);
-    // #287: persistentUserId / BP_USER_ID are ignored; warn once so anything
-    // still setting them notices instead of silently getting the new layout.
+    // #287: these no longer select the active root. Warn and retain the old
+    // resolved value solely to identify the directory eligible for migration.
     warnOnDeprecatedPersistentUserId(opts.persistentUserId);
+    this.legacyPersistentUserId = resolveLegacyPersistentUserId(opts.persistentUserId);
     this.sharedDir = resolveSharedDir(opts.sharedDir);
 
     // Test-only injection path: if callers pass `toolToggles`, use it verbatim
@@ -588,145 +581,19 @@ export class SessionManager {
   private persistentDir(): string {
     return join(this.dataRoot, "data");
   }
+
   /**
-   * #287 one-shot migration: flatten the legacy per-user layout
-   * `<dataRoot>/data/<legacyUserId>/…` to `<dataRoot>/data/…`. Guarded by a
-   * `.bp-migrated-from-<name>` sentinel written under `data/` so subsequent
-   * boots take no action even if an agent later creates a directory named
-   * identically to a former user id.
-   *
-   * Design guarantees:
-   *   - **Idempotent.** Sentinel presence short-circuits. The in-process
-   *     `migrationChecked` flag additionally collapses concurrent createSession
-   *     calls within one process boot so the disk scan runs at most once.
-   *   - **Cautious.** Migration only fires when `data/` contains EXACTLY one
-   *     subdirectory (no other files, no other subdirs). Two or more subdirs
-   *     means "state we don't understand" (dev copied trees around, cloud
-   *     mislabelled a user, tests seeded weird layouts) — we log a one-line
-   *     warning and leave everything alone so a human can resolve it.
-   *   - **Non-destructive on conflict.** During move, an existing entry at the
-   *     destination is preserved: the legacy source stays put, we log a
-   *     warning naming the file, and other files continue to migrate. The
-   *     legacy subdir is `rmdir`'d only if it ends up empty. Even a partially-
-   *     complete migration still writes the sentinel so we don't keep retrying
-   *     — the operator's next boot log has the exact skipped names.
-   *   - **Best-effort.** ANY error surfaces as a warning and returns without
-   *     throwing: this migration is a convenience, not a hard gate; a broken
-   *     migration must never prevent the runtime from serving sessions.
+   * Initialize the flat persistent layout exactly once per manager. The shared
+   * promise is awaited by startup and every /data operation, so requests cannot
+   * race migration. Failures stay rejected: serving a split library is less
+   * safe than refusing the request with an actionable error.
    */
-  private async maybeMigrateLegacyPersistentLayout(): Promise<void> {
-    if (this.migrationChecked) return;
-    this.migrationChecked = true;
-
-    const dataDir = this.persistentDir();
-    try {
-      let entries;
-      try {
-        entries = await readdir(dataDir, { withFileTypes: true });
-      } catch (err) {
-        // Fresh install (ENOENT) — nothing to migrate; the caller's mkdir will
-        // create it. Any other error we surface but do not throw.
-        const code = (err as NodeJS.ErrnoException).code;
-        if (code !== "ENOENT") {
-          console.warn(`[persistent-data] scan failed at ${dataDir}: ${(err as Error).message}`);
-        }
-        return;
-      }
-
-      // Sentinel already written on a previous boot → migration is done.
-      if (entries.some((e) => e.isFile() && e.name.startsWith(MIGRATION_SENTINEL_PREFIX))) return;
-
-      // Split into (regular files) + (candidate legacy subdirs, ignoring dotted
-      // helper entries like `.git` / `.tmp` that agents may drop). If there is
-      // ANY regular file in `data/`, the new flat layout is already in use —
-      // don't migrate on top of it.
-      const files = entries.filter((e) => e.isFile());
-      const dirs = entries.filter((e) => e.isDirectory() && !e.name.startsWith("."));
-
-      if (files.length > 0) return; // already flat — no-op
-      if (dirs.length === 0) return; // empty tree — nothing to move
-      if (dirs.length > 1) {
-        console.warn(
-          `[persistent-data] ${dataDir} contains ${dirs.length} subdirectories ` +
-            `(${dirs.map((d) => d.name).join(", ")}); refusing to auto-flatten. ` +
-            `#287 migration expects exactly one legacy user subdir. Please ` +
-            `resolve manually and re-run.`,
-        );
-        return;
-      }
-
-      const legacyName = dirs[0]!.name;
-      const legacyDir = join(dataDir, legacyName);
-      let legacyEntries;
-      try {
-        legacyEntries = await readdir(legacyDir, { withFileTypes: true });
-      } catch (err) {
-        console.warn(`[persistent-data] cannot read legacy dir ${legacyDir}: ${(err as Error).message}`);
-        return;
-      }
-
-      let moved = 0;
-      const skipped: string[] = [];
-      for (const child of legacyEntries) {
-        const src = join(legacyDir, child.name);
-        const dst = join(dataDir, child.name);
-        try {
-          // Refuse to overwrite: if a same-named entry already exists at the
-          // destination (partial prior migration, race, whatever), skip it and
-          // keep the legacy copy intact for the operator to reconcile.
-          try {
-            await stat(dst);
-            skipped.push(child.name);
-            continue;
-          } catch (err) {
-            const code = (err as NodeJS.ErrnoException).code;
-            if (code !== "ENOENT") throw err;
-          }
-          await rename(src, dst);
-          moved++;
-        } catch (err) {
-          skipped.push(child.name);
-          console.warn(
-            `[persistent-data] failed to move ${src} → ${dst}: ${(err as Error).message}`,
-          );
-        }
-      }
-
-      // Try to `rmdir` the (now hopefully empty) legacy dir. If files were
-      // skipped it stays put — that is the intended safety net.
-      try {
-        await rm(legacyDir, { recursive: false });
-      } catch {
-        /* not empty or already gone — either way, nothing else to do */
-      }
-
-      // Write the sentinel even on a partial move: we don't want to keep
-      // retrying every boot. The next-boot operator can read the file's name
-      // and the console warnings to understand what happened.
-      const sentinel = join(dataDir, `${MIGRATION_SENTINEL_PREFIX}${legacyName}`);
-      try {
-        await writeFile(
-          sentinel,
-          `#287 flattened data/${legacyName}/ → data/ at ${new Date().toISOString()}\n` +
-            `moved: ${moved} entries; skipped (kept in legacy dir): ${skipped.length}\n` +
-            (skipped.length ? `skipped names: ${skipped.join(", ")}\n` : ""),
-          "utf8",
-        );
-      } catch (err) {
-        // Sentinel write failed — log but don't rethrow. Next boot will retry
-        // migration; the guards above (files.length > 0) make that safe.
-        console.warn(
-          `[persistent-data] wrote no sentinel at ${sentinel}: ${(err as Error).message}`,
-        );
-      }
-
-      console.info(
-        `[persistent-data] flattened data/${legacyName}/ → data/ ` +
-          `(${moved} moved${skipped.length ? `, ${skipped.length} skipped` : ""})`,
-      );
-    } catch (err) {
-      console.warn(`[persistent-data] migration aborted: ${(err as Error).message}`);
-    }
+  ensurePersistentLayout(): Promise<void> {
+    this.persistentLayoutReady ??= initializePersistentLayout(
+      this.dataRoot,
+      this.legacyPersistentUserId,
+    );
+    return this.persistentLayoutReady;
   }
   /**
    * Conversation-attachments subdir of a session's workspace —
@@ -845,13 +712,18 @@ export class SessionManager {
     return { abs, root, prefix };
   }
 
-  /** Back-compat shim: resolve to just the absolute path (workspace or /data). */
-  private resolveWorkspacePath(sid: string, rawPath: string): string {
-    return this.resolveManagedPath(sid, rawPath).abs;
+  private isPersistentPath(rawPath: string): boolean {
+    const normalized = (rawPath ?? "").replace(/\\/g, "/");
+    return normalized === "/data" || normalized.startsWith("/data/");
+  }
+
+  private async ensureLayoutForPath(rawPath: string): Promise<void> {
+    if (this.isPersistentPath(rawPath)) await this.ensurePersistentLayout();
   }
 
   /** List one directory level under the session workspace (default: root). */
   async listSessionFiles(sid: string, rel = ""): Promise<FileEntry[]> {
+    await this.ensureLayoutForPath(rel);
     const { abs: dir, root, prefix } = this.resolveManagedPath(sid, rel);
     let dirents;
     try {
@@ -908,19 +780,22 @@ export class SessionManager {
 
   /** Read a workspace text file as UTF-8. */
   async readSessionFile(sid: string, rel: string): Promise<FileContent> {
-    const abs = this.resolveWorkspacePath(sid, rel);
+    await this.ensureLayoutForPath(rel);
+    const abs = this.resolveManagedPath(sid, rel).abs;
     const content = await readFile(abs, "utf8");
     return { path: rel, content, size: Buffer.byteLength(content) };
   }
 
   /** Read a workspace file's raw bytes (images/PDF/download). */
   async readSessionFileRaw(sid: string, rel: string): Promise<Buffer> {
-    const abs = this.resolveWorkspacePath(sid, rel);
+    await this.ensureLayoutForPath(rel);
+    const abs = this.resolveManagedPath(sid, rel).abs;
     return readFile(abs);
   }
 
   /** Delete a workspace file. Returns false if it was already gone. */
   async deleteSessionFile(sid: string, rel: string): Promise<boolean> {
+    await this.ensureLayoutForPath(rel);
     const { abs, prefix } = this.resolveManagedPath(sid, rel);
     this.assertWritable(prefix, rel); // #261: the shared root is read-only
     try {
@@ -968,6 +843,7 @@ export class SessionManager {
     if (buf.byteLength > maxBytes) {
       throw new Error(`file too large: ${buf.byteLength} bytes exceeds limit of ${maxBytes}`);
     }
+    await this.ensureLayoutForPath(rel);
     const { abs, root, prefix } = this.resolveManagedPath(sid, rel);
     this.assertWritable(prefix, rel); // #261: the shared root is read-only
     await mkdir(dirname(abs), { recursive: true });
@@ -996,6 +872,7 @@ export class SessionManager {
     body: ReadableStream<Uint8Array> | Readable | null,
     maxBytes = this.uploadMaxBytes,
   ): Promise<{ path: string; size: number }> {
+    await this.ensureLayoutForPath(rel);
     const { abs, root, prefix } = this.resolveManagedPath(sid, rel);
     this.assertWritable(prefix, rel); // #261: the shared root is read-only
     await mkdir(dirname(abs), { recursive: true });
@@ -1182,6 +1059,9 @@ export class SessionManager {
     if (this.memWatchdog?.isOverSoftLimit()) {
       throw new Error("memory budget exceeded: refusing new session");
     }
+    // Persisted sessions may hand the absolute data/ path to agents, so finish
+    // layout initialization before creating any durable session state.
+    if (this.persist) await this.ensurePersistentLayout();
     const id = input.id ?? randomUUID();
     if (this.sessions.has(id)) return this.toSession(this.sessions.get(id)!);
     const nowIso = _restore ? _restore.updatedAt : new Date().toISOString();
@@ -1246,13 +1126,6 @@ export class SessionManager {
       this.lastActivityAt = Math.max(this.lastActivityAt, Date.now());
     }
 
-    // #287: one-shot migration from the legacy `data/<userId>/` layout to
-    // flat `data/`. Runs unconditionally (not gated on `persist`) because the
-    // persistent library at `data/` is a real on-disk resource even when
-    // per-session metadata is not persisted, and migration is a cheap no-op
-    // (ENOENT) on fresh installs. Guarded by a sentinel so it fires at most
-    // once per dataRoot.
-    await this.maybeMigrateLegacyPersistentLayout();
     if (this.persist) {
       await mkdir(join(this.bpDir(id), "history"), { recursive: true });
       await mkdir(this.workspaceDir(id), { recursive: true });

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -104,22 +104,46 @@ function resolveMaxConcurrentAgents(opt?: number): number {
   return DEFAULT_MAX_CONCURRENT_AGENTS;
 }
 
-/** #257 default per-user persistent root id (self-hosted single user). */
-const DEFAULT_PERSISTENT_USER_ID = "local";
+/**
+ * #287: name of the one-shot migration sentinel written under `<dataRoot>/data/`
+ * once the legacy `data/<legacyUserId>/` layout has been flattened. Its
+ * presence is what makes `maybeMigrateLegacyPersistentLayout` idempotent — a
+ * second boot sees the sentinel and takes no action, even if a new
+ * subdirectory named identically to a former user id is later created by an
+ * agent.
+ */
+const MIGRATION_SENTINEL_PREFIX = ".bp-migrated-from-";
 
 /**
- * #257: resolve the persistent-root user id. Explicit option wins, else
- * `BP_USER_ID`, else `local`. The id names a subdir under `<dataRoot>/data/`,
- * so it is sanitized to a single safe path segment (no separators, no `..`) —
- * a hostile `BP_USER_ID` must not let the "persistent root" escape `data/`.
- * An empty/blank value falls back to the default.
+ * #287 (former #257 hook): the runtime is now single-user by contract, so
+ * `BP_USER_ID` no longer influences on-disk layout. We keep reading the env
+ * only to print a one-shot deprecation notice — a hosted deployment that still
+ * exports it should learn quickly that the value is ignored, without a hard
+ * error that would break rollout. `opt` is likewise ignored (kept in the
+ * SessionManagerOptions surface for API compatibility) but a non-empty value
+ * still triggers the same warning so integrators notice.
+ * Returns true when a warning was printed, purely so tests can assert on it.
  */
-export function resolvePersistentUserId(opt?: string, env = process.env): string {
-  const raw = (opt ?? env.BP_USER_ID ?? "").trim();
-  const candidate = raw === "" ? DEFAULT_PERSISTENT_USER_ID : raw;
-  // Collapse any path separators / traversal to keep this a single segment.
-  const safe = candidate.replace(/[\\/]/g, "_").replace(/\.\.+/g, "_");
-  return safe === "" || safe === "." ? DEFAULT_PERSISTENT_USER_ID : safe;
+export function warnOnDeprecatedPersistentUserId(
+  opt?: string,
+  env: NodeJS.ProcessEnv = process.env,
+  log: (msg: string) => void = (m) => console.warn(m),
+): boolean {
+  const envVal = (env.BP_USER_ID ?? "").trim();
+  const optVal = (opt ?? "").trim();
+  if (envVal === "" && optVal === "") return false;
+  const source =
+    optVal !== "" && envVal !== ""
+      ? `persistentUserId option ("${optVal}") + BP_USER_ID env ("${envVal}")`
+      : optVal !== ""
+        ? `persistentUserId option ("${optVal}")`
+        : `BP_USER_ID env ("${envVal}")`;
+  log(
+    `[persistent-data] ${source} is ignored since #287: the runtime is single-user ` +
+      `and stores its persistent library flat under <dataRoot>/data/. Multi-user ` +
+      `isolation is the deployment layer's job (one dataRoot per user).`,
+  );
+  return true;
 }
 
 /**
@@ -279,13 +303,12 @@ export interface SessionManagerOptions {
    */
   uploadMaxBytes?: number;
   /**
-   * #257: per-user persistent root identity. Files under
-   * `<dataRoot>/data/<persistentUserId>/` are shared across ALL sessions of
-   * this runtime (a private "library" that outlives any single session),
-   * unlike the per-session `workspaces/<sid>/`. Default `local` (self-hosted
-   * single user); env override `BP_USER_ID`. Hosted deployments set this
-   * per-user (they already isolate users by container/dataRoot, so this just
-   * names the on-disk subdir). Tests inject directly.
+   * @deprecated since #287. The runtime is single-user by contract and the
+   * persistent library lives flat under `<dataRoot>/data/`. This field (and
+   * the `BP_USER_ID` env var) are IGNORED for path resolution — supplying
+   * either only produces a one-shot deprecation warning so old integrations
+   * find out quickly. Multi-user isolation belongs to the deployment layer:
+   * give each user their own `dataRoot` (bind mount / container / volume).
    */
   persistentUserId?: string;
   /**
@@ -407,10 +430,12 @@ export class SessionManager {
   // so hosted deployments can accept large files; default 20 MiB.
   private readonly uploadMaxBytes: number;
 
-  // #257: per-user persistent root identity. `data/<persistentUserId>/` is
-  // shared across all sessions (cross-session library), unlike per-session
-  // `workspaces/<sid>/`. Default `local`; env `BP_USER_ID`.
-  private readonly persistentUserId: string;
+  // #287: legacy `data/<userId>/` was flattened to `data/`. `BP_USER_ID` / the
+  // `persistentUserId` option are ignored (with a one-shot deprecation warning
+  // in the ctor). Multi-user isolation is delegated to the deployment layer
+  // (one dataRoot per user). See `maybeMigrateLegacyPersistentLayout` for the
+  // one-shot on-disk migration.
+  private migrationChecked = false;
 
   // Per-tool on/off overrides. Populated by `ensureToolToggles()` on the
   // first agent creation and cached for the process lifetime; a restart is
@@ -451,7 +476,9 @@ export class SessionManager {
 
     this.maxConcurrentAgents = resolveMaxConcurrentAgents(opts.maxConcurrentAgents);
     this.uploadMaxBytes = resolveUploadMaxBytes(opts.uploadMaxBytes);
-    this.persistentUserId = resolvePersistentUserId(opts.persistentUserId);
+    // #287: persistentUserId / BP_USER_ID are ignored; warn once so anything
+    // still setting them notices instead of silently getting the new layout.
+    warnOnDeprecatedPersistentUserId(opts.persistentUserId);
     this.sharedDir = resolveSharedDir(opts.sharedDir);
 
     // Test-only injection path: if callers pass `toolToggles`, use it verbatim
@@ -549,15 +576,157 @@ export class SessionManager {
     return join(this.dataRoot, "workspaces", sid);
   }
   /**
-   * #257: the per-user persistent root, shared across all sessions —
-   * `<dataRoot>/data/<persistentUserId>/`. Files here outlive any single
-   * session (a reusable "library"), unlike `workspaces/<sid>/`. The whole
-   * `dataRoot` is already the persisted volume, so no extra mount is needed.
-   * Addressed by agents/file-routes via the `/data` prefix (see
+   * #287 (formerly #257): the persistent library shared across all sessions
+   * of this runtime — `<dataRoot>/data/`. Files here outlive any single
+   * session (a reusable "library"), unlike `workspaces/<sid>/`. Flat: the
+   * runtime is single-user by contract, so there is no per-user subdir; a
+   * hosted multi-user deployment gives each user their own dataRoot. The
+   * whole `dataRoot` is already the persisted volume, so no extra mount is
+   * needed. Addressed by agents/file-routes via the `/data` prefix (see
    * `resolveManagedPath`).
    */
   private persistentDir(): string {
-    return join(this.dataRoot, "data", this.persistentUserId);
+    return join(this.dataRoot, "data");
+  }
+  /**
+   * #287 one-shot migration: flatten the legacy per-user layout
+   * `<dataRoot>/data/<legacyUserId>/…` to `<dataRoot>/data/…`. Guarded by a
+   * `.bp-migrated-from-<name>` sentinel written under `data/` so subsequent
+   * boots take no action even if an agent later creates a directory named
+   * identically to a former user id.
+   *
+   * Design guarantees:
+   *   - **Idempotent.** Sentinel presence short-circuits. The in-process
+   *     `migrationChecked` flag additionally collapses concurrent createSession
+   *     calls within one process boot so the disk scan runs at most once.
+   *   - **Cautious.** Migration only fires when `data/` contains EXACTLY one
+   *     subdirectory (no other files, no other subdirs). Two or more subdirs
+   *     means "state we don't understand" (dev copied trees around, cloud
+   *     mislabelled a user, tests seeded weird layouts) — we log a one-line
+   *     warning and leave everything alone so a human can resolve it.
+   *   - **Non-destructive on conflict.** During move, an existing entry at the
+   *     destination is preserved: the legacy source stays put, we log a
+   *     warning naming the file, and other files continue to migrate. The
+   *     legacy subdir is `rmdir`'d only if it ends up empty. Even a partially-
+   *     complete migration still writes the sentinel so we don't keep retrying
+   *     — the operator's next boot log has the exact skipped names.
+   *   - **Best-effort.** ANY error surfaces as a warning and returns without
+   *     throwing: this migration is a convenience, not a hard gate; a broken
+   *     migration must never prevent the runtime from serving sessions.
+   */
+  private async maybeMigrateLegacyPersistentLayout(): Promise<void> {
+    if (this.migrationChecked) return;
+    this.migrationChecked = true;
+
+    const dataDir = this.persistentDir();
+    try {
+      let entries;
+      try {
+        entries = await readdir(dataDir, { withFileTypes: true });
+      } catch (err) {
+        // Fresh install (ENOENT) — nothing to migrate; the caller's mkdir will
+        // create it. Any other error we surface but do not throw.
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code !== "ENOENT") {
+          console.warn(`[persistent-data] scan failed at ${dataDir}: ${(err as Error).message}`);
+        }
+        return;
+      }
+
+      // Sentinel already written on a previous boot → migration is done.
+      if (entries.some((e) => e.isFile() && e.name.startsWith(MIGRATION_SENTINEL_PREFIX))) return;
+
+      // Split into (regular files) + (candidate legacy subdirs, ignoring dotted
+      // helper entries like `.git` / `.tmp` that agents may drop). If there is
+      // ANY regular file in `data/`, the new flat layout is already in use —
+      // don't migrate on top of it.
+      const files = entries.filter((e) => e.isFile());
+      const dirs = entries.filter((e) => e.isDirectory() && !e.name.startsWith("."));
+
+      if (files.length > 0) return; // already flat — no-op
+      if (dirs.length === 0) return; // empty tree — nothing to move
+      if (dirs.length > 1) {
+        console.warn(
+          `[persistent-data] ${dataDir} contains ${dirs.length} subdirectories ` +
+            `(${dirs.map((d) => d.name).join(", ")}); refusing to auto-flatten. ` +
+            `#287 migration expects exactly one legacy user subdir. Please ` +
+            `resolve manually and re-run.`,
+        );
+        return;
+      }
+
+      const legacyName = dirs[0]!.name;
+      const legacyDir = join(dataDir, legacyName);
+      let legacyEntries;
+      try {
+        legacyEntries = await readdir(legacyDir, { withFileTypes: true });
+      } catch (err) {
+        console.warn(`[persistent-data] cannot read legacy dir ${legacyDir}: ${(err as Error).message}`);
+        return;
+      }
+
+      let moved = 0;
+      const skipped: string[] = [];
+      for (const child of legacyEntries) {
+        const src = join(legacyDir, child.name);
+        const dst = join(dataDir, child.name);
+        try {
+          // Refuse to overwrite: if a same-named entry already exists at the
+          // destination (partial prior migration, race, whatever), skip it and
+          // keep the legacy copy intact for the operator to reconcile.
+          try {
+            await stat(dst);
+            skipped.push(child.name);
+            continue;
+          } catch (err) {
+            const code = (err as NodeJS.ErrnoException).code;
+            if (code !== "ENOENT") throw err;
+          }
+          await rename(src, dst);
+          moved++;
+        } catch (err) {
+          skipped.push(child.name);
+          console.warn(
+            `[persistent-data] failed to move ${src} → ${dst}: ${(err as Error).message}`,
+          );
+        }
+      }
+
+      // Try to `rmdir` the (now hopefully empty) legacy dir. If files were
+      // skipped it stays put — that is the intended safety net.
+      try {
+        await rm(legacyDir, { recursive: false });
+      } catch {
+        /* not empty or already gone — either way, nothing else to do */
+      }
+
+      // Write the sentinel even on a partial move: we don't want to keep
+      // retrying every boot. The next-boot operator can read the file's name
+      // and the console warnings to understand what happened.
+      const sentinel = join(dataDir, `${MIGRATION_SENTINEL_PREFIX}${legacyName}`);
+      try {
+        await writeFile(
+          sentinel,
+          `#287 flattened data/${legacyName}/ → data/ at ${new Date().toISOString()}\n` +
+            `moved: ${moved} entries; skipped (kept in legacy dir): ${skipped.length}\n` +
+            (skipped.length ? `skipped names: ${skipped.join(", ")}\n` : ""),
+          "utf8",
+        );
+      } catch (err) {
+        // Sentinel write failed — log but don't rethrow. Next boot will retry
+        // migration; the guards above (files.length > 0) make that safe.
+        console.warn(
+          `[persistent-data] wrote no sentinel at ${sentinel}: ${(err as Error).message}`,
+        );
+      }
+
+      console.info(
+        `[persistent-data] flattened data/${legacyName}/ → data/ ` +
+          `(${moved} moved${skipped.length ? `, ${skipped.length} skipped` : ""})`,
+      );
+    } catch (err) {
+      console.warn(`[persistent-data] migration aborted: ${(err as Error).message}`);
+    }
   }
   /**
    * Conversation-attachments subdir of a session's workspace —
@@ -606,8 +775,8 @@ export class SessionManager {
    * FOUR roots are addressable, by path prefix:
    *  - `/workspace[/...]` → the per-session workspace `workspaces/<sid>/`
    *    (the agent's cwd; default when no prefix is given, for backward compat).
-   *  - `/data[/...]`      → the shared per-user persistent root
-   *    `data/<userId>/`, reusable across sessions (#257).
+   *  - `/data[/...]`      → the persistent library `data/`, reusable across
+   *    sessions (#287; flat, single-user — per-user layout was removed).
    *  - `/attachments[/...]` → conversation attachments the user attached to a
    *    message, kept in the hidden `workspaces/<sid>/.attachments/` subdir so
    *    they are scoped to the session but visually separate from agent-produced
@@ -1077,12 +1246,18 @@ export class SessionManager {
       this.lastActivityAt = Math.max(this.lastActivityAt, Date.now());
     }
 
+    // #287: one-shot migration from the legacy `data/<userId>/` layout to
+    // flat `data/`. Runs unconditionally (not gated on `persist`) because the
+    // persistent library at `data/` is a real on-disk resource even when
+    // per-session metadata is not persisted, and migration is a cheap no-op
+    // (ENOENT) on fresh installs. Guarded by a sentinel so it fires at most
+    // once per dataRoot.
+    await this.maybeMigrateLegacyPersistentLayout();
     if (this.persist) {
       await mkdir(join(this.bpDir(id), "history"), { recursive: true });
       await mkdir(this.workspaceDir(id), { recursive: true });
-      // #257: ensure the shared per-user persistent root exists so the agent
-      // (and file routes) can read/write the cross-session library from the
-      // first session onward. Cheap + idempotent.
+      // Ensure the persistent library exists so the agent + file routes can
+      // read/write it from the first session onward. Cheap + idempotent.
       await mkdir(this.persistentDir(), { recursive: true });
       // On restore, meta.json on disk is the authority — do not write it back.
       if (!_restore) await this.writeMeta(entry);


### PR DESCRIPTION
Fixes #287.

## Why

`SessionManager.persistentDir()` used to return `<dataRoot>/data/<userId>/`,
with `<userId>` sourced from `BP_USER_ID` (default `local`). Both current
deployment shapes make that inner layer redundant:

- **Open-source single machine** — always one user; `data/local/` is redundant.
- **BrainPilot Cloud** — each user already has an isolated bind mount at
  `users/<username>/.bp-root`, so the old layout duplicated the username.

## What

- `SessionManager.persistentDir()` now returns `<dataRoot>/data/`.
- `persistentUserId` and `BP_USER_ID` no longer control active path resolution.
  During upgrade only, the old value identifies the one legacy directory that
  may be migrated; when unset, only the former default `data/local/` is checked.
- Layout v2 is recorded in `<dataRoot>/.bp-persistent-layout.json`, outside the
  user-visible `data/` tree. Migration never infers a user id from directory
  count, so a valid v2 tree such as `data/project/` is left intact.
- Migration is a readiness gate and uses a journaled whole-directory rename via
  `<dataRoot>/.bp-persistent-data-v1-migration`. Interrupted migrations resume
  on restart; mixed v1/v2 layouts fail without moving or overwriting files.
- `startServer()` completes layout initialization before restore/listen, and all
  `/data` list/read/write/delete paths await the same single-flight promise.
- The logical `/data/...` API, frontend behavior, and agent usage are unchanged.
- English/Chinese root READMEs, runtime documentation, protocol comments, and
  Docker Compose comments now describe the single-user data-root contract.

## Acceptance criteria

- [x] New installs write directly to `<BP_DATA_DIR>/data/`.
- [x] `/data/foo` is reusable across sessions.
- [x] `BP_USER_ID` is not required and no longer selects the active root.
- [x] Legacy `data/<userId>/` data has a guarded, recoverable migration.
- [x] Documentation assigns multi-user isolation to the deployment layer.

## Tests

- Valid v2 `data/project/` is not flattened, including after restart.
- Only `BP_USER_ID` (or default `local`) is eligible as a legacy directory.
- Mixed v1/v2 layouts fail without changing either side.
- Concurrent `/data` writes before session creation single-flight migration.
- A staged migration resumes after interruption.
- Runtime readiness writes a v2 layout marker before serving requests.
- `npm run typecheck` passes.
- Full monorepo suite passes: **63 files, 745 tests**.

## Commits

- `8dd8cde` — original flat-layout implementation by GTC2333.
- `83aaa97` — follow-up safety fixes after migration-risk review.

🤖 Original implementation generated with [Claude Code](https://claude.com/claude-code); safety follow-up completed by the maintainer.
