### PR TITLE
fix(runtime): fall back when skill_name is empty

### DIFF
--- a/packages/runtime/src/__tests__/skill-search.test.ts
+++ b/packages/runtime/src/__tests__/skill-search.test.ts
@@ -184,6 +184,37 @@ describe("searchSkills — query mode", () => {
     expect(text).toContain("Visualization helper.");
   });
 
+  it("query with empty skill_name falls back to keyword search", async () => {
+    const out = JSON.parse(
+      await searchSkills(base, {
+        mode: "query",
+        keywords: "figure, plotting",
+        skill_name: "",
+      }),
+    );
+    expect(out.keywords).toEqual(["figure", "plotting"]);
+    expect(out.results[0].name).toBe("figure-builder");
+  });
+
+  it("query with whitespace-only skill_name falls back to keyword search", async () => {
+    const out = JSON.parse(
+      await searchSkills(base, {
+        mode: "query",
+        keywords: "figure",
+        skill_name: "   ",
+      }),
+    );
+    expect(out.results[0].name).toBe("figure-builder");
+  });
+
+  it("trims skill_name before direct lookup", async () => {
+    const text = await searchSkills(base, {
+      mode: "query",
+      skill_name: "  figure-builder  ",
+    });
+    expect(text).toContain("Visualization helper.");
+  });
+
   it("query with unknown skill_name throws", async () => {
     await expect(
       searchSkills(base, { mode: "query", skill_name: "does-not-exist" }),

--- a/packages/runtime/src/tools/skill-search.ts
+++ b/packages/runtime/src/tools/skill-search.ts
@@ -222,8 +222,9 @@ export async function searchSkills(base: string, args: SkillSearchArgs): Promise
   /* ----------------------------- QUERY ----------------------------- */
   if (mode === "query") {
     // Sub-mode B: direct skill lookup by name (returns full SKILL.md).
-    if (args.skill_name !== undefined && args.skill_name !== null) {
-      const name = String(args.skill_name);
+    const name =
+      typeof args.skill_name === "string" ? args.skill_name.trim() : "";
+    if (name !== "") {
       const cats = await listDirs(baseAbs);
       for (const cat of cats) {
         const candidate = join(baseAbs, cat, name, "SKILL.md");


### PR DESCRIPTION
## Summary

- treat empty and whitespace-only `skill_name` values as absent so query mode falls back to keyword search
- trim non-empty skill names before exact lookup
- add regression coverage for empty, whitespace-only, and padded skill names

## Testing

- `npm test -- packages/runtime/src/__tests__/skill-search.test.ts`
- `npm run typecheck -w @brainpilot/runtime`
