### PR TITLE
fix(runtime): raise DEFAULT_MAX_TOKENS to 32k so long tool args don't truncate (#293)

### DIFF
--- a/packages/runtime/src/__tests__/pi-provider.test.ts
+++ b/packages/runtime/src/__tests__/pi-provider.test.ts
@@ -96,7 +96,9 @@ describe("resolveGatewayModel", () => {
     const cfg = JSON.parse(readFileSync(lastPath()!, "utf8"));
     const m = cfg.providers[GATEWAY_PROVIDER].models[0];
     expect(m.contextWindow).toBe(200_000);
-    expect(m.maxTokens).toBe(8_192);
+    // #293: default raised to 32_768 so long tool-call arguments (write/edit/
+    // send_message content) don't get truncated mid-stream.
+    expect(m.maxTokens).toBe(32_768);
   });
 
   it("honours ANTHROPIC_CONTEXT_WINDOW / ANTHROPIC_MAX_TOKENS overrides", () => {

--- a/packages/runtime/src/pi-provider.ts
+++ b/packages/runtime/src/pi-provider.ts
@@ -29,7 +29,17 @@ export const GATEWAY_PROVIDER = "bp-gateway";
 
 /** Defaults applied to an auto-generated gateway model when env is unset. */
 const DEFAULT_CONTEXT_WINDOW = 200_000;
-const DEFAULT_MAX_TOKENS = 8_192;
+// #293: 8_192 is far below what modern models (Claude Sonnet 5, GPT-5, Gemini 2.5)
+// support and — critically — below what a single tool call can require. Anthropic/
+// OpenAI stream tool_use arguments as JSON in order, so a `write` / `edit` /
+// `send_message` whose `content` runs long gets its stream cut off mid-string when
+// `max_tokens` is hit; Pi's streaming JSON repair recovers earlier fields (`path`)
+// but the truncated `content` is lost, and the agent then retries indefinitely
+// against the same ceiling. 32_768 matches the modal maxTokens in Pi's built-in
+// model catalogue (see `pi-ai/dist/models.generated.js`) and is well above the
+// 16_384 SDK-side fallback (`model-registry.js`). Users can still raise it
+// further via the `ANTHROPIC_MAX_TOKENS` env override.
+const DEFAULT_MAX_TOKENS = 32_768;
 
 /** Minimal structural surface of the Pi SDK bits this module needs. */
 export interface PiProviderSdk {


### PR DESCRIPTION
Fixes #293.

## Symptom

Expert agents' `write` / `edit` / `send_message` calls with long content fail repeatedly. The tool is invoked with only `path` populated; `content` is missing/empty. Short writes work; long writes get stuck retrying.

## Root cause

The per-session `models.json` synthesized in `packages/runtime/src/pi-provider.ts` defaults `maxTokens` to **8192**.

Anthropic and OpenAI stream `tool_use` arguments as a single JSON payload in field order, so a `write` / `edit` / `send_message` whose `content` runs long has its response cut off mid-string once `max_tokens` is hit. Pi's streaming JSON repair (`pi-ai/dist/utils/json-parse.js` → `parseStreamingJson`) recovers the earlier `path` field but the truncated `content` is silently lost — the tool call reaches `system-tools.ts` with `content=''`. The agent retries into the same ceiling and never succeeds.

Principal rarely trips this (short handoffs). Experts trip it constantly: they write files (engineer / experimentalist) and deliver long results back to PI via `send_message`. This is also the sibling issue behind #97 / #125's "silent expert failures" — many of those were truncated payloads, not actual silence.

## Fix

Bump `DEFAULT_MAX_TOKENS` `8192` → `32768` in `packages/runtime/src/pi-provider.ts` (used by both auto-generated gateway configs and per-session provider registries).

- `32768` matches the modal `maxTokens` across Pi's built-in model catalogue (`pi-ai/dist/models.generated.js`; most modern models advertise 32k–128k).
- Sits above the SDK-side fallback of `16384` (`pi-ai/dist/core/model-registry.js:458`).
- The env override `ANTHROPIC_MAX_TOKENS` still wins for anyone who wants to go higher/lower.

## Tests

`pi-provider.test.ts` had a pin at `8_192` — updated to `32_768` with a comment linking back to this issue. All 751 tests pass.

## Follow-ups (out of scope here)

- UI-exposed per-provider `maxTokens` in the Providers settings, backed by `providers.json`, so users don't need to know about the env var.
- Guard in `send_message`: reject `content === ''` with `isError: true` so a truncated call surfaces immediately instead of writing an empty envelope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)