### PR TITLE
feat(runtime): isolate per-session domain resources

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -265,6 +265,19 @@ agent 就会立刻获得两个内置工具：
 完整流水线说明、增量构建语义、FAQ 与离线模式请见
 [`KnowledgeBase/README.md`](./KnowledgeBase/README.md)。
 
+#### 按会话切换资源模式（高级）
+
+Runtime 的 `POST /sessions` 接口支持
+`domainResources: "full" | "base"`（缺省为向后兼容的 `full`）。`base`
+会话保留正常的多智能体协作与通用文件/代码工具，但不加载 always-on 技能目录，
+不暴露 `skill_search`，也不暴露上面的两个本地知识库/论文工具。该选择写入会话
+元数据并在恢复后保持不变，同时由 Session 与 SessionState API 返回。
+
+为支持可审计评测，事件流会针对领域工具调用、技能关键词搜索和成功加载完整技能正文，
+发出不含内容的 `CUSTOM(name="domain_resource_usage")` 记录。记录不包含查询、工具结果、
+技能正文或凭证；provider 上报的累计 token 用量仍位于
+`session_state.tokenUsage`。
+
 ---
 
 ## 🔌 接入 MCP 服务

--- a/README.md
+++ b/README.md
@@ -292,6 +292,21 @@ existing LLM key).
 See [`KnowledgeBase/README.md`](./KnowledgeBase/README.md) for the full pipeline walkthrough,
 incremental-build semantics, FAQ and offline mode.
 
+#### Per-session resource mode (advanced)
+
+The Runtime session API accepts `domainResources: "full" | "base"` on
+`POST /sessions` (`full` is the backward-compatible default). A `base` session
+keeps normal multi-agent orchestration and generic file/code tools, but does not
+load the always-on skill catalog, expose `skill_search`, or expose the two local
+knowledge/paper tools above. The choice is frozen in the session metadata,
+survives restore, and is returned by the Session and SessionState APIs.
+
+For auditable evaluation, the event stream emits content-free
+`CUSTOM(name="domain_resource_usage")` records for domain tool calls, skill
+keyword searches, and successful full skill-body loads. The records contain no
+query, tool result, skill body, or credential; cumulative provider-reported
+token usage remains available in `session_state.tokenUsage`.
+
 ---
 
 ## 🔌 Connecting MCP servers

--- a/packages/client-cli/src/client.test.ts
+++ b/packages/client-cli/src/client.test.ts
@@ -57,6 +57,20 @@ describe("BrainPilotClient.url", () => {
       "http://localhost:8081/sessions/s/agents",
     );
   });
+
+  it("sends the requested per-session domain-resource mode", async () => {
+    let body: unknown;
+    const fetchFn = (async (_url: string | URL, init?: RequestInit) => {
+      body = JSON.parse(String(init?.body));
+      return new Response(JSON.stringify({ id: "base-session" }), {
+        status: 201,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+    const client = new BrainPilotClient({ baseUrl: "http://runtime", fetchFn });
+    expect(await client.createSession({ domainResources: "base" })).toBe("base-session");
+    expect(body).toEqual({ domainResources: "base" });
+  });
 });
 
 /** Build a ReadableStream from string chunks (simulating wire fragmentation). */

--- a/packages/client-cli/src/client.ts
+++ b/packages/client-cli/src/client.ts
@@ -10,6 +10,7 @@
 import {
   RUNTIME_ROUTES,
   type AgUiEvent,
+  type CreateSessionRequest,
   type CreateSessionResponse,
   type SendMessageResponse,
 } from "@brainpilot/protocol";
@@ -66,7 +67,7 @@ export class BrainPilotClient {
   }
 
   /** POST /sessions → the new session id. */
-  async createSession(body: { id?: string; title?: string } = {}): Promise<string> {
+  async createSession(body: CreateSessionRequest = {}): Promise<string> {
     const res = await this.fetchFn(this.url(RUNTIME_ROUTES.createSession.path), {
       method: RUNTIME_ROUTES.createSession.method,
       headers: { "content-type": "application/json" },

--- a/packages/protocol/src/domain.ts
+++ b/packages/protocol/src/domain.ts
@@ -24,11 +24,17 @@ export const EXAMPLE_MODEL = "claude-sonnet-4-6";
  * Session
  * ------------------------------------------------------------------ */
 
+/** Per-session domain-resource ablation mode. Defaults to full in the runtime. */
+export const DomainResourcesSchema = z.enum(["full", "base"]);
+export type DomainResources = z.infer<typeof DomainResourcesSchema>;
+
 export const SessionSchema = z.object({
   id: z.string(),
   title: z.string(),
   createdAt: z.string(),
   updatedAt: z.string(),
+  /** Optional for compatibility with older runtimes; new runtimes always emit it. */
+  domainResources: DomainResourcesSchema.optional(),
 });
 export type Session = z.infer<typeof SessionSchema>;
 
@@ -110,6 +116,8 @@ export const SessionStateSnapshotSchema = z.object({
   }),
   agents: z.array(AgentStatusSchema),
   lastActivityTs: z.string(),
+  /** Frozen when the session is created and persisted across restore. */
+  domainResources: DomainResourcesSchema.optional(),
   /**
    * Cumulative real token usage for this session (total + per-agent). Optional
    * for forward/backward compat: a frame from an older runtime, or before the

--- a/packages/protocol/src/events.ts
+++ b/packages/protocol/src/events.ts
@@ -290,6 +290,7 @@ export type CustomEvent = z.infer<typeof CustomEventSchema>;
  *   `CompactionStartValue | CompactionEndValue`. Emitted verbatim from the
  *   Pi `compaction_start` / `compaction_end` events (mas-agent.ts) so clients
  *   can render compaction transparently instead of a mid-run context reset.
+ * - `domain_resource_usage` — content-free domain tool / skill usage edge.
  */
 export const CUSTOM_EVENT = {
   SESSION_STATE: "session_state",
@@ -297,7 +298,36 @@ export const CUSTOM_EVENT = {
   SESSION_HEARTBEAT: "session_heartbeat",
   TRACE_NODE: "trace_node",
   COMPACTION: "compaction",
+  /** Auditable, content-free domain tool / skill usage edge. */
+  DOMAIN_RESOURCE_USAGE: "domain_resource_usage",
 } as const;
+
+/**
+ * Normalized resource-use event. Queries, skill bodies, tool results, and
+ * credentials are deliberately absent; the AG-UI envelope carries session,
+ * run, agent, and timestamp identity.
+ */
+export const DomainResourceUsageValueSchema = z.discriminatedUnion("kind", [
+  z.object({
+    schemaVersion: z.literal("1.0"),
+    kind: z.literal("domain_tool_call"),
+    toolName: z.enum(["get_domain_knowledge_local", "search_papers_local"]),
+    source: z.literal("system_tool"),
+  }).strict(),
+  z.object({
+    schemaVersion: z.literal("1.0"),
+    kind: z.literal("skill_search"),
+    toolName: z.literal("skill_search"),
+    source: z.literal("router"),
+  }).strict(),
+  z.object({
+    schemaVersion: z.literal("1.0"),
+    kind: z.literal("skill_load"),
+    skillName: z.string().min(1).max(128),
+    source: z.enum(["router", "builtin_read"]),
+  }).strict(),
+]);
+export type DomainResourceUsageValue = z.infer<typeof DomainResourceUsageValueSchema>;
 
 /**
  * `CUSTOM.value` shape for `name: "compaction"` — mirrors Pi SDK's

--- a/packages/protocol/src/http.ts
+++ b/packages/protocol/src/http.ts
@@ -78,6 +78,8 @@ export const CreateSessionRequestSchema = z.object({
   providerId: z.string().optional(),
   /** Optional model id within that provider. */
   modelId: z.string().optional(),
+  /** Per-session domain resources; omitted means full for backward compatibility. */
+  domainResources: z.enum(["full", "base"]).optional(),
 });
 export type CreateSessionRequest = z.infer<typeof CreateSessionRequestSchema>;
 

--- a/packages/protocol/test/domain.test.ts
+++ b/packages/protocol/test/domain.test.ts
@@ -17,14 +17,16 @@ import {
 
 describe("domain schemas", () => {
   it("validates Session", () => {
-    expect(
-      SessionSchema.parse({
+    const session = SessionSchema.parse({
         id: "s1",
         title: "T",
         createdAt: "2026-06-12T00:00:00Z",
         updatedAt: "2026-06-12T00:00:00Z",
-      }).id,
-    ).toBe("s1");
+        domainResources: "base",
+      });
+    expect(session.id).toBe("s1");
+    expect(session.domainResources).toBe("base");
+    expect(SessionSchema.safeParse({ ...session, domainResources: "unknown" }).success).toBe(false);
   });
 
   it("validates SessionStateSnapshot with agents", () => {
@@ -32,8 +34,10 @@ describe("domain schemas", () => {
       runState: { active: true, runId: "r1" },
       agents: [{ name: "principal", status: "running", task: "thinking", alive: true }],
       lastActivityTs: "2026-06-12T00:00:00Z",
+      domainResources: "full",
     };
     expect(SessionStateSnapshotSchema.parse(snap).agents[0]?.name).toBe("principal");
+    expect(SessionStateSnapshotSchema.parse(snap).domainResources).toBe("full");
   });
 
   it("SessionStateSnapshot allows null runId", () => {

--- a/packages/protocol/test/events.test.ts
+++ b/packages/protocol/test/events.test.ts
@@ -4,6 +4,7 @@ import {
   AgUiEventSchema,
   CompactionCustomValueSchema,
   CUSTOM_EVENT,
+  DomainResourceUsageValueSchema,
   isAgUiEvent,
   parseEvent,
   safeParseEvent,
@@ -219,6 +220,32 @@ describe("discriminated union behavior", () => {
     // Rejects unknown op / reason.
     expect(CompactionCustomValueSchema.safeParse({ op: "middle", reason: "threshold" }).success).toBe(false);
     expect(CompactionCustomValueSchema.safeParse({ op: "start", reason: "nope" }).success).toBe(false);
+  });
+
+  it("CUSTOM domain-resource usage exposes counts without resource contents", () => {
+    const value = DomainResourceUsageValueSchema.parse({
+      schemaVersion: "1.0",
+      kind: "skill_load",
+      skillName: "fmri-analysis",
+      source: "router",
+    });
+    expect(value.skillName).toBe("fmri-analysis");
+    expect(value).not.toHaveProperty("query");
+    expect(value).not.toHaveProperty("content");
+    expect(DomainResourceUsageValueSchema.safeParse({
+      schemaVersion: "1.0",
+      kind: "skill_load",
+      source: "router",
+      query: "private query",
+    }).success).toBe(false);
+    const wrapped = parseEvent({
+      type: "CUSTOM",
+      session_id: "s1",
+      agent_name: "engineer",
+      name: CUSTOM_EVENT.DOMAIN_RESOURCE_USAGE,
+      value,
+    });
+    expect((wrapped as { name?: string }).name).toBe("domain_resource_usage");
   });
 
   it("passthrough keeps forward-compat extras", () => {

--- a/packages/protocol/test/http.test.ts
+++ b/packages/protocol/test/http.test.ts
@@ -43,6 +43,8 @@ describe("Runtime HTTP contract", () => {
 
   it("validates create session req/res", () => {
     expect(CreateSessionRequestSchema.parse({ title: "T" }).title).toBe("T");
+    expect(CreateSessionRequestSchema.parse({ domainResources: "base" }).domainResources).toBe("base");
+    expect(CreateSessionRequestSchema.safeParse({ domainResources: "disabled" }).success).toBe(false);
     expect(CreateSessionRequestSchema.parse({}).title).toBeUndefined();
     expect(CreateSessionResponseSchema.parse({ id: "s1" }).id).toBe("s1");
   });

--- a/packages/runtime/src/__tests__/domain-resources.test.ts
+++ b/packages/runtime/src/__tests__/domain-resources.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { DomainResourceUsageValueSchema } from "@brainpilot/protocol";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  domainResourceUsageOnStart,
+  domainResourceUsageOnSuccess,
+  toolTogglesForDomainResources,
+  withoutDomainResourceInstructions,
+  resolveDomainResources,
+} from "../domain-resources.js";
+import { PERSONAS, personaFor } from "../personas.js";
+import { SessionManager } from "../session-manager.js";
+import { mockAgentFactory } from "../agent-factory.js";
+
+describe("per-session domain resources", () => {
+  it("defaults only omission to full and rejects explicit bad values", () => {
+    expect(resolveDomainResources(undefined)).toBe("full");
+    expect(resolveDomainResources("base")).toBe("base");
+    expect(() => resolveDomainResources("bsae")).toThrow(/invalid domainResources/);
+  });
+  it("base overrides only the copied effective toggles", () => {
+    const global = { skill_search: true, get_domain_knowledge_local: true } as const;
+    const base = toolTogglesForDomainResources("base", global);
+    expect(base).toEqual({
+      skill_search: false,
+      get_domain_knowledge_local: false,
+      search_papers_local: false,
+    });
+    expect(global).toEqual({ skill_search: true, get_domain_knowledge_local: true });
+    expect(toolTogglesForDomainResources("full", global)).toBe(global);
+  });
+
+  it("removes unavailable-resource sections while preserving role instructions", () => {
+    for (const persona of [...Object.values(PERSONAS), personaFor("statistician", "expert")]) {
+      const base = withoutDomainResourceInstructions(persona);
+      expect(base).not.toMatch(/skill_search|<available_skills>|SKILL\.md|Router skill library/i);
+      expect(base.length).toBeGreaterThan(200);
+    }
+    expect(withoutDomainResourceInstructions(PERSONAS.principal!)).toContain("User authorization gate");
+    expect(withoutDomainResourceInstructions(PERSONAS.engineer!)).toContain("Execution discipline");
+  });
+
+  it("classifies only the frozen, content-free usage edges", () => {
+    const domain = domainResourceUsageOnStart("get_domain_knowledge_local", { query: "private" });
+    expect(DomainResourceUsageValueSchema.parse(domain)).toEqual({
+      schemaVersion: "1.0",
+      kind: "domain_tool_call",
+      toolName: "get_domain_knowledge_local",
+      source: "system_tool",
+    });
+    expect(JSON.stringify(domain)).not.toContain("private");
+
+    const search = domainResourceUsageOnStart("skill_search", {
+      mode: "query",
+      keywords: "private keywords",
+    });
+    expect(search).toMatchObject({ kind: "skill_search", source: "router" });
+    expect(JSON.stringify(search)).not.toContain("private keywords");
+
+    expect(domainResourceUsageOnSuccess("skill_search", {
+      mode: "query",
+      skill_name: "fmri-analysis",
+    }, false, "full skill body")).toMatchObject({
+      kind: "skill_load",
+      skillName: "fmri-analysis",
+      source: "router",
+    });
+    expect(domainResourceUsageOnSuccess("read", {
+      path: "/skills/fmri-analysis/SKILL.md",
+    }, false, "full skill body")).toMatchObject({
+      kind: "skill_load",
+      skillName: "fmri-analysis",
+      source: "builtin_read",
+    });
+    expect(domainResourceUsageOnSuccess("read", {
+      path: "/skills/fmri-analysis/SKILL.md",
+      limit: 10,
+    }, false)).toBeNull();
+    expect(domainResourceUsageOnSuccess("read", {
+      path: "/skills/fmri-analysis/SKILL.md",
+    }, false, "[Showing lines 1-200 of 300]")).toBeNull();
+    expect(domainResourceUsageOnSuccess("read", {
+      path: "SKILL.md",
+    }, false, "full body")).toMatchObject({ kind: "skill_load", skillName: "unknown" });
+    expect(domainResourceUsageOnSuccess("skill_search", {
+      mode: "query",
+      skill_name: "fmri-analysis",
+    }, true)).toBeNull();
+  });
+
+  it("persists and restores the frozen mode and rejects a conflicting reopen", async () => {
+    const root = await mkdtemp(join(tmpdir(), "bp-domain-resources-"));
+    try {
+      const first = new SessionManager({ dataRoot: root, agentFactory: mockAgentFactory });
+      const created = await first.createSession({ id: "base-session", domainResources: "base" });
+      expect(created.domainResources).toBe("base");
+      const meta = JSON.parse(await readFile(join(root, ".bp", created.id, "meta.json"), "utf8"));
+      expect(meta.domainResources).toBe("base");
+
+      const restored = new SessionManager({ dataRoot: root, agentFactory: mockAgentFactory });
+      expect(await restored.restoreFromDisk()).toContain(created.id);
+      expect(restored.getSession(created.id)?.domainResources).toBe("base");
+      expect(restored.getSessionState(created.id)?.domainResources).toBe("base");
+      await expect(restored.createSession({ id: created.id, domainResources: "full" })).rejects.toThrow(
+        /already uses domainResources=base/,
+      );
+      await expect(first.createSession({
+        id: "invalid",
+        domainResources: "bsae" as never,
+      })).rejects.toThrow(/invalid domainResources/);
+
+      meta.domainResources = "bsae";
+      await writeFile(
+        join(root, ".bp", created.id, "meta.json"),
+        `${JSON.stringify(meta)}\n`,
+        "utf8",
+      );
+      const corrupted = new SessionManager({ dataRoot: root, agentFactory: mockAgentFactory });
+      expect(await corrupted.restoreFromDisk()).not.toContain(created.id);
+      expect(corrupted.getSession(created.id)).toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/runtime/src/__tests__/event-mapping.test.ts
+++ b/packages/runtime/src/__tests__/event-mapping.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { parseEvent, type AgUiEvent } from "@brainpilot/protocol";
+import {
+  CUSTOM_EVENT,
+  DomainResourceUsageValueSchema,
+  parseEvent,
+  type AgUiEvent,
+} from "@brainpilot/protocol";
 import { EventBus } from "../event-bus.js";
 import { MasAgent } from "../mas-agent.js";
 import { MockAgentSession } from "../mock-agent.js";
@@ -87,6 +92,53 @@ describe("event mapping (Pi -> AG-UI via parseEvent)", () => {
     expect(types).toContain("TOOL_CALL_RESULT");
     const result = captured.find((e) => e.type === "TOOL_CALL_RESULT") as { content: string };
     expect(result.content).toBe("pong");
+  });
+
+  it("emits content-free domain tool, skill search, and successful skill load events", async () => {
+    const bus = new EventBus();
+    const captured: AgUiEvent[] = [];
+    bus.subscribe((event) => captured.push(event));
+    const okTool = (name: string) => ({
+      name,
+      description: name,
+      parameters: { type: "object", properties: {} },
+      execute: async () => ({ content: [{ type: "text" as const, text: "resource body" }] }),
+    });
+    const session = new MockAgentSession({
+      sessionId: "resource-session",
+      agentName: "principal",
+      systemTools: [
+        okTool("get_domain_knowledge_local"),
+        okTool("skill_search"),
+        okTool("read"),
+      ],
+    });
+    const agent = new MasAgent({
+      sessionId: "resource-session",
+      name: "principal",
+      role: "principal",
+      session,
+      bus,
+    });
+    await agent.prompt('[[tool:get_domain_knowledge_local {"query":"private query"}]]');
+    await agent.prompt('[[tool:skill_search {"mode":"query","keywords":"private keywords"}]]');
+    await agent.prompt('[[tool:skill_search {"mode":"query","skill_name":"fmri-analysis"}]]');
+    await agent.prompt('[[tool:read {"path":"/skills/place-cell/SKILL.md"}]]');
+
+    const usage = captured
+      .filter((event) => event.type === "CUSTOM" && (event as { name?: string }).name === CUSTOM_EVENT.DOMAIN_RESOURCE_USAGE)
+      .map((event) => DomainResourceUsageValueSchema.parse((event as { value?: unknown }).value));
+    expect(usage.map((value) => value.kind)).toEqual([
+      "domain_tool_call",
+      "skill_search",
+      "skill_load",
+      "skill_load",
+    ]);
+    expect(usage[2]).toMatchObject({ skillName: "fmri-analysis", source: "router" });
+    expect(usage[3]).toMatchObject({ skillName: "place-cell", source: "builtin_read" });
+    expect(JSON.stringify(usage)).not.toContain("private query");
+    expect(JSON.stringify(usage)).not.toContain("private keywords");
+    expect(JSON.stringify(usage)).not.toContain("resource body");
   });
 
   describe("ev.userInputRequest", () => {

--- a/packages/runtime/src/__tests__/server.test.ts
+++ b/packages/runtime/src/__tests__/server.test.ts
@@ -45,11 +45,15 @@ describe("HTTP server (RUNTIME_ROUTES)", () => {
     const created = await a.request("/sessions", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ title: "Demo" }),
+      body: JSON.stringify({ title: "Demo", domainResources: "base" }),
     });
     expect(created.status).toBe(201);
-    const { id } = (await created.json()) as { id: string };
+    const { id, session } = (await created.json()) as {
+      id: string;
+      session: { domainResources?: string };
+    };
     expect(id).toBeTruthy();
+    expect(session.domainResources).toBe("base");
 
     // list
     const list = (await (await a.request("/sessions")).json()) as { sessions: unknown[] };
@@ -76,6 +80,7 @@ describe("HTTP server (RUNTIME_ROUTES)", () => {
     // state
     const state = await a.request(`/sessions/${id}/state`);
     expect(state.status).toBe(200);
+    expect((await state.json()) as { domainResources?: string }).toMatchObject({ domainResources: "base" });
 
     // trace (Graph of Trace) — returns { meta, nodes } for an existing session
     const trace = await a.request(`/sessions/${id}/trace`);
@@ -92,6 +97,18 @@ describe("HTTP server (RUNTIME_ROUTES)", () => {
     const evict = await a.request(`/sessions/${id}/evict`, { method: "POST" });
     expect(evict.status).toBe(200);
     expect((await evict.json()) as { evicted: boolean }).toMatchObject({ evicted: true });
+  });
+
+  it("rejects an invalid domain-resource mode instead of silently creating full", async () => {
+    const a = app();
+    const invalid = await a.request("/sessions", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ domainResources: "bsae" }),
+    });
+    expect(invalid.status).toBe(400);
+    const list = (await (await a.request("/sessions")).json()) as { sessions: unknown[] };
+    expect(list.sessions).toEqual([]);
   });
 
   it("PUT /sessions/:id renames and the new title survives a re-GET (#29)", async () => {

--- a/packages/runtime/src/__tests__/two-skill-paths.test.ts
+++ b/packages/runtime/src/__tests__/two-skill-paths.test.ts
@@ -121,4 +121,38 @@ describe("two-path skill loading", () => {
     expect(traceTools).not.toContain("skill_search");
     // Trace also gets no skillPaths (it is skill-less by design).
   });
+
+  it("keeps full and base sessions isolated without global mutation", async () => {
+    const root = await tmp();
+    type Captured = Parameters<AgentSessionFactory>[0];
+    const captured = new Map<string, Captured>();
+    const wrappedFactory: AgentSessionFactory = async (params) => {
+      captured.set(params.sessionId, params);
+      return mockAgentFactory(params);
+    };
+    const mgr = new SessionManager({
+      dataRoot: root,
+      agentFactory: wrappedFactory,
+      persist: false,
+      toolToggles: {},
+    });
+    const base = await mgr.createSession({ domainResources: "base" });
+    const full = await mgr.createSession({ domainResources: "full" });
+    await mgr.ensureAgent(base.id, "principal");
+    await mgr.ensureAgent(full.id, "principal");
+
+    const baseParams = captured.get(base.id)!;
+    const fullParams = captured.get(full.id)!;
+    for (const name of ["skill_search", "get_domain_knowledge_local", "search_papers_local"]) {
+      expect(baseParams.systemTools.map((tool) => tool.name)).not.toContain(name);
+      expect(fullParams.systemTools.map((tool) => tool.name)).toContain(name);
+    }
+    expect(baseParams.skillPaths).toBeUndefined();
+    expect(fullParams.skillPaths).toEqual([join(root, "bp_template", "skills")]);
+    expect(baseParams.systemPrompt).not.toMatch(/skill_search|<available_skills>|SKILL\.md/i);
+    expect(fullParams.systemPrompt).toContain("skill_search");
+    expect(baseParams.allowedToolNames).toEqual(expect.arrayContaining(["read", "write", "bash"]));
+    expect(mgr.getSessionState(base.id)?.domainResources).toBe("base");
+    expect(mgr.getSessionState(full.id)?.domainResources).toBe("full");
+  });
 });

--- a/packages/runtime/src/domain-resources.ts
+++ b/packages/runtime/src/domain-resources.ts
@@ -1,0 +1,121 @@
+/** Per-session domain-resource isolation and content-free usage classification. */
+import { basename, dirname } from "node:path";
+import type { DomainResources, DomainResourceUsageValue } from "@brainpilot/protocol";
+import type { ToolToggles } from "./tool-toggles.js";
+
+export const DOMAIN_TOOL_NAMES = [
+  "get_domain_knowledge_local",
+  "search_papers_local",
+] as const;
+
+/** Only omission means the backward-compatible full mode; bad values fail. */
+export function resolveDomainResources(value: unknown): DomainResources {
+  if (value === undefined || value === "full") return "full";
+  if (value === "base") return "base";
+  throw new Error(`invalid domainResources: ${String(value)}`);
+}
+
+/** Base always wins over global defaults without mutating the shared table. */
+export function toolTogglesForDomainResources(
+  mode: DomainResources,
+  toggles: ToolToggles | null,
+): ToolToggles | null {
+  if (mode === "full") return toggles;
+  return {
+    ...(toggles ?? {}),
+    skill_search: false,
+    get_domain_knowledge_local: false,
+    search_papers_local: false,
+  };
+}
+
+/**
+ * Remove complete Markdown sections whose H2 heading advertises skills or the
+ * router. Built-in personas keep all orchestration/safety instructions while
+ * base sessions receive none of the unavailable-resource guidance.
+ */
+export function withoutDomainResourceInstructions(persona: string): string {
+  const lines = persona.split("\n");
+  const kept: string[] = [];
+  let skipping = false;
+  for (const line of lines) {
+    const heading = /^(#{1,6})\s+(.+?)\s*$/.exec(line);
+    if (heading && heading[1]!.length <= 2) {
+      const isResourceSection = /(?:^|\W)(?:skills?|router)(?:\W|$)/i.test(heading[2]!);
+      if (isResourceSection) {
+        skipping = true;
+        continue;
+      }
+      skipping = false;
+    }
+    if (!skipping) kept.push(line);
+  }
+  return kept.join("\n").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+function safeSkillName(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const name = value.trim();
+  return /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(name) ? name : undefined;
+}
+
+function skillNameFromPath(value: unknown): string | undefined {
+  if (typeof value !== "string" || !/(?:^|[\\/])SKILL\.md$/i.test(value)) return undefined;
+  return safeSkillName(basename(dirname(value))) ?? "unknown";
+}
+
+/** Count attempts at the moment the provider starts the tool call. */
+export function domainResourceUsageOnStart(
+  toolName: string,
+  args: Record<string, unknown>,
+): DomainResourceUsageValue | null {
+  if (toolName === "get_domain_knowledge_local" || toolName === "search_papers_local") {
+    return { schemaVersion: "1.0", kind: "domain_tool_call", toolName, source: "system_tool" };
+  }
+  if (
+    toolName === "skill_search" &&
+    args.mode === "query" &&
+    typeof args.keywords === "string" &&
+    args.keywords.trim().length > 0
+  ) {
+    return { schemaVersion: "1.0", kind: "skill_search", toolName, source: "router" };
+  }
+  return null;
+}
+
+/** Count a skill load only after the tool reports success. */
+export function domainResourceUsageOnSuccess(
+  toolName: string,
+  args: Record<string, unknown>,
+  isError: boolean,
+  result?: unknown,
+): DomainResourceUsageValue | null {
+  if (isError) return null;
+  let resultText = "";
+  try { resultText = typeof result === "string" ? result : JSON.stringify(result ?? ""); }
+  catch { return null; } // opaque/cyclic results are not evidence of a full load
+  if (!resultText.trim()) return null;
+  const details =
+    typeof result === "object" && result !== null
+      ? (result as { details?: { truncation?: { truncated?: boolean } } }).details
+      : undefined;
+  if (
+    details?.truncation?.truncated === true ||
+    /\[(?:Showing lines|Truncated:|⚠️ 结果已截断)/.test(resultText)
+  ) return null;
+  if (toolName === "skill_search") {
+    const direct = args.mode === "query" ? safeSkillName(args.skill_name) : undefined;
+    const browsed = args.mode === "browse" ? skillNameFromPath(args.relative_path) : undefined;
+    const skillName = direct ?? browsed;
+    return skillName
+      ? { schemaVersion: "1.0", kind: "skill_load", skillName, source: "router" }
+      : null;
+  }
+  if (toolName === "read" && args.offset === undefined && args.limit === undefined) {
+    const skillName = skillNameFromPath(args.path ?? args.file_path);
+    return skillName
+      ? { schemaVersion: "1.0", kind: "skill_load", skillName, source: "builtin_read" }
+      : null;
+  }
+  return null;
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -57,6 +57,15 @@ export {
 } from "./tool-toggles.js";
 export type { ToolToggles, ToggleableToolName } from "./tool-toggles.js";
 
+export {
+  DOMAIN_TOOL_NAMES,
+  resolveDomainResources,
+  toolTogglesForDomainResources,
+  withoutDomainResourceInstructions,
+  domainResourceUsageOnStart,
+  domainResourceUsageOnSuccess,
+} from "./domain-resources.js";
+
 export { materializeSkills, resolveBundledSkillsDir } from "./materialize-skills.js";
 export type { MaterializeSkillsResult } from "./materialize-skills.js";
 

--- a/packages/runtime/src/mas-agent.ts
+++ b/packages/runtime/src/mas-agent.ts
@@ -14,7 +14,12 @@
  * (`extensions/trace-reminder.ts`), registered per AgentSession by the real
  * factory. MasAgent is back to a pure Pi→AG-UI translator.
  */
-import type { AgUiEvent, AgentState, TokenUsage } from "@brainpilot/protocol";
+import {
+  CUSTOM_EVENT,
+  type AgUiEvent,
+  type AgentState,
+  type TokenUsage,
+} from "@brainpilot/protocol";
 import type { EventBus } from "./event-bus.js";
 import { ev, newMessageId, newRunId } from "./events.js";
 import { normalizeAgentError, classifyAgentError, type AgentErrorKind } from "./agent-error.js";
@@ -25,6 +30,10 @@ import type {
   PiAssistantMessageEvent,
   PiUsage,
 } from "./types.js";
+import {
+  domainResourceUsageOnStart,
+  domainResourceUsageOnSuccess,
+} from "./domain-resources.js";
 
 export type AgentStatus = "idle" | "running" | "error" | "stopped";
 
@@ -82,6 +91,8 @@ export class MasAgent {
   private currentMessageId: string | undefined;
   private inReasoning = false;
   private activeToolExecutions = new Set<string>();
+  /** Correlates end events with start args without emitting those args again. */
+  private activeToolCalls = new Map<string, { toolName: string; args: Record<string, unknown> }>();
   private lastError: AgentState["lastError"];
   /**
    * Cumulative real token usage for THIS agent across every assistant turn,
@@ -270,11 +281,14 @@ export class MasAgent {
       /* prompt() is error-isolated; nothing to surface */
     }
     this.activeToolExecutions.clear();
+    this.activeToolCalls.clear();
   }
 
   stop(): void {
     this.unsubscribe();
     this.session.dispose();
+    this.activeToolExecutions.clear();
+    this.activeToolCalls.clear();
     this.setStatus("stopped");
   }
 
@@ -416,18 +430,38 @@ export class MasAgent {
       case "tool_execution_start": {
         const t = e as Extract<PiAgentEvent, { type: "tool_execution_start" }>;
         this.activeToolExecutions.add(t.toolCallId);
+        const args =
+          typeof t.args === "object" && t.args !== null && !Array.isArray(t.args)
+            ? (t.args as Record<string, unknown>)
+            : {};
+        this.activeToolCalls.set(t.toolCallId, { toolName: t.toolName, args });
         this.bus.emit(ev.toolCallStart(ctx, t.toolCallId, t.toolName, this.currentMessageId));
         const argsStr = safeStringify(t.args);
         if (argsStr) this.bus.emit(ev.toolCallArgs(ctx, t.toolCallId, argsStr));
+        const usage = domainResourceUsageOnStart(t.toolName, args);
+        if (usage) {
+          this.bus.emit(ev.custom(ctx, CUSTOM_EVENT.DOMAIN_RESOURCE_USAGE, usage));
+        }
         return;
       }
 
       case "tool_execution_end": {
         const t = e as Extract<PiAgentEvent, { type: "tool_execution_end" }>;
         this.activeToolExecutions.delete(t.toolCallId);
+        const started = this.activeToolCalls.get(t.toolCallId);
+        this.activeToolCalls.delete(t.toolCallId);
         this.bus.emit(ev.toolCallEnd(ctx, t.toolCallId));
         const resultStr = typeof t.result === "string" ? t.result : safeStringify(t.result);
         this.bus.emit(ev.toolCallResult(ctx, t.toolCallId, resultStr, t.isError));
+        const usage = domainResourceUsageOnSuccess(
+          started?.toolName ?? t.toolName,
+          started?.args ?? {},
+          t.isError,
+          t.result,
+        );
+        if (usage) {
+          this.bus.emit(ev.custom(ctx, CUSTOM_EVENT.DOMAIN_RESOURCE_USAGE, usage));
+        }
         // §7 L1: surface tool errors as system_message.
         if (t.isError) {
           this.bus.emit(

--- a/packages/runtime/src/server.ts
+++ b/packages/runtime/src/server.ts
@@ -36,8 +36,8 @@ export function createServer(opts: SessionManagerOptions & { manager?: SessionMa
   app.post("/sessions", async (c) => {
     const body = await safeBody(c);
     const parsed = CreateSessionRequestSchema.safeParse(body);
-    const input = parsed.success ? parsed.data : {};
-    const session = await manager.createSession(input);
+    if (!parsed.success) return c.json({ error: "invalid body" }, 400);
+    const session = await manager.createSession(parsed.data);
     return c.json({ id: session.id, session }, 201);
   });
 

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -19,6 +19,7 @@ import {
   CUSTOM_EVENT,
   type AgUiEvent,
   type AgentStatus,
+  type DomainResources,
   type FileContent,
   type FileEntry,
   type Session,
@@ -51,6 +52,11 @@ import {
   resolveLegacyPersistentUserId,
 } from "./persistent-layout.js";
 import type { AgentRole, AgentSessionFactory, EventListener, SystemTool, SystemToolResult } from "./types.js";
+import {
+  toolTogglesForDomainResources,
+  withoutDomainResourceInstructions,
+  resolveDomainResources,
+} from "./domain-resources.js";
 
 interface Deferred<T> {
   promise: Promise<T>;
@@ -198,6 +204,7 @@ interface SessionMeta {
   createdAt?: string;
   updatedAt?: string;
   lastActivityAt?: number;
+  domainResources?: DomainResources;
 }
 
 interface SessionEntry {
@@ -233,6 +240,8 @@ interface SessionEntry {
   pendingInputs: Map<string, Deferred<string>>;
   /** This session's chosen provider/model (resolved against providers.json). */
   providerRef: SessionProviderRef;
+  /** Frozen per-session domain-resource mode; never read from global state. */
+  domainResources: DomainResources;
   /**
    * Cumulative real token usage for this session: whole-session `total` plus a
    * per-agent breakdown (keyed by agent name). Fed by each MasAgent's `onUsage`
@@ -1029,7 +1038,11 @@ export class SessionManager {
    * rebuild); falls back to the curated built-in persona (`personaFor`) when no
    * file is present or it's empty.
    */
-  private async loadPersona(name: string, role: AgentRole): Promise<string> {
+  private async loadPersona(
+    name: string,
+    role: AgentRole,
+    domainResources: DomainResources,
+  ): Promise<string> {
     let base: string | undefined;
     try {
       const raw = (await readFile(this.agentPromptPath(name), "utf8")).trim();
@@ -1040,7 +1053,10 @@ export class SessionManager {
     // #97: append the language-following directive here (not in the persona text
     // / on-disk prompt.md) so it also reaches users who scaffolded earlier, and
     // applies whether the persona came from disk or the built-in constant.
-    let persona = withLanguageDirective(base ?? personaFor(name, role));
+    const selected = base ?? personaFor(name, role);
+    let persona = withLanguageDirective(
+      domainResources === "base" ? withoutDomainResourceInstructions(selected) : selected,
+    );
     // #257: tell working agents (not the passive trace recorder) where the
     // shared cross-session persistent root lives, by absolute path, so they can
     // read/write reusable data directly. Injected at load time (like the
@@ -1059,7 +1075,13 @@ export class SessionManager {
   /* ---------------------------- session CRUD ---------------------------- */
 
   async createSession(
-    input: { id?: string; title?: string; providerId?: string; modelId?: string } = {},
+    input: {
+      id?: string;
+      title?: string;
+      providerId?: string;
+      modelId?: string;
+      domainResources?: DomainResources;
+    } = {},
     /**
      * Internal restore path (see `restoreFromDisk`): when provided, the entry
      * inherits the on-disk meta.json timestamps verbatim instead of stamping
@@ -1075,11 +1097,21 @@ export class SessionManager {
     // layout initialization before creating any durable session state.
     if (this.persist) await this.ensurePersistentLayout();
     const id = input.id ?? randomUUID();
-    if (this.sessions.has(id)) return this.toSession(this.sessions.get(id)!);
+    if (this.sessions.has(id)) {
+      const existing = this.sessions.get(id)!;
+      if (input.domainResources && input.domainResources !== existing.domainResources) {
+        throw new Error(
+          `session ${id} already uses domainResources=${existing.domainResources}; ` +
+            `cannot reopen it as ${input.domainResources}`,
+        );
+      }
+      return this.toSession(existing);
+    }
     const nowIso = _restore ? _restore.updatedAt : new Date().toISOString();
     const createdAt = _restore ? _restore.createdAt : nowIso;
     const lastActivityAt = _restore ? _restore.lastActivityAt : Date.now();
     const persistBase = this.persist ? this.bpDir(id) : undefined;
+    const domainResources = resolveDomainResources(input.domainResources);
 
     // Provider ref: explicit input wins; otherwise reuse an existing on-disk ref
     // (restore path) so reviving a session never clobbers its chosen model.
@@ -1120,6 +1152,7 @@ export class SessionManager {
       activeRunId: null,
       pendingInputs: new Map(),
       providerRef,
+      domainResources,
       tokenUsage: { total: emptyTokenUsage(), byAgent: {} },
     };
     this.sessions.set(id, entry);
@@ -1212,6 +1245,7 @@ export class SessionManager {
           title: meta.title ?? "Untitled session",
           createdAt: meta.createdAt ?? "",
           updatedAt: meta.updatedAt ?? "",
+          domainResources: meta.domainResources === "base" ? "base" : "full",
         });
       }
     }
@@ -1623,7 +1657,10 @@ export class SessionManager {
       requestUserInput: (req) => this.requestUserInput(entry, name, req),
       routerSkillsDir: this.routerSkillsDir,
     };
-    const toolToggles = await this.ensureToolToggles();
+    const toolToggles = toolTogglesForDomainResources(
+      entry.domainResources,
+      await this.ensureToolToggles(),
+    );
     const systemTools = systemToolsForRole(role, name, deps, toolToggles);
     // External MCP tools go to non-trace agents (trace agent is graph-only, §9).
     const mcpTools = role === "trace" ? [] : await this.ensureMcpTools();
@@ -1632,7 +1669,7 @@ export class SessionManager {
     // bundled content into bp_template/skills once, then hand the dir to the
     // factory as additionalSkillPaths. Trace agent is skill-less (graph-only).
     let skillPaths: string[] | undefined;
-    if (role !== "trace") {
+    if (role !== "trace" && entry.domainResources === "full") {
       await this.ensureSkillsMaterialized();
       skillPaths = [this.skillsDir];
     }
@@ -1653,7 +1690,7 @@ export class SessionManager {
       cwd: this.workspaceDir(sessionId),
       systemTools: agentTools,
       allowedToolNames,
-      systemPrompt: await this.loadPersona(name, role),
+      systemPrompt: await this.loadPersona(name, role, entry.domainResources),
       skillPaths,
       providerConfig,
       // 意图二 fallback: the trace-reminder extension calls this when an expert
@@ -2042,6 +2079,7 @@ export class SessionManager {
         runState: { active: this.deriveRunActive(entry), runId: entry.activeRunId },
         agents: this.listAgents(entry.id),
         lastActivityTs: new Date(entry.lastActivityAt).toISOString(),
+        domainResources: entry.domainResources,
         tokenUsage: entry.tokenUsage,
       }),
     );
@@ -2051,6 +2089,7 @@ export class SessionManager {
     runState: { active: boolean; runId: string | null };
     agents: AgentStatus[];
     lastActivityTs: string;
+    domainResources: DomainResources;
     tokenUsage: SessionTokenUsage;
   } | undefined {
     const entry = this.sessions.get(sessionId);
@@ -2059,6 +2098,7 @@ export class SessionManager {
       runState: { active: this.deriveRunActive(entry), runId: entry.activeRunId },
       agents: this.listAgents(sessionId),
       lastActivityTs: new Date(entry.lastActivityAt).toISOString(),
+      domainResources: entry.domainResources,
       tokenUsage: entry.tokenUsage,
     };
   }
@@ -2213,7 +2253,13 @@ export class SessionManager {
   }
 
   private toSession(e: SessionEntry): Session {
-    return { id: e.id, title: e.title, createdAt: e.createdAt, updatedAt: e.updatedAt };
+    return {
+      id: e.id,
+      title: e.title,
+      createdAt: e.createdAt,
+      updatedAt: e.updatedAt,
+      domainResources: e.domainResources,
+    };
   }
 
   private async writeMeta(entry: SessionEntry): Promise<void> {
@@ -2224,6 +2270,7 @@ export class SessionManager {
       createdAt: entry.createdAt,
       updatedAt: entry.updatedAt,
       lastActivityAt: entry.lastActivityAt,
+      domainResources: entry.domainResources,
     };
     await mkdir(this.bpDir(entry.id), { recursive: true }).catch(() => {});
     await writeFile(join(this.bpDir(entry.id), "meta.json"), JSON.stringify(meta, null, 2), "utf8").catch(() => {});
@@ -2330,7 +2377,9 @@ export class SessionManager {
   private async readMeta(id: string): Promise<SessionMeta | null> {
     try {
       const raw = await readFile(join(this.dataRoot, ".bp", id, "meta.json"), "utf8");
-      return JSON.parse(raw) as SessionMeta;
+      const meta = JSON.parse(raw) as SessionMeta;
+      resolveDomainResources(meta.domainResources);
+      return meta;
     } catch {
       return null;
     }
@@ -2353,7 +2402,11 @@ export class SessionManager {
     try {
       const now = new Date().toISOString();
       await this.createSession(
-        { id: sid, title: meta.title },
+        {
+          id: sid,
+          title: meta.title,
+          domainResources: resolveDomainResources(meta.domainResources),
+        },
         {
           createdAt: meta.createdAt ?? now,
           updatedAt: meta.updatedAt ?? now,

--- a/packages/web/src/__tests__/tokenUsage.test.ts
+++ b/packages/web/src/__tests__/tokenUsage.test.ts
@@ -4,7 +4,7 @@
  * its absence (older runtime / pre-first-turn).
  */
 import { describe, it, expect } from "vitest";
-import { normalizeSessionState } from "../contracts/backend";
+import { normalizeSession, normalizeSessionState } from "../contracts/backend";
 
 describe("normalizeSessionState tokenUsage", () => {
   it("parses total + per-agent breakdown", () => {
@@ -25,6 +25,17 @@ describe("normalizeSessionState tokenUsage", () => {
     expect(snap.tokenUsage!.total.cacheRead).toBe(4);
     expect(snap.tokenUsage!.byAgent.principal.input).toBe(20);
     expect(snap.tokenUsage!.byAgent.librarian.total).toBe(14);
+  });
+
+  it("normalizes the frozen domain-resource mode", () => {
+    expect(normalizeSession({ id: "base", domain_resources: "base" }).domainResources).toBe("base");
+    expect(normalizeSession({ id: "legacy" }).domainResources).toBe("full");
+    expect(normalizeSessionState({
+      run_state: { active: false, run_id: null },
+      agents: [],
+      last_activity_ts: "",
+      domain_resources: "base",
+    }).domainResources).toBe("base");
   });
 
   it("omits tokenUsage when absent and coerces missing numbers to 0", () => {

--- a/packages/web/src/contexts/SessionContext.tsx
+++ b/packages/web/src/contexts/SessionContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 // TODO(dead-code): SessionEventEntry removed with pre-AG-UI polling protocol.
-import { AgentStatus, ChatMessage, MessageFilterConfig, MessageFilterRule, Session, SessionTokenUsage, TraceGraph, normalizeWebSocketEvent, /* SessionEventEntry, */ SessionMessageEntry } from "../contracts/backend";
+import { AgentStatus, ChatMessage, DomainResources, MessageFilterConfig, MessageFilterRule, Session, SessionTokenUsage, TraceGraph, normalizeWebSocketEvent, /* SessionEventEntry, */ SessionMessageEntry } from "../contracts/backend";
 import { api } from "../utils/api";
 import { tg } from "../i18n/translate";
 import { useAuth } from "./AuthContext";
@@ -66,7 +66,7 @@ interface SessionContextValue {
   /** Re-seed the trace graph from the HTTP route (manual refresh). */
   refreshTrace: (sessionId: string) => Promise<void>;
   selectSession: (sessionId: string) => void;
-  createSession: (title?: string, opts?: { providerId?: string; modelId?: string }) => Promise<Session | null>;
+  createSession: (title?: string, opts?: { providerId?: string; modelId?: string; domainResources?: DomainResources }) => Promise<Session | null>;
   /**
    * Open a fresh draft conversation without persisting anything. Idempotent —
    * repeated calls collapse to the single draft state. The real session is
@@ -77,7 +77,7 @@ interface SessionContextValue {
   deleteSession: (sessionId: string) => Promise<void>;
   /** Resolves true when the message was accepted, false on validation/timeout/
    *  error — the composer uses this to restore the draft so input isn't lost. */
-  sendPrompt: (content: string, opts?: { providerId?: string; modelId?: string }) => Promise<boolean>;
+  sendPrompt: (content: string, opts?: { providerId?: string; modelId?: string; domainResources?: DomainResources }) => Promise<boolean>;
   interruptCurrent: () => Promise<void>;
   /**
    * 修正6 — answer an ask_user (user_input_request) card. Optimistically
@@ -502,7 +502,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   }, [disconnectSession]);
 
   const createSession = useCallback(
-    async (title = "New research session", opts: { providerId?: string; modelId?: string } = {}) => {
+    async (title = "New research session", opts: { providerId?: string; modelId?: string; domainResources?: DomainResources } = {}) => {
       if (!currentSandbox || currentSandbox.status !== "running") {
         setError(tg("ctx.session.startSandbox"));
         return null;
@@ -534,7 +534,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   }, [sessions.length, isLoading, currentSandbox, currentSessionId, isDraft, startDraftSession]);
 
   const sendPrompt = useCallback(
-    async (content: string, opts: { providerId?: string; modelId?: string } = {}) => {
+    async (content: string, opts: { providerId?: string; modelId?: string; domainResources?: DomainResources } = {}) => {
       const trimmed = content.trim();
       console.log(`[SessionContext] sendPrompt: "${trimmed.slice(0, 40)}...", isConnected=${isConnected}, isDraft=${isDraft}`);
       if (!trimmed) {

--- a/packages/web/src/contracts/backend.ts
+++ b/packages/web/src/contracts/backend.ts
@@ -12,6 +12,7 @@
 // ---------------------------------------------------------------------------
 import type {
   Session,
+  DomainResources,
   AgentStatus,
   SessionStateSnapshot,
   SessionTokenUsage,
@@ -36,6 +37,7 @@ import type {
 // all `import { … } from "../contracts/backend"` sites continue to resolve.
 export type {
   Session,
+  DomainResources,
   AgentStatus,
   SessionStateSnapshot,
   SessionTokenUsage,
@@ -414,6 +416,8 @@ interface RawSession {
   createdAt?: string;
   updated_at?: string;
   updatedAt?: string;
+  domain_resources?: unknown;
+  domainResources?: unknown;
 }
 
 interface RawFileEntry {
@@ -637,6 +641,8 @@ export function normalizeSession(raw: RawSession): Session {
     title: stringValue(raw.title, id ? `Session ${id.slice(0, 8)}` : "Untitled session"),
     createdAt: isoValue(raw.createdAt ?? raw.created_at),
     updatedAt: isoValue(raw.updatedAt ?? raw.updated_at ?? raw.createdAt ?? raw.created_at),
+    domainResources:
+      (raw.domainResources ?? raw.domain_resources) === "base" ? "base" : "full",
   };
 }
 
@@ -824,6 +830,7 @@ export function normalizeSessionState(rawValue: unknown): SessionStateSnapshot {
     },
     agents,
     lastActivityTs: stringValue(camelized.lastActivityTs, ""),
+    domainResources: camelized.domainResources === "base" ? "base" : "full",
   };
   const tokenUsage = normalizeSessionTokenUsage(camelized.tokenUsage);
   if (tokenUsage) out.tokenUsage = tokenUsage;

--- a/packages/web/src/utils/api.ts
+++ b/packages/web/src/utils/api.ts
@@ -9,6 +9,7 @@ import {
   Sandbox,
   SandboxStats,
   Session,
+  DomainResources,
   SessionMessageEntry,
   SessionStateSnapshot,
   SettingsData,
@@ -459,7 +460,7 @@ export const api = {
 
     async create(
       title = "New research session",
-      opts: { providerId?: string; modelId?: string } = {},
+      opts: { providerId?: string; modelId?: string; domainResources?: DomainResources } = {},
     ): Promise<Session> {
       if (runtimeConfig.useMockBackend) {
         return mockBackend.createSession(title);
@@ -473,6 +474,7 @@ export const api = {
             title,
             ...(opts.providerId ? { providerId: opts.providerId } : {}),
             ...(opts.modelId ? { modelId: opts.modelId } : {}),
+            ...(opts.domainResources ? { domainResources: opts.domainResources } : {}),
           }),
         }),
       );


### PR DESCRIPTION
## Summary

- add persisted per-session `domainResources: full | base` across protocol, runtime, CLI client, and web contracts
- make `base` fail closed by removing always-on/router skills, `skill_search`, local knowledge tools, and their prompt guidance while retaining orchestration and generic file/code tools
- emit strict content-free usage events for domain-tool calls, skill searches, and successful complete skill loads
- preserve and expose existing cumulative provider token telemetry

## Safety and compatibility

- omission remains backward-compatible `full`
- invalid API bodies and corrupt persisted modes are rejected
- concurrent full/base sessions do not mutate global tool configuration
- usage events contain no queries, skill bodies, tool results, or credentials

## Verification

- `npm run typecheck`
- `npm test` — 65 files, 761 tests
- `npm --workspace @brainpilot/web test -- --run` — 32 files, 239 tests
- `npm run build`
- `npm run docs:check`
- `npm run version:check`
- `git diff --check`

Closes #296