### PR TITLE
chore(release): bump version to 0.0.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brainpilot",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "brainpilot",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "workspaces": [
@@ -9737,11 +9737,11 @@
     },
     "packages/backend-core": {
       "name": "@brainpilot/backend-core",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@brainpilot/protocol": "^0.0.13",
-        "@brainpilot/runtime": "^0.0.13",
+        "@brainpilot/protocol": "^0.0.14",
+        "@brainpilot/runtime": "^0.0.14",
         "@hono/node-server": "^1.13.0",
         "hono": "^4.6.0"
       },
@@ -9757,13 +9757,13 @@
     },
     "packages/cli": {
       "name": "@brainpilot/app",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@brainpilot/backend-core": "^0.0.13",
-        "@brainpilot/protocol": "^0.0.13",
-        "@brainpilot/runtime": "^0.0.13",
-        "@brainpilot/web": "^0.0.13",
+        "@brainpilot/backend-core": "^0.0.14",
+        "@brainpilot/protocol": "^0.0.14",
+        "@brainpilot/runtime": "^0.0.14",
+        "@brainpilot/web": "^0.0.14",
         "commander": "^12.1.0",
         "picocolors": "^1.1.0"
       },
@@ -9777,7 +9777,7 @@
     },
     "packages/client-cli": {
       "name": "@brainpilot/client-cli",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "dependencies": {
         "@brainpilot/protocol": "*",
         "commander": "^12.1.0"
@@ -9788,7 +9788,7 @@
     },
     "packages/docs": {
       "name": "@brainpilot/docs",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "hasInstallScript": true,
       "dependencies": {
         "@orama/orama": "3.1.18",
@@ -10126,7 +10126,7 @@
     },
     "packages/protocol": {
       "name": "@brainpilot/protocol",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "zod": "^3.24.0"
@@ -10137,11 +10137,11 @@
     },
     "packages/runtime": {
       "name": "@brainpilot/runtime",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@brainpilot/protocol": "^0.0.13",
-        "@brainpilot/skills": "^0.0.13",
+        "@brainpilot/protocol": "^0.0.14",
+        "@brainpilot/skills": "^0.0.14",
         "@earendil-works/pi-coding-agent": "0.80.3",
         "@hono/node-server": "^1.19.0",
         "@modelcontextprotocol/sdk": "^1.0.0",
@@ -11972,7 +11972,7 @@
     },
     "packages/skills": {
       "name": "@brainpilot/skills",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "AGPL-3.0-only",
       "engines": {
         "node": ">=22"
@@ -11980,10 +11980,10 @@
     },
     "packages/web": {
       "name": "@brainpilot/web",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "AGPL-3.0-only",
       "devDependencies": {
-        "@brainpilot/protocol": "^0.0.13",
+        "@brainpilot/protocol": "^0.0.14",
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource-variable/geist-mono": "^5.2.8",
         "@types/react": "^18.3.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainpilot",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "description": "BrainPilot — multi-agent research collaboration platform (TS + Pi SDK)",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/backend-core",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "engines": {
     "node": ">=22"
   },
@@ -37,8 +37,8 @@
     "start": "node ./dist/server.js"
   },
   "dependencies": {
-    "@brainpilot/protocol": "^0.0.13",
-    "@brainpilot/runtime": "^0.0.13",
+    "@brainpilot/protocol": "^0.0.14",
+    "@brainpilot/runtime": "^0.0.14",
     "@hono/node-server": "^1.13.0",
     "hono": "^4.6.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/app",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "engines": {
     "node": ">=22"
   },
@@ -32,10 +32,10 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@brainpilot/backend-core": "^0.0.13",
-    "@brainpilot/protocol": "^0.0.13",
-    "@brainpilot/runtime": "^0.0.13",
-    "@brainpilot/web": "^0.0.13",
+    "@brainpilot/backend-core": "^0.0.14",
+    "@brainpilot/protocol": "^0.0.14",
+    "@brainpilot/runtime": "^0.0.14",
+    "@brainpilot/web": "^0.0.14",
     "commander": "^12.1.0",
     "picocolors": "^1.1.0"
   }

--- a/packages/client-cli/package.json
+++ b/packages/client-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/client-cli",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "description": "BrainPilot headless verification client (dev/CI) — drive a session without the web UI",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/docs",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/protocol",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "engines": {
     "node": ">=22"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/runtime",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "engines": {
     "node": ">=22"
   },
@@ -37,8 +37,8 @@
     "start": "node ./dist/server.js"
   },
   "dependencies": {
-    "@brainpilot/protocol": "^0.0.13",
-    "@brainpilot/skills": "^0.0.13",
+    "@brainpilot/protocol": "^0.0.14",
+    "@brainpilot/skills": "^0.0.14",
     "@earendil-works/pi-coding-agent": "0.80.3",
     "@hono/node-server": "^1.19.0",
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/skills",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "engines": {
     "node": ">=22"
   },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/web",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "engines": {
     "node": ">=22"
   },
@@ -31,7 +31,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@brainpilot/protocol": "^0.0.13",
+    "@brainpilot/protocol": "^0.0.14",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.8",
     "@types/react": "^18.3.12",


### PR DESCRIPTION
Release cut for v0.0.14. This PR bumps the monorepo version so the release commit rides in as part of the merge (per CLAUDE.md release-on-dev→main workflow) — after this merges to `main`, run `npm run release` locally to publish the workspace packages.

## Scope of the release

Fixes/features landed on `main` since v0.0.13:

- **#285** CLI scaffold flakiness fix (`BP_SKIP_SKILL_COPY` gate skips the 600-file bundled-skill copy in test)
- **#286** `tool_toggles` hot-read on new sessions (drop process-wide cache)
- **#289** persistent library flattened to `data/`
- **#290** Live Demo bundle safety
- **#291** provider probes for selected Responses / Azure protocol variants
- **#292** knowledge base settings build flag
- **#293 / #295** raise `DEFAULT_MAX_TOKENS` 8k → 32k — fixes expert `write` / `edit` / `send_message` truncation on long content (the user-reported regression)
- **#294** empty `skill_name` fallback
- **#297** per-session domain resource isolation
- **#299** README research-cases docs

## Mechanical changes

- Root `package.json` `0.0.13` → `0.0.14`
- `npm run version:sync` propagated version + cross-package dependency ranges to all 8 workspace packages
- `npm install --package-lock-only` regenerated `package-lock.json`

## Verification

- `npm run typecheck` — pass
- `npm test` — 704 tests, 64 files, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)