### PR TITLE
fix(runtime): ignore Finder metadata during layout migration

### DIFF
--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -401,6 +401,18 @@ describe("SessionManager legacy `data/<userId>/` migration (#287)", () => {
     expect(marker).toMatchObject({ version: 2, status: "ready", migratedFrom: "data/local" });
   });
 
+  it("ignores Finder metadata beside the legacy directory", async () => {
+    await mkdir(join(root, "data", "local"), { recursive: true });
+    await writeFile(join(root, "data", "local", "dataset.csv"), "kept", "utf8");
+    await writeFile(join(root, "data", ".DS_Store"), "finder metadata", "utf8");
+
+    const m = new SessionManager({ dataRoot: root, persist: false, agentFactory: mockAgentFactory });
+    await m.ensurePersistentLayout();
+
+    expect(await readFile(join(root, "data", "dataset.csv"), "utf8")).toBe("kept");
+    await expect(readFile(join(root, "data", ".DS_Store"), "utf8")).rejects.toThrow();
+  });
+
   it("uses BP_USER_ID only as a legacy migration hint", async () => {
     await mkdir(join(root, "data", "alice"), { recursive: true });
     await writeFile(join(root, "data", "alice", "a.txt"), "alice", "utf8");

--- a/packages/runtime/src/persistent-layout.ts
+++ b/packages/runtime/src/persistent-layout.ts
@@ -8,7 +8,7 @@
  * directory-count heuristic cannot distinguish a v1 user id from a perfectly
  * valid v2 directory such as data/project/.
  */
-import { mkdir, readFile, readdir, rename, rmdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, rename, rmdir, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 const LAYOUT_VERSION = 2;
@@ -82,6 +82,13 @@ async function readDirOrNull(path: string) {
   }
 }
 
+function isIgnorableDataRootEntry(entry: { name: string; isFile(): boolean }): boolean {
+  // Finder creates this file merely by viewing data/. It is not persistent
+  // library content and must not turn an otherwise unambiguous v1 tree into a
+  // mixed-layout conflict.
+  return entry.name === ".DS_Store" && entry.isFile();
+}
+
 function layoutConflict(dataDir: string, legacyUserId: string, entries: string[]): Error {
   return new Error(
     `[persistent-data] cannot migrate ${dataDir}/${legacyUserId}: data/ also contains ` +
@@ -106,12 +113,18 @@ async function finishStagedMigration(
     }
   } else {
     const dataEntries = await readDirOrNull(dataDir);
-    if (dataEntries !== null && dataEntries.length > 0) {
+    const meaningfulEntries = dataEntries?.filter((entry) => !isIgnorableDataRootEntry(entry));
+    if (meaningfulEntries !== undefined && meaningfulEntries.length > 0) {
       throw new Error(
         `[persistent-data] cannot resume migration: ${dataDir} is non-empty while ${stagingDir} exists`,
       );
     }
-    if (dataEntries !== null) await rmdir(dataDir);
+    if (dataEntries !== null) {
+      for (const entry of dataEntries) {
+        if (isIgnorableDataRootEntry(entry)) await unlink(join(dataDir, entry.name));
+      }
+      await rmdir(dataDir);
+    }
     await rename(stagingDir, dataDir);
   }
 
@@ -138,7 +151,9 @@ async function runOrResumeMigration(
       if (entries === null) {
         throw new Error(`[persistent-data] migration source is missing: ${dataDir}`);
       }
-      const others = entries.filter((entry) => entry.name !== marker.legacyUserId);
+      const others = entries.filter(
+        (entry) => entry.name !== marker.legacyUserId && !isIgnorableDataRootEntry(entry),
+      );
       const legacy = entries.find((entry) => entry.name === marker.legacyUserId);
       if (!legacy?.isDirectory() || others.length > 0) {
         throw layoutConflict(dataDir, marker.legacyUserId, others.map((entry) => entry.name));
@@ -210,7 +225,9 @@ export async function ensurePersistentLayout(
     );
   }
 
-  const others = entries.filter((entry) => entry.name !== legacyUserId);
+  const others = entries.filter(
+    (entry) => entry.name !== legacyUserId && !isIgnorableDataRootEntry(entry),
+  );
   if (others.length > 0) {
     throw layoutConflict(dataDir, legacyUserId, others.map((entry) => entry.name));
   }


### PR DESCRIPTION
## Summary
- treat a root-level .DS_Store regular file as Finder metadata during v1-to-v2 persistent-layout migration
- remove the metadata only after the journaled migration has started
- keep rejecting conflicts involving any other root-level entries
- add regression coverage for the macOS local-build scenario

## Verification
- npm test -w @brainpilot/runtime -- --run src/__tests__/session-manager.test.ts
- npm run typecheck -w @brainpilot/runtime
- git diff --check