### PR TITLE
feat(backend-core): per-user sandbox in Docker dynamic mode (#301)

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,31 @@ baseline (Node + runtime only).
 | Mode | Sandbox topology | Selected by | This repo |
 |------|------------------|-------------|-----------|
 | `static` | 1 shared `main` + 1 fixed `sandbox`, single user | `BP_RUNTIME_URL` set | ✅ shipped |
-| `dynamic` | shared `main` + per-user sandbox via docker.sock | `BP_ORCHESTRATOR=docker` | 🚧 skeleton only |
+| `dynamic` | shared `main` + per-user sandbox via docker.sock | `BP_ORCHESTRATOR=docker` + `BP_DYNAMIC=1` | ✅ shipped |
+
+**Choosing static vs dynamic.** Use **static** for a single user or a trusted
+small team sharing one workspace — it is the simplest topology and what `docker
+compose up` gives you. Use **dynamic** when each user needs an *isolated*
+sandbox: `main` `docker run`s one `brainpilot-sandbox` container per user on
+first request (reusing it on subsequent requests, reclaiming it once idle).
+
+Run dynamic mode with the dedicated compose file (build the sandbox image first
+so the daemon can run it per user):
+
+```bash
+docker build -f docker/sandbox/Dockerfile -t brainpilot-sandbox:latest .
+docker compose -f docker-compose.dynamic.yml up
+```
+
+Key env (see [`docker-compose.dynamic.yml`](docker-compose.dynamic.yml)):
+`BP_ORCHESTRATOR=docker` + `BP_DYNAMIC=1` (the switch), `BP_DATA_DIR` (host data
+root; each user → `<root>/<userId>`), `BP_DYNAMIC_PORT_MIN`/`MAX` (host port
+pool), `BP_DYNAMIC_IDLE_MS` (idle-reclaim threshold, `0` disables).
+
+*Identity (trust-front):* the backend routes each request to a user's sandbox by
+the `X-BP-User` request header, which a hosted auth gateway in front of `main`
+is expected to set. When the header is absent (e.g. a bare self-hosted run) it
+falls back to a single `local` sandbox, so behaviour matches single-user mode.
 
 **Memory budget (`BP_MEM_LIMIT_MB`, optional).** For capped containers:
 

--- a/docker-compose.dynamic.yml
+++ b/docker-compose.dynamic.yml
@@ -1,30 +1,77 @@
 # =============================================================================
-# DYNAMIC SANDBOX SKELETON — NOT IMPLEMENTED IN THIS REPO.
+# BrainPilot — DYNAMIC (multi-user) deployment: 1 shared `main` + 1 sandbox PER
+# USER, started on demand by the backend via the mounted docker.sock (#301).
 # =============================================================================
-# This file documents how a downstream multi-user repo wires Docker when each
-# user needs an isolated sandbox. In `dynamic` mode the single `main` container
-# is shared by all users and starts one sandbox container PER USER on demand,
-# via the mounted docker.sock + DockerOrchestrator.
+# How it differs from the single-user static compose (docker-compose.yml):
+#   • static  → 1 main + 1 FIXED sandbox; main is pointed at it via BP_RUNTIME_URL.
+#   • dynamic → 1 main + N sandboxes; main `docker run`s a sandbox per user on
+#     first request (PerUserDockerOrchestrator), reusing existing ones and
+#     reclaiming idle ones. There is NO fixed `sandbox` service here.
 #
-# This repo ships only `static` mode (docker-compose.yml): 1 main + 1 fixed
-# sandbox. The per-user runtime logic, auth, and gateway live in the separate
-# downstream repo. The image build (docker/main, docker/sandbox) is reused
-# UNCHANGED — only the compose file and orchestrator selection differ.
+# The sandbox IMAGE is reused UNCHANGED from docker/sandbox — build it once
+# (e.g. `docker build -f docker/sandbox/Dockerfile -t brainpilot-sandbox:latest .`)
+# so the daemon can run it per user. Only the compose file + orchestrator
+# selection differ from static mode.
 #
-# To switch a downstream repo to dynamic mode:
-#   1. Mount docker.sock into main (so backend can `docker run` sandboxes).
-#   2. Set BP_ORCHESTRATOR=docker (this is the actual switch; and DO NOT set
-#      BP_RUNTIME_URL — a non-empty value forces the `static` orchestrator).
-#   3. Do NOT define a fixed `sandbox` service; the backend creates them per user.
+# Identity / routing (trust-front, #21/#35):
+#   Hosted deployments put an auth gateway in front of `main` that resolves the
+#   user and forwards the id in the `X-BP-User` request header. The backend
+#   routes each request to that user's sandbox (falling back to a single `local`
+#   sandbox when the header is absent, e.g. a bare self-hosted run).
 #
-# services:
-#   main:
-#     build: { context: ., dockerfile: docker/main/Dockerfile }
-#     image: brainpilot-main:latest
-#     ports: ["${BP_MAIN_PORT:-9001}:${BP_MAIN_PORT:-9001}"]
-#     environment:
-#       - PORT=${BP_MAIN_PORT:-9001}
-#       - BP_ORCHESTRATOR=docker
-#       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
-#     volumes:
-#       - /var/run/docker.sock:/var/run/docker.sock
+# Run:
+#   docker build -f docker/sandbox/Dockerfile -t brainpilot-sandbox:latest .
+#   docker compose -f docker-compose.dynamic.yml up
+services:
+  main:
+    build:
+      context: .
+      dockerfile: docker/main/Dockerfile
+      args:
+        HTTP_PROXY: ${HTTP_PROXY:-}
+        HTTPS_PROXY: ${HTTPS_PROXY:-}
+        NPM_REGISTRY: ${NPM_REGISTRY:-}
+        APT_MIRROR: ${APT_MIRROR:-}
+        VITE_KB_SETTINGS_ENABLED: ${VITE_KB_SETTINGS_ENABLED:-1}
+    image: brainpilot-main:latest
+    ports:
+      - "${BP_MAIN_PORT:-9001}:${BP_MAIN_PORT:-9001}"
+    environment:
+      - PORT=${BP_MAIN_PORT:-9001}
+      # `docker` orchestrator is the switch to daemon-managed sandboxes. Do NOT
+      # set BP_RUNTIME_URL — a non-empty value forces the `static` orchestrator.
+      - BP_ORCHESTRATOR=docker
+      # BP_DYNAMIC=1 upgrades the docker orchestrator from one shared container
+      # to one PER USER (PerUserDockerOrchestrator).
+      - BP_DYNAMIC=1
+      # Image the backend runs per user (must exist on the host daemon).
+      - BP_SANDBOX_IMAGE=${BP_SANDBOX_IMAGE:-brainpilot-sandbox:latest}
+      # Host port pool for per-user sandboxes (published on the daemon host).
+      - BP_DYNAMIC_PORT_MIN=${BP_DYNAMIC_PORT_MIN:-8100}
+      - BP_DYNAMIC_PORT_MAX=${BP_DYNAMIC_PORT_MAX:-8199}
+      # Idle reclaim: stop a user's sandbox after this many ms with no running
+      # agents + no activity. 0 disables reclaim. (default 30m below)
+      - BP_DYNAMIC_IDLE_MS=${BP_DYNAMIC_IDLE_MS:-1800000}
+      # Per-user data root on the HOST (each user → <root>/<userId>). This must
+      # be a host path the daemon can bind-mount into the per-user containers.
+      - BP_DATA_DIR=${BP_DATA_DIR:-/srv/brainpilot/users}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - ANTHROPIC_BASE_URL=${ANTHROPIC_BASE_URL:-}
+      - ANTHROPIC_MODEL=${ANTHROPIC_MODEL:-}
+      - ANTHROPIC_CONTEXT_WINDOW=${ANTHROPIC_CONTEXT_WINDOW:-}
+      - ANTHROPIC_MAX_TOKENS=${ANTHROPIC_MAX_TOKENS:-}
+      - BP_MODELS_JSON=${BP_MODELS_JSON:-}
+      - BP_MODEL_PROVIDER=${BP_MODEL_PROVIDER:-}
+      - BP_MOCK=${BP_MOCK:-}
+    volumes:
+      # docker.sock: lets the backend `docker run` per-user sandbox containers.
+      - /var/run/docker.sock:/var/run/docker.sock
+      # Bind the same host data root into main so the path it hands to the
+      # daemon for per-user bind mounts resolves identically on the host.
+      - ${BP_DATA_DIR:-/srv/brainpilot/users}:${BP_DATA_DIR:-/srv/brainpilot/users}:rw
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:${BP_MAIN_PORT:-9001}/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s

--- a/packages/backend-core/src/app.ts
+++ b/packages/backend-core/src/app.ts
@@ -101,13 +101,17 @@ export function createApp(options: CreateAppOptions): Hono {
   const orchestrator = options.orchestrator;
   const env = options.env;
 
-  // Lazily-created runtime client, bound to the ensured runtime's baseUrl.
-  let client: RuntimeClient | null = null;
-  async function getClient(): Promise<RuntimeClient> {
-    const handle = await orchestrator.ensureRuntime();
-    if (!client || (client as { _baseUrl?: string })._baseUrl !== handle.baseUrl) {
+  // Runtime clients cached per runtime baseUrl. In single-instance modes
+  // (local/static/single-user-docker) this Map holds exactly one entry; in
+  // dynamic (per-user) docker mode it holds one client per user's sandbox.
+  const clients = new Map<string, RuntimeClient>();
+  async function getClient(c?: import("hono").Context): Promise<RuntimeClient> {
+    const userId = c ? resolveUserId(c) : undefined;
+    const handle = await orchestrator.ensureRuntime(userId ? { userId } : undefined);
+    let client = clients.get(handle.baseUrl);
+    if (!client) {
       client = new RuntimeClient({ baseUrl: handle.baseUrl, fetchFn: options.fetchFn });
-      (client as { _baseUrl?: string })._baseUrl = handle.baseUrl;
+      clients.set(handle.baseUrl, client);
     }
     return client;
   }
@@ -164,9 +168,14 @@ export function createApp(options: CreateAppOptions): Hono {
   // self-hosted `bp --up` there is no gateway, so we answer locally with a
   // single default identity. Without this the SPA's auth bootstrap 404s into a
   // hosted-login redirect loop (#38). Shape matches the web `User` contract.
-  api.get("/auth/me", (c) =>
-    c.json({ id: "local", username: "local", createdAt: new Date(0).toISOString() }),
-  );
+  api.get("/auth/me", (c) => {
+    const id = resolveUserId(c);
+    return c.json({
+      id,
+      username: id,
+      createdAt: new Date(0).toISOString(),
+    });
+  });
 
   // ---- Metrics (proxied to runtime; idle-reclaim source, §15.4 修正2) --
   api.get("/metrics", forward("metrics"));
@@ -203,7 +212,7 @@ export function createApp(options: CreateAppOptions): Hono {
   api.post("/sandbox/:id/files", async (c) => {
     const contentType = c.req.header("content-type") ?? "";
     if (contentType.includes("application/octet-stream")) {
-      const rc = await getClient();
+      const rc = await getClient(c);
       const query = new URL(c.req.url).search.replace(/^\?/, "");
       const upstream = await rc.forward("writeFile", {
         params: { id: c.req.param("id") ?? "" },
@@ -717,12 +726,29 @@ export function createApp(options: CreateAppOptions): Hono {
 
   // ---------------- helpers ----------------
 
+  /**
+   * Resolve the current user id for per-user sandbox routing (#301).
+   *
+   * Trust-front (#21/#35): hosted deployments run an upstream gateway that
+   * authenticates the request and forwards the resolved user id in the
+   * `X-BP-User` header. Self-hosted `bp --up` has no gateway, so the header is
+   * absent and we fall back to the single `local` identity — keeping the
+   * single-user path (and its /auth/me contract) unchanged. The value is used
+   * only as an opaque routing key, so we defensively sanitize it.
+   */
+  function resolveUserId(c: import("hono").Context): string {
+    const raw = c.req.header("x-bp-user")?.trim();
+    if (!raw) return "local";
+    const safe = raw.replace(/[^A-Za-z0-9._-]/g, "").slice(0, 128);
+    return safe.length > 0 ? safe : "local";
+  }
+
   function forward(
     route: keyof typeof RUNTIME_ROUTES,
     opts: { idParam?: string; withBody?: boolean; withQuery?: boolean } = {},
   ) {
     return async (c: import("hono").Context) => {
-      const rc = await getClient();
+      const rc = await getClient(c);
       const params: Record<string, string> = {};
       if (opts.idParam) params.id = c.req.param(opts.idParam) ?? "";
       const body = opts.withBody ? await c.req.text() : undefined;
@@ -741,7 +767,7 @@ export function createApp(options: CreateAppOptions): Hono {
   }
 
   async function sseHandler(c: import("hono").Context): Promise<Response> {
-    const rc = await getClient();
+    const rc = await getClient(c);
     const id = c.req.param("id") ?? "";
     const upstream = await rc.openSse(id, {
       query: c.req.query("token") ? `token=${encodeURIComponent(c.req.query("token")!)}` : undefined,

--- a/packages/backend-core/src/create-orchestrator.ts
+++ b/packages/backend-core/src/create-orchestrator.ts
@@ -18,6 +18,10 @@ import {
   DockerOrchestrator,
   type DockerOrchestratorOptions,
 } from "./docker-orchestrator.js";
+import {
+  PerUserDockerOrchestrator,
+  type PerUserDockerOrchestratorOptions,
+} from "./per-user-docker-orchestrator.js";
 import { runtimeArtifactPaths } from "./runtime-paths.js";
 
 export interface CreateOrchestratorOptions {
@@ -26,7 +30,33 @@ export interface CreateOrchestratorOptions {
   local?: LocalOrchestratorOptions;
   static?: Partial<StaticOrchestratorOptions>;
   docker?: DockerOrchestratorOptions;
+  /** #301: per-user (dynamic) docker options; used when perUser mode is on. */
+  perUserDocker?: PerUserDockerOrchestratorOptions;
+  /**
+   * #301: force dynamic per-user docker mode. When undefined, resolved from
+   * `BP_DYNAMIC` env ("1"/"true"). Only consulted in docker mode.
+   */
+  perUser?: boolean;
   env?: Record<string, string | undefined>;
+}
+
+/** Truthy BP_DYNAMIC values that switch docker mode to per-user (#301). */
+function resolvePerUser(
+  explicit: boolean | undefined,
+  env: Record<string, string | undefined>,
+): boolean {
+  if (explicit !== undefined) return explicit;
+  const raw = (env.BP_DYNAMIC ?? "").toLowerCase();
+  return raw === "1" || raw === "true" || raw === "yes";
+}
+
+function intFromEnv(
+  value: string | undefined,
+  fallback: number | undefined,
+): number | undefined {
+  if (value === undefined || value.trim() === "") return fallback;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
 }
 
 export function createOrchestrator(
@@ -42,7 +72,42 @@ export function createOrchestrator(
     // modes inherit the parent env, so the runtime reads BP_SHARED_DIR directly.)
     const sharedRaw = options.docker?.sharedDir ?? env.BP_SHARED_DIR ?? "";
     const sharedDir = sharedRaw.trim() === "" ? undefined : sharedRaw;
-    return new DockerOrchestrator({ ...options.docker, sharedDir });
+
+    // The sandbox image the daemon runs. Env-overridable (BP_SANDBOX_IMAGE) so
+    // compose can pin a tag without a code change; falls back to the
+    // DockerOrchestrator default when unset.
+    const imageRaw = options.docker?.image ?? env.BP_SANDBOX_IMAGE ?? "";
+    const image = imageRaw.trim() === "" ? undefined : imageRaw;
+
+    // #301: dynamic multi-user mode gives each user an isolated sandbox. Opt-in
+    // via BP_DYNAMIC (or options.perUser) so the default docker path stays the
+    // single shared container it is today.
+    if (resolvePerUser(options.perUser, env)) {
+      const dataRoot =
+        options.perUserDocker?.dataRoot ??
+        options.docker?.dataDir ??
+        env.BP_DATA_DIR ??
+        undefined;
+      // Per-user options own hostPort/dataDir (allocated per user), so drop any
+      // single-instance values carried on options.docker before spreading.
+      const {
+        hostPort: _hostPort,
+        dataDir: _dataDir,
+        ...dockerBase
+      } = options.docker ?? {};
+      return new PerUserDockerOrchestrator({
+        ...dockerBase,
+        ...options.perUserDocker,
+        ...(image ? { image } : {}),
+        sharedDir,
+        dataRoot,
+        portMin: intFromEnv(env.BP_DYNAMIC_PORT_MIN, options.perUserDocker?.portMin),
+        portMax: intFromEnv(env.BP_DYNAMIC_PORT_MAX, options.perUserDocker?.portMax),
+        idleMs: intFromEnv(env.BP_DYNAMIC_IDLE_MS, options.perUserDocker?.idleMs),
+      });
+    }
+
+    return new DockerOrchestrator({ ...options.docker, ...(image ? { image } : {}), sharedDir });
   }
 
   if (mode === "static") {

--- a/packages/backend-core/src/index.ts
+++ b/packages/backend-core/src/index.ts
@@ -40,6 +40,9 @@ export type {
 export { DockerOrchestrator } from "./docker-orchestrator.js";
 export type { DockerOrchestratorOptions } from "./docker-orchestrator.js";
 
+export { PerUserDockerOrchestrator } from "./per-user-docker-orchestrator.js";
+export type { PerUserDockerOrchestratorOptions } from "./per-user-docker-orchestrator.js";
+
 export { StaticRuntimeOrchestrator } from "./static-orchestrator.js";
 export type { StaticOrchestratorOptions } from "./static-orchestrator.js";
 

--- a/packages/backend-core/src/orchestrator.ts
+++ b/packages/backend-core/src/orchestrator.ts
@@ -22,6 +22,13 @@ export interface EnsureRuntimeOptions {
   /** Host data dir injected as BP_DATA_DIR (§11A.2). */
   readonly dataDir?: string;
   /**
+   * #301: routing key for per-user (dynamic) sandbox allocation. Only the
+   * PerUserDockerOrchestrator interprets it: each distinct `userId` gets its
+   * own container. All other orchestrators ignore it (single-instance), so the
+   * local/static/single-user-docker behaviour is unchanged when it is omitted.
+   */
+  readonly userId?: string;
+  /**
    * #261: host dir for the cross-user READ-ONLY shared root. Docker mode
    * bind-mounts it read-only and injects `BP_SHARED_DIR`; other orchestrators
    * forward it as env so the runtime exposes it at the `/shared` prefix.
@@ -41,8 +48,14 @@ export interface Orchestrator {
   ensureRuntime(opts?: EnsureRuntimeOptions): Promise<RuntimeHandle>;
   /** Probe the runtime `GET /health` (§15.4). Returns false if not started. */
   health(): Promise<boolean>;
-  /** Gracefully stop the runtime. Safe to call when not started. */
-  stopRuntime(): Promise<void>;
+  /**
+   * Gracefully stop the runtime. Safe to call when not started.
+   *
+   * #301: multi-tenant orchestrators accept an optional `userId` to stop a
+   * single user's runtime; omitting it stops everything. Single-instance
+   * orchestrators ignore the argument.
+   */
+  stopRuntime(userId?: string): Promise<void>;
 }
 
 export type OrchestratorMode = "local" | "static" | "docker";

--- a/packages/backend-core/src/per-user-docker-orchestrator.ts
+++ b/packages/backend-core/src/per-user-docker-orchestrator.ts
@@ -1,0 +1,314 @@
+/**
+ * PerUserDockerOrchestrator — dynamic (multi-user) Docker mode (#301).
+ *
+ * In `dynamic` deployment mode each logged-in user gets an ISOLATED sandbox
+ * container. This orchestrator is a thin multi-tenant layer OVER the tested
+ * single-user `DockerOrchestrator`: it keeps one `DockerOrchestrator` per
+ * `userId`, hands each a distinct host port (from a pool) and a per-user data
+ * dir, and reaps idle users' containers.
+ *
+ * Routing key is `EnsureRuntimeOptions.userId`. When no `userId` is supplied
+ * (self-hosted / no gateway) it degrades to a single shared instance keyed by a
+ * sentinel id, so the behaviour matches the single-user DockerOrchestrator.
+ *
+ * The per-user runtime logic that #301 asked for lives here (in the public
+ * `@brainpilot/backend-core` package) so downstream multi-user repos only need
+ * to wire the gateway/auth + storage, not fork the orchestrator.
+ */
+import type {
+  EnsureRuntimeOptions,
+  Orchestrator,
+  RuntimeHandle,
+} from "./orchestrator.js";
+import {
+  DockerOrchestrator,
+  type DockerOrchestratorOptions,
+} from "./docker-orchestrator.js";
+
+/** Sentinel user id used when a caller supplies none (single shared sandbox). */
+const DEFAULT_USER = "__default__";
+
+/** Metrics shape we read off a per-user runtime for idle-reclaim (R-3). */
+interface RuntimeMetrics {
+  runningAgents?: number;
+  lastActivityAt?: string | null;
+}
+
+export interface PerUserDockerOrchestratorOptions
+  extends Omit<DockerOrchestratorOptions, "hostPort" | "dataDir"> {
+  /**
+   * Host data root. Each user's data dir is `<dataRoot>/<userId>`, bind-mounted
+   * into that user's container as `containerDataDir`. Omitted → no per-user
+   * bind mount (containers run with ephemeral storage).
+   */
+  dataRoot?: string;
+  /** Lowest host port to hand out. Default 8100. */
+  portMin?: number;
+  /** Highest host port to hand out (inclusive). Default 8199. */
+  portMax?: number;
+  /**
+   * Idle threshold (ms). A user's container with `runningAgents === 0` and no
+   * activity newer than this is stopped by the reaper. `0` disables reclaim.
+   * Default 0 (off) — callers/compose opt in via BP_DYNAMIC_IDLE_MS.
+   */
+  idleMs?: number;
+  /** Reaper poll interval (ms). Default 60_000. */
+  reapIntervalMs?: number;
+  /**
+   * Factory for the per-user orchestrator (injectable for tests). Receives the
+   * fully-resolved options (with hostPort + dataDir bound) and must return an
+   * Orchestrator. Defaults to `new DockerOrchestrator(opts)`.
+   */
+  createOrchestrator?: (opts: DockerOrchestratorOptions) => Orchestrator;
+  /**
+   * Read a runtime's `GET /metrics` (injectable for tests). Defaults to a fetch
+   * of `${baseUrl}/metrics`. Used only by the idle reaper.
+   */
+  metricsProbe?: (baseUrl: string) => Promise<RuntimeMetrics | null>;
+  /** Injectable clock (ms). Defaults to Date.now. */
+  now?: () => number;
+  /** Injectable timer setter. Defaults to setInterval. */
+  setIntervalFn?: (cb: () => void, ms: number) => ReturnType<typeof setInterval>;
+  /** Injectable timer clearer. Defaults to clearInterval. */
+  clearIntervalFn?: (t: ReturnType<typeof setInterval>) => void;
+}
+
+interface UserEntry {
+  orch: Orchestrator;
+  baseUrl: string;
+  hostPort: number;
+  lastEnsuredAt: number;
+}
+
+async function defaultMetricsProbe(
+  baseUrl: string,
+): Promise<RuntimeMetrics | null> {
+  try {
+    const res = await fetch(`${baseUrl}/metrics`);
+    if (!res.ok) return null;
+    return (await res.json()) as RuntimeMetrics;
+  } catch {
+    return null;
+  }
+}
+
+export class PerUserDockerOrchestrator implements Orchestrator {
+  private readonly base: Omit<DockerOrchestratorOptions, "hostPort" | "dataDir">;
+  private readonly dataRoot?: string;
+  private readonly containerDataDir: string;
+  private readonly portMin: number;
+  private readonly portMax: number;
+  private readonly idleMs: number;
+  private readonly reapIntervalMs: number;
+  private readonly makeOrchestrator: (
+    opts: DockerOrchestratorOptions,
+  ) => Orchestrator;
+  private readonly metricsProbe: (baseUrl: string) => Promise<RuntimeMetrics | null>;
+  private readonly now: () => number;
+  private readonly setIntervalFn: (
+    cb: () => void,
+    ms: number,
+  ) => ReturnType<typeof setInterval>;
+  private readonly clearIntervalFn: (t: ReturnType<typeof setInterval>) => void;
+
+  private readonly users = new Map<string, UserEntry>();
+  /** Single-flight per user (issue #58 pattern): concurrent first requests share one launch. */
+  private readonly starting = new Map<string, Promise<RuntimeHandle>>();
+  private readonly usedPorts = new Set<number>();
+  private reaper: ReturnType<typeof setInterval> | null = null;
+
+  constructor(options: PerUserDockerOrchestratorOptions = {}) {
+    const {
+      dataRoot,
+      portMin,
+      portMax,
+      idleMs,
+      reapIntervalMs,
+      createOrchestrator,
+      metricsProbe,
+      now,
+      setIntervalFn,
+      clearIntervalFn,
+      ...dockerOpts
+    } = options;
+    this.base = dockerOpts;
+    this.dataRoot = dataRoot;
+    this.containerDataDir = dockerOpts.containerDataDir ?? "/root/.bp-root";
+    this.portMin = portMin ?? 8100;
+    this.portMax = portMax ?? 8199;
+    this.idleMs = idleMs ?? 0;
+    this.reapIntervalMs = reapIntervalMs ?? 60_000;
+    this.makeOrchestrator =
+      createOrchestrator ?? ((opts) => new DockerOrchestrator(opts));
+    this.metricsProbe = metricsProbe ?? defaultMetricsProbe;
+    this.now = now ?? (() => Date.now());
+    this.setIntervalFn =
+      setIntervalFn ?? ((cb, ms) => setInterval(cb, ms));
+    this.clearIntervalFn = clearIntervalFn ?? ((t) => clearInterval(t));
+  }
+
+  /** Users currently holding a live container (excluding the sentinel). */
+  get activeUsers(): string[] {
+    return [...this.users.keys()].filter((u) => u !== DEFAULT_USER);
+  }
+
+  async ensureRuntime(opts?: EnsureRuntimeOptions): Promise<RuntimeHandle> {
+    const userId = opts?.userId ?? DEFAULT_USER;
+
+    const existing = this.users.get(userId);
+    if (existing) {
+      const orch = existing.orch as Orchestrator & { health?: () => Promise<boolean> };
+      const healthy = orch.health ? await orch.health() : true;
+      if (healthy) {
+        existing.lastEnsuredAt = this.now();
+        return { baseUrl: existing.baseUrl };
+      }
+      // Container died — drop it so we recreate below (also frees the port).
+      await this.disposeUser(userId);
+    }
+
+    const inFlight = this.starting.get(userId);
+    if (inFlight) return inFlight;
+
+    const launch = this.launchUser(userId, opts).finally(() => {
+      this.starting.delete(userId);
+    });
+    this.starting.set(userId, launch);
+    return launch;
+  }
+
+  private async launchUser(
+    userId: string,
+    opts?: EnsureRuntimeOptions,
+  ): Promise<RuntimeHandle> {
+    const hostPort = this.allocatePort();
+    const dataDir =
+      opts?.dataDir ??
+      (this.dataRoot ? joinPath(this.dataRoot, userId) : undefined);
+
+    const orch = this.makeOrchestrator({
+      ...this.base,
+      hostPort,
+      ...(dataDir ? { dataDir } : {}),
+    });
+
+    let handle: RuntimeHandle;
+    try {
+      handle = await orch.ensureRuntime({
+        ...(dataDir ? { dataDir } : {}),
+        ...(opts?.sharedDir ? { sharedDir: opts.sharedDir } : {}),
+        ...(opts?.env ? { env: opts.env } : {}),
+      });
+    } catch (err) {
+      this.usedPorts.delete(hostPort);
+      await orch.stopRuntime().catch(() => {});
+      throw err;
+    }
+
+    this.users.set(userId, {
+      orch,
+      baseUrl: handle.baseUrl,
+      hostPort,
+      lastEnsuredAt: this.now(),
+    });
+    this.startReaperIfNeeded();
+    return handle;
+  }
+
+  /** Health of the sentinel/default instance (Orchestrator contract). */
+  async health(): Promise<boolean> {
+    const entry = this.users.get(DEFAULT_USER) ?? this.users.values().next().value;
+    if (!entry) return false;
+    const orch = entry.orch as Orchestrator & { health?: () => Promise<boolean> };
+    return orch.health ? orch.health() : true;
+  }
+
+  /** Health of a specific user's runtime. */
+  async healthOf(userId: string): Promise<boolean> {
+    const entry = this.users.get(userId);
+    if (!entry) return false;
+    const orch = entry.orch as Orchestrator & { health?: () => Promise<boolean> };
+    return orch.health ? orch.health() : true;
+  }
+
+  /** Stop one user's runtime, or all of them when `userId` is omitted. */
+  async stopRuntime(userId?: string): Promise<void> {
+    if (userId !== undefined) {
+      await this.disposeUser(userId);
+      if (this.users.size === 0) this.stopReaper();
+      return;
+    }
+    const ids = [...this.users.keys()];
+    await Promise.all(ids.map((id) => this.disposeUser(id)));
+    this.stopReaper();
+  }
+
+  private async disposeUser(userId: string): Promise<void> {
+    const entry = this.users.get(userId);
+    if (!entry) return;
+    this.users.delete(userId);
+    this.usedPorts.delete(entry.hostPort);
+    await entry.orch.stopRuntime().catch(() => {});
+  }
+
+  private allocatePort(): number {
+    for (let p = this.portMin; p <= this.portMax; p++) {
+      if (!this.usedPorts.has(p)) {
+        this.usedPorts.add(p);
+        return p;
+      }
+    }
+    throw new Error(
+      `PerUserDockerOrchestrator: no free host port in range ` +
+        `${this.portMin}-${this.portMax} (${this.usedPorts.size} in use). ` +
+        `Widen BP_DYNAMIC_PORT_MIN/MAX or lower BP_DYNAMIC_IDLE_MS.`,
+    );
+  }
+
+  private startReaperIfNeeded(): void {
+    if (this.reaper || this.idleMs <= 0) return;
+    this.reaper = this.setIntervalFn(() => {
+      void this.reapIdle();
+    }, this.reapIntervalMs);
+    // Don't keep the event loop alive just for the reaper.
+    (this.reaper as { unref?: () => void }).unref?.();
+  }
+
+  private stopReaper(): void {
+    if (!this.reaper) return;
+    this.clearIntervalFn(this.reaper);
+    this.reaper = null;
+  }
+
+  /**
+   * Idle reclaim (#301 req 4 / R-3): stop+remove any user's container that has
+   * no running agents AND whose most recent activity is older than `idleMs`.
+   * `lastActivityAt` (from the runtime) wins; we fall back to `lastEnsuredAt`.
+   */
+  async reapIdle(): Promise<void> {
+    if (this.idleMs <= 0) return;
+    const now = this.now();
+    const candidates = [...this.users.entries()];
+    for (const [userId, entry] of candidates) {
+      const metrics = await this.metricsProbe(entry.baseUrl);
+      // If metrics are unreadable, don't reap — a transient probe failure must
+      // not evict an in-use sandbox.
+      if (!metrics) continue;
+      if ((metrics.runningAgents ?? 0) > 0) continue;
+      const lastActivity = metrics.lastActivityAt
+        ? Date.parse(metrics.lastActivityAt)
+        : entry.lastEnsuredAt;
+      const idleFor = now - (Number.isNaN(lastActivity) ? entry.lastEnsuredAt : lastActivity);
+      if (idleFor >= this.idleMs) {
+        await this.disposeUser(userId);
+      }
+    }
+    if (this.users.size === 0) this.stopReaper();
+  }
+}
+
+/** Join a data root and user id with a single separator, POSIX-style. */
+function joinPath(root: string, userId: string): string {
+  const trimmed = root.replace(/\/+$/, "");
+  return `${trimmed}/${userId}`;
+}

--- a/packages/backend-core/test/app.test.ts
+++ b/packages/backend-core/test/app.test.ts
@@ -816,3 +816,66 @@ describe("Hono app — local config routes", () => {
     });
   });
 });
+
+// #301: per-user (dynamic) routing. The backend passes the resolved user id
+// (X-BP-User header, trust-front) to the orchestrator and caches one runtime
+// client per baseUrl, so two users hit two different sandboxes.
+describe("per-user sandbox routing (#301)", () => {
+  function routingOrchestrator(): {
+    orch: Orchestrator;
+    seen: string[];
+  } {
+    const seen: string[] = [];
+    const orch: Orchestrator = {
+      async ensureRuntime(opts): Promise<RuntimeHandle> {
+        const userId = opts?.userId ?? "none";
+        seen.push(userId);
+        return { baseUrl: `http://runtime-${userId}.test` };
+      },
+      async health() {
+        return true;
+      },
+      async stopRuntime() {},
+    };
+    return { orch, seen };
+  }
+
+  it("routes distinct X-BP-User values to distinct runtimes", async () => {
+    const { orch, seen } = routingOrchestrator();
+    const hit: string[] = [];
+    const fetchFn = vi.fn(async (url: string) => {
+      hit.push(url);
+      return new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+    const app = createApp({ orchestrator: orch, fetchFn: fetchFn as never, serveWeb: false });
+
+    await app.request("/api/sessions", { headers: { "x-bp-user": "alice" } });
+    await app.request("/api/sessions", { headers: { "x-bp-user": "bob" } });
+
+    expect(seen).toEqual(["alice", "bob"]);
+    expect(hit).toEqual([
+      "http://runtime-alice.test/sessions",
+      "http://runtime-bob.test/sessions",
+    ]);
+  });
+
+  it("falls back to `local` when no header is present", async () => {
+    const { orch, seen } = routingOrchestrator();
+    const fetchFn = vi.fn(async () =>
+      new Response("{}", { status: 200, headers: { "content-type": "application/json" } }),
+    );
+    const app = createApp({ orchestrator: orch, fetchFn: fetchFn as never, serveWeb: false });
+    await app.request("/api/sessions");
+    expect(seen).toEqual(["local"]);
+  });
+
+  it("/auth/me reflects the X-BP-User identity", async () => {
+    const { orch } = routingOrchestrator();
+    const app = createApp({ orchestrator: orch, serveWeb: false });
+    const res = await app.request("/api/auth/me", { headers: { "x-bp-user": "alice" } });
+    expect(await res.json()).toMatchObject({ id: "alice", username: "alice" });
+  });
+});

--- a/packages/backend-core/test/create-orchestrator.test.ts
+++ b/packages/backend-core/test/create-orchestrator.test.ts
@@ -6,6 +6,7 @@ import { createOrchestrator } from "../src/create-orchestrator.js";
 import { resolveOrchestratorMode } from "../src/orchestrator.js";
 import { LocalProcessOrchestrator } from "../src/local-orchestrator.js";
 import { DockerOrchestrator } from "../src/docker-orchestrator.js";
+import { PerUserDockerOrchestrator } from "../src/per-user-docker-orchestrator.js";
 import { StaticRuntimeOrchestrator } from "../src/static-orchestrator.js";
 
 describe("resolveOrchestratorMode", () => {
@@ -53,6 +54,22 @@ describe("createOrchestrator factory", () => {
   it("creates a DockerOrchestrator when mode=docker", () => {
     const fakeDocker = {} as never;
     const orch = createOrchestrator({ mode: "docker", docker: { docker: fakeDocker } });
+    expect(orch).toBeInstanceOf(DockerOrchestrator);
+  });
+  it("creates a PerUserDockerOrchestrator when docker mode + BP_DYNAMIC=1 (#301)", () => {
+    const orch = createOrchestrator({
+      mode: "docker",
+      env: { BP_DYNAMIC: "1" },
+      docker: { docker: {} as never },
+    });
+    expect(orch).toBeInstanceOf(PerUserDockerOrchestrator);
+  });
+  it("stays single-instance DockerOrchestrator in docker mode without BP_DYNAMIC (#301)", () => {
+    const orch = createOrchestrator({
+      mode: "docker",
+      env: {},
+      docker: { docker: {} as never },
+    });
     expect(orch).toBeInstanceOf(DockerOrchestrator);
   });
   it("respects an explicit mode override", () => {

--- a/packages/backend-core/test/per-user-docker-orchestrator.test.ts
+++ b/packages/backend-core/test/per-user-docker-orchestrator.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi } from "vitest";
+import { PerUserDockerOrchestrator } from "../src/per-user-docker-orchestrator.js";
+import type {
+  EnsureRuntimeOptions,
+  Orchestrator,
+  RuntimeHandle,
+} from "../src/orchestrator.js";
+import type { DockerOrchestratorOptions } from "../src/docker-orchestrator.js";
+
+/** A fake per-user orchestrator recording its bound hostPort/dataDir. */
+class FakeOrchestrator implements Orchestrator {
+  static instances: FakeOrchestrator[] = [];
+  readonly hostPort: number;
+  readonly dataDir?: string;
+  started = false;
+  stopped = false;
+  healthy = true;
+
+  constructor(opts: DockerOrchestratorOptions) {
+    this.hostPort = opts.hostPort!;
+    this.dataDir = opts.dataDir;
+    FakeOrchestrator.instances.push(this);
+  }
+  async ensureRuntime(_opts?: EnsureRuntimeOptions): Promise<RuntimeHandle> {
+    this.started = true;
+    return { baseUrl: `http://127.0.0.1:${this.hostPort}` };
+  }
+  async health(): Promise<boolean> {
+    return this.healthy;
+  }
+  async stopRuntime(): Promise<void> {
+    this.stopped = true;
+  }
+}
+
+function makeOrch(
+  overrides: Partial<
+    ConstructorParameters<typeof PerUserDockerOrchestrator>[0]
+  > = {},
+) {
+  FakeOrchestrator.instances = [];
+  const orch = new PerUserDockerOrchestrator({
+    dataRoot: "/data/users",
+    portMin: 8100,
+    portMax: 8102,
+    createOrchestrator: (o) => new FakeOrchestrator(o),
+    ...overrides,
+  });
+  return orch;
+}
+
+describe("PerUserDockerOrchestrator", () => {
+  it("gives each user a distinct container/port and data dir", async () => {
+    const orch = makeOrch();
+    const a = await orch.ensureRuntime({ userId: "alice" });
+    const b = await orch.ensureRuntime({ userId: "bob" });
+    expect(a.baseUrl).not.toBe(b.baseUrl);
+    expect(FakeOrchestrator.instances).toHaveLength(2);
+    expect(FakeOrchestrator.instances[0]!.dataDir).toBe("/data/users/alice");
+    expect(FakeOrchestrator.instances[1]!.dataDir).toBe("/data/users/bob");
+    expect(orch.activeUsers.sort()).toEqual(["alice", "bob"]);
+  });
+
+  it("reuses an existing healthy container for the same user (idempotent)", async () => {
+    const orch = makeOrch();
+    const a1 = await orch.ensureRuntime({ userId: "alice" });
+    const a2 = await orch.ensureRuntime({ userId: "alice" });
+    expect(a2.baseUrl).toBe(a1.baseUrl);
+    expect(FakeOrchestrator.instances).toHaveLength(1);
+  });
+
+  it("recreates the container when the user's runtime is unhealthy", async () => {
+    const orch = makeOrch();
+    await orch.ensureRuntime({ userId: "alice" });
+    FakeOrchestrator.instances[0]!.healthy = false;
+    const a2 = await orch.ensureRuntime({ userId: "alice" });
+    expect(FakeOrchestrator.instances).toHaveLength(2);
+    expect(a2.baseUrl).toBe("http://127.0.0.1:8100");
+    expect(FakeOrchestrator.instances[0]!.stopped).toBe(true);
+  });
+
+  it("falls back to a single shared instance when no userId is given", async () => {
+    const orch = makeOrch();
+    const a = await orch.ensureRuntime();
+    const b = await orch.ensureRuntime();
+    expect(b.baseUrl).toBe(a.baseUrl);
+    expect(FakeOrchestrator.instances).toHaveLength(1);
+    expect(orch.activeUsers).toEqual([]);
+  });
+
+  it("is single-flight per user under concurrent first requests", async () => {
+    const orch = makeOrch();
+    const [a1, a2] = await Promise.all([
+      orch.ensureRuntime({ userId: "alice" }),
+      orch.ensureRuntime({ userId: "alice" }),
+    ]);
+    expect(a1.baseUrl).toBe(a2.baseUrl);
+    expect(FakeOrchestrator.instances).toHaveLength(1);
+  });
+
+  it("releases a port on stop so it can be reallocated", async () => {
+    const orch = makeOrch();
+    await orch.ensureRuntime({ userId: "alice" });
+    await orch.ensureRuntime({ userId: "bob" });
+    await orch.stopRuntime("alice");
+    expect(orch.activeUsers).toEqual(["bob"]);
+    // alice's freed port (8100) is reused by the next new user.
+    const c = await orch.ensureRuntime({ userId: "carol" });
+    expect(c.baseUrl).toBe("http://127.0.0.1:8100");
+  });
+
+  it("throws when the port pool is exhausted", async () => {
+    const orch = makeOrch({ portMin: 8100, portMax: 8100 });
+    await orch.ensureRuntime({ userId: "alice" });
+    await expect(orch.ensureRuntime({ userId: "bob" })).rejects.toThrow(
+      /no free host port/i,
+    );
+  });
+
+  it("frees the port when a user's launch fails", async () => {
+    let calls = 0;
+    const orch = makeOrch({
+      portMin: 8100,
+      portMax: 8100,
+      createOrchestrator: (o) => {
+        calls++;
+        if (calls === 1) {
+          return {
+            async ensureRuntime() {
+              throw new Error("boom");
+            },
+            async health() {
+              return false;
+            },
+            async stopRuntime() {},
+          } satisfies Orchestrator;
+        }
+        return new FakeOrchestrator(o);
+      },
+    });
+    await expect(orch.ensureRuntime({ userId: "alice" })).rejects.toThrow("boom");
+    // Port was released → a retry (single-port pool) can succeed.
+    const a = await orch.ensureRuntime({ userId: "alice" });
+    expect(a.baseUrl).toBe("http://127.0.0.1:8100");
+  });
+
+  it("stopRuntime() with no arg stops all users", async () => {
+    const orch = makeOrch();
+    await orch.ensureRuntime({ userId: "alice" });
+    await orch.ensureRuntime({ userId: "bob" });
+    await orch.stopRuntime();
+    expect(orch.activeUsers).toEqual([]);
+    expect(FakeOrchestrator.instances.every((i) => i.stopped)).toBe(true);
+  });
+
+  describe("idle reclaim (R-3)", () => {
+    it("reaps an idle user with no running agents past the threshold", async () => {
+      let clock = 1_000_000;
+      const metricsProbe = vi.fn(async () => ({
+        runningAgents: 0,
+        lastActivityAt: new Date(clock - 10 * 60_000).toISOString(),
+      }));
+      const orch = makeOrch({
+        idleMs: 5 * 60_000,
+        metricsProbe,
+        now: () => clock,
+        setIntervalFn: () => 0 as unknown as ReturnType<typeof setInterval>,
+        clearIntervalFn: () => {},
+      });
+      await orch.ensureRuntime({ userId: "alice" });
+      await orch.reapIdle();
+      expect(orch.activeUsers).toEqual([]);
+      expect(FakeOrchestrator.instances[0]!.stopped).toBe(true);
+    });
+
+    it("does NOT reap a user with running agents", async () => {
+      let clock = 1_000_000;
+      const orch = makeOrch({
+        idleMs: 1,
+        metricsProbe: async () => ({ runningAgents: 2, lastActivityAt: null }),
+        now: () => clock,
+        setIntervalFn: () => 0 as unknown as ReturnType<typeof setInterval>,
+        clearIntervalFn: () => {},
+      });
+      await orch.ensureRuntime({ userId: "alice" });
+      await orch.reapIdle();
+      expect(orch.activeUsers).toEqual(["alice"]);
+    });
+
+    it("does NOT reap when metrics are unreadable (transient probe failure)", async () => {
+      const orch = makeOrch({
+        idleMs: 1,
+        metricsProbe: async () => null,
+        setIntervalFn: () => 0 as unknown as ReturnType<typeof setInterval>,
+        clearIntervalFn: () => {},
+      });
+      await orch.ensureRuntime({ userId: "alice" });
+      await orch.reapIdle();
+      expect(orch.activeUsers).toEqual(["alice"]);
+    });
+  });
+});


### PR DESCRIPTION
Closes #301.

## What
Implements per-user sandbox allocation for `dynamic` Docker mode — the "登录用户无沙盒时自动分配 per-user sandbox" link that was previously only a commented skeleton.

## How
- **`orchestrator.ts`** — add `EnsureRuntimeOptions.userId` (routing key) and `stopRuntime(userId?)` (multi-tenant semantics). Optional → existing impls/callers unchanged.
- **`PerUserDockerOrchestrator`** (new) — a multi-tenant layer over the tested single-user `DockerOrchestrator`:
  - `Map<userId, …>` + host **port pool** (`BP_DYNAMIC_PORT_MIN/MAX`)
  - per-user `dataDir` = `<dataRoot>/<userId>`
  - **per-user single-flight** (issue #58 pattern) so concurrent first requests share one launch
  - **idempotent reuse** of a healthy container; recreate when unhealthy
  - **idle reclaim** (#301 req 4 / R-3): stop+remove a user's container with `runningAgents === 0` idle past `BP_DYNAMIC_IDLE_MS`, read from the runtime `/metrics`; never reaps on a transient probe failure
  - no `userId` → single shared instance (backward compatible with today's docker mode)
- **`create-orchestrator.ts`** — `BP_DYNAMIC=1` (or `options.perUser`) selects per-user in docker mode; reads `BP_DYNAMIC_PORT_MIN/MAX`, `BP_DYNAMIC_IDLE_MS`, `BP_SANDBOX_IMAGE`. Default docker path stays single-instance.
- **`app.ts`** — resolve user id from the `X-BP-User` header (trust-front, #21/#35; sanitized), cache one `RuntimeClient` per `baseUrl`, thread `userId` into `ensureRuntime`. `/auth/me` reflects the identity (`local` fallback unchanged).
- **`docker-compose.dynamic.yml`** — skeleton → runnable minimal example (main + docker.sock + `BP_DYNAMIC` + port pool + data volume).
- **README** — dynamic vs static selection + `X-BP-User` gateway contract.

## Identity contract (note for reviewers)
`X-BP-User` is a **new contract for the downstream auth gateway** — this repo only *consumes* it. When absent (bare self-hosted run) it falls back to a single `local` sandbox, so single-user behaviour and the `/auth/me` contract are unchanged.

## Tests
- `per-user-docker-orchestrator.test.ts` (12): per-user isolation, idempotent reuse, unhealthy recreate, no-userId fallback, single-flight, port release/exhaustion, launch-failure port release, stop-all, idle reclaim (reap / running-agents / unreadable-metrics).
- `app.test.ts` (+3): `X-BP-User` routing, `local` fallback, `/auth/me` identity.
- `create-orchestrator.test.ts` (+2): `BP_DYNAMIC` switch on/off.

Repo-wide `typecheck` passes; `@brainpilot/backend-core` `186 passed`.