### PR TITLE
fix(web): make stream content merge idempotent on restore (#314)

### DIFF
--- a/packages/web/src/__tests__/messageStreamIdempotency.test.ts
+++ b/packages/web/src/__tests__/messageStreamIdempotency.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from "vitest";
+import { reduceMessagesForEvent } from "../contexts/messageReducer";
+import type { ChatMessage, WebSocketEvent } from "../contracts/backend";
+
+/**
+ * #314 — Restoring a conversation can concatenate assistant content more than
+ * once. History rehydrate folds events.jsonl through reduceMessagesForEvent;
+ * SSE then replays the in-memory ring buffer through the same reducer. START
+ * is already keyed by messageId, but CONTENT used to always append — so the
+ * same deltas landed twice in one message bubble.
+ *
+ * Fix: stream-append events (CONTENT / REASONING_CONTENT / TOOL_CALL_ARGS) are
+ * idempotent via stable event identity (_ts + type + id + delta) and by
+ * ignoring further appends once a message is finalized (streaming:false).
+ * Intentionally repeated model text (distinct events) must still survive.
+ */
+
+function fold(events: WebSocketEvent[]): ChatMessage[] {
+  let msgs: ChatMessage[] = [];
+  for (const ev of events) msgs = reduceMessagesForEvent(msgs, ev);
+  return msgs;
+}
+
+function textTriad(
+  messageId: string,
+  deltas: string[],
+  opts: { agentName?: string; tsBase?: string; end?: boolean } = {},
+): WebSocketEvent[] {
+  const agentName = opts.agentName ?? "principal";
+  const tsBase = opts.tsBase ?? "2026-07-15T12:00:00.000Z";
+  const out: WebSocketEvent[] = [
+    {
+      type: "TEXT_MESSAGE_START",
+      messageId,
+      role: "assistant",
+      agentName,
+      _ts: tsBase,
+    } as WebSocketEvent,
+  ];
+  deltas.forEach((delta, i) => {
+    out.push({
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId,
+      delta,
+      agentName,
+      // Distinct ms per delta so intentional repeats with identical text still
+      // differ when _ts differs (and same-event replays share the exact _ts).
+      _ts: `2026-07-15T12:00:00.00${i}Z`,
+    } as WebSocketEvent);
+  });
+  if (opts.end !== false) {
+    out.push({
+      type: "TEXT_MESSAGE_END",
+      messageId,
+      agentName,
+      _ts: "2026-07-15T12:00:01.000Z",
+    } as WebSocketEvent);
+  }
+  return out;
+}
+
+describe("message stream idempotency (#314)", () => {
+  it("does not re-append CONTENT when the same history stream is folded twice", () => {
+    // Reproduces: history rehydrate, then SSE ring-buffer replay of the same
+    // START/CONTENT/END events for a completed assistant message.
+    const history = textTriad("msg_a", ["你爱后", "的风"]);
+    const once = fold(history);
+    expect(once).toHaveLength(1);
+    expect(once[0]!.content).toBe("你爱后的风");
+    expect(once[0]!.streaming).toBe(false);
+
+    // Second pass — same events as SSE recent() would re-deliver.
+    const twice = fold([...history, ...history]);
+    expect(twice).toHaveLength(1);
+    expect(twice[0]!.content).toBe("你爱后的风");
+  });
+
+  it("does not re-append when CONTENT is applied again after END (finalized)", () => {
+    const history = textTriad("msg_b", ["hello ", "world"]);
+    let msgs = fold(history);
+    // Simulate a ring-buffer CONTENT with no identity (legacy / test shape):
+    // finalized messages must still refuse further appends.
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "msg_b",
+      delta: "hello ",
+    } as WebSocketEvent);
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "msg_b",
+      delta: "world",
+    } as WebSocketEvent);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]!.content).toBe("hello world");
+  });
+
+  it("keeps a second continuation message from doubling under replay", () => {
+    const first = textTriad("msg_c1", ["第一句。", "第二句。"], {
+      tsBase: "2026-07-15T12:00:00.000Z",
+    });
+    const cont = textTriad("msg_c2", ["续写：", "还在说。"], {
+      tsBase: "2026-07-15T12:01:00.000Z",
+    });
+    const stream = [...first, ...cont];
+    const once = fold(stream);
+    expect(once.map((m) => m.content)).toEqual(["第一句。第二句。", "续写：还在说。"]);
+
+    const twice = fold([...stream, ...stream]);
+    expect(twice.map((m) => m.content)).toEqual(["第一句。第二句。", "续写：还在说。"]);
+    expect(twice).toHaveLength(2);
+  });
+
+  it("preserves intentionally repeated model text (distinct events)", () => {
+    // Model genuinely emitted the same token twice as two separate CONTENT
+    // events — different _ts — must not be collapsed by the idempotency key.
+    const stream = textTriad("msg_d", ["yes", "yes", "yes"]);
+    const msgs = fold(stream);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]!.content).toBe("yesyesyes");
+  });
+
+  it("still streams live CONTENT without _ts (identity optional)", () => {
+    // Live / unit paths may omit transport _ts. Incremental append must work.
+    let msgs = fold([
+      {
+        type: "TEXT_MESSAGE_START",
+        messageId: "msg_e",
+        role: "assistant",
+      } as WebSocketEvent,
+    ]);
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "msg_e",
+      delta: "Hel",
+    } as WebSocketEvent);
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "msg_e",
+      delta: "lo",
+    } as WebSocketEvent);
+    expect(msgs[0]!.content).toBe("Hello");
+    expect(msgs[0]!.streaming).toBe(true);
+  });
+
+  it("dedupes mid-stream CONTENT replay via stable _ts identity", () => {
+    // History rehydrate of an unfinished message, then SSE ring buffer replays
+    // the same CONTENT events while streaming is still true.
+    const partial = textTriad("msg_f", ["ab", "cd"], { end: false });
+    let msgs = fold(partial);
+    expect(msgs[0]!.content).toBe("abcd");
+    expect(msgs[0]!.streaming).toBe(true);
+
+    // Replay identical CONTENT events (same _ts + delta).
+    for (const ev of partial) {
+      if (ev.type === "TEXT_MESSAGE_CONTENT") {
+        msgs = reduceMessagesForEvent(msgs, ev);
+      }
+    }
+    expect(msgs[0]!.content).toBe("abcd");
+
+    // A genuinely new live delta (new _ts) still appends.
+    msgs = reduceMessagesForEvent(msgs, {
+      type: "TEXT_MESSAGE_CONTENT",
+      messageId: "msg_f",
+      delta: "ef",
+      _ts: "2026-07-15T12:00:00.009Z",
+    } as WebSocketEvent);
+    expect(msgs[0]!.content).toBe("abcdef");
+  });
+
+  it("dedupes TOOL_CALL_ARGS and REASONING_MESSAGE_CONTENT the same way", () => {
+    const toolStart = {
+      type: "TOOL_CALL_START",
+      toolCallId: "tc1",
+      toolCallName: "bash",
+      agentName: "principal",
+      _ts: "2026-07-15T12:00:00.000Z",
+    } as WebSocketEvent;
+    const toolArgs = {
+      type: "TOOL_CALL_ARGS",
+      toolCallId: "tc1",
+      delta: '{"cmd":"ls"}',
+      _ts: "2026-07-15T12:00:00.001Z",
+    } as WebSocketEvent;
+    const toolEnd = {
+      type: "TOOL_CALL_END",
+      toolCallId: "tc1",
+      _ts: "2026-07-15T12:00:00.002Z",
+    } as WebSocketEvent;
+
+    let msgs = fold([toolStart, toolArgs, toolEnd, toolStart, toolArgs, toolEnd]);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]!.toolInput).toBe('{"cmd":"ls"}');
+
+    const reason = [
+      {
+        type: "REASONING_MESSAGE_START",
+        messageId: "r1",
+        agentName: "principal",
+        _ts: "2026-07-15T12:00:00.000Z",
+      } as WebSocketEvent,
+      {
+        type: "REASONING_MESSAGE_CONTENT",
+        messageId: "r1",
+        delta: "think ",
+        _ts: "2026-07-15T12:00:00.001Z",
+      } as WebSocketEvent,
+      {
+        type: "REASONING_MESSAGE_CONTENT",
+        messageId: "r1",
+        delta: "hard",
+        _ts: "2026-07-15T12:00:00.002Z",
+      } as WebSocketEvent,
+      {
+        type: "REASONING_MESSAGE_END",
+        messageId: "r1",
+        _ts: "2026-07-15T12:00:00.003Z",
+      } as WebSocketEvent,
+    ];
+    const reasonOnce = fold(reason);
+    const reasonTwice = fold([...reason, ...reason]);
+    expect(reasonOnce[0]!.content).toBe("think hard");
+    expect(reasonTwice[0]!.content).toBe("think hard");
+    expect(reasonTwice[0]!.reasoning).toBe("think hard");
+  });
+});

--- a/packages/web/src/contexts/SessionContext.tsx
+++ b/packages/web/src/contexts/SessionContext.tsx
@@ -386,8 +386,9 @@ export function SessionProvider({ children }: { children: ReactNode }) {
 
         // Replay the persisted event stream through the same reducers SSE uses
         // (messageReducer / traceReducer / agents seed via session_state). The
-        // SSE ring buffer that arrives next is deduped by messageId/toolCallId
-        // inside the reducer, so any overlap is a no-op.
+        // SSE ring buffer that arrives next is deduped inside the reducer:
+        // START/CHUNK by messageId/toolCallId, and CONTENT/ARGS by stable
+        // event identity + finalized-message guard (#314), so overlap is a no-op.
         const { messages: nextMessages, trace: nextTrace, agents: lastAgents, tokenUsage: lastUsage } =
           foldSessionHistory(events, sessionId);
 

--- a/packages/web/src/contexts/messageReducer.ts
+++ b/packages/web/src/contexts/messageReducer.ts
@@ -70,7 +70,7 @@ function sweepStreaming(messages: ChatMessage[], agentName?: string): ChatMessag
   const next = messages.map((m) => {
     if (m.streaming && (!agentName || m.agent === agentName)) {
       changed = true;
-      return { ...m, streaming: false };
+      return finalizeStreamMessage(m);
     }
     return m;
   });
@@ -106,10 +106,47 @@ export function agUiMessageToChatMessage(msg: AgUiMessage): ChatMessage {
 }
 
 /**
+ * Stable identity for a stream-append event so history rehydrate + SSE ring
+ * buffer replay can merge idempotently (#314). Requires transport `_ts` (always
+ * set by the runtime EventBus envelope). Events without `_ts` (unit tests /
+ * legacy) return null and fall back to "always apply while streaming".
+ *
+ * Key = type + stream id + _ts + delta. Distinct CONTENT events that happen to
+ * carry the same text (intentional model repetition) still differ when `_ts`
+ * differs, so they are not collapsed.
+ */
+function streamAppendKey(event: WebSocketEvent, streamId: string, delta: string): string | null {
+  const raw = event as Record<string, unknown>;
+  const ts = raw._ts;
+  if (typeof ts !== "string" || !ts) return null;
+  return `${event.type}\0${streamId}\0${ts}\0${delta}`;
+}
+
+function withAppliedStreamKey(msg: ChatMessage, key: string | null): ChatMessage {
+  if (!key) return msg;
+  const prev = msg.appliedStreamKeys;
+  if (prev?.includes(key)) return msg;
+  return { ...msg, appliedStreamKeys: prev ? [...prev, key] : [key] };
+}
+
+function finalizeStreamMessage(msg: ChatMessage): ChatMessage {
+  // Drop reducer-internal keys once the stream is closed — further CONTENT is
+  // rejected via streaming:false, so the fingerprint set is no longer needed.
+  if (!msg.streaming && !msg.appliedStreamKeys) return msg;
+  const { appliedStreamKeys: _drop, ...rest } = msg;
+  return { ...rest, streaming: false };
+}
+
+/**
  * Apply an AG-UI canonical event to the running messages array. Events are
  * keyed by `messageId` / `toolCallId`; START emits a placeholder, CONTENT
  * appends delta, END marks completion. MESSAGES_SNAPSHOT replaces state
  * wholesale.
+ *
+ * Stream-append events (CONTENT / REASONING_CONTENT / TOOL_CALL_ARGS) are
+ * idempotent under replay (#314): a finalized message (`streaming:false`)
+ * ignores further appends, and events carrying a stable `_ts` identity are
+ * applied at most once per message even while still streaming.
  */
 export function reduceMessagesForEvent(existing: ChatMessage[], event: WebSocketEvent): ChatMessage[] {
   const agent = event.agentName;
@@ -171,6 +208,7 @@ export function reduceMessagesForEvent(existing: ChatMessage[], event: WebSocket
       // Strip NO-RENDER wrapper used by record_trace "Message Complete" hint
       delta = delta.replace(/<!--NO-RENDER-->[\s\S]*?<!--\/NO-RENDER-->/g, "");
       if (!delta) return existing;
+      const key = streamAppendKey(event, id, delta);
       // Orphaned CONTENT (no matching START) — recover gracefully instead of
       // dropping it. This happens when a demo bundle was exported from a
       // tail-sliced history: the leading START of the earliest messages is gone,
@@ -179,20 +217,27 @@ export function reduceMessagesForEvent(existing: ChatMessage[], event: WebSocket
       if (!existing.some((m) => m.id === id)) {
         return [
           ...existing,
-          {
-            id,
-            role: "assistant",
-            content: delta,
-            createdAt: new Date().toISOString(),
-            agent,
-            streaming: true,
-            kind: "text",
-          },
+          withAppliedStreamKey(
+            {
+              id,
+              role: "assistant",
+              content: delta,
+              createdAt: new Date().toISOString(),
+              agent,
+              streaming: true,
+              kind: "text",
+            },
+            key,
+          ),
         ];
       }
-      return existing.map((m) =>
-        m.id === id ? { ...m, content: (m.content ?? "") + delta } : m,
-      );
+      return existing.map((m) => {
+        if (m.id !== id) return m;
+        // Finalized message: history/SSE replay must not re-append (#314).
+        if (m.streaming === false) return m;
+        if (key && m.appliedStreamKeys?.includes(key)) return m;
+        return withAppliedStreamKey({ ...m, content: (m.content ?? "") + delta }, key);
+      });
     }
 
     case "TEXT_MESSAGE_END": {
@@ -201,7 +246,7 @@ export function reduceMessagesForEvent(existing: ChatMessage[], event: WebSocket
       // Drop messages whose entire content was a NO-RENDER wrapper
       return existing
         .filter((m) => !(m.id === id && (m.content ?? "").trim() === ""))
-        .map((m) => (m.id === id ? { ...m, streaming: false } : m));
+        .map((m) => (m.id === id ? finalizeStreamMessage(m) : m));
     }
 
     case "TEXT_MESSAGE_CHUNK": {
@@ -250,15 +295,22 @@ export function reduceMessagesForEvent(existing: ChatMessage[], event: WebSocket
       const id = event.toolCallId;
       const delta = typeof event.delta === "string" ? event.delta : "";
       if (!id || !delta) return existing;
-      return existing.map((m) =>
-        m.id === id ? { ...m, toolInput: ((m.toolInput as string) ?? "") + delta } : m,
-      );
+      const key = streamAppendKey(event, id, delta);
+      return existing.map((m) => {
+        if (m.id !== id) return m;
+        if (m.streaming === false) return m;
+        if (key && m.appliedStreamKeys?.includes(key)) return m;
+        return withAppliedStreamKey(
+          { ...m, toolInput: ((m.toolInput as string) ?? "") + delta },
+          key,
+        );
+      });
     }
 
     case "TOOL_CALL_END": {
       const id = event.toolCallId;
       if (!id) return existing;
-      return existing.map((m) => (m.id === id ? { ...m, streaming: false } : m));
+      return existing.map((m) => (m.id === id ? finalizeStreamMessage(m) : m));
     }
 
     case "TOOL_CALL_RESULT": {
@@ -307,17 +359,26 @@ export function reduceMessagesForEvent(existing: ChatMessage[], event: WebSocket
       const id = event.messageId;
       const delta = typeof event.delta === "string" ? event.delta : "";
       if (!id || !delta) return existing;
-      return existing.map((m) =>
-        m.id === id
-          ? { ...m, content: (m.content ?? "") + delta, reasoning: (m.reasoning ?? "") + delta }
-          : m,
-      );
+      const key = streamAppendKey(event, id, delta);
+      return existing.map((m) => {
+        if (m.id !== id) return m;
+        if (m.streaming === false) return m;
+        if (key && m.appliedStreamKeys?.includes(key)) return m;
+        return withAppliedStreamKey(
+          {
+            ...m,
+            content: (m.content ?? "") + delta,
+            reasoning: (m.reasoning ?? "") + delta,
+          },
+          key,
+        );
+      });
     }
 
     case "REASONING_MESSAGE_END": {
       const id = event.messageId;
       if (!id) return existing;
-      return existing.map((m) => (m.id === id ? { ...m, streaming: false } : m));
+      return existing.map((m) => (m.id === id ? finalizeStreamMessage(m) : m));
     }
 
     case "RUN_ERROR": {

--- a/packages/web/src/contracts/backend.ts
+++ b/packages/web/src/contracts/backend.ts
@@ -182,6 +182,13 @@ export interface ChatMessage {
   askUser?: AskUserView;
   // kind === "auto_retry": auto-retry countdown + cancel indicator (doc §6)
   autoRetry?: AutoRetryView;
+  /**
+   * Reducer-internal: stable keys of stream-append events already applied to
+   * this message (`TEXT_MESSAGE_CONTENT` / `REASONING_MESSAGE_CONTENT` /
+   * `TOOL_CALL_ARGS`). Used so history rehydrate + SSE ring-buffer replay do
+   * not concatenate the same delta twice (#314). Not rendered.
+   */
+  appliedStreamKeys?: string[];
 }
 
 /** View-model for a `system_message` AG-UI event (post-normalize). */


### PR DESCRIPTION
## Summary

- Fixes [#314](https://github.com/NeuroAIHub/BrainPilot/issues/314): restoring a conversation could concatenate the same assistant (and continuation) content twice inside one message bubble.
- Root cause: history rehydrate folds `events.jsonl` through `reduceMessagesForEvent`, then the SSE ring buffer replays the same recent events. `TEXT_MESSAGE_START` was already idempotent by `messageId`, but `TEXT_MESSAGE_CONTENT` always did `content + delta`.
- Fix: stream-append events (`TEXT_MESSAGE_CONTENT`, `REASONING_MESSAGE_CONTENT`, `TOOL_CALL_ARGS`) ignore further appends once a message is finalized (`streaming: false`), and dedupe in-flight appends via stable event identity (`_ts` + type + id + delta). Distinct events with the same text (intentional model repeats) still apply.

## Acceptance criteria

- [x] Automated test reproduces the historical-message duplication path (`messageStreamIdempotency.test.ts`)
- [x] Boundary identified: frontend streaming reconciliation / message merge (not persistence or render)
- [x] Refresh / re-attach / replay no longer re-append the same CONTENT deltas
- [x] Stable event identity + finalized-message guard for continuation and regular assistant streams
- [x] No destructive string-halving or generic text dedupe of intentional repeats

## Test plan

- [x] `packages/web` unit tests (`npm test`) — 256 passed, including new #314 cases
- [ ] CI green on this PR
- [ ] Manual: open a session that previously showed doubled assistant text after restore; confirm single content after refresh / session switch