### PR TITLE
fix(web): make Settings dialog usable on mobile viewports (#318)

### DIFF
--- a/packages/web/src/__tests__/settingsLayoutCss.test.ts
+++ b/packages/web/src/__tests__/settingsLayoutCss.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// #318 — Settings must leave the fixed 190px side nav on narrow viewports so
+// the content pane is not crushed (~134px at 390×844). There is no screenshot
+// harness (node vitest, no Playwright UI suite), so we contract-test the
+// fenced mobile CSS block in global.css.
+
+const cssPath = fileURLToPath(new URL("../styles/global.css", import.meta.url));
+const css = readFileSync(cssPath, "utf8");
+
+const START = "/* #318 settings-mobile-start";
+const END = "/* #318 settings-mobile-end */";
+
+function mobileBlock(): string {
+  const start = css.indexOf(START);
+  const end = css.indexOf(END);
+  if (start < 0 || end < 0 || end <= start) {
+    throw new Error("missing #318 settings-mobile fence in global.css");
+  }
+  return css.slice(start, end);
+}
+
+describe("#318 Settings mobile layout CSS contract", () => {
+  it("fences a max-width 860px media query for Settings", () => {
+    const block = mobileBlock();
+    expect(block).toMatch(/@media\s*\(\s*max-width:\s*860px\s*\)/);
+  });
+
+  it("stacks the body and drops the fixed side-nav column", () => {
+    const block = mobileBlock();
+    expect(block).toContain(".settings-modal__body");
+    // Single full-width column (not 190px + content).
+    expect(block).toMatch(
+      /\.settings-modal__body\s*\{[^}]*grid-template-columns:\s*1fr/s,
+    );
+  });
+
+  it("drops the desktop 16/9 aspect-ratio on the panel", () => {
+    const block = mobileBlock();
+    expect(block).toContain(".settings-modal__panel");
+    expect(block).toMatch(/aspect-ratio:\s*auto/);
+  });
+
+  it("turns section tabs into a horizontal scroll strip", () => {
+    const block = mobileBlock();
+    expect(block).toContain(".settings-tabs");
+    expect(block).toMatch(/\.settings-tabs\s*\{[^}]*display:\s*flex/s);
+    expect(block).toMatch(/overflow-x:\s*auto/);
+  });
+
+  it("reflows provider/MCP action grids so fixed 82px columns do not clip", () => {
+    const block = mobileBlock();
+    expect(block).toContain(".provider-actions");
+    expect(block).toContain(".mcp-actions");
+    expect(block).toMatch(/repeat\(\s*auto-fill/);
+  });
+
+  it("stacks split preference fields and list items", () => {
+    const block = mobileBlock();
+    expect(block).toContain(".settings-field--split");
+    expect(block).toContain(".settings-list-item");
+    expect(block).toMatch(
+      /\.settings-list-item\s*\{[^}]*grid-template-columns:\s*1fr/s,
+    );
+  });
+});

--- a/packages/web/src/components/settings/SettingsDialog.tsx
+++ b/packages/web/src/components/settings/SettingsDialog.tsx
@@ -367,6 +367,7 @@ export function SettingsDialog({ isOpen, onClose, initialTab }: SettingsDialogPr
                 <button
                   className={activeTab === tab.id ? "is-active" : ""}
                   key={tab.id}
+                  aria-current={activeTab === tab.id ? "page" : undefined}
                   onClick={() => setActiveTab(tab.id)}
                   type="button"
                 >

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -5917,6 +5917,150 @@ button {
   padding: 8px 18px;
 }
 
+/* #318 settings-mobile-start
+   Narrow viewports: drop the fixed 190px side nav so the content pane is not
+   crushed to ~134px (390×844). Desktop two-column IA above 860px is unchanged. */
+@media (max-width: 860px) {
+  .settings-modal__panel {
+    width: calc(100vw - 24px);
+    height: min(90dvh, calc(100vh - 24px));
+    max-height: calc(100vh - 24px);
+    aspect-ratio: auto;
+  }
+
+  .settings-modal__body {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto minmax(0, 1fr);
+  }
+
+  .settings-tabs {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    align-content: stretch;
+    gap: 4px;
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    border-right: none;
+    border-bottom: 1px solid var(--color-border);
+    padding: 8px 10px;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin;
+  }
+
+  .settings-tabs button {
+    flex: 0 0 auto;
+    white-space: nowrap;
+  }
+
+  .settings-content {
+    padding: 14px;
+  }
+
+  .settings-section__header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .settings-section__header .settings-button {
+    align-self: stretch;
+  }
+
+  .settings-list-item {
+    grid-template-columns: 1fr;
+    align-items: start;
+  }
+
+  .settings-list-item span,
+  .settings-list-item small {
+    white-space: normal;
+  }
+
+  .settings-list-item__actions {
+    flex-wrap: wrap;
+    width: 100%;
+  }
+
+  .provider-actions,
+  .mcp-actions {
+    grid-template-columns: repeat(auto-fill, minmax(72px, 1fr));
+    justify-content: stretch;
+    width: 100%;
+  }
+
+  .provider-actions button {
+    width: 100%;
+  }
+
+  .settings-field--split {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+
+  .settings-kv div {
+    grid-template-columns: 1fr;
+    gap: 2px;
+  }
+
+  .settings-kv dd {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: unset;
+  }
+
+  .settings-inline-form {
+    grid-template-columns: 1fr;
+  }
+
+  .provider-form__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .provider-form-modal {
+    padding: 12px;
+  }
+
+  .provider-form--modal {
+    width: min(720px, calc(100vw - 24px));
+    max-height: min(720px, calc(100vh - 24px));
+    padding: 16px;
+  }
+
+  .provider-form-modal__actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: stretch;
+    gap: 8px;
+  }
+
+  .provider-form-modal__actions .settings-button {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .settings-toggle-row {
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .kb-env__facts div {
+    grid-template-columns: 1fr;
+    gap: 2px;
+  }
+
+  .kb-env__facts dd,
+  .kb-inv__metrics dd {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: unset;
+  }
+
+  .kb-inv__metrics {
+    grid-template-columns: 1fr;
+  }
+}
+/* #318 settings-mobile-end */
+
 /* Inline checkbox row — used by the Knowledge Base panel (reuse-agent-key,
    per-stage toggles). Preferences uses .settings-toggle-row instead. */
 .settings-check {


### PR DESCRIPTION
## Summary

- Below **860px**, Settings drops the fixed 190px side nav in favor of a horizontal, scrollable section strip so the content pane is full-width.
- Reflows provider/MCP action grids, split preference fields, list items, nested form grids, and KB fact rows so controls are not clipped at **390 × 844**.
- Desktop two-column IA above 860px is unchanged; active tab gets `aria-current="page"`.

## Test plan

- [x] `packages/web` vitest (307 tests, including 6 new CSS contract tests)
- [x] `packages/web` `tsc --noEmit`
- [ ] Manual **390 × 844**: Providers / Tools / KB / Preferences readable and operable; no 1-char wrap
- [ ] Manual **768 × 900**: stacked mobile layout, tabs scroll, close works
- [ ] Manual **1280 × 720**: desktop side nav + content unchanged
- [ ] Keyboard: tab through sections + close; content scrolls

Closes #318