### PR TITLE
fix(web): restore active conversation after reload (#324)

### DIFF
--- a/packages/web/src/__tests__/sessionSelection.test.ts
+++ b/packages/web/src/__tests__/sessionSelection.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  resolveSessionSelection,
+  shouldAutoStartDraft,
+  loadLastSessionId,
+  saveLastSessionId,
+  clearLastSessionId,
+  LAST_SESSION_STORAGE_KEY,
+} from "../contexts/sessionSelection";
+
+function sessions(...ids: string[]) {
+  return ids.map((id) => ({ id }));
+}
+
+describe("shouldAutoStartDraft (#324)", () => {
+  it("never drafts while the session list is still loading", () => {
+    expect(shouldAutoStartDraft("idle", 0, null, false, true)).toBe(false);
+    expect(shouldAutoStartDraft("loading", 0, null, false, true)).toBe(false);
+  });
+
+  it("drafts only when list is ready, empty, no selection, not already draft, sandbox up", () => {
+    expect(shouldAutoStartDraft("ready", 0, null, false, true)).toBe(true);
+  });
+
+  it("does not draft when conversations exist or selection/draft already set", () => {
+    expect(shouldAutoStartDraft("ready", 2, null, false, true)).toBe(false);
+    expect(shouldAutoStartDraft("ready", 0, "s1", false, true)).toBe(false);
+    expect(shouldAutoStartDraft("ready", 0, null, true, true)).toBe(false);
+    expect(shouldAutoStartDraft("ready", 0, null, false, false)).toBe(false);
+  });
+
+  it("does not draft on list error", () => {
+    expect(shouldAutoStartDraft("error", 0, null, false, true)).toBe(false);
+  });
+});
+
+describe("resolveSessionSelection (#324)", () => {
+  it("does not invent a draft while list is delayed (idle/loading)", () => {
+    expect(
+      resolveSessionSelection({
+        listStatus: "loading",
+        sessions: [],
+        preferredId: "old",
+        currentSessionId: null,
+        isDraft: false,
+      }),
+    ).toEqual({ sessionId: null, isDraft: false });
+
+    expect(
+      resolveSessionSelection({
+        listStatus: "idle",
+        sessions: [],
+        preferredId: null,
+        currentSessionId: null,
+        isDraft: false,
+      }),
+    ).toEqual({ sessionId: null, isDraft: false });
+  });
+
+  it("restores preferred selection when it still exists after delayed load", () => {
+    const r = resolveSessionSelection({
+      listStatus: "ready",
+      sessions: sessions("a", "b", "c", "d"),
+      preferredId: "c",
+      currentSessionId: null,
+      isDraft: false,
+    });
+    expect(r).toEqual({ sessionId: "c", isDraft: false });
+  });
+
+  it("falls back to first session when preferred is unavailable (no transient draft)", () => {
+    const r = resolveSessionSelection({
+      listStatus: "ready",
+      sessions: sessions("newest", "older"),
+      preferredId: "deleted-id",
+      currentSessionId: null,
+      isDraft: false,
+    });
+    expect(r).toEqual({ sessionId: "newest", isDraft: false });
+  });
+
+  it("keeps current session when still present (preferred ignored)", () => {
+    const r = resolveSessionSelection({
+      listStatus: "ready",
+      sessions: sessions("a", "b"),
+      preferredId: "b",
+      currentSessionId: "a",
+      isDraft: false,
+    });
+    expect(r).toEqual({ sessionId: "a", isDraft: false });
+  });
+
+  it("preserves intentional draft after list is ready", () => {
+    const r = resolveSessionSelection({
+      listStatus: "ready",
+      sessions: sessions("a", "b"),
+      preferredId: "a",
+      currentSessionId: null,
+      isDraft: true,
+    });
+    expect(r).toEqual({ sessionId: null, isDraft: true });
+  });
+
+  it("opens draft when list is ready and empty", () => {
+    expect(
+      resolveSessionSelection({
+        listStatus: "ready",
+        sessions: [],
+        preferredId: "gone",
+        currentSessionId: null,
+        isDraft: false,
+      }),
+    ).toEqual({ sessionId: null, isDraft: true });
+  });
+
+  it("on error with empty list does not force a draft", () => {
+    expect(
+      resolveSessionSelection({
+        listStatus: "error",
+        sessions: [],
+        preferredId: null,
+        currentSessionId: null,
+        isDraft: false,
+      }),
+    ).toEqual({ sessionId: null, isDraft: false });
+  });
+
+  it("replaces a stale current id with preferred or fallback", () => {
+    expect(
+      resolveSessionSelection({
+        listStatus: "ready",
+        sessions: sessions("x", "y"),
+        preferredId: "y",
+        currentSessionId: "stale",
+        isDraft: false,
+      }),
+    ).toEqual({ sessionId: "y", isDraft: false });
+  });
+});
+
+describe("last session id storage", () => {
+  const mem = new Map<string, string>();
+  const storage = {
+    getItem: (k: string) => mem.get(k) ?? null,
+    setItem: (k: string, v: string) => {
+      mem.set(k, v);
+    },
+    removeItem: (k: string) => {
+      mem.delete(k);
+    },
+  };
+
+  beforeEach(() => {
+    mem.clear();
+  });
+
+  it("round-trips preferred id", () => {
+    expect(loadLastSessionId(storage)).toBe(null);
+    saveLastSessionId("sess-1", storage);
+    expect(loadLastSessionId(storage)).toBe("sess-1");
+    expect(mem.get(LAST_SESSION_STORAGE_KEY)).toBe("sess-1");
+    clearLastSessionId(storage);
+    expect(loadLastSessionId(storage)).toBe(null);
+  });
+
+  it("returns null for empty / whitespace values", () => {
+    mem.set(LAST_SESSION_STORAGE_KEY, "   ");
+    expect(loadLastSessionId(storage)).toBe(null);
+  });
+});

--- a/packages/web/src/contexts/SessionContext.tsx
+++ b/packages/web/src/contexts/SessionContext.tsx
@@ -9,6 +9,14 @@ import { useSSE } from "./SSEContext";
 import { draftStore } from "./draftStore";
 import { defaultFilterRules, isNonFatalAgentErrorMessage, HIDE_NON_FATAL_AGENT_ERRORS } from "./messageFilters";
 import {
+  clearLastSessionId,
+  loadLastSessionId,
+  resolveSessionSelection,
+  saveLastSessionId,
+  shouldAutoStartDraft,
+  type SessionsListStatus,
+} from "./sessionSelection";
+import {
   eventSessionId,
   finalizeAssistant,
   generateUUID,
@@ -266,12 +274,21 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   const [sessions, setSessions] = useState<Session[]>([]);
   const [currentSessionId, setCurrentSessionId] = useState<string | null>(null);
   const [isDraft, setIsDraft] = useState(false);
+  // #324 — session-list readiness. Draft auto-open and selection restore must
+  // wait until the first list request has finished; the initial empty in-memory
+  // list is not "no conversations exist".
+  const [sessionsListStatus, setSessionsListStatus] = useState<SessionsListStatus>("idle");
   // Mirror of isDraft for reading inside callbacks that must not re-create when
   // the draft flag flips (e.g. refreshSessions, keyed only on isAuthReady).
   const isDraftRef = useRef(false);
   useEffect(() => {
     isDraftRef.current = isDraft;
   }, [isDraft]);
+  // Mirror of currentSessionId for refreshSessions selection resolve.
+  const currentSessionIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    currentSessionIdRef.current = currentSessionId;
+  }, [currentSessionId]);
   const [messagesBySession, setMessagesBySession] = useState<Record<string, ChatMessage[]>>({});
   const [isLoading, setIsLoading] = useState(false);
   const [isSending, setIsSending] = useState(false);
@@ -340,20 +357,36 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     if (!isAuthReady) {
       setSessions([]);
       setCurrentSessionId(null);
+      setIsDraft(false);
+      setSessionsListStatus("idle");
       return;
     }
 
     setIsLoading(true);
+    setSessionsListStatus("loading");
     setError(null);
     try {
       const nextSessions = await api.sessions.list();
       const sorted = [...nextSessions].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
       setSessions(sorted);
-      // Don't auto-select an existing session while the user is composing a
-      // draft — that would yank them out of the new conversation.
-      setCurrentSessionId((current) => (isDraftRef.current ? current : current ?? sorted[0]?.id ?? null));
+      // #324 — restore preferred / fallback only after the list is ready.
+      // Never open a draft from the pre-list empty array; preserve intentional drafts.
+      const resolved = resolveSessionSelection({
+        listStatus: "ready",
+        sessions: sorted,
+        preferredId: loadLastSessionId(),
+        currentSessionId: currentSessionIdRef.current,
+        isDraft: isDraftRef.current,
+      });
+      setIsDraft(resolved.isDraft);
+      setCurrentSessionId(resolved.sessionId);
+      if (resolved.sessionId) {
+        saveLastSessionId(resolved.sessionId);
+      }
+      setSessionsListStatus("ready");
     } catch (err) {
       setError(err instanceof Error ? err.message : tg("ctx.session.loadFailed"));
+      setSessionsListStatus("error");
     } finally {
       setIsLoading(false);
     }
@@ -448,6 +481,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     console.log(`[SessionContext] selectSession: ${sessionId}`);
     setIsDraft(false);
     setCurrentSessionId(sessionId);
+    saveLastSessionId(sessionId);
     setCurrentView("chat");
     setRunActive(null); // #99: drop the previous session's turn-active signal
     setTokenUsage(null); // drop the previous session's token totals
@@ -484,7 +518,16 @@ export function SessionProvider({ children }: { children: ReactNode }) {
       disconnectSession(sessionId);
       setSessions((current) => {
         const next = current.filter((session) => session.id !== sessionId);
-        setCurrentSessionId((currentId) => (currentId === sessionId ? next[0]?.id ?? null : currentId));
+        setCurrentSessionId((currentId) => {
+          if (currentId !== sessionId) return currentId;
+          const fallback = next[0]?.id ?? null;
+          if (fallback) {
+            saveLastSessionId(fallback);
+          } else {
+            clearLastSessionId();
+          }
+          return fallback;
+        });
         return next;
       });
       setMessagesBySession((current) => {
@@ -516,6 +559,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
         setSessions((current) => [session, ...current.filter((item) => item.id !== session.id)]);
         setIsDraft(false);
         setCurrentSessionId(session.id);
+        saveLastSessionId(session.id);
         setMessagesBySession((current) => ({ ...current, [session.id]: current[session.id] ?? [] }));
         return session;
       } catch (err) {
@@ -528,11 +572,28 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     [currentSandbox],
   );
 
+  // #324 — only auto-open a draft after the session list has confirmed empty.
+  // Sandbox must be running (same gate as before) so the composer can send later.
   useEffect(() => {
-    if (sessions.length === 0 && !isLoading && currentSandbox?.status === "running" && !currentSessionId && !isDraft) {
+    if (
+      shouldAutoStartDraft(
+        sessionsListStatus,
+        sessions.length,
+        currentSessionId,
+        isDraft,
+        currentSandbox?.status === "running",
+      )
+    ) {
       startDraftSession();
     }
-  }, [sessions.length, isLoading, currentSandbox, currentSessionId, isDraft, startDraftSession]);
+  }, [
+    sessionsListStatus,
+    sessions.length,
+    currentSandbox,
+    currentSessionId,
+    isDraft,
+    startDraftSession,
+  ]);
 
   const sendPrompt = useCallback(
     async (content: string, opts: { providerId?: string; modelId?: string; domainResources?: DomainResources } = {}) => {

--- a/packages/web/src/contexts/sessionSelection.ts
+++ b/packages/web/src/contexts/sessionSelection.ts
@@ -1,0 +1,141 @@
+/**
+ * Pure helpers for session-list readiness and restore-on-reload (#324).
+ *
+ * Prevents the empty-session draft effect from racing an in-flight
+ * session-list request, and restores a persisted previous selection
+ * (or a documented fallback) once the list is ready.
+ */
+
+export type SessionsListStatus = "idle" | "loading" | "ready" | "error";
+
+export const LAST_SESSION_STORAGE_KEY = "bp.web.lastSessionId";
+
+export interface SessionRef {
+  id: string;
+}
+
+export interface ResolveSessionSelectionInput {
+  listStatus: SessionsListStatus;
+  /** Caller should pass the list sorted as displayed (e.g. updatedAt desc). */
+  sessions: SessionRef[];
+  /** Persisted last selection from localStorage (may be stale). */
+  preferredId: string | null;
+  currentSessionId: string | null;
+  isDraft: boolean;
+}
+
+export interface ResolveSessionSelectionResult {
+  sessionId: string | null;
+  isDraft: boolean;
+}
+
+/**
+ * Decide which conversation to show after a session-list read.
+ *
+ * Rules (list must be ready or error-with-empty fallback):
+ * - Preserve an intentional draft (isDraft && no current id).
+ * - Empty list → draft only when list is ready.
+ * - Keep current id if it still exists.
+ * - Else restore preferredId if still in the list.
+ * - Else fall back to sessions[0] (documented: most-recent when sorted).
+ * - While list is idle/loading: do not change selection / do not invent draft.
+ */
+export function resolveSessionSelection(
+  input: ResolveSessionSelectionInput,
+): ResolveSessionSelectionResult {
+  const { listStatus, sessions, preferredId, currentSessionId, isDraft } = input;
+
+  if (listStatus === "idle" || listStatus === "loading") {
+    return { sessionId: currentSessionId, isDraft };
+  }
+
+  // Intentional new-conversation draft after the list is known — don't yank.
+  if (isDraft && currentSessionId == null) {
+    return { sessionId: null, isDraft: true };
+  }
+
+  if (sessions.length === 0) {
+    // Ready with no conversations: only path that auto-opens a draft.
+    // Error with empty list: stay non-draft so the user sees the error path.
+    if (listStatus === "ready") {
+      return { sessionId: null, isDraft: true };
+    }
+    return { sessionId: null, isDraft: false };
+  }
+
+  const ids = new Set(sessions.map((s) => s.id));
+
+  if (currentSessionId && ids.has(currentSessionId)) {
+    return { sessionId: currentSessionId, isDraft: false };
+  }
+
+  if (preferredId && ids.has(preferredId)) {
+    return { sessionId: preferredId, isDraft: false };
+  }
+
+  return { sessionId: sessions[0]!.id, isDraft: false };
+}
+
+/**
+ * Whether the empty-session draft effect may run.
+ * Never true until the session list has finished successfully.
+ */
+export function shouldAutoStartDraft(
+  listStatus: SessionsListStatus,
+  sessionsLength: number,
+  currentSessionId: string | null,
+  isDraft: boolean,
+  sandboxRunning: boolean,
+): boolean {
+  return (
+    listStatus === "ready" &&
+    sessionsLength === 0 &&
+    currentSessionId == null &&
+    !isDraft &&
+    sandboxRunning
+  );
+}
+
+export function loadLastSessionId(
+  storage: Pick<Storage, "getItem"> | null = defaultStorage(),
+): string | null {
+  if (!storage) return null;
+  try {
+    const raw = storage.getItem(LAST_SESSION_STORAGE_KEY);
+    if (!raw || typeof raw !== "string") return null;
+    const trimmed = raw.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveLastSessionId(
+  sessionId: string,
+  storage: Pick<Storage, "setItem"> | null = defaultStorage(),
+): void {
+  if (!storage || !sessionId) return;
+  try {
+    storage.setItem(LAST_SESSION_STORAGE_KEY, sessionId);
+  } catch {
+    // Quota / private mode — selection still works for this page load.
+  }
+}
+
+export function clearLastSessionId(
+  storage: Pick<Storage, "removeItem"> | null = defaultStorage(),
+): void {
+  if (!storage) return;
+  try {
+    storage.removeItem(LAST_SESSION_STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+function defaultStorage(): Storage | null {
+  if (typeof window === "undefined" || typeof window.localStorage === "undefined") {
+    return null;
+  }
+  return window.localStorage;
+}


### PR DESCRIPTION
## Summary

- Fixes #324: reloading no longer drops into a New Conversation draft when persisted sessions exist.
- Session-list status (`idle | loading | ready | error`) gates auto-draft — draft only after list confirms empty.
- Persists last selected session id (`bp.web.lastSessionId`) and restores it when still present.
- Documented fallback: most recently updated session (`sorted[0]`) when preferred is missing.
- Pure `resolveSessionSelection` / `shouldAutoStartDraft` helpers with unit coverage for delayed load, preferred hit/miss, and empty list.

## Test plan

- [x] `sessionSelection.test.ts` (14 cases)
- [x] `tsc -b` for web package
- [ ] Manual: open a conversation, reload — same conversation restored
- [ ] Manual: delete that conversation elsewhere, reload — falls back to another session without draft flash
- [ ] Manual: empty workspace — draft only after list returns empty