### PR TITLE
fix(web): avoid empty Analytics tab when switching conversations (#326)

### DIFF
--- a/packages/web/src/__tests__/agentPanelTab.test.ts
+++ b/packages/web/src/__tests__/agentPanelTab.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  hasAnalyticsData,
+  resolveAgentTabForSession,
+  loadPreferredAgentTab,
+  savePreferredAgentTab,
+  parseAgentTab,
+  AGENT_TAB_STORAGE_KEY,
+} from "../components/session/agentPanelTab";
+
+describe("hasAnalyticsData (#326)", () => {
+  it("is false when there are no edges or only empty edges", () => {
+    expect(hasAnalyticsData([])).toBe(false);
+    expect(hasAnalyticsData([{ messages: [] }, { messages: [] }])).toBe(false);
+  });
+
+  it("is true when any edge carries messages", () => {
+    expect(
+      hasAnalyticsData([
+        { messages: [] },
+        { messages: [{ id: "m1" }] },
+      ]),
+    ).toBe(true);
+  });
+});
+
+describe("resolveAgentTabForSession (#326)", () => {
+  it("falls back to detail when preferred is analytics but session has no data", () => {
+    expect(resolveAgentTabForSession("analytics", false)).toBe("detail");
+  });
+
+  it("keeps analytics when the destination conversation has data", () => {
+    expect(resolveAgentTabForSession("analytics", true)).toBe("analytics");
+  });
+
+  it("preserves detail and timeline regardless of analytics data", () => {
+    expect(resolveAgentTabForSession("detail", false)).toBe("detail");
+    expect(resolveAgentTabForSession("detail", true)).toBe("detail");
+    expect(resolveAgentTabForSession("timeline", false)).toBe("timeline");
+    expect(resolveAgentTabForSession("timeline", true)).toBe("timeline");
+  });
+
+  it("models switching from a data-rich Analytics view to an empty conversation", () => {
+    // User left session A on analytics (preferred stays analytics).
+    const preferred = "analytics" as const;
+    // Enter session B with no inter-agent traffic.
+    expect(resolveAgentTabForSession(preferred, hasAnalyticsData([]))).toBe("detail");
+    // Enter session C that has traffic — restore preferred analytics.
+    const rich = [{ messages: [{}, {}] }];
+    expect(resolveAgentTabForSession(preferred, hasAnalyticsData(rich))).toBe("analytics");
+  });
+});
+
+describe("preferred tab storage", () => {
+  const mem = new Map<string, string>();
+  const storage = {
+    getItem: (k: string) => mem.get(k) ?? null,
+    setItem: (k: string, v: string) => {
+      mem.set(k, v);
+    },
+  };
+
+  beforeEach(() => mem.clear());
+
+  it("round-trips user preference without treating auto-detail as preferred", () => {
+    savePreferredAgentTab("analytics", storage);
+    expect(loadPreferredAgentTab(storage)).toBe("analytics");
+    // Auto-correct display to detail must NOT call savePreferredAgentTab.
+    expect(resolveAgentTabForSession(loadPreferredAgentTab(storage), false)).toBe("detail");
+    expect(loadPreferredAgentTab(storage)).toBe("analytics");
+    expect(mem.get(AGENT_TAB_STORAGE_KEY)).toBe("analytics");
+  });
+
+  it("parseAgentTab rejects unknown values", () => {
+    expect(parseAgentTab("nope")).toBe(null);
+    expect(parseAgentTab("detail")).toBe("detail");
+  });
+});

--- a/packages/web/src/components/session/AgentNetwork.tsx
+++ b/packages/web/src/components/session/AgentNetwork.tsx
@@ -39,19 +39,14 @@ import { AnalyticsTab } from "./AnalyticsTab";
 import { TimelineTab } from "./TimelineTab";
 import { useT } from "../../i18n/useT";
 import { HIDE_NON_FATAL_AGENT_ERRORS } from "../../contexts/messageFilters";
-
-type AgentTab = "detail" | "analytics" | "timeline";
-const TAB_STORAGE_KEY = "agent-network-active-tab";
-
-function loadActiveTab(): AgentTab {
-  try {
-    const v = localStorage.getItem(TAB_STORAGE_KEY);
-    if (v === "detail" || v === "analytics" || v === "timeline") return v;
-  } catch {
-    /* ignore */
-  }
-  return "detail";
-}
+import { useSessions } from "../../contexts/SessionContext";
+import {
+  type AgentTab,
+  hasAnalyticsData,
+  loadPreferredAgentTab,
+  resolveAgentTabForSession,
+  savePreferredAgentTab,
+} from "./agentPanelTab";
 
 type Selection =
   | { kind: "node"; id: string }
@@ -234,28 +229,30 @@ export function AgentNetwork({
   hiddenErrorsCount,
 }: AgentNetworkProps) {
   const t = useT();
+  const { currentSession } = useSessions();
+  const sessionId = currentSession?.id ?? null;
   const [selection, setSelection] = useState<Selection>(null);
   const [hoverEdgeKey, setHoverEdgeKey] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<AgentTab>(loadActiveTab);
+  // Display tab. User-initiated changes also update preferred storage;
+  // auto-corrections for empty Analytics (#326) do not.
+  const [activeTab, setActiveTab] = useState<AgentTab>(() => loadPreferredAgentTab());
 
-  // Persist active tab across reloads (same pattern as PreferencesContext).
-  useEffect(() => {
-    try {
-      localStorage.setItem(TAB_STORAGE_KEY, activeTab);
-    } catch {
-      /* ignore quota / privacy-mode errors */
+  const selectTab = (tab: AgentTab, source: "user" | "auto" = "user") => {
+    setActiveTab(tab);
+    if (source === "user") {
+      savePreferredAgentTab(tab);
     }
-  }, [activeTab]);
+  };
 
   // Selecting a node/edge always brings the Detail tab forward so the user
   // sees what they clicked (Analytics/Timeline are global, not per-selection).
   const selectNode = (id: string) => {
     setSelection({ kind: "node", id });
-    setActiveTab("detail");
+    selectTab("detail", "user");
   };
   const selectEdge = (key: string) => {
     setSelection({ kind: "edge", key });
-    setActiveTab("detail");
+    selectTab("detail", "user");
   };
 
   // Node hover tooltip: a short delay on show (avoid flicker on quick passes)
@@ -319,6 +316,17 @@ export function AgentNetwork({
   useEffect(() => clearHoverTimers, []);
 
   const edges = useMemo(() => buildEdges(messages), [messages]);
+  const analyticsAvailable = hasAnalyticsData(edges);
+
+  // #326 — on session change (and when hydration fills edges), never leave the
+  // user stuck on empty Analytics from a previous conversation's preference.
+  // Auto-corrections do not rewrite preferred storage, so a later rich session
+  // can still reopen Analytics from the user's last explicit choice.
+  useEffect(() => {
+    const preferred = loadPreferredAgentTab();
+    const resolved = resolveAgentTabForSession(preferred, analyticsAvailable);
+    setActiveTab(resolved);
+  }, [sessionId, analyticsAvailable]);
 
   // Default view: only agents that actually participated in this session.
   // Built-in agents that were not used are listed below as available, rather
@@ -786,16 +794,16 @@ export function AgentNetwork({
               type="button"
               aria-selected={activeTab === tab}
               className={`agent-network__tab ${activeTab === tab ? "agent-network__tab--active" : ""}`}
-              onClick={() => setActiveTab(tab)}
+              onClick={() => selectTab(tab, "user")}
               onKeyDown={(event) => {
                 const order: AgentTab[] = ["detail", "analytics", "timeline"];
                 const idx = order.indexOf(activeTab);
                 if (event.key === "ArrowRight") {
                   event.preventDefault();
-                  setActiveTab(order[(idx + 1) % order.length]);
+                  selectTab(order[(idx + 1) % order.length]!, "user");
                 } else if (event.key === "ArrowLeft") {
                   event.preventDefault();
-                  setActiveTab(order[(idx - 1 + order.length) % order.length]);
+                  selectTab(order[(idx - 1 + order.length) % order.length]!, "user");
                 }
               }}
             >

--- a/packages/web/src/components/session/agentPanelTab.ts
+++ b/packages/web/src/components/session/agentPanelTab.ts
@@ -1,0 +1,74 @@
+/**
+ * Agent panel subview (Detail / Analytics / Timeline) selection (#326).
+ *
+ * Global tab preference must not force an empty Analytics screen when the
+ * destination conversation has no analytics content. Auto-correct is applied
+ * on session entry; user clicks still work even when data is empty.
+ */
+
+export type AgentTab = "detail" | "analytics" | "timeline";
+
+export const AGENT_TAB_STORAGE_KEY = "agent-network-active-tab";
+
+/** Same emptiness rule as AnalyticsTab (`totalMessages === 0`). */
+export function hasAnalyticsData(
+  edges: ReadonlyArray<{ messages: readonly unknown[] }>,
+): boolean {
+  for (const e of edges) {
+    if (e.messages.length > 0) return true;
+  }
+  return false;
+}
+
+/**
+ * Resolve the tab to show when entering a conversation (session switch or
+ * first paint for a session). Never defaults to Analytics when there is no
+ * meaningful analytics content.
+ */
+export function resolveAgentTabForSession(
+  preferred: AgentTab,
+  hasAnalytics: boolean,
+): AgentTab {
+  if (preferred === "analytics" && !hasAnalytics) {
+    return "detail";
+  }
+  return preferred;
+}
+
+export function parseAgentTab(value: string | null | undefined): AgentTab | null {
+  if (value === "detail" || value === "analytics" || value === "timeline") {
+    return value;
+  }
+  return null;
+}
+
+export function loadPreferredAgentTab(
+  storage: Pick<Storage, "getItem"> | null = defaultStorage(),
+): AgentTab {
+  if (!storage) return "detail";
+  try {
+    return parseAgentTab(storage.getItem(AGENT_TAB_STORAGE_KEY)) ?? "detail";
+  } catch {
+    return "detail";
+  }
+}
+
+/** Persist only user-initiated tab choices, not auto-corrections. */
+export function savePreferredAgentTab(
+  tab: AgentTab,
+  storage: Pick<Storage, "setItem"> | null = defaultStorage(),
+): void {
+  if (!storage) return;
+  try {
+    storage.setItem(AGENT_TAB_STORAGE_KEY, tab);
+  } catch {
+    /* quota / privacy mode */
+  }
+}
+
+function defaultStorage(): Storage | null {
+  if (typeof window === "undefined" || typeof window.localStorage === "undefined") {
+    return null;
+  }
+  return window.localStorage;
+}


### PR DESCRIPTION
## Summary

- Fixes #326: opening Agents for a conversation without analytics data no longer lands on an empty Analytics screen inherited from a previous conversation.
- `resolveAgentTabForSession` maps preferred `analytics` → `detail` when edges have no messages (same emptiness rule as `AnalyticsTab`).
- Preferred tab is saved only on user tab clicks (and node/edge selection → detail), not on auto-corrections.
- Within a session, the chosen tab stays stable; Analytics remains manually selectable even when empty.

## Test plan

- [x] `agentPanelTab.test.ts` (empty/rich switch, storage vs auto-detail)
- [x] `tsc -b` for web package
- [ ] Manual: session with traffic on Analytics → switch to empty session → Detail overview
- [ ] Manual: still able to click Analytics on empty session; preference survives for next rich session