### PR TITLE
fix(runtime): stop without a follow-up model run to acknowledge interrupt (#327)

### DIFF
--- a/packages/runtime/src/__tests__/interrupt-cancel.test.ts
+++ b/packages/runtime/src/__tests__/interrupt-cancel.test.ts
@@ -1,16 +1,12 @@
 /**
- * #101: interrupt must cancel the active run and NOT race a second one.
+ * #101 / #327: interrupt must cancel the active run and NOT start a follow-up
+ * provider run to acknowledge the stop.
  *
- * Before the fix, interrupt() aborted the agent (signal only, no wait) and
- * immediately prompted the principal with the interrupt notice. The original
- * prompt()'s run was still in-flight, so the notice prompt hit Pi's "Agent is
- * already processing a prompt" guard, surfaced a RUN_ERROR, and left the agent
- * stuck in `error` — while the original provider stream kept emitting text.
+ * #101: abort waits for the in-flight prompt to settle so we never hit Pi's
+ * "Agent is already processing a prompt" guard.
  *
- * The fix makes MasAgent.abort() await the in-flight prompt's settlement, and
- * interrupt() awaits every abort before notifying the principal. So after an
- * interrupt: no "already processing" error, no RUN_ERROR from the notice run,
- * the agent settles cleanly, and no further old-run content is appended.
+ * #327: whole-session Stop must not prompt the principal solely to say it
+ * stopped — that burned tokens and left Stop/running indicators active.
  */
 import { describe, it, expect } from "vitest";
 import { SessionManager } from "../session-manager.js";
@@ -30,8 +26,7 @@ function gatedPrincipalFactory(observe: {
     const listeners = new Set<(e: PiAgentEvent) => void>();
     let aborted = false;
     // Mirror Pi's single-active-run guard: a second prompt() while one is still
-    // in-flight throws the same error the real SDK does. This is what made the
-    // pre-fix interrupt path surface "Agent is already processing a prompt".
+    // in-flight throws the same error the real SDK does.
     let activeRun = false;
     let release!: () => void;
     const gate = new Promise<void>((r) => (release = r));
@@ -60,28 +55,27 @@ function gatedPrincipalFactory(observe: {
         activeRun = true;
         observe.prompts.push({ agent: agentName, text });
         try {
-        emit({ type: "agent_start" });
-        emit({ type: "turn_start" });
-        emit({ type: "message_start", message: { role: "assistant", content: [] } });
-        if (gated && !text.includes("interrupt")) {
-          // The long, interruptible run: block until aborted.
-          await gate;
-          if (aborted) {
-            // Simulate the real provider stream taking a tick to tear down after
-            // abort — the window in which the pre-fix interrupt path raced a
-            // second prompt while this run's activeRun guard was still set.
-            await new Promise((r) => setTimeout(r, 15));
-            emit({ type: "turn_end" });
-            emit({ type: "agent_end", messages: [], willRetry: false });
-            return;
+          emit({ type: "agent_start" });
+          emit({ type: "turn_start" });
+          emit({ type: "message_start", message: { role: "assistant", content: [] } });
+          if (gated) {
+            // The long, interruptible run: block until aborted.
+            await gate;
+            if (aborted) {
+              // Simulate the real provider stream taking a tick to tear down after
+              // abort — the window in which a raced second prompt would hit activeRun.
+              await new Promise((r) => setTimeout(r, 15));
+              emit({ type: "turn_end" });
+              emit({ type: "agent_end", messages: [], willRetry: false });
+              return;
+            }
           }
-        }
-        emit({
-          type: "message_end",
-          message: { role: "assistant", content: [{ type: "text", text: `ok ${agentName}` }] },
-        });
-        emit({ type: "turn_end" });
-        emit({ type: "agent_end", messages: [], willRetry: false });
+          emit({
+            type: "message_end",
+            message: { role: "assistant", content: [{ type: "text", text: `ok ${agentName}` }] },
+          });
+          emit({ type: "turn_end" });
+          emit({ type: "agent_end", messages: [], willRetry: false });
         } finally {
           activeRun = false;
         }
@@ -104,8 +98,8 @@ async function waitFor(pred: () => boolean, timeoutMs = 2000): Promise<void> {
   }
 }
 
-describe("interrupt cancels the active run without racing a second (#101)", () => {
-  it("does not emit RUN_ERROR or an 'already processing' error after interrupt", async () => {
+describe("interrupt cancels the active run without a follow-up notice run (#101 / #327)", () => {
+  it("does not emit RUN_ERROR or start a second principal prompt after interrupt", async () => {
     const observe = { prompts: [] as Array<{ agent: string; text: string }> };
     const m = new SessionManager({ persist: false, agentFactory: gatedPrincipalFactory(observe) });
     const s = await m.createSession();
@@ -115,14 +109,14 @@ describe("interrupt cancels the active run without racing a second (#101)", () =
     // Start the long run; principal blocks inside prompt().
     await m.sendMessage(s.id, "write a very long report");
     await waitFor(() => observe.prompts.some((p) => p.agent === "principal"));
+    const principalBefore = observe.prompts.filter((p) => p.agent === "principal").length;
 
-    // Stop the whole session. With the fix this awaits the old run's settlement
-    // before prompting the principal with the interrupt notice.
     await m.interrupt(s.id);
+    await new Promise((r) => setTimeout(r, 40));
 
-    // The interrupt-notice run should have fired AND completed.
-    await waitFor(() => observe.prompts.filter((p) => p.text.includes("interrupt")).length > 0);
-    await new Promise((r) => setTimeout(r, 30));
+    // #327: no interrupt-notice prompt / second principal run.
+    expect(observe.prompts.filter((p) => p.agent === "principal").length).toBe(principalBefore);
+    expect(observe.prompts.some((p) => /interrupt|system_notice/i.test(p.text))).toBe(false);
 
     // No run ended in error, and the SDK "already processing" guard never fired.
     const runErrors = events.filter((e) => e.type === "RUN_ERROR");
@@ -134,9 +128,10 @@ describe("interrupt cancels the active run without racing a second (#101)", () =
     );
     expect(alreadyProcessing).toHaveLength(0);
 
-    // The principal settled to a non-error status.
+    // The principal settled to a non-error status; turn is no longer active.
     const principal = m.getSessionState(s.id)?.agents.find((a) => a.name === "principal");
     expect(principal?.status).not.toBe("error");
+    expect(m.getSessionState(s.id)?.runState?.active).toBe(false);
   });
 
   it("abort() resolves only after the interrupted run has settled (RUN_FINISHED emitted)", async () => {

--- a/packages/runtime/src/__tests__/interrupt.test.ts
+++ b/packages/runtime/src/__tests__/interrupt.test.ts
@@ -1,11 +1,13 @@
 /**
- * #90: whole-session Stop must really interrupt + clear mailboxes + notify PI.
+ * #90 / #327: whole-session Stop must interrupt + clear mailboxes without a
+ * follow-up model run solely to acknowledge the stop.
  *
  * The frontend Stop button calls POST /sessions/:id/interrupt with no agent,
- * meaning "interrupt the whole session". Beyond aborting every agent, that must:
+ * meaning "interrupt the whole session". That must:
  *   - clear ALL mailboxes so a queued message can't re-wake a stopped agent;
- *   - immediately prompt the principal one run with an interrupt notice so PI
- *     knows the user interrupted and should await further instructions.
+ *   - emit one deterministic system_message acknowledgement;
+ *   - settle runActive so the UI can clear Stop immediately;
+ *   - NOT prompt the principal (no extra provider tokens for "I stopped").
  *
  * A targeted interrupt(id, agent) keeps its narrow contract: abort just that
  * agent, leave mailboxes and the principal alone.
@@ -13,6 +15,7 @@
 import { describe, it, expect } from "vitest";
 import { SessionManager } from "../session-manager.js";
 import type { AgentSessionFactory, IAgentSession, PiAgentEvent, SystemTool } from "../types.js";
+import type { AgUiEvent } from "@brainpilot/protocol";
 
 interface Script {
   onPrompt?: (text: string) => { tool: string; args: Record<string, unknown> } | undefined;
@@ -97,7 +100,7 @@ async function waitFor(pred: () => boolean, timeoutMs = 2000): Promise<void> {
   }
 }
 
-describe("whole-session interrupt (#90)", () => {
+describe("whole-session interrupt (#90 / #327)", () => {
   it("clears all mailboxes so a queued message can't re-wake a stopped agent", async () => {
     const observe = { prompts: [] as Array<{ agent: string; text: string }> };
     const factory = scriptedFactory(
@@ -131,23 +134,38 @@ describe("whole-session interrupt (#90)", () => {
     expect(m.mailboxCount(s.id, "librarian")).toBe(0);
   });
 
-  it("prompts the principal with an interrupt notice after stopping", async () => {
+  it("does not prompt the principal after stop; emits one system acknowledgement (#327)", async () => {
     const observe = { prompts: [] as Array<{ agent: string; text: string }> };
     const factory = scriptedFactory({ principal: {}, librarian: {} }, observe);
     const m = new SessionManager({ persist: false, agentFactory: factory });
     const s = await m.createSession();
+    const events: AgUiEvent[] = [];
+    m.subscribe(s.id, (e) => events.push(e));
 
     await m.sendMessage(s.id, "hello");
     await waitFor(() => observe.prompts.some((p) => p.agent === "principal"));
-    const before = observe.prompts.filter((p) => p.agent === "principal").length;
+    const principalBefore = observe.prompts.filter((p) => p.agent === "principal").length;
 
     await m.interrupt(s.id);
+    // Allow any accidental async follow-up prompt to surface.
+    await new Promise((r) => setTimeout(r, 40));
 
-    // Principal is prompted again, and the prompt carries an interrupt notice
-    // telling it the user interrupted and to await further instructions.
-    await waitFor(() => observe.prompts.filter((p) => p.agent === "principal").length > before);
-    const notice = observe.prompts.filter((p) => p.agent === "principal").at(-1)!;
-    expect(notice.text).toContain("interrupt");
+    // No follow-up model run solely to acknowledge the interruption.
+    expect(observe.prompts.filter((p) => p.agent === "principal").length).toBe(principalBefore);
+    expect(observe.prompts.some((p) => /interrupt|system_notice/i.test(p.text))).toBe(false);
+
+    // One deterministic system acknowledgement (not model-generated).
+    const sysAcks = events.filter(
+      (e) =>
+        e.type === "system_message" &&
+        typeof (e as { message?: string }).message === "string" &&
+        String((e as { message?: string }).message).includes("中断"),
+    );
+    expect(sysAcks.length).toBeGreaterThanOrEqual(1);
+
+    // Run state settled so the UI can clear Stop immediately.
+    const state = m.getSessionState(s.id);
+    expect(state?.runState?.active).toBe(false);
   });
 
   it("targeted interrupt(agent) does not prompt the principal with a notice", async () => {
@@ -174,8 +192,6 @@ describe("whole-session interrupt (#90)", () => {
 
     await m.interrupt(s.id, "librarian");
 
-    // A targeted interrupt is narrow: it must NOT re-prompt the principal with
-    // an interrupt notice (that is the whole-session Stop behavior only).
     await new Promise((r) => setTimeout(r, 20));
     expect(observe.prompts.filter((p) => p.agent === "principal").length).toBe(principalBefore);
   });

--- a/packages/runtime/src/mas-agent.ts
+++ b/packages/runtime/src/mas-agent.ts
@@ -364,9 +364,9 @@ export class MasAgent {
    * already awaits the agent back to idle). We then await the in-flight
    * `prompt()` promise so that by the time abort() resolves: the original run
    * has emitted its terminal RUN_FINISHED/RUN_ERROR, `status` has settled, and
-   * no further assistant content can be appended. This lets `interrupt()` start
-   * the principal's interrupt-notice run WITHOUT racing the old run (which would
-   * otherwise throw "Agent is already processing a prompt").
+   * no further assistant content can be appended. Whole-session interrupt waits
+   * on this settlement before emitting its deterministic system ack (#327) —
+   * it must not start a follow-up provider run while the old run is still open.
    */
   async abort(): Promise<void> {
     // Snapshot the run identity before session.abort() causes runPrompt's

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -1514,12 +1514,12 @@ export class SessionManager {
    * Targeted (`agentName` given): abort just that agent. Mailboxes and the
    * principal are left untouched — a narrow "stop this one expert" contract.
    *
-   * Whole-session (`agentName` omitted, the Stop button — #90): abort EVERY
-   * agent (incl. their running script subprocesses, via Pi `session.abort()`),
-   * then clear ALL mailboxes so a queued message can't re-wake a stopped agent,
-   * surface a user-facing system_message, and immediately prompt the principal
-   * one run with an interrupt notice so PI knows the user interrupted and should
-   * await further instructions.
+   * Whole-session (`agentName` omitted, the Stop button — #90 / #327): abort
+   * EVERY agent (incl. their running script subprocesses, via Pi
+   * `session.abort()`), clear ALL mailboxes so a queued message can't re-wake a
+   * stopped agent, emit one deterministic system_message acknowledgement, and
+   * settle run state so the UI clears Stop without a follow-up provider call.
+   * Do NOT prompt the principal solely to acknowledge the interruption (#327).
    */
   async interrupt(sessionId: string, agentName?: string): Promise<boolean> {
     const entry = this.sessions.get(sessionId);
@@ -1534,55 +1534,25 @@ export class SessionManager {
       entry.pendingInputs.delete(id);
     }
     // Abort every target and WAIT for each in-flight run to fully settle (#101)
-    // — RUN_FINISHED emitted, status settled, provider stream fenced — so the
-    // interrupt-notice run below can't race the old run ("already processing").
+    // — RUN_FINISHED emitted, status settled, provider stream fenced.
     await Promise.all(targets.map((a) => a!.abort()));
     entry.runActive = false;
     entry.activeRunId = null;
     if (wholeSession) {
-      // Clear every inbox BEFORE notifying PI: otherwise a queued task_delegate
-      // would re-wake the expert the user just stopped.
+      // Clear every inbox so a queued task_delegate cannot re-wake an agent
+      // the user just stopped.
       await entry.mailbox.clearAll();
+      // Deterministic UI/runtime acknowledgement — no model/provider run (#327).
       entry.bus.emit(
-        ev.systemMessage(sessionId, "info", "⏹️ 用户已中断当前任务,信箱已清空,正在等候进一步指示。", {
+        ev.systemMessage(sessionId, "info", "⏹️ 用户已中断当前任务，信箱已清空，正在等候进一步指示。", {
           agent: "principal",
           recoverable: true,
         }),
       );
-      this.notifyPrincipalInterrupted(entry);
+      this.touch(entry);
+      this.emitSessionState(entry);
     }
     return targets.length > 0;
-  }
-
-  /**
-   * #90: after a whole-session Stop, prompt the principal one run with an
-   * interrupt notice. Mirrors `sendMessage`'s fire-and-track run accounting but
-   * emits NO role:"user" text chunk — the notice is system context, not a user
-   * bubble. The principal should acknowledge briefly and await the user.
-   */
-  private notifyPrincipalInterrupted(entry: SessionEntry): void {
-    const notice =
-      "<system_notice>\n" +
-      "  The user interrupted the current task. All running agents were stopped " +
-      "and every mailbox was cleared, so any in-flight delegation is cancelled. " +
-      "Do not resume or re-delegate the prior work. Briefly acknowledge the " +
-      "interruption and wait for the user's next instruction.\n" +
-      "</system_notice>";
-    void this.ensureAgent(entry.id, "principal")
-      .then((agent) => {
-        entry.runActive = true;
-        entry.activeRunId = `run_${randomUUID()}`;
-        this.emitSessionState(entry);
-        return agent.prompt(notice).finally(() => {
-          entry.runActive = false;
-          entry.activeRunId = null;
-          this.touch(entry);
-          this.emitSessionState(entry);
-        });
-      })
-      .catch(() => {
-        /* error-isolated: prompt() never throws, ensureAgent failure is best-effort */
-      });
   }
 
   /** Test/diagnostic accessor: number of queued messages in `agent`'s inbox. */


### PR DESCRIPTION
## Summary

- Fixes #327: whole-session Stop no longer launches a principal/provider run just to acknowledge the interruption.
- After aborts settle: clear mailboxes, emit one deterministic `system_message`, set `runActive` false, `emitSessionState` — no `agent.prompt(interrupt notice)`.
- Updates `#90` / `#101` tests to assert zero follow-up prompts, settled `runState.active`, and no RUN_ERROR race.

## Test plan

- [x] `interrupt.test.ts` + `interrupt-cancel.test.ts` (5 tests)
- [ ] Manual: Stop mid-stream — Stop clears promptly, one system ack, no extra assistant acknowledgements, partial output kept