### PR TITLE
fix(web): distinguish same-title search results and complete search a11y (#315)

### DIFF
--- a/packages/web/src/__tests__/searchResults.test.ts
+++ b/packages/web/src/__tests__/searchResults.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import {
+  clampActiveIndex,
+  filterSessionsByQuery,
+  moveActiveIndex,
+  searchResultMeta,
+  shortSessionId,
+  titleCollisionIds,
+} from "../components/search/searchResults";
+
+const sessions = [
+  { id: "aaaaaaaa-1111", title: "你好", updatedAt: "2026-07-01T10:00:00.000Z" },
+  { id: "bbbbbbbb-2222", title: "你好", updatedAt: "2026-07-02T11:00:00.000Z" },
+  { id: "cccccccc-3333", title: "Other", updatedAt: "2026-07-03T12:00:00.000Z" },
+];
+
+describe("titleCollisionIds / searchResultMeta (#315)", () => {
+  it("marks same-title conversations for short-id disambiguation", () => {
+    const collisions = titleCollisionIds(sessions);
+    expect(collisions.has("aaaaaaaa-1111")).toBe(true);
+    expect(collisions.has("bbbbbbbb-2222")).toBe(true);
+    expect(collisions.has("cccccccc-3333")).toBe(false);
+
+    expect(searchResultMeta(sessions[0]!, collisions)).toEqual({
+      showShortId: true,
+      shortId: "aaaaaaaa",
+    });
+    expect(searchResultMeta(sessions[2]!, collisions).showShortId).toBe(false);
+  });
+
+  it("shortens ids to 8 chars by default", () => {
+    expect(shortSessionId("abcdefghij")).toBe("abcdefgh");
+    expect(shortSessionId("short")).toBe("short");
+  });
+});
+
+describe("filterSessionsByQuery", () => {
+  it("returns all when query empty", () => {
+    expect(filterSessionsByQuery(sessions, "  ")).toHaveLength(3);
+  });
+
+  it("filters by title case-insensitively", () => {
+    expect(filterSessionsByQuery(sessions, "other").map((s) => s.id)).toEqual([
+      "cccccccc-3333",
+    ]);
+  });
+
+  it("returns empty list when nothing matches", () => {
+    expect(filterSessionsByQuery(sessions, "zzz")).toEqual([]);
+  });
+});
+
+describe("keyboard active index", () => {
+  it("clamps and wraps", () => {
+    expect(clampActiveIndex(5, 3)).toBe(2);
+    expect(clampActiveIndex(-1, 3)).toBe(0);
+    expect(clampActiveIndex(0, 0)).toBe(-1);
+    expect(moveActiveIndex(0, 3, "down")).toBe(1);
+    expect(moveActiveIndex(2, 3, "down")).toBe(0);
+    expect(moveActiveIndex(0, 3, "up")).toBe(2);
+  });
+});

--- a/packages/web/src/components/search/SearchDialog.tsx
+++ b/packages/web/src/components/search/SearchDialog.tsx
@@ -1,96 +1,203 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { MessageCircle } from "lucide-react";
+import { MessageCircle, X } from "lucide-react";
 import { useSessions } from "../../contexts/SessionContext";
 import { useT } from "../../i18n/useT";
+import { IconButton } from "../primitives/IconButton";
+import { listFocusable, trapFocusKeyDown } from "../settings/settingsModalStack";
+import {
+  clampActiveIndex,
+  filterSessionsByQuery,
+  moveActiveIndex,
+  searchResultMeta,
+  titleCollisionIds,
+} from "./searchResults";
 
 type SearchDialogProps = {
   isOpen: boolean;
   onClose: () => void;
 };
 
+/**
+ * Conversation search modal (#315).
+ * list + listitem buttons (not listbox/button mismatch), arrow navigation,
+ * visible Close, and same-title disambiguation via date + short id.
+ */
 export function SearchDialog({ isOpen, onClose }: SearchDialogProps) {
   const { sessions, selectSession } = useSessions();
   const t = useT();
   const [query, setQuery] = useState("");
+  const [activeIndex, setActiveIndex] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
+  const dialogRef = useRef<HTMLElement>(null);
+  const returnFocusRef = useRef<HTMLElement | null>(null);
+
+  const filteredSessions = useMemo(
+    () => filterSessionsByQuery(sessions, query),
+    [query, sessions],
+  );
+
+  const collisions = useMemo(
+    () => titleCollisionIds(filteredSessions),
+    [filteredSessions],
+  );
+
+  // Keep highlight in range when the filtered list changes.
+  useEffect(() => {
+    setActiveIndex((i) => clampActiveIndex(i, filteredSessions.length));
+  }, [filteredSessions.length]);
 
   useEffect(() => {
     if (!isOpen) {
       setQuery("");
+      setActiveIndex(0);
       return;
     }
 
+    returnFocusRef.current =
+      document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
     const focusTimer = window.setTimeout(() => inputRef.current?.focus(), 0);
+
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
+      const dialog = dialogRef.current;
+      if (dialog && trapFocusKeyDown(dialog, event)) {
+        return;
+      }
+
+      if (event.key === "Escape" || event.key === "Esc") {
+        event.preventDefault();
         onClose();
+        return;
+      }
+
+      if (filteredSessions.length === 0) return;
+
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setActiveIndex((i) => moveActiveIndex(i, filteredSessions.length, "down"));
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setActiveIndex((i) => moveActiveIndex(i, filteredSessions.length, "up"));
+        return;
+      }
+      if (event.key === "Enter") {
+        const target = filteredSessions[clampActiveIndex(activeIndex, filteredSessions.length)];
+        if (target && document.activeElement === inputRef.current) {
+          event.preventDefault();
+          selectSession(target.id);
+          onClose();
+        }
       }
     };
 
-    window.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("keydown", handleKeyDown, true);
     return () => {
       window.clearTimeout(focusTimer);
-      window.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("keydown", handleKeyDown, true);
+      const el = returnFocusRef.current;
+      if (el && typeof el.focus === "function") {
+        try {
+          el.focus();
+        } catch {
+          /* gone */
+        }
+      }
     };
-  }, [isOpen, onClose]);
-
-  const filteredSessions = useMemo(() => {
-    const normalizedQuery = query.trim().toLowerCase();
-    if (!normalizedQuery) {
-      return sessions;
-    }
-
-    return sessions.filter((session) => {
-      return session.title.toLowerCase().includes(normalizedQuery);
-    });
-  }, [query, sessions]);
+  }, [isOpen, onClose, filteredSessions, activeIndex, selectSession]);
 
   if (!isOpen) {
     return null;
   }
 
+  const openSession = (sessionId: string) => {
+    selectSession(sessionId);
+    onClose();
+  };
+
+  const formatWhen = (iso: string) => {
+    try {
+      return new Date(iso).toLocaleString();
+    } catch {
+      return iso;
+    }
+  };
+
   return (
     <div className="search-modal" role="presentation" onMouseDown={onClose}>
       <section
+        ref={dialogRef}
         aria-label={t("search.aria")}
         aria-modal="true"
         className="search-dialog"
         onMouseDown={(event) => event.stopPropagation()}
         role="dialog"
       >
-        <label className="sr-only" htmlFor="conversation-search">
-          {t("search.placeholder")}
-        </label>
-        <input
-          id="conversation-search"
-          ref={inputRef}
-          autoComplete="off"
-          className="search-dialog__input"
-          onChange={(event) => setQuery(event.target.value)}
-          placeholder={t("search.placeholder")}
-          type="search"
-          value={query}
-        />
+        <header className="search-dialog__header">
+          <label className="sr-only" htmlFor="conversation-search">
+            {t("search.placeholder")}
+          </label>
+          <input
+            id="conversation-search"
+            ref={inputRef}
+            autoComplete="off"
+            className="search-dialog__input"
+            onChange={(event) => {
+              setQuery(event.target.value);
+              setActiveIndex(0);
+            }}
+            placeholder={t("search.placeholder")}
+            type="search"
+            value={query}
+            aria-controls="search-results-list"
+          />
+          <IconButton label={t("search.close")} onClick={onClose} className="search-dialog__close">
+            <X size={16} />
+          </IconButton>
+        </header>
 
         <div className="search-dialog__body">
-          <p className="search-dialog__heading">{t("search.recent")}</p>
+          <p className="search-dialog__heading">
+            {query.trim() ? t("search.results") : t("search.recent")}
+          </p>
           {filteredSessions.length > 0 ? (
-            <div className="search-results" role="listbox">
-              {filteredSessions.map((session, index) => (
-                <button
-                  className={`search-result ${index === 0 ? "is-highlighted" : ""}`}
-                  key={session.id}
-                  onClick={() => {
-                    selectSession(session.id);
-                    onClose();
-                  }}
-                  type="button"
-                >
-                  <MessageCircle size={18} />
-                  <span className="search-result__title">{session.title}</span>
-                </button>
-              ))}
-            </div>
+            <ul className="search-results" id="search-results-list" role="list">
+              {filteredSessions.map((session, index) => {
+                const meta = searchResultMeta(session, collisions);
+                const isActive = index === activeIndex;
+                return (
+                  <li key={session.id} role="listitem">
+                    <button
+                      className={`search-result${isActive ? " is-highlighted" : ""}`}
+                      id={`search-result-${session.id}`}
+                      onClick={() => openSession(session.id)}
+                      onMouseEnter={() => setActiveIndex(index)}
+                      type="button"
+                      aria-current={isActive ? "true" : undefined}
+                    >
+                      <MessageCircle size={18} aria-hidden />
+                      <span className="search-result__text">
+                        <span className="search-result__title">{session.title}</span>
+                        <span className="search-result__meta">
+                          <time dateTime={session.updatedAt}>{formatWhen(session.updatedAt)}</time>
+                          {meta.showShortId ? (
+                            <>
+                              <span className="search-result__meta-sep" aria-hidden>
+                                ·
+                              </span>
+                              <span className="search-result__id" title={session.id}>
+                                {t("search.shortId", { id: meta.shortId })}
+                              </span>
+                            </>
+                          ) : null}
+                        </span>
+                      </span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
           ) : (
             <p className="search-dialog__empty">{t("search.empty")}</p>
           )}

--- a/packages/web/src/components/search/searchResults.ts
+++ b/packages/web/src/components/search/searchResults.ts
@@ -1,0 +1,80 @@
+/**
+ * Pure helpers for conversation search results (#315).
+ */
+
+export type SearchSession = {
+  id: string;
+  title: string;
+  updatedAt: string;
+};
+
+/** True when more than one session shares this title (case-sensitive as stored). */
+export function titleCollisionIds(sessions: SearchSession[]): Set<string> {
+  const counts = new Map<string, number>();
+  for (const s of sessions) {
+    counts.set(s.title, (counts.get(s.title) ?? 0) + 1);
+  }
+  const out = new Set<string>();
+  for (const s of sessions) {
+    if ((counts.get(s.title) ?? 0) > 1) out.add(s.id);
+  }
+  return out;
+}
+
+/** Short id fragment for disambiguating same-title rows. */
+export function shortSessionId(id: string, len = 8): string {
+  const trimmed = id.trim();
+  if (trimmed.length <= len) return trimmed;
+  return trimmed.slice(0, len);
+}
+
+export type SearchResultMeta = {
+  showShortId: boolean;
+  shortId: string;
+};
+
+export function searchResultMeta(
+  session: SearchSession,
+  collisions: Set<string>,
+): SearchResultMeta {
+  const showShortId = collisions.has(session.id);
+  return {
+    showShortId,
+    shortId: shortSessionId(session.id),
+  };
+}
+
+/**
+ * Clamp active index into [0, length-1], or -1 when the list is empty.
+ */
+export function clampActiveIndex(index: number, length: number): number {
+  if (length <= 0) return -1;
+  if (index < 0) return 0;
+  if (index >= length) return length - 1;
+  return index;
+}
+
+/**
+ * Move highlight for ArrowUp / ArrowDown. Wraps at ends.
+ */
+export function moveActiveIndex(
+  current: number,
+  length: number,
+  direction: "up" | "down",
+): number {
+  if (length <= 0) return -1;
+  const base = current < 0 ? (direction === "down" ? -1 : 0) : current;
+  if (direction === "down") {
+    return (base + 1) % length;
+  }
+  return (base - 1 + length) % length;
+}
+
+export function filterSessionsByQuery(
+  sessions: SearchSession[],
+  query: string,
+): SearchSession[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return sessions;
+  return sessions.filter((s) => s.title.toLowerCase().includes(q));
+}

--- a/packages/web/src/i18n/messages/search.ts
+++ b/packages/web/src/i18n/messages/search.ts
@@ -5,12 +5,18 @@ export default defineMessages(
     "search.aria": "搜索对话",
     "search.placeholder": "搜索对话",
     "search.recent": "近期对话",
+    "search.results": "搜索结果",
     "search.empty": "没有找到匹配的对话",
+    "search.close": "关闭搜索",
+    "search.shortId": "ID {id}",
   },
   {
     "search.aria": "Search conversations",
     "search.placeholder": "Search conversations",
     "search.recent": "Recent conversations",
+    "search.results": "Search results",
     "search.empty": "No matching conversations found",
+    "search.close": "Close search",
+    "search.shortId": "ID {id}",
   },
 );

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -5190,6 +5190,23 @@ button {
   }
 }
 
+/* #315 — header row: search input + visible Close */
+.search-dialog__header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding-right: 8px;
+}
+
+.search-dialog__header .search-dialog__input {
+  flex: 1;
+  min-width: 0;
+}
+
+.search-dialog__close {
+  flex-shrink: 0;
+}
+
 .search-dialog__input {
   display: block;
   width: 100%;
@@ -5209,6 +5226,8 @@ button {
 
 .search-dialog__body {
   padding: 0 8px 10px;
+  max-height: min(320px, calc(100vh - 160px));
+  overflow-y: auto;
 }
 
 .search-dialog__heading,
@@ -5227,13 +5246,16 @@ button {
 .search-results {
   display: grid;
   gap: 0;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
 .search-result {
   display: grid;
   width: 100%;
   min-width: 0;
-  height: 46px;
+  min-height: 52px;
   grid-template-columns: 28px minmax(0, 1fr);
   align-items: center;
   gap: 10px;
@@ -5241,8 +5263,9 @@ button {
   border-radius: 14px;
   background: transparent;
   color: var(--color-text);
-  padding: 0 12px;
+  padding: 8px 12px;
   text-align: left;
+  cursor: pointer;
 }
 
 .search-result:hover,
@@ -5262,14 +5285,37 @@ button {
   color: var(--color-text-muted);
 }
 
+.search-result__text {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
 .search-result__title {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-size: 15px;
 }
 
-.search-result__title {
-  font-size: 15px;
+.search-result__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px 6px;
+  font-size: 12px;
+  color: var(--color-text-muted);
+  line-height: 1.3;
+}
+
+.search-result__meta-sep {
+  opacity: 0.6;
+}
+
+.search-result__id {
+  font-variant-numeric: tabular-nums;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 11px;
 }
 
 .settings-modal {


### PR DESCRIPTION
## Summary

- Fixes #315: same-title conversations show date/time and a short ID in search.
- Visible Close button (keeps Escape + backdrop).
- Results use `list` / `listitem` + buttons (not mismatched listbox).
- Arrow keys move highlight; Enter from the search field opens the active result; Tab is trapped in the dialog.

## Test plan

- [x] `searchResults.test.ts`
- [x] `tsc -b`
- [ ] Manual: two sessions named 你好 — both show dates + short IDs
- [ ] Manual: keyboard arrows + Enter + Close