### PR TITLE
fix(runtime): rewrite logical /workspace onto durable session workspace (#346)

### DIFF
--- a/packages/runtime/src/__tests__/managed-path-guard.test.ts
+++ b/packages/runtime/src/__tests__/managed-path-guard.test.ts
@@ -1,0 +1,59 @@
+/**
+ * #346 — managed-path-guard extension rewrites / blocks tool_call events.
+ */
+import { describe, expect, it } from "vitest";
+import { resolve } from "node:path";
+import { makeManagedPathGuardExt } from "../extensions/managed-path-guard.js";
+import { denyEphemeralWriteReason } from "../managed-path-rewrite.js";
+
+const cwd = resolve("/root/.bp-root/workspaces/s1");
+const persistentDir = resolve("/root/.bp-root/data");
+
+type ToolCallHandler = (e: {
+  toolName: string;
+  input: Record<string, unknown>;
+}) => { block?: boolean; reason?: string } | void;
+
+function install(): ToolCallHandler {
+  let handler: ToolCallHandler | null = null;
+  const ext = makeManagedPathGuardExt({
+    roots: { cwd, persistentDir },
+  });
+  ext({
+    on(_event, h) {
+      handler = h as ToolCallHandler;
+    },
+  });
+  if (!handler) throw new Error("expected tool_call handler");
+  return handler;
+}
+
+describe("makeManagedPathGuardExt", () => {
+  it("rewrites write /workspace onto the session workspace", () => {
+    const handler = install();
+    const input: Record<string, unknown> = {
+      path: "/workspace/foo.txt",
+      content: "hello",
+    };
+    expect(handler({ toolName: "write", input })).toBeUndefined();
+    expect(input.path).toBe("foo.txt");
+  });
+
+  it("blocks ephemeral write targets", () => {
+    const handler = install();
+    const input: Record<string, unknown> = { path: "/tmp/x", content: "x" };
+    expect(handler({ toolName: "write", input })).toEqual({
+      block: true,
+      reason: denyEphemeralWriteReason("/tmp/x"),
+    });
+  });
+
+  it("rewrites bash commands that use /workspace", () => {
+    const handler = install();
+    const input: Record<string, unknown> = {
+      command: "mkdir -p /workspace/demo",
+    };
+    expect(handler({ toolName: "bash", input })).toBeUndefined();
+    expect(String(input.command)).toBe(`mkdir -p ${cwd}/demo`);
+  });
+});

--- a/packages/runtime/src/__tests__/managed-path-rewrite.test.ts
+++ b/packages/runtime/src/__tests__/managed-path-rewrite.test.ts
@@ -1,0 +1,275 @@
+/**
+ * #346 — logical path rewrite + write confinement for Pi file tools.
+ */
+import { describe, expect, it } from "vitest";
+import { join, resolve } from "node:path";
+import {
+  applyManagedPathToolCall,
+  denyEphemeralWriteReason,
+  denyPathEscapeReason,
+  denySharedWriteReason,
+  denyWriteOutsideDurable,
+  isUnderRoot,
+  rewriteBashWorkspacePaths,
+  rewriteLogicalPath,
+  type ManagedPathRoots,
+} from "../managed-path-rewrite.js";
+
+const cwd = resolve("/root/.bp-root/workspaces/s1");
+const persistentDir = resolve("/root/.bp-root/data");
+const sharedDir = resolve("/srv/shared");
+const otherSid = resolve("/root/.bp-root/workspaces/s2");
+
+const roots: ManagedPathRoots = { cwd, persistentDir, sharedDir };
+const rootsNoShared: ManagedPathRoots = { cwd, persistentDir };
+
+describe("isUnderRoot", () => {
+  it("matches the root and descendants only at a path boundary", () => {
+    expect(isUnderRoot(cwd, cwd)).toBe(true);
+    expect(isUnderRoot(join(cwd, "a", "b.txt"), cwd)).toBe(true);
+    expect(isUnderRoot(join(cwd + "-evil", "x"), cwd)).toBe(false);
+    expect(isUnderRoot(otherSid, cwd)).toBe(false);
+  });
+});
+
+describe("rewriteLogicalPath", () => {
+  it("rewrites /workspace to a cwd-relative path", () => {
+    const r = rewriteLogicalPath("/workspace/EEG_MI/train.py", roots);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.rewritten).toBe(true);
+    expect(r.root).toBe("workspace");
+    expect(r.path).toBe("EEG_MI/train.py");
+    expect(r.abs).toBe(resolve(cwd, "EEG_MI/train.py"));
+  });
+
+  it("rewrites bare /workspace to '.'", () => {
+    const r = rewriteLogicalPath("/workspace", roots);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.path).toBe(".");
+    expect(r.abs).toBe(cwd);
+  });
+
+  it("rewrites /data to the absolute persistent library path", () => {
+    const r = rewriteLogicalPath("/data/lib/set.csv", roots);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.rewritten).toBe(true);
+    expect(r.root).toBe("data");
+    expect(r.path).toBe(resolve(persistentDir, "lib/set.csv"));
+    expect(r.abs).toBe(resolve(persistentDir, "lib/set.csv"));
+  });
+
+  it("rewrites /attachments under the session .attachments dir", () => {
+    const r = rewriteLogicalPath("/attachments/report.pdf", roots);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.rewritten).toBe(true);
+    expect(r.root).toBe("attachments");
+    expect(r.path).toBe(".attachments/report.pdf");
+    expect(r.abs).toBe(resolve(cwd, ".attachments/report.pdf"));
+  });
+
+  it("rewrites /shared when sharedDir is configured", () => {
+    const r = rewriteLogicalPath("/shared/public/ref.txt", roots);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.rewritten).toBe(true);
+    expect(r.root).toBe("shared");
+    expect(r.path).toBe(resolve(sharedDir, "public/ref.txt"));
+  });
+
+  it("does not treat /shared as logical when sharedDir is unset", () => {
+    const r = rewriteLogicalPath("/shared/x", rootsNoShared);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.rewritten).toBe(false);
+    expect(r.root).toBe("other");
+    expect(r.abs).toBe(resolve("/shared/x"));
+  });
+
+  it("leaves relative paths unchanged", () => {
+    const r = rewriteLogicalPath("EEG_MI/train.py", roots);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.rewritten).toBe(false);
+    expect(r.path).toBe("EEG_MI/train.py");
+    expect(r.root).toBe("workspace");
+    expect(r.abs).toBe(resolve(cwd, "EEG_MI/train.py"));
+  });
+
+  it("leaves real absolute durable paths unchanged", () => {
+    const abs = resolve(persistentDir, "reuse.csv");
+    const r = rewriteLogicalPath(abs, roots);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.rewritten).toBe(false);
+    expect(r.root).toBe("data");
+    expect(r.path).toBe(abs);
+  });
+
+  it("rejects traversal out of /workspace", () => {
+    const r = rewriteLogicalPath("/workspace/../../etc/passwd", roots);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toBe(denyPathEscapeReason("workspace", "/workspace/../../etc/passwd"));
+  });
+
+  it("rejects traversal out of /data", () => {
+    const r = rewriteLogicalPath("/data/../workspaces/evil.txt", roots);
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error).toContain("data root");
+  });
+
+  it("normalizes backslashes like resolveManagedPath", () => {
+    const r = rewriteLogicalPath("\\workspace\\a.py", roots);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(r.rewritten).toBe(true);
+    expect(r.path).toBe("a.py");
+  });
+
+  it("two session cwds rewrite /workspace independently (no clobber)", () => {
+    const a = rewriteLogicalPath("/workspace/x", { ...roots, cwd });
+    const b = rewriteLogicalPath("/workspace/x", { ...roots, cwd: otherSid });
+    expect(a.ok && b.ok).toBe(true);
+    if (!a.ok || !b.ok) return;
+    expect(a.abs).toBe(resolve(cwd, "x"));
+    expect(b.abs).toBe(resolve(otherSid, "x"));
+    expect(a.abs).not.toBe(b.abs);
+  });
+});
+
+describe("denyWriteOutsideDurable", () => {
+  it("allows workspace and persistent library targets", () => {
+    expect(denyWriteOutsideDurable("notes.md", roots)).toBeNull();
+    expect(denyWriteOutsideDurable("/workspace/out.txt", roots)).toBeNull();
+    expect(denyWriteOutsideDurable("/data/lib.csv", roots)).toBeNull();
+    expect(denyWriteOutsideDurable(resolve(persistentDir, "z"), roots)).toBeNull();
+  });
+
+  it("rejects shared root writes", () => {
+    expect(denyWriteOutsideDurable("/shared/x", roots)).toBe(
+      denySharedWriteReason("/shared/x"),
+    );
+  });
+
+  it("rejects ephemeral absolute paths (container layer)", () => {
+    expect(denyWriteOutsideDurable("/tmp/model.pt", roots)).toBe(
+      denyEphemeralWriteReason("/tmp/model.pt"),
+    );
+    // Un-rewritten bare /workspace is allowed after rewrite; real container
+    // path that is NOT the logical prefix still denied if somehow passed as
+    // a different ephemeral path:
+    expect(denyWriteOutsideDurable("/var/log/x", roots)).toContain("durable storage");
+  });
+
+  it("rejects another session's workspace", () => {
+    expect(denyWriteOutsideDurable(join(otherSid, "stolen.txt"), roots)).toContain(
+      "durable storage",
+    );
+  });
+});
+
+describe("rewriteBashWorkspacePaths", () => {
+  it("rewrites path-bounded /workspace tokens to cwd", () => {
+    const { command, rewritten } = rewriteBashWorkspacePaths(
+      "mkdir -p /workspace/EEG_MI && cd /workspace/EEG_MI && python train.py",
+      cwd,
+    );
+    expect(rewritten).toBe(true);
+    expect(command).toContain(`${cwd}/EEG_MI`);
+    expect(command).not.toMatch(/(^|[\s])\/workspace(\/|[\s]|$)/);
+  });
+
+  it("does not rewrite /workspace_backup or substring workspace", () => {
+    const { command, rewritten } = rewriteBashWorkspacePaths(
+      "ls /workspace_backup && cat my/workspace/file",
+      cwd,
+    );
+    expect(rewritten).toBe(false);
+    expect(command).toBe("ls /workspace_backup && cat my/workspace/file");
+  });
+
+  it("rewrites quoted and assigned forms", () => {
+    const { command, rewritten } = rewriteBashWorkspacePaths(
+      `OUT="/workspace/out.txt" && echo hi > "/workspace/a"`,
+      cwd,
+    );
+    expect(rewritten).toBe(true);
+    expect(command).toContain(`${cwd}/out.txt`);
+    expect(command).toContain(`${cwd}/a`);
+  });
+});
+
+describe("applyManagedPathToolCall", () => {
+  it("mutates write path /workspace → relative and allows the call", () => {
+    const input: Record<string, unknown> = {
+      path: "/workspace/EEG_MI/train.py",
+      content: "print(1)\n",
+    };
+    const result = applyManagedPathToolCall({ toolName: "write", input, roots });
+    expect(result).toBeUndefined();
+    expect(input.path).toBe("EEG_MI/train.py");
+  });
+
+  it("mutates edit file_path alias", () => {
+    const input: Record<string, unknown> = {
+      file_path: "/workspace/a.py",
+      oldText: "a",
+      newText: "b",
+    };
+    expect(applyManagedPathToolCall({ toolName: "edit", input, roots })).toBeUndefined();
+    expect(input.file_path).toBe("a.py");
+  });
+
+  it("blocks write to /tmp after no rewrite", () => {
+    const input: Record<string, unknown> = { path: "/tmp/x", content: "x" };
+    const result = applyManagedPathToolCall({ toolName: "write", input, roots });
+    expect(result).toEqual({
+      block: true,
+      reason: denyEphemeralWriteReason("/tmp/x"),
+    });
+  });
+
+  it("blocks write to /shared", () => {
+    const input: Record<string, unknown> = { path: "/shared/x", content: "x" };
+    const result = applyManagedPathToolCall({ toolName: "write", input, roots });
+    expect(result?.block).toBe(true);
+    expect(result?.reason).toBe(denySharedWriteReason("/shared/x"));
+  });
+
+  it("blocks path escape on read", () => {
+    const input: Record<string, unknown> = { path: "/workspace/../../etc/passwd" };
+    const result = applyManagedPathToolCall({ toolName: "read", input, roots });
+    expect(result?.block).toBe(true);
+    expect(result?.reason).toContain("escapes");
+  });
+
+  it("rewrites bash /workspace without blocking", () => {
+    const input: Record<string, unknown> = {
+      command: "mkdir -p /workspace/demo && echo hi > /workspace/demo/out.txt",
+    };
+    expect(applyManagedPathToolCall({ toolName: "bash", input, roots })).toBeUndefined();
+    expect(String(input.command)).toContain(`${cwd}/demo`);
+    expect(String(input.command)).not.toContain("/workspace/");
+  });
+
+  it("allows read of relative and persistent paths without mutation of real abs", () => {
+    const abs = resolve(persistentDir, "lib.csv");
+    const input: Record<string, unknown> = { path: abs };
+    expect(applyManagedPathToolCall({ toolName: "read", input, roots })).toBeUndefined();
+    expect(input.path).toBe(abs);
+  });
+
+  it("rewrites /data on write to absolute persistent path", () => {
+    const input: Record<string, unknown> = {
+      path: "/data/models/best.pt",
+      content: "x",
+    };
+    expect(applyManagedPathToolCall({ toolName: "write", input, roots })).toBeUndefined();
+    expect(input.path).toBe(resolve(persistentDir, "models/best.pt"));
+  });
+});

--- a/packages/runtime/src/__tests__/two-skill-paths.test.ts
+++ b/packages/runtime/src/__tests__/two-skill-paths.test.ts
@@ -186,6 +186,11 @@ describe("two-path skill loading", () => {
       // Hard path guard is armed for the real factory.
       expect(params.blockRouterSkills).toBe(true);
       expect(params.routerSkillsDir).toBe(join(root, "bp_template", "skills-router"));
+      // #346: durable roots for logical /workspace rewrite on the real factory.
+      expect(params.managedPathRoots).toEqual({
+        cwd: join(root, "workspaces", session.id),
+        persistentDir: join(root, "data"),
+      });
       // Builtins still include read (always-on skills remain loadable via read).
       expect(params.allowedToolNames).toContain("read");
     }

--- a/packages/runtime/src/agent-factory.ts
+++ b/packages/runtime/src/agent-factory.ts
@@ -20,6 +20,7 @@ import { resolveGatewayModel, resolveSessionModel, type PiProviderSdk } from "./
 import { makeTraceReminderExt } from "./extensions/trace-reminder.js";
 import { makeAgentStatusExt } from "./extensions/agent-status.js";
 import { makeRouterSkillGuardExt } from "./extensions/router-skill-guard.js";
+import { makeManagedPathGuardExt } from "./extensions/managed-path-guard.js";
 
 export function isMockMode(env: Record<string, string | undefined> = process.env): boolean {
   return env.BP_MOCK === "1" || env.BP_MOCK === "true";
@@ -85,6 +86,21 @@ export const realAgentFactory: AgentSessionFactory = async (params) => {
   const extensionFactories: unknown[] = [traceReminder];
   if (params.renderAgentStatus) {
     extensionFactories.push(makeAgentStatusExt({ renderStatus: params.renderAgentStatus }));
+  }
+  // #346: rewrite logical /workspace (and /data, …) onto durable volume roots
+  // BEFORE other path guards run, so subsequent handlers see post-rewrite paths.
+  if (params.managedPathRoots) {
+    extensionFactories.push(
+      makeManagedPathGuardExt({
+        roots: {
+          cwd: params.managedPathRoots.cwd,
+          persistentDir: params.managedPathRoots.persistentDir,
+          ...(params.managedPathRoots.sharedDir
+            ? { sharedDir: params.managedPathRoots.sharedDir }
+            : {}),
+        },
+      }),
+    );
   }
   // #309: when skill_search is off, hard-deny file-tool access to skills-router.
   if (params.blockRouterSkills && params.routerSkillsDir) {

--- a/packages/runtime/src/extensions/managed-path-guard.ts
+++ b/packages/runtime/src/extensions/managed-path-guard.ts
@@ -1,0 +1,46 @@
+/**
+ * managed-path-guard — Pi extension that rewrites logical managed prefixes
+ * (`/workspace`, `/data`, …) onto durable volume roots before tool execution
+ * (#346). Also confines write/edit to the session workspace and persistent
+ * library so ephemeral container paths cannot silently swallow deliverables.
+ *
+ * Uses Pi's `tool_call` hook: `event.input` is mutated in place (official API).
+ * Register BEFORE router-skill-guard so #309 sees post-rewrite paths.
+ */
+import {
+  applyManagedPathToolCall,
+  type ManagedPathRoots,
+} from "../managed-path-rewrite.js";
+
+/** Minimal structural surface of Pi's ExtensionAPI we depend on. */
+export interface ManagedPathGuardApi {
+  on(
+    event: "tool_call",
+    handler: (
+      e: { toolName: string; toolCallId?: string; input: Record<string, unknown> },
+    ) => { block?: boolean; reason?: string } | void | Promise<{ block?: boolean; reason?: string } | void>,
+  ): void;
+}
+
+export interface ManagedPathGuardOpts {
+  roots: ManagedPathRoots;
+}
+
+/**
+ * Build a Pi extension factory that rewrites/confines managed paths on every
+ * tool_call. Closure-captured roots are fixed at agent creation (same lifetime
+ * as cwd / session workspace).
+ */
+export function makeManagedPathGuardExt(
+  opts: ManagedPathGuardOpts,
+): (pi: ManagedPathGuardApi) => void {
+  return (pi) => {
+    pi.on("tool_call", (event) => {
+      return applyManagedPathToolCall({
+        toolName: event.toolName,
+        input: (event.input ?? {}) as Record<string, unknown>,
+        roots: opts.roots,
+      });
+    });
+  };
+}

--- a/packages/runtime/src/managed-path-rewrite.ts
+++ b/packages/runtime/src/managed-path-rewrite.ts
@@ -1,0 +1,285 @@
+/**
+ * #346 — logical managed-path rewrite for Pi file tools.
+ *
+ * The HTTP Files API maps logical prefixes (`/workspace`, `/data`, …) onto the
+ * durable volume via SessionManager.resolveManagedPath. Pi's built-in write/
+ * edit/bash tools do NOT: absolute `/workspace` lands on the container
+ * writable layer and vanishes on idle docker stop.
+ *
+ * These pure helpers mirror resolveManagedPath for agent tool args so the two
+ * channels agree. Wired through the managed-path-guard Pi extension.
+ */
+import { isAbsolute, normalize, relative, resolve, sep } from "node:path";
+
+export interface ManagedPathRoots {
+  /** Session workspace (agent cwd): `<dataRoot>/workspaces/<sid>/`. */
+  cwd: string;
+  /** Persistent cross-session library: `<dataRoot>/data/`. */
+  persistentDir: string;
+  /** Optional cross-user read-only shared root (`BP_SHARED_DIR`). */
+  sharedDir?: string;
+  /** Hidden attachments subdir name under cwd. Default `.attachments`. */
+  attachmentsDirname?: string;
+}
+
+export type ManagedRootKind = "workspace" | "data" | "attachments" | "shared" | "other";
+
+export type RewriteOk = {
+  ok: true;
+  /** Path to put back into the tool arg (relative under cwd when possible). */
+  path: string;
+  rewritten: boolean;
+  root: ManagedRootKind;
+  /** Absolute resolved path (for confinement checks). */
+  abs: string;
+};
+
+export type RewriteErr = { ok: false; error: string };
+
+export type RewriteResult = RewriteOk | RewriteErr;
+
+const ATTACHMENTS_DEFAULT = ".attachments";
+
+/** Stable deny message when a write/edit targets non-durable storage. */
+export function denyEphemeralWriteReason(rawPath: string): string {
+  return (
+    `Refusing write outside durable storage (${rawPath}). ` +
+    `Use a relative path (cwd is the session workspace) or the persistent library path. ` +
+    `Absolute /workspace is rewritten to the session workspace; other container paths ` +
+    `are not persisted across sandbox recycle.`
+  );
+}
+
+export function denySharedWriteReason(rawPath: string): string {
+  return `shared root is read-only: ${rawPath}`;
+}
+
+export function denyPathEscapeReason(label: string, rawPath: string): string {
+  return `path escapes ${label}: ${rawPath}`;
+}
+
+/** True when `abs` is exactly `root` or a path under it (segment boundary). */
+export function isUnderRoot(abs: string, root: string): boolean {
+  if (!abs || !root) return false;
+  const base = normalize(resolve(root));
+  const target = normalize(resolve(abs));
+  if (target === base) return true;
+  const prefix = base.endsWith(sep) ? base : base + sep;
+  return target.startsWith(prefix);
+}
+
+function posixJoinRoot(rootAbs: string, rel: string): string {
+  const clean = rel.replace(/^\/+/, "");
+  return clean ? resolve(rootAbs, clean) : resolve(rootAbs);
+}
+
+/**
+ * Prefer a cwd-relative path when the target lives under the session workspace
+ * (cleaner tool results; teaches the model to stay relative). Otherwise return
+ * the absolute path (persistent / shared roots match persona-injected abs paths).
+ */
+function displayPath(abs: string, roots: ManagedPathRoots, kind: ManagedRootKind): string {
+  if (kind === "workspace" || kind === "attachments") {
+    const rel = relative(resolve(roots.cwd), abs);
+    if (rel === "") return ".";
+    // relative() can still produce `..` escapes on weird inputs; fall back to abs.
+    if (!rel.startsWith(`..${sep}`) && rel !== ".." && !isAbsolute(rel)) {
+      return rel.split(sep).join("/");
+    }
+  }
+  return abs;
+}
+
+function classifyAbs(abs: string, roots: ManagedPathRoots): ManagedRootKind {
+  if (isUnderRoot(abs, roots.cwd)) {
+    const att = resolve(roots.cwd, roots.attachmentsDirname ?? ATTACHMENTS_DEFAULT);
+    if (isUnderRoot(abs, att)) return "attachments";
+    return "workspace";
+  }
+  if (isUnderRoot(abs, roots.persistentDir)) return "data";
+  if (roots.sharedDir && isUnderRoot(abs, roots.sharedDir)) return "shared";
+  return "other";
+}
+
+/**
+ * Rewrite a tool path argument that uses a logical managed prefix onto the
+ * real durable root. Non-logical paths (relative or real abs) pass through
+ * unchanged (still classified for confinement).
+ */
+export function rewriteLogicalPath(raw: string, roots: ManagedPathRoots): RewriteResult {
+  if (typeof raw !== "string") {
+    return { ok: false, error: denyPathEscapeReason("workspace", String(raw)) };
+  }
+  const original = raw;
+  // Cross-platform: accept `\` the way resolveManagedPath does.
+  let p = raw.replace(/\\/g, "/").trim();
+  if (!p) {
+    return {
+      ok: true,
+      path: original,
+      rewritten: false,
+      root: "other",
+      abs: resolve(roots.cwd),
+    };
+  }
+
+  const cwdAbs = resolve(roots.cwd);
+  const dataAbs = resolve(roots.persistentDir);
+  const attName = roots.attachmentsDirname ?? ATTACHMENTS_DEFAULT;
+  const attAbs = resolve(cwdAbs, attName);
+
+  let rootAbs: string;
+  let kind: ManagedRootKind;
+  let rel: string;
+  let logical = false;
+
+  if (p === "/data" || p.startsWith("/data/")) {
+    rootAbs = dataAbs;
+    kind = "data";
+    rel = p === "/data" ? "" : p.slice("/data/".length);
+    logical = true;
+  } else if (p === "/attachments" || p.startsWith("/attachments/")) {
+    rootAbs = attAbs;
+    kind = "attachments";
+    rel = p === "/attachments" ? "" : p.slice("/attachments/".length);
+    logical = true;
+  } else if (roots.sharedDir && (p === "/shared" || p.startsWith("/shared/"))) {
+    rootAbs = resolve(roots.sharedDir);
+    kind = "shared";
+    rel = p === "/shared" ? "" : p.slice("/shared/".length);
+    logical = true;
+  } else if (p === "/workspace" || p.startsWith("/workspace/")) {
+    rootAbs = cwdAbs;
+    kind = "workspace";
+    rel = p === "/workspace" ? "" : p.slice("/workspace/".length);
+    logical = true;
+  } else {
+    const abs = normalize(isAbsolute(p) ? resolve(p) : resolve(cwdAbs, p));
+    const classified = classifyAbs(abs, roots);
+    return {
+      ok: true,
+      path: p,
+      rewritten: false,
+      root: classified,
+      abs,
+    };
+  }
+
+  rel = rel.replace(/\\/g, "/").replace(/^\/+/, "");
+  const abs = normalize(posixJoinRoot(rootAbs, rel));
+  if (!isUnderRoot(abs, rootAbs)) {
+    const label =
+      kind === "data"
+        ? "data root"
+        : kind === "attachments"
+          ? "attachments"
+          : kind === "shared"
+            ? "shared root"
+            : "workspace";
+    return { ok: false, error: denyPathEscapeReason(label, original) };
+  }
+
+  return {
+    ok: true,
+    path: displayPath(abs, roots, kind),
+    rewritten: logical,
+    root: kind,
+    abs,
+  };
+}
+
+/**
+ * write/edit may only land under the session workspace or the persistent
+ * library. The cross-user shared root is read-only (HTTP assertWritable parity).
+ * Returns a reason string when denied, or null when allowed.
+ */
+export function denyWriteOutsideDurable(
+  pathOrAbs: string,
+  roots: ManagedPathRoots,
+  rawForMessage?: string,
+): string | null {
+  const r = rewriteLogicalPath(pathOrAbs, roots);
+  if (!r.ok) return r.error;
+  const msgPath = rawForMessage ?? pathOrAbs;
+  if (r.root === "shared") return denySharedWriteReason(msgPath);
+  if (r.root === "workspace" || r.root === "attachments" || r.root === "data") {
+    return null;
+  }
+  return denyEphemeralWriteReason(msgPath);
+}
+
+/**
+ * Best-effort rewrite of absolute `/workspace` tokens inside a bash command so
+ * `mkdir -p /workspace/foo` and `cd /workspace/foo` land on the session cwd.
+ * Not a shell parser — `$var` expansion can still bypass; structured tools are
+ * the hard guarantee.
+ */
+export function rewriteBashWorkspacePaths(
+  command: string,
+  cwd: string,
+): { command: string; rewritten: boolean } {
+  if (!command) return { command, rewritten: false };
+  const cwdPosix = resolve(cwd).split(sep).join("/");
+  // Path-boundary match: do not rewrite `/workspace_backup` or `my/workspace`.
+  // Lookbehind-ish via capturing the preceding delimiter.
+  let rewritten = false;
+  const next = command.replace(
+    /(^|[\s"'`=])\/workspace(?=\/|[\s"'`]|$)/g,
+    (_m, pre: string) => {
+      rewritten = true;
+      return `${pre}${cwdPosix}`;
+    },
+  );
+  return { command: next, rewritten };
+}
+
+const PATH_KEYS = ["path", "file_path", "filePath"] as const;
+
+/**
+ * Apply rewrite (+ write confinement for write/edit) to a Pi tool_call input
+ * object in place. Returns `{ block, reason }` when the call must be denied.
+ */
+export function applyManagedPathToolCall(opts: {
+  toolName: string;
+  input: Record<string, unknown> | null | undefined;
+  roots: ManagedPathRoots;
+}): { block: true; reason: string } | void {
+  const { toolName, roots } = opts;
+  const input = opts.input;
+  if (!input || typeof input !== "object") return;
+
+  const name = toolName.toLowerCase();
+
+  if (name === "bash") {
+    const command = typeof input.command === "string" ? input.command : "";
+    if (command) {
+      const r = rewriteBashWorkspacePaths(command, roots.cwd);
+      if (r.rewritten) input.command = r.command;
+    }
+    return;
+  }
+
+  // Tools that never carry a filesystem path for this guard.
+  if (name === "skill_search") return;
+
+  const mutating = name === "write" || name === "edit";
+
+  for (const key of PATH_KEYS) {
+    const v = input[key];
+    if (typeof v !== "string" || v.trim() === "") continue;
+    const raw = v;
+    const r = rewriteLogicalPath(raw, roots);
+    if (!r.ok) return { block: true, reason: r.error };
+    // Confine mutating tools before mutating the arg, so deny messages keep
+    // the model-facing path the agent actually sent.
+    if (mutating) {
+      if (r.root === "shared") {
+        return { block: true, reason: denySharedWriteReason(raw) };
+      }
+      if (r.root === "other") {
+        return { block: true, reason: denyEphemeralWriteReason(raw) };
+      }
+    }
+    if (r.rewritten) input[key] = r.path;
+  }
+}

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -1710,12 +1710,13 @@ export class SessionManager {
     // unset/empty the factory falls back to Pi's env-based default.
     const providerConfig = await resolveSessionProvider(this.dataRoot, entry.providerRef);
 
+    const sessionCwd = this.workspaceDir(sessionId);
     const session = await this.agentFactory({
       sessionId,
       agentName: name,
       role,
       historyPath: this.historyPath(sessionId, name),
-      cwd: this.workspaceDir(sessionId),
+      cwd: sessionCwd,
       systemTools: agentTools,
       allowedToolNames,
       systemPrompt: await this.loadPersona(
@@ -1725,6 +1726,13 @@ export class SessionManager {
         skillSearchEnabled,
       ),
       skillPaths,
+      // #346: map logical /workspace (and /data, …) onto durable roots so Pi
+      // write/edit/bash do not land on the ephemeral container layer.
+      managedPathRoots: {
+        cwd: sessionCwd,
+        persistentDir: this.persistentDir(),
+        ...(this.sharedDir ? { sharedDir: this.sharedDir } : {}),
+      },
       // #309: when skill_search is off, block generic file tools from the router
       // skill directory (Pi tool_call extension). Always-on skills stay readable.
       blockRouterSkills: !skillSearchEnabled,

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -190,6 +190,18 @@ export type AgentSessionFactory = (params: {
    */
   routerSkillsDir?: string;
   /**
+   * #346: durable roots for logical path rewrite (`/workspace`, `/data`, …).
+   * When set, the real factory registers managed-path-guard so Pi write/edit/
+   * bash map logical prefixes onto the volume instead of the ephemeral
+   * container FS. `cwd` is the session workspace (same as `params.cwd`).
+   * Omitted by the mock factory.
+   */
+  managedPathRoots?: {
+    cwd: string;
+    persistentDir: string;
+    sharedDir?: string;
+  };
+  /**
    * 意图二 fallback (Pi-native hooks): invoked by the trace-reminder extension
    * when an expert was reminded once and STILL did not report back, so the host
    * can write a fallback note into the principal's mailbox (the PI never


### PR DESCRIPTION
## Summary

- Fixes agent writes to absolute `/workspace/...` landing on the **ephemeral container layer** instead of `workspaces/<sid>/` on the volume (data loss after idle reclaim).
- Adds a Pi `tool_call` extension (`managed-path-guard`) that rewrites logical managed prefixes and confines `write`/`edit` to durable roots.
- Mirrors HTTP `resolveManagedPath` semantics for agent tools so Files panel and agent FS agree.

## Changes

| Area | Behavior |
|------|----------|
| `/workspace/*` | → session cwd (prefer relative path) |
| `/data/*` | → `persistentDir` absolute path |
| `/attachments/*` | → `cwd/.attachments/` |
| `/shared/*` | → `sharedDir` when configured; writes denied |
| `write`/`edit` outside durable roots | blocked with a clear error |
| `bash` | best-effort rewrite of path-bounded `/workspace` tokens |

Registration order: managed-path-guard **before** router-skill-guard (#309) so path denies see post-rewrite paths.

## Test plan

- [x] Unit tests: `managed-path-rewrite`, `managed-path-guard`
- [x] Wiring: `two-skill-paths` asserts `managedPathRoots` on factory params
- [x] Full `@brainpilot/runtime` suite (432) + typecheck
- [ ] Manual / cloud: agent `write` to `/workspace/foo.txt` appears under Files `path=/workspace`
- [ ] Manual: two sessions writing `/workspace/x` do not clobber each other
- [ ] Manual: after sandbox stop/wake with only `BP_DATA_DIR` volume, file still present

Closes #346