### PR TITLE
chore: prepare repository for public access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches: [main, testbed]
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,14 @@
+# Keep public contributor summaries stable without rewriting signed release
+# history. The original commit objects remain unchanged.
+GTC2333 <145904505+GTC2333@users.noreply.github.com> <2837314566@qq.com>
+GTC2333 <145904505+GTC2333@users.noreply.github.com> <GTC2333@users.noreply.github.com>
+GTC2333 <145904505+GTC2333@users.noreply.github.com> <gtc2333@users.noreply.github.com>
+GTC2333 <145904505+GTC2333@users.noreply.github.com> <gtc2333@example.com>
+GTC2333 <145904505+GTC2333@users.noreply.github.com> <203295868+GTC2333@users.noreply.github.com>
+GTC2333 <145904505+GTC2333@users.noreply.github.com> GTC <145904505+GTC2333@users.noreply.github.com>
+Haoxuan Li <HaoxuanLiTHUAI@users.noreply.github.com> <hx-li25@mails.tsinghua.edu.cn>
+Jianhe Li <160411765+bondingelectron@users.noreply.github.com> <bondingelectron@qq.com>
+Jianhe Li <160411765+bondingelectron@users.noreply.github.com> <bondingelectron@users.noreply.github.com>
+Jianhe Li <160411765+bondingelectron@users.noreply.github.com> bondingelectron <160411765+bondingelectron@users.noreply.github.com>
+lucasli1015 <lucasli1015@users.noreply.github.com> <lucaslibhu@gmail.com>
+Yang Fan <147404690+Fxde42@users.noreply.github.com> <fxde42@gmail.com>


### PR DESCRIPTION
## Summary
- add `.mailmap` aliases so contributor summaries use GitHub noreply identities without rewriting history
- give public pull-request CI explicit read-only permissions

## Scope
- no README or runtime changes
- no Git history rewrite

## Verification
- workflow YAML parses successfully
- `git diff --check`