### PR TITLE
fix(web): render LaTeX and recover collapsed Markdown tables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -374,6 +374,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1544,6 +1545,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
       "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2397,6 +2399,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2410,6 +2413,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2423,6 +2427,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2436,6 +2441,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2449,6 +2455,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2462,6 +2469,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2475,6 +2483,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2488,6 +2497,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2501,6 +2511,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2514,6 +2525,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2527,6 +2539,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2540,6 +2553,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2553,6 +2567,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2566,6 +2581,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2579,6 +2595,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2592,6 +2609,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2605,6 +2623,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2618,6 +2637,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2631,6 +2651,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2644,6 +2665,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2657,6 +2679,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2670,6 +2693,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2683,6 +2707,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2696,6 +2721,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2709,6 +2735,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2877,6 +2904,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2893,6 +2921,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2909,6 +2938,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2925,6 +2955,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2941,6 +2972,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2957,6 +2989,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2973,6 +3006,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2989,6 +3023,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3005,6 +3040,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3029,6 +3065,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3050,6 +3087,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3066,6 +3104,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3093,6 +3132,7 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3217,6 +3257,13 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/katex": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+      "integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/mdast": {
       "version": "4.0.4",
@@ -4816,6 +4863,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -4948,6 +4996,58 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
+      "integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/hast-util-from-parse5": {
@@ -5382,7 +5482,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
       "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -5464,11 +5564,38 @@
         "node": ">=6"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.47",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+      "dev": true,
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/lightningcss": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -5501,11 +5628,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5521,11 +5650,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5541,11 +5672,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5561,11 +5694,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5581,11 +5716,13 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5601,11 +5738,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5621,11 +5760,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5641,11 +5782,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5661,11 +5804,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5681,11 +5826,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5701,11 +5848,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -5975,6 +6124,26 @@
         "devlop": "^1.0.0",
         "mdast-util-from-markdown": "^2.0.0",
         "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -6328,6 +6497,26 @@
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
@@ -7561,6 +7750,26 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rehype-katex": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
+      "integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/katex": "^0.16.0",
+        "hast-util-from-html-isomorphic": "^2.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "katex": "^0.16.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-raw": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
@@ -7618,6 +7827,23 @@
         "micromark-extension-gfm": "^3.0.0",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+      "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-math": "^3.0.0",
         "unified": "^11.0.0"
       },
       "funding": {
@@ -8392,7 +8618,7 @@
       "version": "4.22.4",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.28.0"
@@ -8856,6 +9082,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8872,6 +9099,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8888,6 +9116,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8904,6 +9133,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8920,6 +9150,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8936,6 +9167,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8952,6 +9184,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8968,6 +9201,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8984,6 +9218,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9000,6 +9235,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9016,6 +9252,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9032,6 +9269,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9048,6 +9286,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9064,6 +9303,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9080,6 +9320,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9096,6 +9337,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9112,6 +9354,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9128,6 +9371,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9144,6 +9388,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9160,6 +9405,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9176,6 +9422,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9192,6 +9439,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9208,6 +9456,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9224,6 +9473,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9240,6 +9490,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9256,6 +9507,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12046,12 +12298,15 @@
         "@xterm/xterm": "^6.0.0",
         "highlight.js": "^11.11.1",
         "html-to-image": "^1.11.13",
+        "katex": "^0.16.47",
         "lucide-react": "^0.468.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^10.1.0",
         "rehype-highlight": "^7.0.2",
+        "rehype-katex": "^7.0.1",
         "remark-gfm": "^4.0.1",
+        "remark-math": "^6.0.0",
         "typescript": "^5.6.3",
         "vite": "^6.0.0"
       },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -41,12 +41,15 @@
     "@xterm/xterm": "^6.0.0",
     "highlight.js": "^11.11.1",
     "html-to-image": "^1.11.13",
+    "katex": "^0.16.47",
     "lucide-react": "^0.468.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",
     "rehype-highlight": "^7.0.2",
+    "rehype-katex": "^7.0.1",
     "remark-gfm": "^4.0.1",
+    "remark-math": "^6.0.0",
     "typescript": "^5.6.3",
     "vite": "^6.0.0"
   }

--- a/packages/web/src/__tests__/MarkdownMessage.test.tsx
+++ b/packages/web/src/__tests__/MarkdownMessage.test.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { MarkdownMessage } from "../components/chat/MarkdownMessage";
+import {
+  normalizeMarkdownTables,
+  protectCurrencyDollars,
+} from "../components/chat/normalizeMarkdown";
+
+describe("MarkdownMessage", () => {
+  it("renders inline and display LaTeX with KaTeX", () => {
+    const html = render("Inline: $E = mc^2$\n\n$$\n\\sum_{i=1}^{n} i\n$$");
+
+    expect(html).toContain('class="katex"');
+    expect(html).toContain('class="katex-display"');
+    expect(html).toContain('encoding="application/x-tex">E = mc^2</annotation>');
+    expect(html).toContain("\\sum_{i=1}^{n} i</annotation>");
+  });
+
+  it("leaves LaTeX delimiters inside code untouched", () => {
+    const html = render("`$E = mc^2$`\n\n```tex\n$E = mc^2$\n```");
+
+    expect(html).not.toContain('class="katex"');
+    expect(html).toContain("$E = mc^2$");
+  });
+
+  it("renders a collapsed model-generated table", () => {
+    const html = render(
+      "| 数据集 | 被试数 | 通道数 | 类别 | 采样率 | 试次/类 | 说明 ||------------|------------|------------|------------|------------|------------| **BCI III IVa** | 5 | 118 | 右手 vs 脚（2类） | 100 Hz | 140 | 全头蒙太奇 |",
+    );
+
+    expect(html).toContain("<table>");
+    expect(html).toContain("<th>数据集</th>");
+    expect(html).toContain("<strong>BCI III IVa</strong>");
+    expect(html).toContain("<td>全头蒙太奇</td>");
+  });
+
+  it("preserves existing GFM features", () => {
+    const html = render("[link](https://example.com)\n\n~~removed~~\n\n```ts\nconst x = 1;\n```");
+
+    expect(html).toContain('<a href="https://example.com">link</a>');
+    expect(html).toContain("<del>removed</del>");
+    expect(html).toContain("hljs-keyword");
+  });
+});
+
+describe("normalizeMarkdownTables", () => {
+  it("leaves valid multiline tables unchanged", () => {
+    const markdown = "| A | B |\n|---|---|\n| 1 | 2 |";
+    expect(normalizeMarkdownTables(markdown)).toBe(markdown);
+  });
+
+  it("recovers multiple collapsed rows", () => {
+    expect(normalizeMarkdownTables("| A | B ||---|---| 1 | 2 || 3 | 4 |")).toBe(
+      "| A | B |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |",
+    );
+  });
+
+  it("does not split escaped pipes, inline code, or fenced code", () => {
+    expect(normalizeMarkdownTables("| A | B ||---|---| left \\| right | `x|y` |")).toBe(
+      "| A | B |\n| --- | --- |\n| left \\| right | `x|y` |",
+    );
+
+    const fenced = "```md\n| A | B ||---|---| 1 | 2 |\n```";
+    expect(normalizeMarkdownTables(fenced)).toBe(fenced);
+  });
+
+  it("leaves ambiguous pipe-delimited prose untouched", () => {
+    const prose = "Compare A | B ||---|---| without treating this as a table.";
+    expect(normalizeMarkdownTables(prose)).toBe(prose);
+  });
+});
+
+describe("protectCurrencyDollars", () => {
+  it("protects paired prices without changing numeric math", () => {
+    expect(protectCurrencyDollars("Costs $5 and $10 today; math is $5$."))
+      .toBe("Costs \\$5 and \\$10 today; math is $5$.");
+  });
+
+  it("does not alter currency-like text inside code", () => {
+    expect(protectCurrencyDollars("`Costs $5 and $10`"))
+      .toBe("`Costs $5 and $10`");
+  });
+
+  it("handles surrogate pairs before currency markers", () => {
+    expect(protectCurrencyDollars("🧠 costs $5 or $10"))
+      .toBe("🧠 costs \\$5 or \\$10");
+  });
+});
+
+function render(content: string): string {
+  return renderToStaticMarkup(<MarkdownMessage content={content} />);
+}

--- a/packages/web/src/components/chat/MarkdownMessage.tsx
+++ b/packages/web/src/components/chat/MarkdownMessage.tsx
@@ -1,17 +1,25 @@
 import { memo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
 import rehypeHighlight from "rehype-highlight";
+import rehypeKatex from "rehype-katex";
+import { normalizeMarkdownForRendering } from "./normalizeMarkdown";
 
 interface MarkdownMessageProps {
   content: string;
 }
 
 function MarkdownMessageImpl({ content }: MarkdownMessageProps) {
+  const normalizedContent = normalizeMarkdownForRendering(content);
+
   return (
     <div className="message-card__content">
-      <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeHighlight]}>
-        {content}
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm, [remarkMath, { singleDollarTextMath: true }]]}
+        rehypePlugins={[rehypeHighlight, rehypeKatex]}
+      >
+        {normalizedContent}
       </ReactMarkdown>
     </div>
   );
@@ -21,4 +29,3 @@ function MarkdownMessageImpl({ content }: MarkdownMessageProps) {
 // component changing) don't re-parse markdown for every visible message —
 // `content` is a string so default shallow-equal compare is precise.
 export const MarkdownMessage = memo(MarkdownMessageImpl);
-

--- a/packages/web/src/components/chat/normalizeMarkdown.ts
+++ b/packages/web/src/components/chat/normalizeMarkdown.ts
@@ -1,0 +1,228 @@
+/**
+ * Rendering-only repairs for common model-generated Markdown damage.
+ *
+ * Keep these transforms deliberately conservative: the original message is
+ * still the source of truth, and ambiguous prose must remain untouched.
+ */
+
+interface FenceState {
+  marker: "`" | "~";
+  length: number;
+}
+
+const fencePattern = /^( {0,3})(`{3,}|~{3,})/;
+const tableDelimiterPattern = /^:?-{3,}:?$/;
+
+/**
+ * Repair tables whose row breaks were removed, for example:
+ * `| A | B ||---|---| 1 | 2 |`.
+ *
+ * Structural pipes inside inline code or escaped as `\|` are ignored. A line
+ * is changed only when it starts and ends like a table, has at least two
+ * headers, contains a delimiter run, and has complete body rows.
+ */
+export function normalizeMarkdownTables(markdown: string): string {
+  let fence: FenceState | null = null;
+
+  return markdown
+    .split("\n")
+    .map((line) => {
+      const fenceMatch = line.match(fencePattern);
+      if (fenceMatch) {
+        const markers = fenceMatch[2]!;
+        const marker = markers[0] as "`" | "~";
+
+        if (!fence) {
+          fence = { marker, length: markers.length };
+        } else if (
+          fence.marker === marker &&
+          markers.length >= fence.length &&
+          line.slice(fenceMatch[0].length).trim() === ""
+        ) {
+          fence = null;
+        }
+        return line;
+      }
+
+      return fence ? line : repairCollapsedTableLine(line);
+    })
+    .join("\n");
+}
+
+/**
+ * Single-dollar math is conventional in scientific Markdown, but two prices
+ * in one sentence (`$5 and $10`) otherwise look like one math span. Escape the
+ * common unambiguous currency pair while leaving real `$5$` math untouched.
+ */
+export function protectCurrencyDollars(markdown: string): string {
+  let fence: FenceState | null = null;
+
+  return markdown
+    .split("\n")
+    .map((line) => {
+      const fenceMatch = line.match(fencePattern);
+      if (fenceMatch) {
+        const markers = fenceMatch[2]!;
+        const marker = markers[0] as "`" | "~";
+
+        if (!fence) {
+          fence = { marker, length: markers.length };
+        } else if (
+          fence.marker === marker &&
+          markers.length >= fence.length &&
+          line.slice(fenceMatch[0].length).trim() === ""
+        ) {
+          fence = null;
+        }
+        return line;
+      }
+
+      return fence ? line : protectCurrencyPairsInLine(line);
+    })
+    .join("\n");
+}
+
+export function normalizeMarkdownForRendering(markdown: string): string {
+  return protectCurrencyDollars(normalizeMarkdownTables(markdown));
+}
+
+function repairCollapsedTableLine(line: string): string {
+  const indentation = line.match(/^ */)?.[0] ?? "";
+  const trimmed = line.trim();
+  if (indentation.length > 3 || !trimmed.startsWith("|") || !trimmed.endsWith("|")) {
+    return line;
+  }
+
+  const parts = splitOnStructuralPipes(trimmed);
+  if (parts.length < 7 || parts[0] !== "" || parts.at(-1) !== "") {
+    return line;
+  }
+
+  let delimiterStart = -1;
+  let delimiterEnd = -1;
+  for (let index = 1; index < parts.length - 1; index += 1) {
+    if (!tableDelimiterPattern.test(parts[index]!.trim())) continue;
+
+    let end = index;
+    while (end + 1 < parts.length - 1 && tableDelimiterPattern.test(parts[end + 1]!.trim())) {
+      end += 1;
+    }
+    if (end - index + 1 >= 2) {
+      delimiterStart = index;
+      delimiterEnd = end;
+      break;
+    }
+    index = end;
+  }
+
+  if (delimiterStart < 0) return line;
+
+  const header = trimBoundaryEmptyParts(parts.slice(1, delimiterStart));
+  const body = trimBoundaryEmptyParts(parts.slice(delimiterEnd + 1, -1));
+  if (header.length < 2 || body.length < header.length) return line;
+
+  const rows = splitBodyRows(body, header.length);
+  if (!rows) return line;
+
+  const delimiters = parts.slice(delimiterStart, delimiterEnd + 1).map((part) => part.trim());
+  const normalizedDelimiters =
+    delimiters.length === header.length ? delimiters : Array<string>(header.length).fill("---");
+
+  return [header, normalizedDelimiters, ...rows]
+    .map((cells) => `${indentation}| ${cells.map((cell) => cell.trim()).join(" | ")} |`)
+    .join("\n");
+}
+
+function splitBodyRows(parts: string[], columnCount: number): string[][] | null {
+  const rows: string[][] = [];
+  let current: string[] = [];
+
+  for (const part of parts) {
+    if (part.trim() === "") {
+      if (current.length === 0) continue;
+      if (current.length !== columnCount) return null;
+      rows.push(current);
+      current = [];
+      continue;
+    }
+
+    current.push(part);
+    if (current.length === columnCount) {
+      rows.push(current);
+      current = [];
+    }
+  }
+
+  return current.length === 0 && rows.length > 0 ? rows : null;
+}
+
+function trimBoundaryEmptyParts(parts: string[]): string[] {
+  let start = 0;
+  let end = parts.length;
+  while (start < end && parts[start]!.trim() === "") start += 1;
+  while (end > start && parts[end - 1]!.trim() === "") end -= 1;
+  return parts.slice(start, end);
+}
+
+function splitOnStructuralPipes(value: string): string[] {
+  const positions = structuralDelimiterPositions(value, "|");
+  const parts: string[] = [];
+  let start = 0;
+  for (const position of positions) {
+    parts.push(value.slice(start, position));
+    start = position + 1;
+  }
+  parts.push(value.slice(start));
+  return parts;
+}
+
+function protectCurrencyPairsInLine(line: string): string {
+  const dollars = structuralDelimiterPositions(line, "$");
+  if (dollars.length < 2) return line;
+
+  const escaped = new Set<number>();
+  for (let index = 0; index < dollars.length - 1; index += 1) {
+    const opening = dollars[index]!;
+    const closing = dollars[index + 1]!;
+    if (/\d/.test(line[opening + 1] ?? "") && /\d/.test(line[closing + 1] ?? "")) {
+      escaped.add(opening);
+      escaped.add(closing);
+      index += 1;
+    }
+  }
+
+  if (escaped.size === 0) return line;
+  let result = "";
+  for (let index = 0; index < line.length; index += 1) {
+    result += escaped.has(index) ? `\\${line[index]}` : line[index];
+  }
+  return result;
+}
+
+/** Return unescaped delimiter positions outside inline code spans. */
+function structuralDelimiterPositions(value: string, delimiter: "|" | "$"): number[] {
+  const positions: number[] = [];
+  let inlineCodeTicks = 0;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index]!;
+    if (character === "\\") {
+      index += 1;
+      continue;
+    }
+
+    if (character === "`") {
+      let end = index + 1;
+      while (value[end] === "`") end += 1;
+      const tickCount = end - index;
+      if (inlineCodeTicks === 0) inlineCodeTicks = tickCount;
+      else if (inlineCodeTicks === tickCount) inlineCodeTicks = 0;
+      index = end - 1;
+      continue;
+    }
+
+    if (inlineCodeTicks === 0 && character === delimiter) positions.push(index);
+  }
+
+  return positions;
+}

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import { App } from "./App";
 import "@fontsource-variable/geist";
 import "@fontsource-variable/geist-mono";
+import "katex/dist/katex.min.css";
 import "./styles/tokens.css";
 import "./styles/global.css";
 

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -3542,6 +3542,18 @@ button {
   border-radius: var(--radius-sm);
 }
 
+.message-card__content .katex-display {
+  max-width: 100%;
+  margin: 0.8em 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  padding-block: 0.15em;
+}
+
+.message-card__content .katex {
+  color: inherit;
+}
+
 /* Syntax highlighting */
 .message-card__content .hljs-keyword {
   color: var(--color-code-keyword);


### PR DESCRIPTION
## Summary

Render inline/display LaTeX in shared Markdown views and conservatively recover model-generated GFM tables whose row breaks were collapsed.

## Related Issues

Fixes #376
Fixes #385

## Changes

- add `remark-math`, `rehype-katex`, and KaTeX styles for chat, step, and Markdown file preview rendering
- protect common paired currency expressions while preserving single-dollar scientific math
- normalize only strongly identified collapsed tables, respecting fenced code, inline code, escaped pipes, and complete row boundaries
- make long display equations horizontally scrollable
- add focused SSR and normalization regressions for math, tables, currency, code, and existing GFM behavior

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] New skill (added under `packages/skills-mcp/skills/`)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### How to test

1. Render `$E = mc^2$` and a multiline `$$...$$` expression in chat or a Markdown preview.
2. Render the collapsed table reproduction from #376 and verify it becomes a table.
3. Verify fenced/inline code remains literal and long equations scroll instead of widening the layout.

### What you personally verified

- all 409 Web tests pass, including 11 new focused regressions
- production Web TypeScript/Vite build passes
- standard GFM links, strikethrough, syntax highlighting, valid tables, escaped pipes, currency pairs, and code fences remain covered
- no browser screenshot was captured; rendering was verified through static markup tests and the production build

### Checks

- [ ] `npm run typecheck` passes
- [ ] `BP_MOCK=1 npx vitest run` passes
- [x] Web build passes (`cd packages/web && npm test && npm run build`) — if web changed
- [ ] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] This PR is AI-assisted, and I have self-reviewed the generated code (see CONTRIBUTING.md)
- [x] My code follows the project style
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings