### PR TITLE
feat(plugins): add range-backed preview host

### DIFF
--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -10,7 +10,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "plugins"
   ],
   "repository": {
     "type": "git",

--- a/packages/backend-core/plugins/nifti-viewer/0.1.0/manifest.json
+++ b/packages/backend-core/plugins/nifti-viewer/0.1.0/manifest.json
@@ -1,0 +1,23 @@
+{
+  "id": "org.brainpilot.nifti-viewer",
+  "version": "0.1.0",
+  "apiVersion": "1",
+  "displayName": "Neuroscience Data Viewer",
+  "description": "Read-only metadata and central axial slice previews for uncompressed NIfTI-1 neuroimaging files.",
+  "categories": ["visualization"],
+  "kind": "previewer",
+  "engines": { "brainpilot": ">=0.1.2 <0.2.0" },
+  "protocols": { "preview": "1" },
+  "environments": ["local", "cloud", "browser"],
+  "permissions": ["read:workspace"],
+  "contributes": {
+    "previewers": [{
+      "id": "nifti-central-slice",
+      "match": { "extensions": [".nii"] },
+      "priority": 100,
+      "mode": "readonly",
+      "delivery": "range",
+      "entry": "ui/index.html"
+    }]
+  }
+}

--- a/packages/backend-core/plugins/nifti-viewer/0.1.0/ui/index.html
+++ b/packages/backend-core/plugins/nifti-viewer/0.1.0/ui/index.html
@@ -1,0 +1,142 @@
+<!doctype html>
+<html lang="en">
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<style>
+  :root { color-scheme: light dark; font: 13px system-ui,sans-serif; }
+  body { margin:0; padding:16px; color:CanvasText; background:Canvas; }
+  h1 { margin:0; font-size:16px; } #status { color:GrayText; }
+  #error { color:#d92d20; white-space:pre-wrap; }
+  #result[hidden] { display:none; }
+  canvas { display:block; width:min(100%,720px); height:auto; margin:14px auto; background:#111; }
+  dl { display:grid; grid-template-columns:max-content 1fr; gap:6px 14px; }
+  dt { color:GrayText; } dd { margin:0; overflow-wrap:anywhere; }
+  #note { padding:10px; border-left:3px solid #b88900; background:color-mix(in srgb,CanvasText 6%,transparent); line-height:1.45; }
+</style>
+<h1>Neuroscience Data Viewer</h1>
+<p id="status">Waiting for file…</p>
+<p id="error" role="alert"></p>
+<section id="result" hidden><canvas id="slice"></canvas><dl id="metadata"></dl><p id="note"></p></section>
+<script>
+(() => {
+  const token = decodeURIComponent(location.hash.slice(1));
+  const status = document.querySelector("#status");
+  const error = document.querySelector("#error");
+  const result = document.querySelector("#result");
+  const canvas = document.querySelector("#slice");
+  const metadata = document.querySelector("#metadata");
+  let openRequestId = "";
+  let header = null;
+
+  const fail = (message, requestId = openRequestId) => {
+    status.textContent = "Preview failed";
+    error.textContent = message;
+    parent.postMessage({ type:"preview/error", rpcVersion:"1", token, requestId, message }, "*");
+  };
+  const requestRange = (requestId, offset, length) => {
+    parent.postMessage({ type:"preview/read-range", rpcVersion:"1", token, requestId, handle:"primary", offset, length }, "*");
+  };
+  const rows = (entries) => metadata.replaceChildren(...entries.flatMap(([key,value]) => {
+    const dt=document.createElement("dt"), dd=document.createElement("dd");
+    dt.textContent=key; dd.textContent=String(value); return [dt,dd];
+  }));
+  const readVoxel = (view, at, datatype, little) => {
+    if (datatype===2) return view.getUint8(at);
+    if (datatype===4) return view.getInt16(at,little);
+    if (datatype===8) return view.getInt32(at,little);
+    if (datatype===16) return view.getFloat32(at,little);
+    if (datatype===64) return view.getFloat64(at,little);
+    if (datatype===256) return view.getInt8(at);
+    if (datatype===512) return view.getUint16(at,little);
+    if (datatype===768) return view.getUint32(at,little);
+    return NaN;
+  };
+  const bytesByType = {2:1,4:2,8:4,16:4,64:8,256:1,512:2,768:4};
+  const namesByType = {2:"uint8",4:"int16",8:"int32",16:"float32",64:"float64",256:"int8",512:"uint16",768:"uint32"};
+
+  addEventListener("message", (event) => {
+    const message = event.data;
+    if (event.source !== parent || message?.token !== token || message?.rpcVersion !== "1") return;
+    if (message.type === "preview/initialize") {
+      parent.postMessage({type:"preview/ready",rpcVersion:"1",token}, "*");
+      return;
+    }
+    if (message.type === "preview/open") {
+      openRequestId = message.requestId;
+      error.textContent = "";
+      result.hidden = true;
+      status.textContent = "Reading NIfTI header…";
+      requestRange("nifti-header", 0, 348);
+      return;
+    }
+    if (message.type === "preview/range-error") {
+      fail(message.message);
+      return;
+    }
+    if (message.type !== "preview/range-result") return;
+
+    try {
+      if (message.requestId === "nifti-header") {
+        if (message.buffer.byteLength < 348) throw new Error("File is too small for a NIfTI-1 header.");
+        const view = new DataView(message.buffer);
+        const little = view.getInt32(0,true) === 348;
+        if (!little && view.getInt32(0,false) !== 348) throw new Error("Unsupported NIfTI header. Only NIfTI-1 .nii files are supported.");
+        const magic = new TextDecoder("latin1").decode(new Uint8Array(message.buffer,344,4)).replace(/\0/g,"");
+        if (!magic.startsWith("n+1")) throw new Error("Expected a single-file NIfTI-1 .nii image.");
+        const rank = Math.max(1,Math.min(7,view.getInt16(40,little)));
+        const dims = Array.from({length:rank},(_,index)=>view.getInt16(42+index*2,little));
+        const width=dims[0], height=dims[1], depth=dims[2] || 1;
+        const datatype=view.getInt16(70,little), bytes=bytesByType[datatype];
+        if (!width || !height || !depth || !bytes) throw new Error("Unsupported NIfTI dimensions or datatype.");
+        const voxOffset=Math.max(352,Math.floor(view.getFloat32(108,little)));
+        const sliceIndex=Math.floor(depth/2), sliceBytes=width*height*bytes;
+        if (sliceBytes > 8*1024*1024) throw new Error("The central slice exceeds the 8 MiB preview range limit.");
+        const pixdim=[view.getFloat32(80,little),view.getFloat32(84,little),view.getFloat32(88,little)];
+        header={little,dims,width,height,depth,datatype,bytes,voxOffset,sliceIndex,sliceBytes,pixdim,
+          slope:view.getFloat32(112,little), intercept:view.getFloat32(116,little), totalSize:message.totalSize};
+        const offset=voxOffset+sliceIndex*sliceBytes;
+        if (offset+sliceBytes>message.totalSize) throw new Error("NIfTI voxel data is truncated.");
+        status.textContent = "Reading central axial slice…";
+        requestRange("nifti-slice", offset, sliceBytes);
+        return;
+      }
+      if (message.requestId === "nifti-slice" && header) {
+        if (message.buffer.byteLength !== header.sliceBytes) throw new Error("Central slice range is incomplete.");
+        const view=new DataView(message.buffer), values=[];
+        let min=Infinity,max=-Infinity;
+        for(let i=0;i<header.width*header.height;i++){
+          let value=readVoxel(view,i*header.bytes,header.datatype,header.little);
+          if (header.slope) value=value*header.slope+header.intercept;
+          values.push(value);
+          if(Number.isFinite(value)){min=Math.min(min,value);max=Math.max(max,value);}
+        }
+        const image=canvas.getContext("2d").createImageData(header.width,header.height);
+        canvas.width=header.width; canvas.height=header.height;
+        const span=max>min?max-min:1;
+        values.forEach((value,index)=>{
+          const gray=Math.max(0,Math.min(255,Math.round((value-min)/span*255)));
+          const x=index%header.width, y=Math.floor(index/header.width);
+          const pixel=(x+header.width*(header.height-y-1))*4;
+          image.data[pixel]=image.data[pixel+1]=image.data[pixel+2]=gray; image.data[pixel+3]=255;
+        });
+        canvas.getContext("2d").putImageData(image,0,0);
+        rows([
+          ["Format","NIfTI-1 (.nii)"],
+          ["Dimensions",header.dims.join(" × ")],
+          ["Voxel size",header.pixdim.map(value=>Number(value).toPrecision(4)).join(" × ")+" mm"],
+          ["Datatype",namesByType[header.datatype] || header.datatype],
+          ["Displayed slice","z = "+header.sliceIndex],
+          ["Intensity range",min+" … "+max],
+          ["File size",header.totalSize.toLocaleString()+" bytes"]
+        ]);
+        document.querySelector("#note").textContent="Central axial slice, displayed without orientation transforms. NIfTI-2, compressed .nii.gz, overlays, and time navigation are not included in this first host contract.";
+        result.hidden=false; status.textContent="Read-only preview";
+        parent.postMessage({type:"preview/rendered",rpcVersion:"1",token,requestId:openRequestId,metadata:{format:"nifti-1",slice:header.sliceIndex}}, "*");
+      }
+    } catch (cause) {
+      fail(cause instanceof Error ? cause.message : String(cause));
+    }
+  });
+})();
+</script>
+</html>

--- a/packages/backend-core/src/app.ts
+++ b/packages/backend-core/src/app.ts
@@ -65,11 +65,13 @@ import {
 import { computeKbInventory } from "./kb-inventory.js";
 import {
   installPlugin,
+  listEnabledPreviewers,
   listInstalledPlugins,
   listMarketplace,
   listMarketplaceSourceStatuses,
   listPluginUpdates,
   preflightPluginCompatibility,
+  readEnabledPluginAsset,
   rollbackPlugin,
   setPluginEnabled,
   uninstallPlugin,
@@ -228,7 +230,7 @@ export function createApp(options: CreateAppOptions): Hono {
   // `/sessions/:id/files*` routes. `?path=` is carried through verbatim.
   api.get("/sandbox/:id/files", forward("listFiles", { idParam: "id", withQuery: true }));
   api.get("/sandbox/:id/files/content", forward("readFile", { idParam: "id", withQuery: true }));
-  api.get("/sandbox/:id/files/raw", forward("readRawFile", { idParam: "id", withQuery: true }));
+  api.get("/sandbox/:id/files/raw", forward("readRawFile", { idParam: "id", withQuery: true, withRange: true }));
   api.delete("/sandbox/:id/files", forward("deleteFile", { idParam: "id", withQuery: true }));
   // #47/#256: file upload. A base64 JSON body goes through the buffered
   // `forward` helper; a raw `application/octet-stream` body is streamed to the
@@ -438,6 +440,7 @@ export function createApp(options: CreateAppOptions): Hono {
   api.get("/plugins/sources", async (c) => c.json(await listMarketplaceSourceStatuses(dataDir)));
   api.get("/plugins/installed", async (c) => c.json(await listInstalledPlugins(dataDir)));
   api.get("/plugins/updates", async (c) => c.json(await listPluginUpdates(dataDir)));
+  api.get("/plugins/enabled-previewers", async (c) => c.json(await listEnabledPreviewers(dataDir)));
   api.get("/plugins/compatibility", async (c) => {
     try {
       const version = c.req.query("brainpilotVersion") ?? pkg.version;
@@ -488,6 +491,26 @@ export function createApp(options: CreateAppOptions): Hono {
     return await uninstallPlugin(dataDir, c.req.param("id"))
       ? c.body(null, 204)
       : c.json({ error: "plugin not installed" }, 404);
+  });
+  api.get("/plugins/:id/:version/assets/*", async (c) => {
+    const encodedAsset = c.req.path.split("/assets/")[1] ?? "";
+    let asset: string;
+    try { asset = encodedAsset.split("/").map(decodeURIComponent).join("/"); }
+    catch { return c.json({ error: "invalid plugin asset path" }, 400); }
+    const bytes = await readEnabledPluginAsset(dataDir, c.req.param("id"), c.req.param("version"), asset);
+    if (!bytes) return c.json({ error: "enabled plugin asset not found" }, 404);
+    const extension = asset.split(".").pop()?.toLowerCase();
+    const contentType = extension === "html" ? "text/html; charset=utf-8"
+      : extension === "js" || extension === "mjs" ? "text/javascript; charset=utf-8"
+        : extension === "css" ? "text/css; charset=utf-8"
+          : extension === "json" ? "application/json; charset=utf-8"
+            : extension === "wasm" ? "application/wasm"
+              : "application/octet-stream";
+    c.header("Content-Type", contentType);
+    c.header("Cache-Control", "no-store");
+    c.header("X-Content-Type-Options", "nosniff");
+    if (extension === "html") c.header("Content-Security-Policy", "default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'none'; worker-src 'self' blob:; font-src 'self'; frame-ancestors 'self'");
+    return c.body(bytes as unknown as ArrayBuffer);
   });
 
   // ---- Built-in tool toggles (disk-backed: bp_template/tool_toggles.json) ----
@@ -850,7 +873,7 @@ export function createApp(options: CreateAppOptions): Hono {
 
   function forward(
     route: keyof typeof RUNTIME_ROUTES,
-    opts: { idParam?: string; withBody?: boolean; withQuery?: boolean } = {},
+    opts: { idParam?: string; withBody?: boolean; withQuery?: boolean; withRange?: boolean } = {},
   ) {
     return async (c: import("hono").Context) => {
       const rc = await getClient(c);
@@ -860,6 +883,8 @@ export function createApp(options: CreateAppOptions): Hono {
       const headers: Record<string, string> = {};
       const ct = c.req.header("content-type");
       if (ct) headers["content-type"] = ct;
+      const range = opts.withRange ? c.req.header("range") : undefined;
+      if (range) headers.range = range;
       const query = opts.withQuery ? new URL(c.req.url).search.replace(/^\?/, "") : undefined;
       const upstream = await rc.forward(route, {
         params,

--- a/packages/backend-core/src/index.ts
+++ b/packages/backend-core/src/index.ts
@@ -51,6 +51,7 @@ export type { RuntimeClientOptions, ForwardOptions } from "./runtime-client.js";
 
 export {
   installPlugin,
+  listEnabledPreviewers,
   listInstalledPlugins,
   listMarketplace,
   listMarketplaceSourceStatuses,
@@ -58,6 +59,7 @@ export {
   loadMarketplaceSources,
   pluginsDir,
   preflightPluginCompatibility,
+  readEnabledPluginAsset,
   rollbackPlugin,
   setPluginEnabled,
   uninstallPlugin,

--- a/packages/backend-core/src/plugins.ts
+++ b/packages/backend-core/src/plugins.ts
@@ -19,6 +19,7 @@ import {
   parsePluginManifest,
   parsePublishablePluginManifest,
   type LegacyPluginKind,
+  type EnabledPreviewer,
   type InstalledPlugin,
   type MarketplaceEntry,
   type MarketplaceRelease,
@@ -58,7 +59,15 @@ interface BuiltinPluginRelease {
 // PR4 adds immutable built-in release directories here. Every source directory
 // contains the exact manifest and files for that version; versions are never
 // synthesized by rewriting the current bundle.
-const BUILTIN_PLUGIN_RELEASES: readonly BuiltinPluginRelease[] = [];
+const BUILTIN_PLUGIN_RELEASES: readonly BuiltinPluginRelease[] = [
+  {
+    plugin: "nifti-viewer",
+    source: "nifti-viewer/0.1.0",
+    version: "0.1.0",
+    publishedAt: "2026-08-03T00:00:00.000Z",
+    releaseNotes: "Initial range-backed NIfTI-1 metadata and central axial slice preview.",
+  },
+];
 const TEST_PLUGIN_SOURCES = new Set<string>();
 
 export function pluginsDir(dataDir: string): string {
@@ -605,4 +614,28 @@ export async function uninstallPlugin(dataDir: string, id: string): Promise<bool
     await fs.rm(path.join(pluginsDir(dataDir), "installed", installed.manifest.id), { recursive: true, force: true });
     return true;
   });
+}
+
+export async function listEnabledPreviewers(dataDir: string): Promise<EnabledPreviewer[]> {
+  return (await listInstalledPlugins(dataDir)).flatMap((plugin) =>
+    plugin.enabled && plugin.compatibility?.compatible
+      ? (plugin.manifest.contributes?.previewers ?? []).map((previewer) => ({
+          pluginId: plugin.manifest.id,
+          pluginVersion: plugin.activeVersion,
+          displayName: plugin.manifest.displayName,
+          previewer,
+        }))
+      : [],
+  );
+}
+
+export async function readEnabledPluginAsset(dataDir: string, id: string, version: string, asset: string): Promise<Buffer | null> {
+  const plugin = (await listInstalledPlugins(dataDir)).find((candidate) =>
+    candidate.enabled && candidate.compatibility?.compatible && candidate.manifest.id === id && candidate.activeVersion === version,
+  );
+  if (!plugin || !isSafePluginPath(asset) || asset === "manifest.json") return null;
+  const root = path.resolve(installedVersionPath(dataDir, plugin.manifest));
+  const target = path.resolve(root, asset);
+  if (!target.startsWith(`${root}${path.sep}`)) return null;
+  try { return await fs.readFile(target); } catch { return null; }
 }

--- a/packages/backend-core/test/app.test.ts
+++ b/packages/backend-core/test/app.test.ts
@@ -94,6 +94,18 @@ describe("Hono app — REST forwarding", () => {
     expect(res.status).toBe(201);
   });
 
+  it("forwards byte Range headers and preserves partial-content metadata", async () => {
+    const fetchFn = vi.fn(async (url: string, init: RequestInit) => {
+      expect(url).toBe("http://runtime.test/sessions/s1/files/raw?path=%2Fworkspace%2Fscan.nii");
+      expect((init.headers as Record<string, string>).range).toBe("bytes=0-347");
+      return new Response(new Uint8Array([1, 2]), { status: 206, headers: { "content-range": "bytes 0-1/4096", "content-type": "application/octet-stream" } });
+    });
+    const app = createApp({ orchestrator: fakeOrchestrator(), fetchFn: fetchFn as never, serveWeb: false });
+    const response = await app.request("/api/sandbox/s1/files/raw?path=%2Fworkspace%2Fscan.nii", { headers: { range: "bytes=0-347" } });
+    expect(response.status).toBe(206);
+    expect(response.headers.get("content-range")).toBe("bytes 0-1/4096");
+  });
+
   // #256: a raw octet-stream upload must be streamed to the runtime BYTE-FOR-BYTE
   // (query carried, octet content-type preserved). Routing it through the
   // buffered `text()` forward would UTF-8-decode and corrupt binary payloads.

--- a/packages/backend-core/test/plugins.test.ts
+++ b/packages/backend-core/test/plugins.test.ts
@@ -197,4 +197,29 @@ describe("plugin marketplace control plane", () => {
     const preflight = await preflightResponse.json() as Array<{ compatibility: { compatible: boolean } }>;
     expect(preflight[0]?.compatibility.compatible).toBe(true);
   });
+
+  it("installs and serves the immutable built-in NIfTI previewer only while enabled", async () => {
+    const dataDir = await mkdtemp(path.join(tmpdir(), "bp-plugin-nifti-"));
+    const app = createApp({ orchestrator: orchestrator(), dataDir, serveWeb: false });
+    const id = "org.brainpilot.nifti-viewer";
+    const marketplace = await (await app.request("/api/plugins/marketplace")).json() as Array<{ manifest: { id: string; version: string }; releases: Array<{ version: string }> }>;
+    const entry = marketplace.find((candidate) => candidate.manifest.id === id);
+    expect(entry?.manifest.version).toBe("0.1.0");
+    expect(entry?.releases.map((release) => release.version)).toEqual(["0.1.0"]);
+
+    const asset = `/api/plugins/${id}/0.1.0/assets/ui/index.html`;
+    expect((await app.request(asset)).status).toBe(404);
+    expect((await app.request("/api/plugins/install", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ id }) })).status).toBe(201);
+    expect((await app.request(`/api/plugins/${id}/enabled`, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify({ enabled: true }) })).status).toBe(200);
+
+    const previewers = await (await app.request("/api/plugins/enabled-previewers")).json() as Array<{ pluginId: string; previewer: { delivery: string; match: { extensions: string[] } } }>;
+    expect(previewers).toEqual([expect.objectContaining({ pluginId: id, previewer: expect.objectContaining({ delivery: "range", match: { extensions: [".nii"] } }) })]);
+    const enabledAsset = await app.request(asset);
+    expect(enabledAsset.status).toBe(200);
+    expect(enabledAsset.headers.get("content-security-policy")).toContain("connect-src 'none'");
+    expect(await enabledAsset.text()).toContain("Neuroscience Data Viewer");
+
+    await app.request(`/api/plugins/${id}/enabled`, { method: "PUT", headers: { "content-type": "application/json" }, body: JSON.stringify({ enabled: false }) });
+    expect((await app.request(asset)).status).toBe(404);
+  });
 });

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -19,6 +19,10 @@
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },
+    "./preview": {
+      "types": "./dist/preview.d.ts",
+      "default": "./dist/preview.js"
+    },
     "./node": {
       "types": "./dist/node.d.ts",
       "default": "./dist/node.js"

--- a/packages/plugin-sdk/src/index.ts
+++ b/packages/plugin-sdk/src/index.ts
@@ -1,7 +1,13 @@
 import { compare, satisfies, valid, validRange } from "semver";
+import {
+  PREVIEW_RPC_VERSION,
+  type PreviewerContribution,
+  type PreviewerMatch,
+} from "./preview.js";
+
+export * from "./preview.js";
 
 export const PLUGIN_API_VERSION = "1" as const;
-export const PREVIEW_RPC_VERSION = "1" as const;
 export const AGENT_INSTRUCTIONS_PROTOCOL_VERSION = "1" as const;
 export const KNOWLEDGE_SERVICE_PROTOCOL_VERSION = "1" as const;
 export const LITERATURE_SERVICE_PROTOCOL_VERSION = "1" as const;
@@ -22,29 +28,6 @@ export interface PluginDependency {
   id: string;
   version: string;
   optional?: boolean;
-}
-
-export interface PreviewDatasetRule {
-  kind: "stem-siblings";
-  companions: string[];
-  required?: string[];
-}
-
-export interface PreviewerMatch {
-  extensions?: string[];
-  mimeTypes?: string[];
-  dataset?: string | PreviewDatasetRule;
-}
-
-export interface PreviewerContribution {
-  id: string;
-  match?: PreviewerMatch;
-  /** Legacy v0 form; normalized into match.extensions by parsePluginManifest. */
-  extensions?: string[];
-  priority?: number;
-  mode?: "readonly" | "editable";
-  delivery?: "whole" | "range" | "derived";
-  entry: string;
 }
 
 export interface EntryContribution { id: string; title: string; entry: string; }
@@ -160,30 +143,6 @@ export interface PluginUpdateStatus {
   publishedAt?: string;
 }
 
-export interface PreviewFileDescriptor {
-  name: string;
-  size: number;
-  mime?: string;
-  handle?: string;
-}
-
-/** A host-selected sibling file for a compound dataset (for example BrainVision). */
-export interface PreviewCompanionFile extends PreviewFileDescriptor { buffer?: ArrayBuffer; }
-export interface PreviewDatasetDescriptor { kind: string; primaryHandle: string; members: PreviewFileDescriptor[]; }
-
-export type PreviewHostToPluginMessage =
-  | { type: "preview/initialize"; rpcVersion: typeof PREVIEW_RPC_VERSION; token: string; theme?: "light" | "dark" }
-  | { type: "preview/open"; rpcVersion: typeof PREVIEW_RPC_VERSION; token: string; requestId: string; file: PreviewFileDescriptor; buffer: ArrayBuffer; companions?: PreviewCompanionFile[]; dataset?: PreviewDatasetDescriptor; derived?: unknown }
-  | { type: "preview/range-result"; rpcVersion: typeof PREVIEW_RPC_VERSION; token: string; requestId: string; handle: string; offset: number; totalSize: number; buffer: ArrayBuffer }
-  | { type: "preview/dispose"; rpcVersion: typeof PREVIEW_RPC_VERSION; token: string };
-
-export type PreviewPluginToHostMessage =
-  | { type: "preview/ready"; rpcVersion: typeof PREVIEW_RPC_VERSION; token: string }
-  | { type: "preview/rendered"; rpcVersion: typeof PREVIEW_RPC_VERSION; token: string; requestId: string; metadata?: Record<string, unknown> }
-  | { type: "preview/error"; rpcVersion: typeof PREVIEW_RPC_VERSION; token: string; requestId?: string; message: string }
-  | { type: "preview/resize"; rpcVersion: typeof PREVIEW_RPC_VERSION; token: string; height: number }
-  | { type: "preview/read-range"; rpcVersion: typeof PREVIEW_RPC_VERSION; token: string; requestId: string; handle: string; offset: number; length: number };
-
 export interface KnowledgeServiceCapabilities {
   protocolVersion: typeof KNOWLEDGE_SERVICE_PROTOCOL_VERSION;
   collections?: boolean;
@@ -209,7 +168,6 @@ function stringArray(value: unknown): string[] | null { return Array.isArray(val
 function uniqueIds(values: Array<{ id: string }>): boolean { return new Set(values.map((value) => value.id)).size === values.length; }
 export function isPluginVersion(value: string): boolean { return valid(value) === value; }
 export function isSafePluginPath(value: string): boolean { return Boolean(value) && !value.startsWith("/") && !value.startsWith("\\") && !/^[A-Za-z]:/.test(value) && !value.split(/[\\/]/).includes(".."); }
-export function previewerExtensions(value: PreviewerContribution): string[] { return value.match?.extensions ?? value.extensions ?? []; }
 
 export function parsePluginManifest(value: unknown): PluginManifest | null {
   if (!object(value)) return null;
@@ -321,12 +279,6 @@ export function parsePluginManifest(value: unknown): PluginManifest | null {
 export function parsePublishablePluginManifest(value: unknown): PluginManifest | null {
   const manifest = parsePluginManifest(value);
   return manifest?.engines?.brainpilot && isBrainPilotVersionRange(manifest.engines.brainpilot) ? manifest : null;
-}
-
-export function isPreviewPluginMessage(value: unknown): value is PreviewPluginToHostMessage {
-  if (!object(value) || value.rpcVersion !== PREVIEW_RPC_VERSION || typeof value.token !== "string" || typeof value.type !== "string") return false;
-  if (value.type === "preview/read-range") return typeof value.requestId === "string" && typeof value.handle === "string" && typeof value.offset === "number" && value.offset >= 0 && typeof value.length === "number" && value.length > 0;
-  return value.type === "preview/ready" || value.type === "preview/rendered" || value.type === "preview/error" || value.type === "preview/resize";
 }
 
 export function isBrainPilotVersionRange(range: string | undefined): range is string {

--- a/packages/plugin-sdk/src/preview.ts
+++ b/packages/plugin-sdk/src/preview.ts
@@ -1,0 +1,70 @@
+export const PREVIEW_RPC_VERSION = "1" as const;
+
+export interface PreviewDatasetRule {
+  kind: "stem-siblings";
+  companions: string[];
+  required?: string[];
+}
+
+export interface PreviewerMatch {
+  extensions?: string[];
+  mimeTypes?: string[];
+  dataset?: string | PreviewDatasetRule;
+}
+
+export interface PreviewerContribution {
+  id: string;
+  match?: PreviewerMatch;
+  /** Legacy v0 form; normalized into match.extensions by parsePluginManifest. */
+  extensions?: string[];
+  priority?: number;
+  mode?: "readonly" | "editable";
+  delivery?: "whole" | "range" | "derived";
+  entry: string;
+}
+
+export interface EnabledPreviewer {
+  pluginId: string;
+  pluginVersion: string;
+  displayName: string;
+  previewer: PreviewerContribution;
+}
+
+export interface PreviewFileDescriptor {
+  name: string;
+  size: number;
+  mime?: string;
+  handle?: string;
+}
+
+export interface PreviewCompanionFile extends PreviewFileDescriptor { buffer?: ArrayBuffer; }
+export interface PreviewDatasetDescriptor { kind: string; primaryHandle: string; members: PreviewFileDescriptor[]; }
+
+export type PreviewHostToPluginMessage =
+  | { type: "preview/initialize"; rpcVersion: typeof PREVIEW_RPC_VERSION; token: string; theme?: "light" | "dark" }
+  | { type: "preview/open"; rpcVersion: typeof PREVIEW_RPC_VERSION; token: string; requestId: string; file: PreviewFileDescriptor; buffer: ArrayBuffer; companions?: PreviewCompanionFile[]; dataset?: PreviewDatasetDescriptor; derived?: unknown }
+  | { type: "preview/range-result"; rpcVersion: typeof PREVIEW_RPC_VERSION; token: string; requestId: string; handle: string; offset: number; totalSize: number; buffer: ArrayBuffer }
+  | { type: "preview/range-error"; rpcVersion: typeof PREVIEW_RPC_VERSION; token: string; requestId: string; handle: string; message: string }
+  | { type: "preview/dispose"; rpcVersion: typeof PREVIEW_RPC_VERSION; token: string };
+
+export type PreviewPluginToHostMessage =
+  | { type: "preview/ready"; rpcVersion: typeof PREVIEW_RPC_VERSION; token: string }
+  | { type: "preview/rendered"; rpcVersion: typeof PREVIEW_RPC_VERSION; token: string; requestId: string; metadata?: Record<string, unknown> }
+  | { type: "preview/error"; rpcVersion: typeof PREVIEW_RPC_VERSION; token: string; requestId?: string; message: string }
+  | { type: "preview/resize"; rpcVersion: typeof PREVIEW_RPC_VERSION; token: string; height: number }
+  | { type: "preview/read-range"; rpcVersion: typeof PREVIEW_RPC_VERSION; token: string; requestId: string; handle: string; offset: number; length: number };
+
+function object(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+export function previewerExtensions(value: PreviewerContribution): string[] {
+  return value.match?.extensions ?? value.extensions ?? [];
+}
+
+export function isPreviewPluginMessage(value: unknown): value is PreviewPluginToHostMessage {
+  if (!object(value) || value.rpcVersion !== PREVIEW_RPC_VERSION || typeof value.token !== "string" || typeof value.type !== "string") return false;
+  if (value.type === "preview/read-range") return typeof value.requestId === "string" && typeof value.handle === "string" && typeof value.offset === "number" && value.offset >= 0 && typeof value.length === "number" && value.length > 0;
+  return value.type === "preview/ready" || value.type === "preview/rendered" || value.type === "preview/error" || value.type === "preview/resize";
+}
+

--- a/packages/runtime/src/__tests__/server.test.ts
+++ b/packages/runtime/src/__tests__/server.test.ts
@@ -272,7 +272,15 @@ describe("workspace file routes", () => {
     // read raw bytes
     const raw = await a.request("/sessions/s1/files/raw?path=/workspace/img.bin");
     expect(raw.status).toBe(200);
+    expect(raw.headers.get("accept-ranges")).toBe("bytes");
     expect(new Uint8Array(await raw.arrayBuffer())).toEqual(new Uint8Array([1, 2, 3, 4]));
+
+    const range = await a.request("/sessions/s1/files/raw?path=/workspace/img.bin", { headers: { range: "bytes=1-2" } });
+    expect(range.status).toBe(206);
+    expect(range.headers.get("content-range")).toBe("bytes 1-2/4");
+    expect(new Uint8Array(await range.arrayBuffer())).toEqual(new Uint8Array([2, 3]));
+
+    expect((await a.request("/sessions/s1/files/raw?path=/workspace/img.bin", { headers: { range: "bytes=-2" } })).status).toBe(416);
 
     // delete
     const del = await a.request("/sessions/s1/files?path=/workspace/a.txt", { method: "DELETE" });

--- a/packages/runtime/src/server.ts
+++ b/packages/runtime/src/server.ts
@@ -200,9 +200,21 @@ export function createServer(opts: SessionManagerOptions & { manager?: SessionMa
     const path = c.req.query("path");
     if (!path) return c.json({ error: "path required" }, 400);
     try {
+      const range = c.req.header("range");
+      if (range) {
+        const match = /^bytes=(\d+)-(\d*)$/.exec(range);
+        if (!match) return c.json({ error: "only one explicit bytes range is supported" }, 416);
+        const result = await manager.readSessionFileRange(c.req.param("id"), path, Number(match[1]), match[2] ? Number(match[2]) : undefined);
+        c.header("Content-Type", "application/octet-stream");
+        c.header("Content-Length", String(result.buffer.length));
+        c.header("Content-Range", `bytes ${result.start}-${result.end}/${result.totalSize}`);
+        c.header("Accept-Ranges", "bytes");
+        return c.body(result.buffer as unknown as ArrayBuffer, 206);
+      }
       const buf = await manager.readSessionFileRaw(c.req.param("id"), path);
       c.header("Content-Type", "application/octet-stream");
       c.header("Content-Length", String(buf.length));
+      c.header("Accept-Ranges", "bytes");
       return c.body(buf as unknown as ArrayBuffer);
     } catch (err) {
       return c.json({ error: (err as Error).message }, 404);

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -9,7 +9,7 @@
  * Persistence (§5): config/history/state live under `<dataRoot>/.bp/{sid}/`,
  * work files under `<dataRoot>/workspaces/{sid}/`.
  */
-import { mkdir, readFile, writeFile, readdir, rm, stat, rename } from "node:fs/promises";
+import { mkdir, open, readFile, writeFile, readdir, rm, stat, rename } from "node:fs/promises";
 import { createWriteStream } from "node:fs";
 import { pipeline } from "node:stream/promises";
 import { Readable, Transform } from "node:stream";
@@ -929,6 +929,27 @@ export class SessionManager {
     await this.ensureLayoutForPath(rel);
     const abs = this.resolveManagedPath(sid, rel).abs;
     return readFile(abs);
+  }
+
+  /** Read one bounded byte range without buffering the full workspace file. */
+  async readSessionFileRange(sid: string, rel: string, start: number, requestedEnd?: number): Promise<{ buffer: Buffer; start: number; end: number; totalSize: number }> {
+    if (!Number.isSafeInteger(start) || start < 0 || (requestedEnd !== undefined && (!Number.isSafeInteger(requestedEnd) || requestedEnd < start))) {
+      throw new Error("invalid file byte range");
+    }
+    await this.ensureLayoutForPath(rel);
+    const abs = this.resolveManagedPath(sid, rel).abs;
+    const info = await stat(abs);
+    if (!info.isFile() || start >= info.size) throw new Error("file byte range is outside the file");
+    const maxBytes = 8 * 1024 * 1024;
+    const end = Math.min(requestedEnd ?? start + maxBytes - 1, start + maxBytes - 1, info.size - 1);
+    const buffer = Buffer.allocUnsafe(end - start + 1);
+    const handle = await open(abs, "r");
+    try {
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, start);
+      return { buffer: buffer.subarray(0, bytesRead), start, end: start + bytesRead - 1, totalSize: info.size };
+    } finally {
+      await handle.close();
+    }
   }
 
   /** Delete a workspace file. Returns false if it was already gone. */

--- a/packages/web/src/__tests__/api.test.ts
+++ b/packages/web/src/__tests__/api.test.ts
@@ -696,6 +696,18 @@ describe("api.mcpByok save/clear", () => {
 });
 
 describe("api.plugins marketplace lifecycle", () => {
+  it("reads an explicit file range and parses Content-Range", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(new Uint8Array([2, 3]), {
+      status: 206,
+      headers: { "content-type": "application/octet-stream", "content-range": "bytes 1-2/4" },
+    }));
+    const result = await api.sandbox.readRawFileRange("s1", "/workspace/scan.nii", 1, 2);
+    expect(result.offset).toBe(1);
+    expect(result.totalSize).toBe(4);
+    expect(new Uint8Array(await result.blob.arrayBuffer())).toEqual(new Uint8Array([2, 3]));
+    expect((fetchMock.mock.calls[0][1].headers as Record<string, string>).Range).toBe("bytes=1-2");
+  });
+
   it("loads the catalogue from the control-plane endpoint", async () => {
     fetchMock.mockResolvedValueOnce(makeResponse({ contentType: "application/json", json: [] }));
     await expect(api.plugins.marketplace()).resolves.toEqual([]);

--- a/packages/web/src/__tests__/previewerRegistry.test.ts
+++ b/packages/web/src/__tests__/previewerRegistry.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { matchEnabledPreviewer, type EnabledPreviewer } from "../components/files/previewerRegistry";
+
+function candidate(id: string, extensions: string[], priority = 0): EnabledPreviewer {
+  return { pluginId: `org.test.${id}`, pluginVersion: "1.0.0", displayName: id, previewer: { id, extensions, priority, entry: "ui/index.html" } };
+}
+
+describe("previewer registry", () => {
+  it("prefers the longest compound extension before priority", () => {
+    const nii = candidate("nii", [".nii"], 999);
+    const gzip = candidate("nifti-gzip", [".nii.gz"], 1);
+    expect(matchEnabledPreviewer("subject.BOLD.NII.GZ", [nii, gzip])?.previewer.id).toBe("nifti-gzip");
+  });
+
+  it("uses priority for equal suffix matches", () => {
+    expect(matchEnabledPreviewer("image.nii", [candidate("low", [".nii"], 1), candidate("high", [".nii"], 10)])?.previewer.id).toBe("high");
+  });
+
+  it("lets an independent worker plugin supersede a browser fallback for FIF", () => {
+    const browserFallback = candidate("browser-neuro", [".fif", ".nwb", ".snirf"], 100);
+    const worker = candidate("worker-neuro", [".fif", ".nwb", ".snirf"], 200);
+    expect(matchEnabledPreviewer("recording.fif", [browserFallback, worker])?.pluginId).toBe(worker.pluginId);
+  });
+});

--- a/packages/web/src/components/files/FileSidebar.tsx
+++ b/packages/web/src/components/files/FileSidebar.tsx
@@ -28,6 +28,8 @@ import { IconButton } from "../primitives/IconButton";
 import { UploadProgressBar } from "../primitives/UploadProgressBar";
 import { ONE_MB, MAX_BINARY_PREVIEW, formatBytes, formatModified, getPreviewKind, isMarkdown } from "./filePreview";
 import { FilePreviewView, PreviewSource } from "./FilePreviewView";
+import { PluginPreviewHost } from "./PluginPreviewHost";
+import { matchEnabledPreviewer, type EnabledPreviewer } from "./previewerRegistry";
 
 /** #305: in-flight persistent-library upload state for the progress row. */
 type DataUploadState = {
@@ -953,13 +955,26 @@ function FilePreviewPanel({
   const [blobUrl, setBlobUrl] = useState<string | null>(null);
   const [blobError, setBlobError] = useState<string | null>(null);
   const [isDownloading, setIsDownloading] = useState(false);
+  const [enabledPreviewers, setEnabledPreviewers] = useState<EnabledPreviewer[]>([]);
   const previewResizeStartRef = useRef<{ pointerX: number; width: number } | null>(null);
   const previewKind = file ? getPreviewKind(file.name) : "download";
+  const pluginPreviewer = file ? matchEnabledPreviewer(file.name, enabledPreviewers) : null;
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = () => void api.plugins.enabledPreviewers()
+      .then((previewers) => { if (!cancelled) setEnabledPreviewers(previewers); })
+      .catch(() => { if (!cancelled) setEnabledPreviewers([]); });
+    load();
+    window.addEventListener("brainpilot:plugins-changed", load);
+    return () => { cancelled = true; window.removeEventListener("brainpilot:plugins-changed", load); };
+  }, []);
 
   useEffect(() => {
     if (
       !file ||
       !sandboxId ||
+      pluginPreviewer !== null ||
       (previewKind !== "image" && previewKind !== "pdf") ||
       file.size > MAX_BINARY_PREVIEW
     ) {
@@ -994,7 +1009,7 @@ function FilePreviewPanel({
         URL.revokeObjectURL(objectUrl);
       }
     };
-  }, [file?.path, previewKind, sandboxId]);
+  }, [file?.path, pluginPreviewer, previewKind, sandboxId]);
 
   useEffect(() => {
     const handlePointerMove = (event: PointerEvent) => {
@@ -1113,15 +1128,26 @@ function FilePreviewPanel({
         </div>
       </dl>
 
-      <FilePreviewView
-        name={file.name}
-        source={previewSource}
-        renderMarkdown={isMarkdown(file.name)}
-        error={blobError}
-        t={t}
-        onDownload={sandboxId ? () => void downloadFile() : undefined}
-        isDownloading={isDownloading}
-      />
+      {pluginPreviewer && sandboxId ? (
+        <PluginPreviewHost
+          key={`${pluginPreviewer.pluginId}:${pluginPreviewer.pluginVersion}:${file.path}`}
+          previewer={pluginPreviewer}
+          sandboxId={sandboxId}
+          path={file.path}
+          name={file.name}
+          size={file.size}
+        />
+      ) : (
+        <FilePreviewView
+          name={file.name}
+          source={previewSource}
+          renderMarkdown={isMarkdown(file.name)}
+          error={blobError}
+          t={t}
+          onDownload={sandboxId ? () => void downloadFile() : undefined}
+          isDownloading={isDownloading}
+        />
+      )}
     </section>
   );
 }

--- a/packages/web/src/components/files/PluginPreviewHost.tsx
+++ b/packages/web/src/components/files/PluginPreviewHost.tsx
@@ -1,0 +1,162 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  PREVIEW_RPC_VERSION,
+  isPreviewPluginMessage,
+  type PreviewHostToPluginMessage,
+} from "@brainpilot/plugin-sdk/preview";
+import { api } from "../../utils/api";
+import type { EnabledPreviewer } from "./previewerRegistry";
+
+const MAX_RANGE_BYTES = 8 * 1024 * 1024;
+const MAX_WHOLE_FILE_BYTES = 50 * 1024 * 1024;
+
+export function PluginPreviewHost({ previewer, sandboxId, path, name, size }: {
+  previewer: EnabledPreviewer;
+  sandboxId: string;
+  path: string;
+  name: string;
+  size: number;
+}) {
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const tokenRef = useRef(crypto.randomUUID());
+  const [status, setStatus] = useState("Loading plugin…");
+  const [error, setError] = useState<string | null>(null);
+  const [height, setHeight] = useState(480);
+
+  useEffect(() => {
+    let cancelled = false;
+    let delivered = false;
+    const handles = new Map<string, string>([["primary", path]]);
+    const send = (message: PreviewHostToPluginMessage, transfer: Transferable[] = []) => {
+      iframeRef.current?.contentWindow?.postMessage(message, "*", transfer);
+    };
+    const fail = (cause: unknown) => {
+      if (!cancelled) setError(cause instanceof Error ? cause.message : String(cause));
+    };
+    const timeout = window.setTimeout(() => {
+      if (!delivered && !cancelled) setError("Plugin did not become ready in time.");
+    }, 10_000);
+
+    const openRangePreview = async () => {
+      const rule = typeof previewer.previewer.match?.dataset === "object"
+        ? previewer.previewer.match.dataset
+        : undefined;
+      let candidates = [{ path, handle: "primary", name }];
+      if (rule?.kind === "stem-siblings") {
+        const selectedSuffix = rule.companions.find((suffix) => path.toLowerCase().endsWith(suffix.toLowerCase()));
+        if (selectedSuffix) {
+          const stem = path.slice(0, -selectedSuffix.length);
+          candidates = rule.companions.map((suffix, index) => {
+            const candidatePath = `${stem}${suffix}`;
+            return { path: candidatePath, handle: candidatePath === path ? "primary" : `companion:${index}`, name: candidatePath.split("/").pop()! };
+          });
+        }
+      }
+      const resolved = await Promise.all(candidates.map(async (candidate) => ({
+        candidate,
+        info: await api.sandbox.readRawFileRange(sandboxId, candidate.path, 0, 1)
+          .catch((cause) => candidate.handle === "primary" ? Promise.reject(cause) : null),
+      })));
+      const missingRequired = (rule?.required ?? []).find((suffix) =>
+        resolved.some(({ candidate, info }) => candidate.path.toLowerCase().endsWith(suffix.toLowerCase()) && info === null),
+      );
+      if (missingRequired) throw new Error(`Required dataset member is missing: ${missingRequired}`);
+      const members = resolved.filter((item) => item.info !== null).map(({ candidate, info }) => {
+        handles.set(candidate.handle, candidate.path);
+        return { name: candidate.name, size: info!.totalSize, handle: candidate.handle };
+      });
+      const primary = members.find((member) => member.handle === "primary");
+      if (!primary) throw new Error("The selected preview file is unavailable.");
+      const buffer = new ArrayBuffer(0);
+      const message: PreviewHostToPluginMessage = {
+        type: "preview/open",
+        rpcVersion: PREVIEW_RPC_VERSION,
+        token: tokenRef.current,
+        requestId: crypto.randomUUID(),
+        file: { name, size: primary.size, handle: "primary" },
+        buffer,
+        ...(rule ? { dataset: { kind: rule.kind, primaryHandle: "primary", members } } : {}),
+      };
+      send(message, [buffer]);
+    };
+
+    const openWholePreview = async () => {
+      if (size > MAX_WHOLE_FILE_BYTES) throw new Error("This whole-file preview exceeds the 50 MiB host limit.");
+      const blob = await api.sandbox.readRawFile(sandboxId, path);
+      const buffer = await blob.arrayBuffer();
+      const message: PreviewHostToPluginMessage = {
+        type: "preview/open",
+        rpcVersion: PREVIEW_RPC_VERSION,
+        token: tokenRef.current,
+        requestId: crypto.randomUUID(),
+        file: { name, size: buffer.byteLength, mime: blob.type || undefined, handle: "primary" },
+        buffer,
+      };
+      send(message, [buffer]);
+    };
+
+    const onMessage = (event: MessageEvent) => {
+      if (event.source !== iframeRef.current?.contentWindow || !isPreviewPluginMessage(event.data) || event.data.token !== tokenRef.current) return;
+      const message = event.data;
+      if (message.type === "preview/read-range") {
+        const sourcePath = handles.get(message.handle);
+        if (!sourcePath) {
+          send({ type: "preview/range-error", rpcVersion: PREVIEW_RPC_VERSION, token: tokenRef.current, requestId: message.requestId, handle: message.handle, message: "Unknown preview file handle." });
+          return;
+        }
+        const length = Math.min(message.length, MAX_RANGE_BYTES);
+        void api.sandbox.readRawFileRange(sandboxId, sourcePath, message.offset, length)
+          .then(async ({ blob, offset, totalSize }) => {
+            if (cancelled) return;
+            const buffer = await blob.arrayBuffer();
+            send({ type: "preview/range-result", rpcVersion: PREVIEW_RPC_VERSION, token: tokenRef.current, requestId: message.requestId, handle: message.handle, offset, totalSize, buffer }, [buffer]);
+          })
+          .catch((cause) => {
+            if (!cancelled) send({ type: "preview/range-error", rpcVersion: PREVIEW_RPC_VERSION, token: tokenRef.current, requestId: message.requestId, handle: message.handle, message: cause instanceof Error ? cause.message : String(cause) });
+          });
+        return;
+      }
+      if (message.type === "preview/error") setError(message.message);
+      if (message.type === "preview/rendered") setStatus("");
+      if (message.type === "preview/resize") setHeight(Math.max(240, Math.min(1600, message.height)));
+      if (message.type !== "preview/ready" || delivered) return;
+      delivered = true;
+      setStatus("Reading file…");
+      void (previewer.previewer.delivery === "range" ? openRangePreview() : openWholePreview()).catch(fail);
+    };
+
+    window.addEventListener("message", onMessage);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timeout);
+      window.removeEventListener("message", onMessage);
+      send({ type: "preview/dispose", rpcVersion: PREVIEW_RPC_VERSION, token: tokenRef.current });
+    };
+  }, [name, path, previewer.pluginId, previewer.pluginVersion, previewer.previewer, sandboxId, size]);
+
+  const src = `${api.plugins.previewAssetUrl(previewer.pluginId, previewer.pluginVersion, previewer.previewer.entry)}#${encodeURIComponent(tokenRef.current)}`;
+  const initialize = () => {
+    const message: PreviewHostToPluginMessage = {
+      type: "preview/initialize",
+      rpcVersion: PREVIEW_RPC_VERSION,
+      token: tokenRef.current,
+      theme: document.documentElement.dataset.theme === "dark" ? "dark" : "light",
+    };
+    iframeRef.current?.contentWindow?.postMessage(message, "*");
+  };
+
+  return (
+    <div className="plugin-preview-host">
+      {error ? <p className="file-preview__notice">{error}</p> : null}
+      {!error && status ? <p className="file-preview__notice">{status}</p> : null}
+      <iframe
+        ref={iframeRef}
+        sandbox="allow-scripts"
+        src={src}
+        onLoad={initialize}
+        style={{ minHeight: height }}
+        title={`${previewer.displayName}: ${name}`}
+      />
+    </div>
+  );
+}

--- a/packages/web/src/components/files/previewerRegistry.ts
+++ b/packages/web/src/components/files/previewerRegistry.ts
@@ -1,0 +1,13 @@
+import { previewerExtensions, type EnabledPreviewer } from "@brainpilot/plugin-sdk/preview";
+
+export type { EnabledPreviewer } from "@brainpilot/plugin-sdk/preview";
+
+/** Longest matching suffix wins, then declared priority. */
+export function matchEnabledPreviewer(fileName: string, previewers: EnabledPreviewer[]): EnabledPreviewer | null {
+  const lower = fileName.toLowerCase();
+  const matches = previewers.flatMap((candidate) => previewerExtensions(candidate.previewer)
+    .filter((extension) => lower.endsWith(extension.toLowerCase()))
+    .map((extension) => ({ candidate, length: extension.length })));
+  matches.sort((a, b) => b.length - a.length || (b.candidate.previewer.priority ?? 0) - (a.candidate.previewer.priority ?? 0));
+  return matches[0]?.candidate ?? null;
+}

--- a/packages/web/src/styles/global.css
+++ b/packages/web/src/styles/global.css
@@ -5228,6 +5228,19 @@ button {
   word-break: break-word;
 }
 
+.plugin-preview-host {
+  position: relative;
+  min-height: 360px;
+  flex: 1;
+}
+
+.plugin-preview-host iframe {
+  width: 100%;
+  min-height: 480px;
+  border: 0;
+  background: var(--color-surface);
+}
+
 .search-modal {
   position: fixed;
   inset: 0;

--- a/packages/web/src/utils/api.ts
+++ b/packages/web/src/utils/api.ts
@@ -37,6 +37,7 @@ import {
 import { runtimeConfig } from "../config";
 import { mockBackend } from "../mocks/backend";
 import { RawAgUiEvent } from "../contracts/demoBundle";
+import type { EnabledPreviewer } from "@brainpilot/plugin-sdk/preview";
 import type {
   InstalledPlugin,
   MarketplaceEntry,
@@ -540,6 +541,21 @@ export const api = {
       return res.blob();
     },
 
+    async readRawFileRange(sandboxId: string, path: string, offset: number, length: number): Promise<{ blob: Blob; offset: number; totalSize: number }> {
+      if (runtimeConfig.useMockBackend) {
+        const whole = await mockBackend.readRawFile(sandboxId, path);
+        return { blob: whole.slice(offset, offset + length), offset, totalSize: whole.size };
+      }
+      const params = new URLSearchParams({ path });
+      const res = await apiFetch(`${API_BASE}/sandbox/${sandboxId}/files/raw?${params}`, {
+        headers: { ...authHeaders(false), Range: `bytes=${offset}-${offset + length - 1}` },
+      });
+      if (!res.ok) throw new Error(await parseError(res));
+      const contentRange = /^bytes (\d+)-(\d+)\/(\d+)$/.exec(res.headers.get("content-range") ?? "");
+      if (!contentRange) throw new Error("The preview host did not return a valid Content-Range header.");
+      return { blob: await res.blob(), offset: Number(contentRange[1]), totalSize: Number(contentRange[3]) };
+    },
+
     async readFileBlob(sandboxId: string, path: string): Promise<Blob> {
       return this.readRawFile(sandboxId, path);
     },
@@ -974,6 +990,11 @@ export const api = {
       return handleJson(await apiFetch(`${API_BASE}/plugins/installed`, { headers: authHeaders() }));
     },
 
+    async enabledPreviewers(): Promise<EnabledPreviewer[]> {
+      if (runtimeConfig.useMockBackend) return [];
+      return handleJson(await apiFetch(`${API_BASE}/plugins/enabled-previewers`, { headers: authHeaders() }));
+    },
+
     async sources(): Promise<MarketplaceSourceStatus[]> {
       if (runtimeConfig.useMockBackend) return [];
       return handleJson(await apiFetch(`${API_BASE}/plugins/sources`, { headers: authHeaders() }));
@@ -1019,6 +1040,11 @@ export const api = {
     async remove(id: string): Promise<void> {
       await handleJson<void>(await apiFetch(`${API_BASE}/plugins/${encodeURIComponent(id)}`, { method: "DELETE", headers: authHeaders(false) }));
       notifyPluginsChanged();
+    },
+
+    previewAssetUrl(pluginId: string, version: string, asset: string): string {
+      const encodedAsset = asset.split("/").map(encodeURIComponent).join("/");
+      return `${API_BASE}/plugins/${encodeURIComponent(pluginId)}/${encodeURIComponent(version)}/assets/${encodedAsset}`;
     },
   },
 


### PR DESCRIPTION
Stack 4/5. Depends on the marketplace UI PR.\n\nAdds the first executable contribution host: sandboxed Preview RPC iframe, opaque file handles, bounded HTTP Range reads, dataset companion matching, enabled previewer discovery and immutable plugin assets. Ships an official Neuroscience Data Viewer for uncompressed NIfTI-1 central-slice preview.\n\nValidation: real marketplace install and enable, plugin asset load, NIfTI upload, and 206 Range smoke test passed. Runtime, backend, SDK and Web suites pass.