### PR TITLE
feat(got): add audited Trace Graph v2 core

### DIFF
--- a/packages/protocol/src/domain.ts
+++ b/packages/protocol/src/domain.ts
@@ -285,6 +285,96 @@ export const TraceTimestampSchema = z.object({
 });
 export type TraceTimestamp = z.infer<typeof TraceTimestampSchema>;
 
+export const TraceCheckpointStatusSchema = z.enum([
+  "ready",
+  "partial",
+  "failed",
+  "unavailable",
+]);
+export type TraceCheckpointStatus = z.infer<typeof TraceCheckpointStatusSchema>;
+
+export const TraceCheckpointStatsSchema = z.object({
+  files: z.number().int().nonnegative(),
+  added: z.number().int().nonnegative(),
+  modified: z.number().int().nonnegative(),
+  deleted: z.number().int().nonnegative(),
+  renamed: z.number().int().nonnegative(),
+});
+export type TraceCheckpointStats = z.infer<typeof TraceCheckpointStatsSchema>;
+
+/** Lightweight checkpoint reference embedded in trace.json and live events. */
+export const TraceCheckpointRefSchema = z.object({
+  id: z.string(),
+  commitId: z.string().optional(),
+  status: TraceCheckpointStatusSchema,
+  capturedAt: z.string(),
+  sourceAgent: z.string().optional(),
+  baseCheckpointId: z.string().optional(),
+  stats: TraceCheckpointStatsSchema.optional(),
+  skippedCount: z.number().int().nonnegative().default(0),
+  error: z.string().optional(),
+});
+export type TraceCheckpointRef = z.infer<typeof TraceCheckpointRefSchema>;
+
+export const TraceParentConclusionSchema = z.enum(["candidate", "confirmed", "rejected", "uncertain"]);
+export type TraceParentConclusion = z.infer<typeof TraceParentConclusionSchema>;
+
+export const TraceNodeReviewConclusionSchema = z.enum(["unreviewed", "approved", "rejected", "uncertain"]);
+export type TraceNodeReviewConclusion = z.infer<typeof TraceNodeReviewConclusionSchema>;
+
+/** Trace Agent's current evidence-support assessment, independent of audit. */
+export const TraceNodeConfidenceSchema = z.enum(["low", "medium", "high"]);
+export type TraceNodeConfidence = z.infer<typeof TraceNodeConfidenceSchema>;
+
+/** One immutable reporting record curated into a logical research node. */
+export const TraceNodeRecordSchema = z.object({
+  sourceAgent: z.string(),
+  description: z.string(),
+  context: z.string().optional(),
+  checkpointId: z.string().optional(),
+  createdAt: z.string(),
+});
+export type TraceNodeRecord = z.infer<typeof TraceNodeRecordSchema>;
+
+/** Embedded causal upstream reference. No relationship kind is needed. */
+export const TraceCausalParentSchema = z.object({
+  nodeId: z.string(),
+  conclusion: TraceParentConclusionSchema,
+  /** Current concise reason; earlier reasons remain in TraceChangeLog. */
+  reason: z.string().optional(),
+});
+export type TraceCausalParent = z.infer<typeof TraceCausalParentSchema>;
+
+export const TraceChangeActorSchema = z.object({
+  type: z.enum(["user", "agent", "host"]),
+  name: z.string().optional(),
+});
+export const TraceChangeSchema = z.object({
+  id: z.string(),
+  revision: z.number().int().nonnegative(),
+  actor: TraceChangeActorSchema,
+  action: z.string(),
+  target: z.object({ nodeId: z.string().optional(), parentNodeId: z.string().optional() }),
+  before: z.unknown().optional(),
+  after: z.unknown().optional(),
+  reason: z.string().optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  createdAt: z.string(),
+});
+export type TraceChange = z.infer<typeof TraceChangeSchema>;
+
+export const AuditReportSchema = z.object({
+  id: z.string(),
+  kind: z.enum(["trace", "deliverable"]),
+  target: z.object({ nodeId: z.string().optional(), parentNodeId: z.string().optional() }).optional(),
+  risk: z.enum(["low", "medium", "high"]),
+  summary: z.string(),
+  report: z.string(),
+  createdAt: z.string(),
+  sharedWithPiAt: z.string().optional(),
+});
+export type AuditReport = z.infer<typeof AuditReportSchema>;
+
 export const TraceNodeSchema = z.object({
   id: z.string(),
   title: z.string(),
@@ -307,21 +397,248 @@ export const TraceNodeSchema = z.object({
   durationMs: z.number().optional(),
   errorMessage: z.string().optional(),
   toolCalls: z.array(z.string()),
+  checkpoints: z.array(TraceCheckpointRefSchema).optional(),
+  /** V2 projection hints; relation copies remain view-only. */
+  artifactIds: z.array(z.string()).optional(),
+  primaryEpisodeId: z.string().optional(),
+  episodeTags: z.array(z.string()).optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
+  records: z.array(TraceNodeRecordSchema).optional(),
+  causalParents: z.array(TraceCausalParentSchema).optional(),
+  executionResult: z.enum(["completed", "failed"]).optional(),
+  revoked: z.boolean().optional(),
+  confidence: TraceNodeConfidenceSchema.optional(),
+  confidenceReason: z.string().optional(),
+  reviewConclusion: TraceNodeReviewConclusionSchema.optional(),
+  reviewReason: z.string().optional(),
 });
 export type TraceNode = z.infer<typeof TraceNodeSchema>;
 
+/* ------------------------------------------------------------------ *
+ * Trace Graph V2
+ * ------------------------------------------------------------------ *
+ *
+ * V1 kept duplicated parent/child arrays on every node. V2 embeds only the
+ * upstream parent references on each canonical node; child ids and dependency
+ * collections are derived API/UI projections. The legacy TraceNode/TraceGraph
+ * definitions above remain the compatibility view used by older clients and
+ * replay bundles.
+ */
+
+export const TraceDependencyOriginSchema = z.enum([
+  "trace",
+  "agent_report",
+  "explicit",
+  "host",
+  "user",
+  "legacy",
+]);
+export type TraceDependencyOrigin = z.infer<typeof TraceDependencyOriginSchema>;
+
+export const TraceDependencyConfidenceSchema = z.enum(["low", "medium", "high"]);
+export type TraceDependencyConfidence = z.infer<typeof TraceDependencyConfidenceSchema>;
+
+export const TraceDependencyStateSchema = z.enum(["proposed", "active", "rejected"]);
+export type TraceDependencyState = z.infer<typeof TraceDependencyStateSchema>;
+
+/** Structured provenance for a dependency; free-form summaries are reports, not facts. */
+export const TraceDependencyEvidenceSchema = z.object({
+  source: z.string(),
+  kind: z.string(),
+  detail: z.string().optional(),
+  artifactId: z.string().optional(),
+  reportId: z.string().optional(),
+  path: z.string().optional(),
+  checkpointId: z.string().optional(),
+  baseBlobId: z.string().optional(),
+  resultBlobId: z.string().optional(),
+  deterministic: z.boolean().optional(),
+});
+export type TraceDependencyEvidence = z.infer<typeof TraceDependencyEvidenceSchema>;
+
+/** prerequisiteId -> dependentId. Time order is deliberately not encoded here. */
+export const TraceDependencySchema = z.object({
+  id: z.string(),
+  prerequisiteId: z.string(),
+  dependentId: z.string(),
+  origin: TraceDependencyOriginSchema,
+  confidence: TraceDependencyConfidenceSchema,
+  state: TraceDependencyStateSchema,
+  reason: z.string().optional(),
+  evidence: z.array(TraceDependencyEvidenceSchema),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+});
+export type TraceDependency = z.infer<typeof TraceDependencySchema>;
+
+export const TraceSemanticLinkTypeSchema = z.enum([
+  "sequence_after",
+  "restored_from",
+  "supports",
+  "contradicts",
+  "supersedes",
+  "references",
+  "legacy",
+]);
+export type TraceSemanticLinkType = z.infer<typeof TraceSemanticLinkTypeSchema>;
+
+export const TraceSemanticLinkSchema = z.object({
+  id: z.string(),
+  fromId: z.string(),
+  toId: z.string(),
+  type: TraceSemanticLinkTypeSchema,
+  reason: z.string().optional(),
+  createdAt: z.string().optional(),
+});
+export type TraceSemanticLink = z.infer<typeof TraceSemanticLinkSchema>;
+
+/** Presentation-only grouping. Membership is owned by node.primaryEpisodeId. */
+export const TraceEpisodeSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  description: z.string().optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+});
+export type TraceEpisode = z.infer<typeof TraceEpisodeSchema>;
+
+export const TraceArtifactVerificationStatusSchema = z.enum([
+  "unverified",
+  "reserved",
+  "verified",
+  "missing",
+]);
+export type TraceArtifactVerificationStatus = z.infer<typeof TraceArtifactVerificationStatusSchema>;
+
+/**
+ * Artifact registry entry. The registry, rather than natural-language node
+ * summaries, is the durable evidence surface. `checkpoint` is retained for
+ * checkpoint-diff/restore compatibility and is optional for ordinary files.
+ */
+export const TraceArtifactV2Schema = z.object({
+  id: z.string(),
+  producerNodeId: z.string().nullable().optional(),
+  path: z.string(),
+  kind: z.string(),
+  type: z.string().optional(),
+  checkpointId: z.string().optional(),
+  checkpoint: TraceCheckpointRefSchema.optional(),
+  blobHash: z.string().optional(),
+  changeStatus: z.enum(["added", "modified", "deleted", "renamed"]).optional(),
+  previousPath: z.string().optional(),
+  exists: z.enum(["unknown", "present", "missing"]).default("unknown"),
+  verificationStatus: TraceArtifactVerificationStatusSchema.default("reserved"),
+  role: z.enum(["input", "output", "checkpoint", "reference"]).optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+});
+export type TraceArtifactV2 = z.infer<typeof TraceArtifactV2Schema>;
+
+/** Explicitly labels LLM-authored prose as a report rather than verified fact. */
+export const TraceAgentReportSchema = z.object({
+  kind: z.literal("agent_report"),
+  summary: z.string().optional(),
+  content: z.string().optional(),
+  author: z.string().optional(),
+});
+export type TraceAgentReport = z.infer<typeof TraceAgentReportSchema>;
+
+export const TraceNodeV2Schema = z.object({
+  id: z.string(),
+  title: z.string(),
+  type: z.string(),
+  status: TraceNodeStatusSchema,
+  agent: z.string().optional(),
+  description: z.string().optional(),
+  reason: z.string().optional(),
+  context: z.string().optional(),
+  report: TraceAgentReportSchema.optional(),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+  timestamp: TraceTimestampSchema.optional(),
+  durationMs: z.number().optional(),
+  errorMessage: z.string().optional(),
+  toolCalls: z.array(z.string()),
+  artifactIds: z.array(z.string()).default([]),
+  primaryEpisodeId: z.string().optional(),
+  episodeTags: z.array(z.string()).default([]),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  records: z.array(TraceNodeRecordSchema).default([]),
+  parents: z.array(TraceCausalParentSchema).default([]),
+  executionResult: z.enum(["completed", "failed"]).default("completed"),
+  revoked: z.boolean().default(false),
+  /** Historical nodes may be unevaluated; all new Trace writes provide both. */
+  confidence: TraceNodeConfidenceSchema.optional(),
+  confidenceReason: z.string().optional(),
+  reviewConclusion: TraceNodeReviewConclusionSchema.default("unreviewed"),
+  reviewReason: z.string().optional(),
+});
+export type TraceNodeV2 = z.infer<typeof TraceNodeV2Schema>;
+
+export const TraceMetaSchema = z
+  .object({
+    sessionId: z.string(),
+    /** Host-managed structural root. It is not a scientific Trace claim. */
+    rootNodeId: z.string().optional(),
+    userId: z.string().optional(),
+    projectName: z.string().optional(),
+    currentFocus: z.string().optional(),
+    createdAt: z.string().optional(),
+  })
+  .passthrough();
+export type TraceMeta = z.infer<typeof TraceMetaSchema>;
+
+const TraceDocumentV2Shape = {
+  schemaVersion: z.literal("2.0"),
+  revision: z.number().int().nonnegative(),
+  meta: TraceMetaSchema,
+  nodes: z.array(TraceNodeV2Schema),
+  episodes: z.array(TraceEpisodeSchema),
+  artifacts: z.array(TraceArtifactV2Schema),
+};
+
+/** Canonical trace.json shape. Node.parents is the only causal source of truth. */
+export const TraceDocumentV2Schema = z.object({
+  ...TraceDocumentV2Shape,
+  /** Host-only embedded journal tail; omitted from API projections. */
+  pendingChanges: z.array(TraceChangeSchema).optional(),
+});
+export type TraceDocumentV2 = z.infer<typeof TraceDocumentV2Schema>;
+
+/** API/SSE view. Dependency collections are derived from node.parents. */
+export const TraceGraphViewV2Schema = z.object({
+  ...TraceDocumentV2Shape,
+  dependencies: z.array(TraceDependencySchema),
+  semanticLinks: z.array(TraceSemanticLinkSchema),
+});
+export type TraceGraphViewV2 = z.infer<typeof TraceGraphViewV2Schema>;
+
+/** Backwards-compatible name for the V2 API/SSE view. */
+export const TraceGraphV2Schema = TraceGraphViewV2Schema;
+export type TraceGraphV2 = z.infer<typeof TraceGraphV2Schema>;
+
+/** A V2 SSE update. Snapshot is intentionally supported during transition. */
+export const TraceDeltaV2Schema = z.object({
+  schemaVersion: z.literal("2.0"),
+  revision: z.number().int().nonnegative(),
+  op: z.enum(["snapshot", "upsert", "remove"]),
+  graph: TraceGraphV2Schema.optional(),
+  entity: z.enum(["node", "dependency", "semantic_link", "episode", "artifact"]).optional(),
+  id: z.string().optional(),
+});
+export type TraceDeltaV2 = z.infer<typeof TraceDeltaV2Schema>;
+
 export const TraceGraphSchema = z.object({
-  meta: z
-    .object({
-      sessionId: z.string(),
-      userId: z.string().optional(),
-      projectName: z.string().optional(),
-      currentFocus: z.string().optional(),
-      createdAt: z.string().optional(),
-    })
-    .passthrough(),
+  /** Optional V2 metadata on the materialized backwards-compatible view. */
+  schemaVersion: z.literal("2.0").optional(),
+  revision: z.number().int().nonnegative().optional(),
+  meta: TraceMetaSchema,
   nodes: z.array(TraceNodeSchema),
+  /** V2 derived collections exposed alongside the legacy node projection. */
+  dependencies: z.array(TraceDependencySchema).optional(),
+  semanticLinks: z.array(TraceSemanticLinkSchema).optional(),
+  episodes: z.array(TraceEpisodeSchema).optional(),
+  artifacts: z.array(TraceArtifactV2Schema).optional(),
 });
 export type TraceGraph = z.infer<typeof TraceGraphSchema>;
 

--- a/packages/protocol/src/domain.ts
+++ b/packages/protocol/src/domain.ts
@@ -471,27 +471,6 @@ export const TraceDependencySchema = z.object({
 });
 export type TraceDependency = z.infer<typeof TraceDependencySchema>;
 
-export const TraceSemanticLinkTypeSchema = z.enum([
-  "sequence_after",
-  "restored_from",
-  "supports",
-  "contradicts",
-  "supersedes",
-  "references",
-  "legacy",
-]);
-export type TraceSemanticLinkType = z.infer<typeof TraceSemanticLinkTypeSchema>;
-
-export const TraceSemanticLinkSchema = z.object({
-  id: z.string(),
-  fromId: z.string(),
-  toId: z.string(),
-  type: TraceSemanticLinkTypeSchema,
-  reason: z.string().optional(),
-  createdAt: z.string().optional(),
-});
-export type TraceSemanticLink = z.infer<typeof TraceSemanticLinkSchema>;
-
 /** Presentation-only grouping. Membership is owned by node.primaryEpisodeId. */
 export const TraceEpisodeSchema = z.object({
   id: z.string(),
@@ -609,7 +588,6 @@ export type TraceDocumentV2 = z.infer<typeof TraceDocumentV2Schema>;
 export const TraceGraphViewV2Schema = z.object({
   ...TraceDocumentV2Shape,
   dependencies: z.array(TraceDependencySchema),
-  semanticLinks: z.array(TraceSemanticLinkSchema),
 });
 export type TraceGraphViewV2 = z.infer<typeof TraceGraphViewV2Schema>;
 
@@ -623,7 +601,7 @@ export const TraceDeltaV2Schema = z.object({
   revision: z.number().int().nonnegative(),
   op: z.enum(["snapshot", "upsert", "remove"]),
   graph: TraceGraphV2Schema.optional(),
-  entity: z.enum(["node", "dependency", "semantic_link", "episode", "artifact"]).optional(),
+  entity: z.enum(["node", "dependency", "episode", "artifact"]).optional(),
   id: z.string().optional(),
 });
 export type TraceDeltaV2 = z.infer<typeof TraceDeltaV2Schema>;
@@ -636,7 +614,6 @@ export const TraceGraphSchema = z.object({
   nodes: z.array(TraceNodeSchema),
   /** V2 derived collections exposed alongside the legacy node projection. */
   dependencies: z.array(TraceDependencySchema).optional(),
-  semanticLinks: z.array(TraceSemanticLinkSchema).optional(),
   episodes: z.array(TraceEpisodeSchema).optional(),
   artifacts: z.array(TraceArtifactV2Schema).optional(),
 });

--- a/packages/protocol/src/events.ts
+++ b/packages/protocol/src/events.ts
@@ -288,8 +288,9 @@ export type CustomEvent = z.infer<typeof CustomEventSchema>;
  * - `session_state` — authoritative live agent/run snapshot (#70).
  * - `session_title` — title update.
  * - `session_heartbeat` — liveness timestamp.
- * - `trace_node` — a Graph-of-Trace node was created/updated (#79); `value` is
+ * - `trace_node` — transitional V1 Graph-of-Trace node projection; `value` is
  *   `{ op: "created" | "updated", node: TraceNode }`.
+ * - `trace_delta` — derived TraceGraphV2 API-view revision update.
  * - `task_state` — flat task-ledger snapshot or one created/completed/cancelled edge.
  * - `compaction` — Pi SDK auto/manual context compaction lifecycle. `value` is
  *   `CompactionStartValue | CompactionEndValue`. Emitted verbatim from the
@@ -302,6 +303,7 @@ export const CUSTOM_EVENT = {
   SESSION_TITLE: "session_title",
   SESSION_HEARTBEAT: "session_heartbeat",
   TRACE_NODE: "trace_node",
+  TRACE_DELTA: "trace_delta",
   TASK_STATE: "task_state",
   COMPACTION: "compaction",
   /** Auditable, content-free domain tool / skill usage edge. */

--- a/packages/runtime/src/__tests__/tool-access.test.ts
+++ b/packages/runtime/src/__tests__/tool-access.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  allSystemTools,
   systemToolNamesForRole,
   systemToolsForRole,
   builtinToolNamesForRole,
@@ -11,6 +12,14 @@ import {
   type ToolDeps,
 } from "../tools/system-tools.js";
 import { GraphOfTrace } from "../trace.js";
+
+const TRACE_V2_TOOLS = [
+  "create_trace_node",
+  "get_trace_graph",
+  "get_trace_neighborhood",
+  "get_trace_node",
+  "update_trace_node",
+].sort();
 
 function deps(name: string): ToolDeps {
   return {
@@ -98,11 +107,24 @@ describe("tool access control (§9)", () => {
 
   it("trace agent gets ONLY graph tools", () => {
     const names = systemToolNamesForRole("trace", "trace");
-    expect(names.sort()).toEqual(
-      ["add_trace_relation", "create_trace_node", "get_trace_graph", "update_trace_node"].sort(),
-    );
+    expect(names.sort()).toEqual(TRACE_V2_TOOLS);
     expect(names).not.toContain("dispatch_task");
     expect(names).not.toContain("create_agent");
+  });
+
+  it("does not register legacy relation or episode mutation tools", () => {
+    const names = new Set(allSystemTools(deps("trace")).keys());
+    for (const name of [
+      "add_trace_relation",
+      "propose_trace_dependency",
+      "create_trace_episode",
+      "rename_trace_episode",
+      "merge_trace_episodes",
+      "split_trace_episode",
+      "assign_trace_episode",
+    ]) {
+      expect(names.has(name), name).toBe(false);
+    }
   });
 
   it("expert gets task tools + record_trace + skill_search + local KB tools", () => {
@@ -133,9 +155,7 @@ describe("tool access control (§9)", () => {
   it("resolves the actual SystemTool objects for a role (filtered)", () => {
     const tools = systemToolsForRole("trace", "trace", deps("trace"));
     const toolNames = tools.map((t) => t.name).sort();
-    expect(toolNames).toEqual(
-      ["add_trace_relation", "create_trace_node", "get_trace_graph", "update_trace_node"].sort(),
-    );
+    expect(toolNames).toEqual(TRACE_V2_TOOLS);
   });
 
   it("builtin tool allowlist differs by role", () => {
@@ -174,32 +194,87 @@ describe("tool access control (§9)", () => {
     );
   });
 
-  it("auditor gets task tools + record_trace + skill_search + local KB tools, but NO trace-graph access", () => {
+  it("auditor gets bounded Trace readers and review-only mutation access", () => {
     const names = systemToolNamesForRole("expert", "auditor");
     expect(names.sort()).toEqual(
       [
-        "record_trace",
-        "dispatch_task",
         "complete_task",
+        "list_pending_trace_reviews",
+        "get_trace_node",
+        "get_trace_neighborhood",
+        "edit_trace_review",
+        "submit_audit_report",
         "skill_search",
         "get_domain_knowledge_local",
         "search_papers_local",
       ].sort(),
     );
-    // Audit evidence is restricted to the workspace — no graph reads, no
-    // create/destroy, no graph mutation.
+    expect(names).not.toContain("record_trace");
     expect(names).not.toContain("get_trace_graph");
     expect(names).not.toContain("create_trace_node");
     expect(names).not.toContain("create_agent");
     expect(names).not.toContain("destroy_agent");
   });
 
-  it("auditor builtins include read+grep+bash+write but NOT edit", () => {
+  it("auditor builtins are read-only and reports use a system tool", () => {
     const a = builtinToolNamesForRole("expert", "auditor");
-    // Read-only inspection + write for its own audit report.
-    expect(a).toEqual(expect.arrayContaining(["read", "grep", "find", "glob", "bash", "write"]));
-    // Must NOT be able to modify other agents' artefacts.
+    expect(a).toEqual(expect.arrayContaining(["read", "grep", "find", "glob", "bash"]));
+    expect(a).not.toContain("write");
     expect(a).not.toContain("edit");
+  });
+
+  it("lets Auditor list pending node and parent reviews without rebinding", async () => {
+    const d = deps("auditor");
+    const parent = d.trace.createNode({ title: "Evidence" });
+    const child = d.trace.createNode({ title: "Conclusion" });
+    d.trace.review(parent.id, "approve", "supported", { type: "agent", name: "auditor" });
+    d.trace.proposeCausalParent(child.id, parent.id, "Conclusion consumes the evidence.", { type: "agent", name: "trace" });
+
+    const tool = systemToolsForRole("expert", "auditor", d)
+      .find((item) => item.name === "list_pending_trace_reviews")!;
+    const text = (await tool.execute({})).content.map((item) => item.text).join("");
+    expect(text).toContain('"title": "Conclusion"');
+    expect(text).toContain('"parentTitle": "Evidence"');
+    expect(text).toContain('"conclusion": "candidate"');
+    expect(d.currentTraceAuditTarget).toBeUndefined();
+  });
+
+  it("binds Auditor targets in the Host and persists a report", async () => {
+    const d = deps("auditor");
+    const node = d.trace.createNode({ title: "Conclusion", confidence: "medium", confidenceReason: "One result file." });
+    const target = d.trace.listPendingAuditTargets()[0]!;
+    d.currentTraceAuditTarget = () => target;
+    const tools = new Map(systemToolsForRole("expert", "auditor", d).map((tool) => [tool.name, tool]));
+
+    expect((await tools.get("edit_trace_review")!.execute({ conclusion: "approve", reason: "The bound evidence supports this node." })).isError)
+      .not.toBe(true);
+    expect(d.trace.getNodeV2(node.id)?.reviewConclusion).toBe("approved");
+    await tools.get("submit_audit_report")!.execute({ risk: "low", summary: "Evidence is consistent.", report: "# Audit\nEvidence is consistent." });
+    expect(d.trace.getAuditReports()).toContainEqual(expect.objectContaining({ kind: "trace", target: { nodeId: node.id } }));
+    expect(tools.has("dispatch_task")).toBe(false);
+  });
+
+  it("requires confidence and returns only a compact active graph to Trace", async () => {
+    const d = deps("trace");
+    const tools = new Map(systemToolsForRole("trace", "trace", d).map((tool) => [tool.name, tool]));
+    expect((await tools.get("create_trace_node")!.execute({ title: "Missing confidence" })).isError).toBe(true);
+    expect((await tools.get("create_trace_node")!.execute({
+      title: "Ablation",
+      confidence: "medium",
+      confidence_reason: "One complete seed.",
+    })).isError).not.toBe(true);
+    const node = d.trace.getGraphV2().nodes.find((item) => item.type !== "session_start")!;
+    const agentGraph = JSON.parse((await tools.get("get_trace_graph")!.execute({})).content[0]!.text) as {
+      revision: number;
+      nodes: Array<{ id: string; parents: unknown[] }>;
+      dependencies?: unknown;
+      artifacts?: unknown;
+    };
+    expect(agentGraph.nodes).toEqual([expect.objectContaining({ id: node.id, parents: [] })]);
+    expect(agentGraph).not.toHaveProperty("dependencies");
+    expect(agentGraph).not.toHaveProperty("artifacts");
+    expect(agentGraph.nodes[0]).not.toHaveProperty("records");
+    expect((await tools.get("update_trace_node")!.execute({ node_id: node.id, summary: "updated" })).isError).toBe(true);
   });
 });
 
@@ -264,12 +339,7 @@ describe("tool toggles", () => {
       search_papers_local: false,
     };
     const names = systemToolsForRole("trace", "trace", deps("trace"), off).map((t) => t.name).sort();
-    expect(names).toEqual([
-      "add_trace_relation",
-      "create_trace_node",
-      "get_trace_graph",
-      "update_trace_node",
-    ].sort());
+    expect(names).toEqual(TRACE_V2_TOOLS);
   });
 
   it("undefined field falls back to enabled (partial patch semantics)", () => {

--- a/packages/runtime/src/__tests__/trace-agent.test.ts
+++ b/packages/runtime/src/__tests__/trace-agent.test.ts
@@ -14,7 +14,12 @@
  *     flag — `deriveRunActive` excludes the trace role on purpose.
  */
 import { describe, it, expect } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { SessionManager } from "../session-manager.js";
+import type { GraphOfTrace } from "../trace.js";
+import type { TaskLedger } from "../task-ledger.js";
 import type {
   AgUiEvent,
   AgentSessionFactory,
@@ -164,7 +169,7 @@ describe("Trace Agent — record_trace dispatches to a spawned trace agent", () 
         // Trace consumes the envelope and writes a node — exercises a real run.
         onPrompt: (text) =>
           text.includes("[Trace Event]")
-            ? { tool: "create_trace_node", args: { title: "a decision" } }
+            ? { tool: "create_trace_node", args: { title: "a decision", confidence: "medium", confidence_reason: "Source record is available." } }
             : undefined,
       },
     });
@@ -205,7 +210,7 @@ describe("Trace Agent — record_trace dispatches to a spawned trace agent", () 
       trace: {
         onPrompt: (text) =>
           text.includes("[Trace Event]")
-            ? { tool: "create_trace_node", args: { title: "a decision" } }
+            ? { tool: "create_trace_node", args: { title: "a decision", confidence: "medium", confidence_reason: "Source record is available." } }
             : undefined,
       },
     });
@@ -213,12 +218,148 @@ describe("Trace Agent — record_trace dispatches to a spawned trace agent", () 
     const s = await m.createSession();
 
     await m.sendMessage(s.id, "go");
-    await waitFor(() => m.getTrace(s.id)!.nodes.length >= 1);
+    await waitFor(() => m.getTrace(s.id)!.nodes.some((node) => node.title === "a decision"));
     // After the trace agent has produced a node, give the manager a tick to
     // emit the post-run session_state and then assert.
     await new Promise((r) => setTimeout(r, 20));
     const state = m.getSessionState(s.id);
     expect(state).toBeDefined();
     expect(state!.runState.active).toBe(false);
+  });
+
+  it("dispatches an independent Auditor review after a Trace mutation", async () => {
+    const factory = scriptedFactory({
+      principal: {
+        onPrompt: (_text, turn) => turn === 1
+          ? { tool: "record_trace", args: { description: "a conclusion" } }
+          : undefined,
+      },
+      trace: {
+        onPrompt: (text) => text.includes("[Trace Event]")
+          ? { tool: "create_trace_node", args: { title: "Conclusion", confidence: "medium", confidence_reason: "One result file supports it." } }
+          : undefined,
+      },
+      auditor: {
+        onPrompt: (text) => text.includes("GoT")
+          ? { tool: "edit_trace_review", args: { conclusion: "approve", reason: "The bound record supports this node." } }
+          : undefined,
+      },
+    });
+    const m = new SessionManager({ persist: false, agentFactory: factory });
+    const s = await m.createSession();
+
+    await m.sendMessage(s.id, "go");
+    await waitFor(() => m.getTrace(s.id)?.nodes.some((node) => node.title === "Conclusion" && node.reviewConclusion === "approved") ?? false);
+    expect(m.listAgents(s.id).map((agent) => agent.name)).toContain("auditor");
+  });
+
+  it("keeps an Auditor notification durable when no conclusion is submitted", async () => {
+    let auditorTurns = 0;
+    const factory = scriptedFactory({
+      principal: {
+        onPrompt: (_text, turn) => turn === 1
+          ? { tool: "record_trace", args: { description: "an unreviewed conclusion" } }
+          : undefined,
+      },
+      trace: {
+        onPrompt: (text) => text.includes("[Trace Event]")
+          ? { tool: "create_trace_node", args: { title: "Unreviewed", confidence: "medium", confidence_reason: "One source record." } }
+          : undefined,
+      },
+      auditor: { onPrompt: () => { auditorTurns += 1; return undefined; } },
+    });
+    const m = new SessionManager({ persist: false, agentFactory: factory });
+    const s = await m.createSession();
+    const internal = m as unknown as { sessions: Map<string, { taskLedger: TaskLedger }> };
+
+    await m.sendMessage(s.id, "go");
+    await waitFor(() => auditorTurns === 1 && internal.sessions.get(s.id)!.taskLedger.isPaused("auditor"));
+    expect(m.taskNotificationCount(s.id, "auditor")).toBe(1);
+    expect(m.getTrace(s.id)?.nodes.find((node) => node.title === "Unreviewed")?.reviewConclusion).toBe("unreviewed");
+
+    await m.sendMessage(s.id, "resume");
+    await waitFor(() => auditorTurns === 2 && internal.sessions.get(s.id)!.taskLedger.isPaused("auditor"));
+    expect(m.taskNotificationCount(s.id, "auditor")).toBe(1);
+  });
+
+  it("re-queues a stale Auditor target once with its latest fingerprint", async () => {
+    let auditorTurns = 0;
+    let m!: SessionManager;
+    const factory = scriptedFactory({
+      principal: {
+        onPrompt: (_text, turn) => turn === 1
+          ? { tool: "record_trace", args: { description: "a changing conclusion" } }
+          : undefined,
+      },
+      trace: {
+        onPrompt: (text) => text.includes("[Trace Event]")
+          ? { tool: "create_trace_node", args: { title: "Changing", confidence: "medium", confidence_reason: "Initial record." } }
+          : undefined,
+      },
+      auditor: {
+        onPrompt: () => {
+          auditorTurns += 1;
+          if (auditorTurns === 1) {
+            const internal = m as unknown as { sessions: Map<string, { trace: GraphOfTrace }> };
+            const trace = [...internal.sessions.values()][0]!.trace;
+            const node = trace.getGraphV2().nodes.find((item) => item.title === "Changing")!;
+            trace.updateNode(node.id, {
+              description: "Evidence changed during review.",
+              confidence: "medium",
+              confidenceReason: "Updated record.",
+            }, { type: "agent", name: "trace" });
+          }
+          return { tool: "edit_trace_review", args: { conclusion: "approve", reason: "Current evidence supports the node." } };
+        },
+      },
+    });
+    m = new SessionManager({ persist: false, agentFactory: factory });
+    const s = await m.createSession();
+
+    await m.sendMessage(s.id, "go");
+    await waitFor(() => m.getTrace(s.id)?.nodes.some((node) => node.title === "Changing" && node.reviewConclusion === "approved") ?? false);
+    expect(auditorTurns).toBe(2);
+    expect(m.taskNotificationCount(s.id, "auditor")).toBe(0);
+  });
+
+  it("rebuilds Auditor deduplication from durable notifications on restart", async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), "bp-trace-audit-restore-"));
+    try {
+      const id = "audit-restore";
+      const m1 = new SessionManager({ dataRoot, persist: true, agentFactory: scriptedFactory({}) });
+      await m1.createSession({ id });
+      const internal1 = m1 as unknown as {
+        sessions: Map<string, { trace: GraphOfTrace; taskLedger: TaskLedger }>;
+      };
+      const entry1 = internal1.sessions.get(id)!;
+      const node = entry1.trace.createNode({ title: "Persisted pending review" });
+      const target = entry1.trace.listPendingAuditTargets([node.id])[0]!;
+      await entry1.taskLedger.enqueueSystem(
+        "auditor",
+        `[Background GoT audit] review ${node.id}\nTrace-Audit-Target: ${JSON.stringify(target)}`,
+      );
+      await m1.emergencySaveAll();
+
+      let auditorTurns = 0;
+      const m2 = new SessionManager({
+        dataRoot,
+        persist: true,
+        agentFactory: scriptedFactory({
+          auditor: { onPrompt: () => { auditorTurns += 1; return undefined; } },
+        }),
+      });
+      await m2.restoreFromDisk();
+      const internal2 = m2 as unknown as {
+        sessions: Map<string, { trace: GraphOfTrace; taskLedger: TaskLedger; traceAuditQueued: Set<string> }>;
+        enqueuePendingTraceAudits(entry: unknown): Promise<void>;
+      };
+      const entry2 = internal2.sessions.get(id)!;
+      await waitFor(() => auditorTurns === 1 && entry2.taskLedger.isPaused("auditor"));
+      expect(entry2.traceAuditQueued.has(node.id)).toBe(true);
+      await internal2.enqueuePendingTraceAudits(entry2);
+      expect(m2.taskNotificationCount(id, "auditor")).toBe(1);
+    } finally {
+      await rm(dataRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+    }
   });
 });

--- a/packages/runtime/src/__tests__/trace-edges.test.ts
+++ b/packages/runtime/src/__tests__/trace-edges.test.ts
@@ -4,14 +4,12 @@
  * After the legacy-parity rewrite, `record_trace` does NOT mutate the graph
  * directly. It dispatches a `[Trace Event]` envelope into the trace agent's
  * internal event queue; the trace agent (a real Pi AgentSession) is the editor that calls
- * `create_trace_node` / `update_trace_node` / `add_trace_relation`. These tests
+ * `create_trace_node` / `update_trace_node`. These tests
  * pin down the host-side plumbing — independent of the Pi-native reminder hooks
  * which only load under the real factory (verified separately per design §7/T2):
  *   - the principal calling `record_trace` causes a trace agent to be spawned
  *     and a trace event to reach its durable queue;
- *   - when the trace agent runs and calls `create_trace_node` consecutively,
- *     the resulting nodes are chained into a connected DAG via the
- *     `getLastNodeId()` fallback (visible edges, not orphan dots);
+ *   - chronology alone does not create causal lineage;
  *   - every trace mutation is pushed to the SSE stream as CUSTOM:trace_node.
  */
 import { describe, it, expect } from "vitest";
@@ -85,11 +83,7 @@ async function waitFor(pred: () => boolean, timeoutMs = 2000): Promise<void> {
 }
 
 describe("Graph of Trace structural plumbing", () => {
-  it("chains consecutive trace agent nodes into a connected DAG (not orphans)", async () => {
-    // Regression: before the agent-driven rewrite, `record_trace` chained nodes
-    // itself; now the trace agent is the writer. The `create_trace_node` tool
-    // still falls back to `getLastNodeId()` when no explicit parent is given,
-    // so consecutive trace-agent decisions remain a connected chain.
+  it("keeps consecutive records as sibling branches under Session Start", async () => {
     let principalTurn = 0;
     let traceTurn = 0;
     const factory = scriptedFactory({
@@ -104,14 +98,17 @@ describe("Graph of Trace structural plumbing", () => {
       },
       trace: {
         onPrompt: (text) => {
-          // The trace agent reads the [Trace Event] envelope and creates a
-          // node; it does NOT pass parent_id, so the chain is via the
-          // create_trace_node fallback to getLastNodeId.
+          // No parent candidate means a sibling branch under Session Start.
           if (!text.includes("[Trace Event]")) return undefined;
           traceTurn += 1;
           return {
             tool: "create_trace_node",
-            args: { title: `decision ${traceTurn}`, type: "trace" },
+            args: {
+              title: `decision ${traceTurn}`,
+              type: "trace",
+              confidence: "medium",
+              confidence_reason: "The source record is available.",
+            },
           };
         },
       },
@@ -120,17 +117,24 @@ describe("Graph of Trace structural plumbing", () => {
     const s = await m.createSession();
 
     await m.sendMessage(s.id, "first");
-    await waitFor(() => m.getTrace(s.id)!.nodes.length >= 1);
+    await waitFor(() => m.getTrace(s.id)!.nodes.some((node) => node.title === "decision 1"));
     await m.sendMessage(s.id, "second");
-    await waitFor(() => m.getTrace(s.id)!.nodes.length >= 2);
+    await waitFor(() => m.getTrace(s.id)!.nodes.some((node) => node.title === "decision 2"));
 
-    const nodes = m.getTrace(s.id)!.nodes;
+    const trace = m.getTrace(s.id)!;
+    const nodes = trace.nodes;
     const first = nodes.find((n) => n.title === "decision 1")!;
     const second = nodes.find((n) => n.title === "decision 2")!;
     expect(first).toBeDefined();
     expect(second).toBeDefined();
-    expect(second.parentIds).toContain(first.id);
-    expect(second.parents[0]!.relation).toBe("follows");
+    expect(first.parentIds).toEqual([trace.meta.rootNodeId]);
+    expect(second.parentIds).toEqual([trace.meta.rootNodeId]);
+    expect(first.records).toEqual([
+      expect.objectContaining({ sourceAgent: "principal", description: "decision 1" }),
+    ]);
+    expect(second.records).toEqual([
+      expect.objectContaining({ sourceAgent: "principal", description: "decision 2" }),
+    ]);
   });
 
   it("pushes every trace mutation to the SSE stream as CUSTOM:trace_node", async () => {
@@ -144,7 +148,15 @@ describe("Graph of Trace structural plumbing", () => {
       trace: {
         onPrompt: (text) =>
           text.includes("[Trace Event]")
-            ? { tool: "create_trace_node", args: { title: "a decision", type: "trace" } }
+            ? {
+                tool: "create_trace_node",
+                args: {
+                  title: "a decision",
+                  type: "trace",
+                  confidence: "medium",
+                  confidence_reason: "The source record is available.",
+                },
+              }
             : undefined,
       },
     });

--- a/packages/runtime/src/__tests__/trace-v2.test.ts
+++ b/packages/runtime/src/__tests__/trace-v2.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { TraceGraph, TraceNode } from "@brainpilot/protocol";
@@ -79,7 +79,7 @@ describe("TraceGraphV2 storage and audit semantics", () => {
         { id: "b", title: "B", type: "task", status: "completed", toolCalls: [], artifactIds: [], episodeTags: [], records: [], parents: [{ nodeId: "a", conclusion: "confirmed" }], executionResult: "completed", revoked: false, reviewConclusion: "approved" },
         { id: "orphan", title: "Orphan", type: "task", status: "completed", toolCalls: [], artifactIds: [], episodeTags: [], records: [], parents: [{ nodeId: "missing", conclusion: "confirmed" }], executionResult: "completed", revoked: false, reviewConclusion: "approved" },
       ],
-      dependencies: [], semanticLinks: [], episodes: [], artifacts: [],
+      dependencies: [], episodes: [], artifacts: [],
     });
 
     const normalized = graph.getGraphV2();
@@ -113,6 +113,10 @@ describe("TraceGraphV2 storage and audit semantics", () => {
       graph.load(original);
 
       expect(await readFile(tracePath, "utf8")).toBe(JSON.stringify(original, null, 2));
+      expect(graph.getNodeV2("b")?.parents).toContainEqual(
+        expect.objectContaining({ nodeId: "a", conclusion: "confirmed" }),
+      );
+      expect(graph.getNode("b")?.parentIds).toContain("a");
       graph.createNode({ title: "first V2 write" });
       await graph.flush();
 
@@ -148,6 +152,35 @@ describe("TraceGraphV2 storage and audit semantics", () => {
         expect.objectContaining({ action: "node_created" }),
         expect.objectContaining({ action: "node_reviewed" }),
       ]));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("retains the complete pending journal tail after an append failure", async () => {
+    const root = await mkdtemp(join(tmpdir(), "bp-trace-pending-"));
+    try {
+      const tracePath = join(root, "trace.json");
+      const journalPath = join(root, "trace-changes.jsonl");
+      await mkdir(journalPath);
+      const graph = new GraphOfTrace("s", tracePath);
+      graph.createNode({ title: "First change" });
+      graph.createNode({ title: "Second change" });
+      await graph.flush();
+
+      const failedSnapshot = JSON.parse(await readFile(tracePath, "utf8")) as { pendingChanges?: unknown[] };
+      expect(failedSnapshot.pendingChanges).toHaveLength(2);
+
+      await rm(journalPath, { recursive: true, force: true });
+      const restored = new GraphOfTrace("s", tracePath);
+      restored.load(failedSnapshot);
+      await restored.recoverChanges();
+
+      const actions = (await readFile(journalPath, "utf8"))
+        .trim().split("\n").map((line) => JSON.parse(line) as { action: string });
+      expect(actions.filter((change) => change.action === "node_created")).toHaveLength(2);
+      const recoveredSnapshot = JSON.parse(await readFile(tracePath, "utf8")) as Record<string, unknown>;
+      expect(recoveredSnapshot).not.toHaveProperty("pendingChanges");
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/runtime/src/__tests__/trace-v2.test.ts
+++ b/packages/runtime/src/__tests__/trace-v2.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { TraceGraph, TraceNode } from "@brainpilot/protocol";
+import { TraceDocumentV2Schema } from "@brainpilot/protocol";
+import { GraphOfTrace } from "../trace.js";
+
+function legacyNode(id: string, createdAt: string, parents: TraceNode["parents"] = []): TraceNode {
+  return {
+    id,
+    title: id,
+    type: "task",
+    status: "completed",
+    parents,
+    artifacts: [],
+    parentIds: parents.map((parent) => parent.id),
+    childIds: [],
+    createdAt,
+    updatedAt: createdAt,
+    toolCalls: [],
+  };
+}
+
+function v1Graph(): TraceGraph {
+  const a = legacyNode("a", "2026-01-01T00:00:00.000Z");
+  const b = legacyNode("b", "2026-01-01T00:01:00.000Z", [
+    { id: "a", relation: "depends_on" },
+  ]);
+  return {
+    meta: { sessionId: "s", createdAt: "2026-01-01T00:00:00.000Z" },
+    nodes: [a, b],
+  };
+}
+
+describe("TraceGraphV2 storage and audit semantics", () => {
+  it("creates one protected Session Start root as the confirmed fallback", () => {
+    const graph = new GraphOfTrace("s");
+    const rootId = graph.getGraphV2().meta.rootNodeId!;
+    expect(graph.getNodeV2(rootId)).toMatchObject({
+      type: "session_start",
+      reviewConclusion: "approved",
+      revoked: false,
+      parents: [],
+    });
+
+    const evidence = graph.createNode({ title: "Evidence" });
+    const conclusion = graph.createNode({ title: "Conclusion" });
+    expect(graph.getNode(evidence.id)?.parentIds).toEqual([rootId]);
+    expect(graph.getNode(conclusion.id)?.parentIds).toEqual([rootId]);
+    expect(graph.updateNode(rootId, { title: "Changed" })).toBeUndefined();
+    expect(graph.listPendingAuditTargets().some((target) => target.nodeId === rootId)).toBe(false);
+
+    expect(graph.proposeCausalParent(
+      conclusion.id,
+      evidence.id,
+      "Conclusion consumes this evidence.",
+      { type: "agent", name: "trace" },
+    )).toBe(true);
+    expect(graph.getNode(conclusion.id)?.parentIds).toEqual([rootId]);
+    expect(graph.review(
+      conclusion.id,
+      "approve",
+      "Direct evidence confirmed.",
+      { type: "agent", name: "auditor" },
+      evidence.id,
+    )).toBe(true);
+    expect(graph.getNode(conclusion.id)?.parentIds).toEqual([evidence.id]);
+  });
+
+  it("repairs rootless and cyclic V2 data into a root-reachable active DAG", () => {
+    const graph = new GraphOfTrace("s");
+    graph.load({
+      schemaVersion: "2.0",
+      revision: 4,
+      meta: { sessionId: "s" },
+      nodes: [
+        { id: "a", title: "A", type: "task", status: "completed", toolCalls: [], artifactIds: [], episodeTags: [], records: [], parents: [{ nodeId: "b", conclusion: "confirmed" }], executionResult: "completed", revoked: false, reviewConclusion: "approved" },
+        { id: "b", title: "B", type: "task", status: "completed", toolCalls: [], artifactIds: [], episodeTags: [], records: [], parents: [{ nodeId: "a", conclusion: "confirmed" }], executionResult: "completed", revoked: false, reviewConclusion: "approved" },
+        { id: "orphan", title: "Orphan", type: "task", status: "completed", toolCalls: [], artifactIds: [], episodeTags: [], records: [], parents: [{ nodeId: "missing", conclusion: "confirmed" }], executionResult: "completed", revoked: false, reviewConclusion: "approved" },
+      ],
+      dependencies: [], semanticLinks: [], episodes: [], artifacts: [],
+    });
+
+    const normalized = graph.getGraphV2();
+    const rootId = normalized.meta.rootNodeId!;
+    const activeParents = new Map(normalized.nodes.map((node) => [
+      node.id,
+      node.parents.filter((parent) => parent.conclusion === "confirmed").map((parent) => parent.nodeId),
+    ]));
+    const reachesRoot = (start: string): boolean => {
+      const seen = new Set<string>();
+      const visit = (id: string): boolean => {
+        if (id === rootId) return true;
+        if (seen.has(id)) return false;
+        seen.add(id);
+        return (activeParents.get(id) ?? []).some(visit);
+      };
+      return visit(start);
+    };
+    expect(normalized.nodes.filter((node) => node.id !== rootId).every((node) => reachesRoot(node.id))).toBe(true);
+    expect(normalized.nodes.flatMap((node) => node.parents).some((parent) => parent.reason?.includes("confirmed cycle rejected"))).toBe(true);
+    expect(graph.getNode("orphan")?.parentIds).toEqual([rootId]);
+  });
+
+  it("migrates V1 lazily and persists only nodes[].parents as authoritative relationships", async () => {
+    const root = await mkdtemp(join(tmpdir(), "bp-trace-v2-"));
+    try {
+      const tracePath = join(root, "trace.json");
+      const original = v1Graph();
+      await writeFile(tracePath, JSON.stringify(original, null, 2), "utf8");
+      const graph = new GraphOfTrace("s", tracePath);
+      graph.load(original);
+
+      expect(await readFile(tracePath, "utf8")).toBe(JSON.stringify(original, null, 2));
+      graph.createNode({ title: "first V2 write" });
+      await graph.flush();
+
+      const persisted = JSON.parse(await readFile(tracePath, "utf8")) as Record<string, unknown>;
+      expect(persisted.schemaVersion).toBe("2.0");
+      expect(JSON.stringify(persisted)).not.toContain('"parentIds"');
+      expect(JSON.stringify(persisted)).not.toContain('"childIds"');
+      expect(persisted).not.toHaveProperty("dependencies");
+      expect(persisted).not.toHaveProperty("semanticLinks");
+      expect(TraceDocumentV2Schema.safeParse(persisted).success).toBe(true);
+      expect(JSON.parse(await readFile(join(root, "trace.v1.json.bak"), "utf8"))).toEqual(original);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("persists and recovers the append-only modification log", async () => {
+    const root = await mkdtemp(join(tmpdir(), "bp-trace-changes-"));
+    try {
+      const tracePath = join(root, "trace.json");
+      const graph = new GraphOfTrace("s", tracePath);
+      const node = graph.createNode({ title: "Model ablation", changeActor: { type: "agent", name: "trace" } });
+      graph.review(node.id, "approve", "evidence is sufficient", { type: "agent", name: "auditor" });
+      await graph.flush();
+
+      const raw = await readFile(join(root, "trace-changes.jsonl"), "utf8");
+      expect(raw).toContain('"action":"node_created"');
+      expect(raw).toContain('"action":"node_reviewed"');
+      const restored = new GraphOfTrace("s", tracePath);
+      restored.load(JSON.parse(await readFile(tracePath, "utf8")));
+      await restored.recoverChanges();
+      expect(restored.getChanges()).toEqual(expect.arrayContaining([
+        expect.objectContaining({ action: "node_created" }),
+        expect.objectContaining({ action: "node_reviewed" }),
+      ]));
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("requires current fingerprints and hides revoked nodes from active graphs", () => {
+    const graph = new GraphOfTrace("s");
+    const node = graph.createNode({
+      title: "Model ablation",
+      confidence: "low",
+      confidenceReason: "One incomplete run.",
+    });
+    const stale = graph.listPendingAuditTargets().find((target) => target.nodeId === node.id)!;
+    graph.updateNode(node.id, {
+      summary: "Three seeds now agree.",
+      confidence: "high",
+      confidenceReason: "Three independent records agree.",
+    }, { type: "agent", name: "trace" });
+
+    expect(graph.review(node.id, "approve", "stale", { type: "agent", name: "auditor" }, undefined, stale.fingerprint)).toBe(false);
+    const current = graph.listPendingAuditTargets().find((target) => target.nodeId === node.id)!;
+    expect(graph.review(node.id, "approve", "supported", { type: "agent", name: "auditor" }, undefined, current.fingerprint)).toBe(true);
+    graph.updateNode(node.id, { revoked: true }, { type: "host" });
+    expect(graph.getActiveGraph().nodes.some((candidate) => candidate.id === node.id)).toBe(false);
+  });
+});

--- a/packages/runtime/src/__tests__/trace.test.ts
+++ b/packages/runtime/src/__tests__/trace.test.ts
@@ -24,17 +24,19 @@ describe("GraphOfTrace onChange (#79)", () => {
     ]);
   });
 
-  it("createChainedNode links to the previous node and tags metadata.auto", () => {
+  it("createChainedNode keeps chronology separate from causality and tags metadata.auto", () => {
     const g = new GraphOfTrace("s");
     const root = g.createChainedNode({ title: "root", agent: "principal" });
-    expect(root.parents).toEqual([]); // first node is a root
+    expect(root.parents).toEqual([
+      expect.objectContaining({ relation: "depends_on", edgeType: "confirmed" }),
+    ]);
     expect(root.metadata?.auto).toBe(true);
 
     const next = g.createChainedNode({ title: "next", agent: "principal" });
-    expect(next.parents).toEqual([{ id: root.id, relation: "follows" }]);
-    expect(next.parentIds).toEqual([root.id]);
-    // Reverse edge maintained.
-    expect(g.getNode(root.id)!.childIds).toContain(next.id);
+    expect(next.parents).toEqual([
+      expect.objectContaining({ relation: "depends_on", edgeType: "confirmed" }),
+    ]);
+    expect(next.parentIds).not.toContain(root.id);
   });
 
   it("getLastNodeId tracks the most recent create", () => {
@@ -60,8 +62,10 @@ describe("GraphOfTrace onChange (#79)", () => {
     // Correct direction: survey (earlier) is prerequisite of synthesis (later).
     expect(g.addRelation("survey", "synthesis", "synthesis builds on the survey")).toBe(true);
     // synthesis depends_on survey: survey recorded as synthesis's parent.
-    expect(g.getNode("synthesis")!.parentIds).toContain("survey");
-    expect(g.getNode("survey")!.childIds).toContain("synthesis");
+    expect(g.getNodeV2("synthesis")!.parents).toContainEqual(
+      expect.objectContaining({ nodeId: "survey", conclusion: "candidate" }),
+    );
+    expect(g.getNode("synthesis")!.parentIds).not.toContain("survey");
   });
 
   it("auto-corrects a reversed depends_on edge to follow chronology (#110)", () => {
@@ -82,26 +86,17 @@ describe("GraphOfTrace onChange (#79)", () => {
     });
 
     // Reversed args: caller says from=synthesis (later) -> to=survey (earlier).
-    // The guard must swap so the edge still points survey -> synthesis.
+    // V2 preserves the caller-declared direction and requires Auditor review.
     expect(g.addRelation("synthesis", "survey", "synthesis depends on survey")).toBe(true);
-    expect(g.getNode("synthesis")!.parentIds).toContain("survey");
-    expect(g.getNode("synthesis")!.parentIds).not.toContain("synthesis");
-    expect(g.getNode("survey")!.childIds).toContain("synthesis");
-    expect(g.getNode("survey")!.parentIds).not.toContain("synthesis");
+    expect(g.getNodeV2("survey")!.parents).toContainEqual(
+      expect.objectContaining({ nodeId: "synthesis", conclusion: "candidate" }),
+    );
 
-    // Reversed again: from=audit (latest) -> to=synthesis. Swap → synthesis -> audit.
+    // Reversed again remains audit -> synthesis as declared.
     expect(g.addRelation("audit", "synthesis", "audit depends on synthesis")).toBe(true);
-    expect(g.getNode("audit")!.parentIds).toContain("synthesis");
-    expect(g.getNode("synthesis")!.childIds).toContain("audit");
-
-    // Every depends_on edge now points earlier → later (no time reversal).
-    for (const node of g.getGraph().nodes) {
-      for (const p of node.parents) {
-        if (p.relation !== "depends_on") continue;
-        const parent = g.getNode(p.id)!;
-        expect(parent.createdAt! <= node.createdAt!).toBe(true);
-      }
-    }
+    expect(g.getNodeV2("synthesis")!.parents).toContainEqual(
+      expect.objectContaining({ nodeId: "audit", conclusion: "candidate" }),
+    );
   });
 
   it("does not reorder non-depends_on relations (parent/follows left intact)", () => {
@@ -118,10 +113,13 @@ describe("GraphOfTrace onChange (#79)", () => {
     // A 'parent' edge from the later node is a legitimate hierarchy link; the
     // chronology guard only applies to depends_on and must leave this as-is.
     expect(g.addRelation("late", "early", "hierarchy", "parent")).toBe(true);
-    expect(g.getNode("early")!.parentIds).toContain("late");
+    expect(g.getNode("early")!.parentIds).not.toContain("late");
+    expect(g.getNodeDetail("early")!.semanticLinks.incoming).toContainEqual(
+      expect.objectContaining({ fromId: "late" }),
+    );
   });
 
-  it("load() resumes chaining from the latest node", () => {
+  it("load() tracks the latest node without manufacturing lineage", () => {
     const g = new GraphOfTrace("s");
     const older: TraceNode = {
       id: "n1", title: "older", type: "task", status: "completed",
@@ -133,6 +131,6 @@ describe("GraphOfTrace onChange (#79)", () => {
     g.load({ meta: { sessionId: "s" }, nodes: [older, newer] });
     expect(g.getLastNodeId()).toBe("n2");
     const chained = g.createChainedNode({ title: "after-restore" });
-    expect(chained.parentIds).toEqual(["n2"]);
+    expect(chained.parentIds).not.toContain("n2");
   });
 });

--- a/packages/runtime/src/__tests__/trace.test.ts
+++ b/packages/runtime/src/__tests__/trace.test.ts
@@ -99,7 +99,7 @@ describe("GraphOfTrace onChange (#79)", () => {
     );
   });
 
-  it("does not reorder non-depends_on relations (parent/follows left intact)", () => {
+  it("ignores non-causal legacy relations", () => {
     const g = new GraphOfTrace("s");
     const mk = (id: string, ts: string): TraceNode => ({
       id, title: id, type: "task", status: "completed",
@@ -110,13 +110,8 @@ describe("GraphOfTrace onChange (#79)", () => {
       meta: { sessionId: "s" },
       nodes: [mk("early", "2026-01-01T00:00:00.000Z"), mk("late", "2026-01-02T00:00:00.000Z")],
     });
-    // A 'parent' edge from the later node is a legitimate hierarchy link; the
-    // chronology guard only applies to depends_on and must leave this as-is.
-    expect(g.addRelation("late", "early", "hierarchy", "parent")).toBe(true);
+    expect(g.addRelation("late", "early", "hierarchy", "parent")).toBe(false);
     expect(g.getNode("early")!.parentIds).not.toContain("late");
-    expect(g.getNodeDetail("early")!.semanticLinks.incoming).toContainEqual(
-      expect.objectContaining({ fromId: "late" }),
-    );
   });
 
   it("load() tracks the latest node without manufacturing lineage", () => {

--- a/packages/runtime/src/personas.ts
+++ b/packages/runtime/src/personas.ts
@@ -1118,6 +1118,18 @@ report in the message; PI reads the file.
 
 After sending, **end your turn**. Do not continue tool calls.
 
+When the Host assigns a Graph of Trace review, use
+\`list_pending_trace_reviews\` only to inspect the outstanding backlog. It is
+read-only and cannot change the target bound to this turn.
+
+Inspect the bound node or proposed parent with \`get_trace_node\` and
+\`get_trace_neighborhood\`, then record exactly one \`approve\`, \`reject\`, or
+\`uncertain\` verdict with \`edit_trace_review\` and a concrete reason. The Host
+binds the exact target, so do not select another node. Finish with
+\`submit_audit_report\`. You may assess node quality or one proposed causal
+parent, but may not create or rewrite nodes, change parents, or revoke nodes.
+Do not delegate a bound GoT review or message PI directly.
+
 ## Hard rules
 
 - **Audit two dimensions only:** claim-vs-evidence, and the named
@@ -1146,53 +1158,55 @@ ${A2A_EXPERT}`;
 
 const TRACE = `# Trace Agent
 
-You are the Trace Agent, an internal system agent that records and curates the
-Graph of Trace (GoT) for this session. You are a passive recorder with editorial
-discretion.
+You are the passive editor of the session's Graph of Trace (GoT). You never do
+the research work yourself. For each Trace Event, inspect the compact active
+graph and make zero, one, or multiple node mutations. Make no graph change when
+the record is duplicate or process noise. Create or update multiple nodes only
+when the event contains independently meaningful scientific units.
 
-## Passive about work, active about recording
+## What one node means
 
-**Passive about work:** you execute nothing. You do not write code, run
-commands, or perform any task described in the events you receive. You are a
-camera that watches what others do — never a participant.
+A node is an independently meaningful research unit: something that can be
+compared, reproduced, inspected as evidence, cited by a conclusion, or revoked
+without revoking every sibling result. It is not one tool call or progress
+message. Multiple reports may be curated into the same node.
 
-**Active about recording:** Principal and experts push trace events to you,
-often describing the SAME logical work from different angles (PI: "delegated
-search to librarian"; librarian: "found 12 papers"). Recognize when events
-describe one thing and MERGE them into a single well-organized node — don't
-record one node per source. You may also SKIP events that add nothing, or SPLIT
-one event into several nodes when it covers independent deliverables. You are the
-camera operator and the editor: you decide what makes the final cut.
+- Each experimental condition or model variant normally gets its own node.
+- Repeated seeds, folds, and runs normally update that variant node.
+- Each distinct analysis, visualization, or scientific claim gets a node.
+- Formatting changes, immediate retries, acknowledgements, and reading one file
+  are not nodes.
+- Use \`completed\` for interpretable outputs, including null findings, and
+  \`failed\` only for a meaningful execution failure.
 
-## Responsibilities
+Choose the correct granularity when creating a node. Update only when the new
+record belongs to the same research unit; append content and evidence rather
+than duplicating it.
 
-1. Receive trace events about work progress.
-2. Decide autonomously when to create a node, update a node, or add a relation.
-3. Maintain the graph using your tools: \`create_trace_node\`,
-   \`update_trace_node\`, \`add_trace_relation\`, \`get_trace_graph\`.
-4. Expand coarse records into fine-grained nodes when warranted.
-5. Deduplicate redundant records and infer relations between nodes from context.
+Every \`create_trace_node\` and \`update_trace_node\` call must set \`confidence\`
+and a concrete \`confidence_reason\`. Confidence measures how strongly the node
+is supported by its records and scientific evidence, not task-success
+probability. Re-evaluate it after every update. Auditor review is independent.
 
-Use \`get_trace_graph\` to see current state before deciding whether an incoming
-event is new, a duplicate to merge, or a refinement of an existing node.
+## Causal parents
 
-## Dependency edge direction (read carefully)
+A parent means the current node would cease to be valid or require recomputation
+without that upstream node. Chronology, adjacency, shared authorship,
+delegation, and textual similarity are not causality. Conclusion nodes should
+propose their direct evidence nodes rather than every transitive ancestor.
 
-When you call \`add_trace_relation(from_id, to_id)\`, the edge means
-"**to_id depends_on from_id**" and is drawn \`from_id ──▶ to_id\`:
+Supply possible parents through \`parent_candidates\` on \`create_trace_node\` or
+\`update_trace_node\`. You only propose candidates; Auditor confirms or rejects
+them. Never recreate a rejected candidate without materially new evidence. The
+Host supplies a hidden Session Start parent until a specific parent is
+confirmed; never propose or edit that structural root yourself.
 
-- \`from_id\` = the **prerequisite** / earlier source work that must exist first.
-- \`to_id\` = the **dependent** / later downstream work that relies on it.
+The Host binds the current source record to your create/update call. Do not pass
+record ids. Revoked nodes are hidden and must never be reused: create a new node
+for re-executed work.
 
-Because later work depends on earlier work, the prerequisite (\`from_id\`) is
-almost always the node that was **created earlier**. If you are about to point an
-edge from a later node back to an earlier one, you have the arguments reversed.
-
-Example chain (each later step depends on the previous deliverable):
-\`survey ──▶ synthesis ──▶ audit ──▶ cleanup ──▶ final verification\`
-recorded as \`add_trace_relation(from_id=survey, to_id=synthesis)\`,
-\`add_trace_relation(from_id=synthesis, to_id=audit)\`, and so on — never the
-reverse.`;
+Use \`get_trace_graph\` for the compact active graph, and \`get_trace_node\` or
+\`get_trace_neighborhood\` only when more detail is necessary.`;
 
 /* ------------------------------- registry -------------------------------- */
 

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -17,6 +17,7 @@ import { join, resolve, sep, dirname } from "node:path";
 import { randomUUID } from "node:crypto";
 import {
   CUSTOM_EVENT,
+  type AuditReport,
   type AgUiEvent,
   type AgentStats,
   type AgentStatus,
@@ -29,6 +30,7 @@ import {
   type SessionTokenUsage,
   type TokenUsage,
   type TraceGraph,
+  type TraceNodeRecord,
   type UserInputCancellationReason,
 } from "@brainpilot/protocol";
 import { EventBus } from "./event-bus.js";
@@ -38,7 +40,7 @@ import {
   type TaskNotification,
   type TaskRecord,
 } from "./task-ledger.js";
-import { GraphOfTrace } from "./trace.js";
+import { GraphOfTrace, type TraceAuditTarget } from "./trace.js";
 import { MasAgent, addUsage, emptyTokenUsage } from "./mas-agent.js";
 import {
   addStatsDelta,
@@ -268,6 +270,12 @@ interface SessionEntry {
   bus: EventBus;
   taskLedger: TaskLedger;
   trace: GraphOfTrace;
+  /** Host-bound source record while Trace processes one durable event. */
+  currentTraceRecord?: TraceNodeRecord;
+  /** Host-bound immutable target for one Auditor turn. */
+  currentTraceAuditTarget?: TraceAuditTarget;
+  /** Deduplicates durable Auditor targets by node/parent identity. */
+  traceAuditQueued: Set<string>;
   agents: Map<string, MasAgent>;
   /**
    * #97 error path: per-agent count of CONSECUTIVE failed delivery runs. Bumped
@@ -1263,6 +1271,9 @@ export class SessionManager {
       (op, node) => {
         bus.emit(ev.custom({ sessionId: id }, CUSTOM_EVENT.TRACE_NODE, { op, node }));
       },
+      (delta) => {
+        bus.emit(ev.custom({ sessionId: id }, CUSTOM_EVENT.TRACE_DELTA, delta));
+      },
     );
 
     const entry: SessionEntry = {
@@ -1274,6 +1285,9 @@ export class SessionManager {
       bus,
       taskLedger,
       trace,
+      currentTraceRecord: undefined,
+      currentTraceAuditTarget: undefined,
+      traceAuditQueued: new Set(),
       agents: new Map(),
       deliveryErrors: new Map(),
       runActive: false,
@@ -1319,6 +1333,7 @@ export class SessionManager {
         throw err;
       }
       await this.loadTrace(entry);
+      this.rebuildQueuedTraceAudits(entry);
       // Rehydrate cumulative token usage so the running total survives restarts.
       await this.loadUsage(entry);
       // Rehydrate full per-run/per-session stats (tokens+tools+skills+errors).
@@ -2033,6 +2048,8 @@ export class SessionManager {
       sessionId,
       fromAgent: name,
       trace: entry.trace,
+      currentTraceRecord: () => entry.currentTraceRecord,
+      currentTraceAuditTarget: () => entry.currentTraceAuditTarget,
       dispatchTask: async (target, content) => {
         const task = await entry.taskLedger.dispatch(name, target, content);
         entry.bus.emit(ev.custom({ sessionId }, CUSTOM_EVENT.TASK_STATE, { op: "created", task }));
@@ -2309,22 +2326,40 @@ export class SessionManager {
       const entry = this.sessions.get(sessionId);
       if (!entry) return;
       if (entry.taskLedger.isPaused(name)) return;
-      const notifications = entry.taskLedger.peekBatch(name);
+      // Trace and Auditor bind exactly one durable event to host-owned state.
+      const notifications = entry.taskLedger.peekBatch(
+        name,
+        name === "trace" || name === "auditor" ? 1 : undefined,
+      );
       if (notifications.length === 0) return;
       const agent = await this.ensureAgent(sessionId, name);
       if (agent.status === "stopped") return;
       this.touch(entry);
       // Surface the delegated run immediately (derived active flag, agent list).
       this.emitSessionState(entry);
+      const traceRecord = name === "trace"
+        ? this.parseInternalEnvelope<TraceNodeRecord>(notifications[0]?.content, "Trace-Record")
+        : undefined;
+      const auditTarget = name === "auditor"
+        ? this.coerceTraceAuditTarget(this.parseInternalEnvelope(notifications[0]?.content, "Trace-Audit-Target"))
+        : undefined;
+      if (name === "trace") entry.currentTraceRecord = traceRecord;
+      if (name === "auditor") entry.currentTraceAuditTarget = auditTarget;
       // #167: cap concurrent provider calls across experts in this session.
-      const ran = await this.withProviderSlot(sessionId, async () => {
-        // Stop may have paused delivery while this run waited for a provider
-        // semaphore slot. Do not start a new model call after Stop completed.
-        const current = this.sessions.get(sessionId);
-        if (!current || current !== entry || current.taskLedger.isPaused(name)) return false;
-        await agent.prompt(this.renderTaskEvents(notifications));
-        return true;
-      });
+      let ran = false;
+      try {
+        ran = await this.withProviderSlot(sessionId, async () => {
+          // Stop may have paused delivery while this run waited for a provider
+          // semaphore slot. Do not start a new model call after Stop completed.
+          const current = this.sessions.get(sessionId);
+          if (!current || current !== entry || current.taskLedger.isPaused(name)) return false;
+          await agent.prompt(this.renderTaskEvents(notifications));
+          return true;
+        });
+      } finally {
+        if (name === "trace") entry.currentTraceRecord = undefined;
+        if (name === "auditor") entry.currentTraceAuditTarget = undefined;
+      }
       if (!ran || entry.taskLedger.isPaused(name)) return;
 
       // Status returns to idle after an explicit abort, so it cannot identify
@@ -2358,6 +2393,16 @@ export class SessionManager {
         ));
         return;
       }
+      if (name === "auditor" && auditTarget) {
+        const pending = entry.trace.listPendingAuditTargets([auditTarget.nodeId])
+          .find((target) => this.traceAuditKey(target) === this.traceAuditKey(auditTarget));
+        if (pending?.fingerprint === auditTarget.fingerprint) {
+          // A clean turn is not a completed audit unless the bound target was
+          // concluded. Keep the notification durable and pause to avoid a spin.
+          await entry.taskLedger.pauseAgent(name);
+          return;
+        }
+      }
       // Linearize acknowledgement with pauseDelivery(): if Stop won the ledger
       // write race, retain the batch for the next explicit user turn.
       const acknowledged = await entry.taskLedger.acknowledgeIfActive(
@@ -2366,6 +2411,74 @@ export class SessionManager {
       );
       if (!acknowledged) return;
       entry.deliveryErrors.delete(name); // clean run → reset the streak
+      if (name === "trace") {
+        void this.enqueuePendingTraceAudits(entry);
+      } else if (name === "auditor" && auditTarget) {
+        entry.traceAuditQueued.delete(this.traceAuditKey(auditTarget));
+        const latest = entry.trace.auditFingerprint(auditTarget.nodeId, auditTarget.parentNodeId);
+        const stillPending = entry.trace.listPendingAuditTargets([auditTarget.nodeId])
+          .some((target) => this.traceAuditKey(target) === this.traceAuditKey(auditTarget));
+        if (stillPending && latest && latest !== auditTarget.fingerprint) {
+          void this.enqueueTraceAudit(entry, { ...auditTarget, fingerprint: latest });
+        }
+      }
+    }
+  }
+
+  private parseInternalEnvelope<T>(content: string | undefined, key: string): T | undefined {
+    if (!content) return undefined;
+    const prefix = `${key}: `;
+    const line = content.split("\n").find((candidate) => candidate.startsWith(prefix));
+    if (!line) return undefined;
+    try { return JSON.parse(line.slice(prefix.length)) as T; } catch { return undefined; }
+  }
+
+  private rebuildQueuedTraceAudits(entry: SessionEntry): void {
+    entry.traceAuditQueued.clear();
+    const notifications = entry.taskLedger.peekBatch("auditor", Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER);
+    for (const notification of notifications) {
+      const target = this.coerceTraceAuditTarget(
+        this.parseInternalEnvelope(notification.content, "Trace-Audit-Target"),
+      );
+      if (target) entry.traceAuditQueued.add(this.traceAuditKey(target));
+    }
+  }
+
+  private traceAuditKey(target: Pick<TraceAuditTarget, "nodeId" | "parentNodeId">): string {
+    return target.parentNodeId ? `${target.nodeId}<-${target.parentNodeId}` : target.nodeId;
+  }
+
+  private coerceTraceAuditTarget(value: unknown): TraceAuditTarget | undefined {
+    if (!value || typeof value !== "object") return undefined;
+    const raw = value as Record<string, unknown>;
+    if (typeof raw.nodeId !== "string" || typeof raw.fingerprint !== "string") return undefined;
+    return {
+      nodeId: raw.nodeId,
+      ...(typeof raw.parentNodeId === "string" ? { parentNodeId: raw.parentNodeId } : {}),
+      fingerprint: raw.fingerprint,
+    };
+  }
+
+  private async enqueuePendingTraceAudits(entry: SessionEntry): Promise<void> {
+    for (const target of entry.trace.listPendingAuditTargets()) await this.enqueueTraceAudit(entry, target);
+  }
+
+  private async enqueueTraceAudit(entry: SessionEntry, target: TraceAuditTarget): Promise<void> {
+    const key = this.traceAuditKey(target);
+    if (entry.traceAuditQueued.has(key)) return;
+    entry.traceAuditQueued.add(key);
+    try {
+      await this.ensureAgent(entry.id, "auditor");
+      const instruction = target.parentNodeId
+        ? `[后台 GoT 审计] 请独立审查节点 ${target.nodeId} 的候选因果父节点 ${target.parentNodeId}。读取必要的局部 Trace 证据，然后用 edit_trace_review 提交一次结论和理由。不要通知 PI。`
+        : `[后台 GoT 审计] 请独立审查节点 ${target.nodeId} 的内容与证据充分性。读取必要的局部 Trace 证据，然后用 edit_trace_review 提交一次结论和理由。不要通知 PI。`;
+      await entry.taskLedger.enqueueSystem(
+        "auditor",
+        `${instruction}\nTrace-Audit-Target: ${JSON.stringify(target)}`,
+      );
+      this.wakeAgent(entry.id, "auditor");
+    } catch {
+      entry.traceAuditQueued.delete(key);
     }
   }
 
@@ -2584,6 +2697,14 @@ export class SessionManager {
   getTrace(sessionId: string): TraceGraph | undefined {
     const entry = this.sessions.get(sessionId);
     return entry?.trace.getGraph();
+  }
+
+  getTraceChanges(sessionId: string, limit = 200): import("@brainpilot/protocol").TraceChange[] | undefined {
+    return this.sessions.get(sessionId)?.trace.getChanges(limit);
+  }
+
+  getAuditReports(sessionId: string): AuditReport[] | undefined {
+    return this.sessions.get(sessionId)?.trace.getAuditReports();
   }
 
   /**
@@ -2813,6 +2934,7 @@ export class SessionManager {
     } catch {
       /* no trace yet */
     }
+    await entry.trace.recoverChanges();
   }
 
   private usagePath(sid: string): string {

--- a/packages/runtime/src/tools/system-tools.ts
+++ b/packages/runtime/src/tools/system-tools.ts
@@ -7,9 +7,10 @@
  * Per-agent access control (§9, ported from legacy `agent_tool_config`) is
  * applied by `toolsForRole` — each role only receives its allowed tools.
  */
-import type { AgentRole, SystemTool } from "../types.js";
+import type { TraceNodeRecord } from "@brainpilot/protocol";
+import type { GraphOfTrace, TraceArtifactInput, TraceAuditTarget } from "../trace.js";
 import { TaskQueueFullError, type TaskRecord } from "../task-ledger.js";
-import type { GraphOfTrace } from "../trace.js";
+import type { AgentRole, SystemTool } from "../types.js";
 import { createSkillSearchTool } from "./skill-search.js";
 import {
   createGetDomainKnowledgeLocalTool,
@@ -48,10 +49,47 @@ export interface ToolDeps {
    * `bp_template/skills/` dir loaded through `additionalSkillPaths`.
    */
   routerSkillsDir: string;
+  /** Current host-owned record while the Trace Agent processes one trace event. */
+  currentTraceRecord?: () => TraceNodeRecord | undefined;
+  /** Host-bound immutable target for one asynchronous Auditor turn. */
+  currentTraceAuditTarget?: () => TraceAuditTarget | undefined;
 }
 
 function ok(text: string): { content: [{ type: "text"; text: string }] } {
   return { content: [{ type: "text", text }] };
+}
+
+/** Detail/read tools are deliberately bounded so one graph query cannot eat a turn. */
+const TRACE_DETAIL_MAX_TOKENS = 1500;
+
+function cappedJson(value: unknown, maxTokens = TRACE_DETAIL_MAX_TOKENS): string {
+  const text = JSON.stringify(value, null, 2);
+  const maxChars = maxTokens * 3.5;
+  if (text.length <= maxChars) return text;
+  const suffix = `\n… truncated at ${maxTokens} estimated tokens`;
+  // Reserve the marker itself so the returned result, not merely its raw JSON
+  // prefix, stays within the declared 1500-token detail cap.
+  return `${text.slice(0, Math.max(0, Math.floor(maxChars - suffix.length)))}${suffix}`;
+}
+
+function artifactInputs(value: unknown): TraceArtifactInput[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item): TraceArtifactInput[] => {
+    if (typeof item === "string" && item) return [{ path: item }];
+    if (!item || typeof item !== "object") return [];
+    const input = item as Record<string, unknown>;
+    if (typeof input.path !== "string" || !input.path) return [];
+    return [{
+      ...(typeof input.id === "string" ? { id: input.id } : {}),
+      path: input.path,
+      ...(typeof input.kind === "string" ? { kind: input.kind } : {}),
+      ...(typeof input.type === "string" ? { type: input.type } : {}),
+      ...(typeof input.producer_node_id === "string" ? { producerNodeId: input.producer_node_id } : {}),
+      ...(typeof input.producerNodeId === "string" ? { producerNodeId: input.producerNodeId } : {}),
+      ...(typeof input.blob_hash === "string" ? { blobHash: input.blob_hash } : {}),
+      ...(typeof input.blobHash === "string" ? { blobHash: input.blobHash } : {}),
+    }];
+  });
 }
 
 export function createDispatchTaskTool(deps: ToolDeps): SystemTool {
@@ -73,6 +111,12 @@ export function createDispatchTaskTool(deps: ToolDeps): SystemTool {
       if (!to || !content) return { ...ok("to and content are required"), isError: true };
       if (to === deps.fromAgent) return { ...ok("cannot dispatch a task to yourself"), isError: true };
       if (to === "trace") return { ...ok("cannot dispatch user tasks to the trace agent"), isError: true };
+      if (deps.fromAgent === "auditor" && deps.currentTraceAuditTarget?.()) {
+        return { ...ok("A bound GoT audit is a single-turn review and cannot delegate tasks"), isError: true };
+      }
+      if (deps.fromAgent === "auditor" && to === "principal") {
+        return { ...ok("Auditor reports are user-gated and cannot be sent directly to PI"), isError: true };
+      }
       await deps.ensureAgent(to);
       try {
         const task = await deps.dispatchTask(to, content);
@@ -224,6 +268,16 @@ export function createRecordTraceTool(deps: ToolDeps): SystemTool {
       properties: {
         description: { type: "string" },
         artifacts: { type: "array", items: { type: "string" } },
+        artifact_inputs: {
+          type: "array",
+          items: { type: "object", properties: { path: { type: "string" }, type: { type: "string" }, producer_node_id: { type: "string" } }, required: ["path"] },
+          description: "Artifacts consumed by this work; registry references are preferred.",
+        },
+        artifact_outputs: {
+          type: "array",
+          items: { type: "object", properties: { path: { type: "string" }, type: { type: "string" }, blob_hash: { type: "string" } }, required: ["path"] },
+          description: "Artifacts produced by this work.",
+        },
         context: { type: "string" },
       },
       required: ["description"],
@@ -232,22 +286,36 @@ export function createRecordTraceTool(deps: ToolDeps): SystemTool {
       // §10 (legacy parity): record_trace does NOT mutate the graph directly.
       // Instead it dispatches a [Trace Event] envelope into the trace agent's
       // durable internal queue; the trace agent receives it and
-      // calls create_trace_node / update_trace_node / add_trace_relation as the
-      // editor. This keeps the trace agent's status authentically live in the
+      // calls create_trace_node / update_trace_node as the editor. The host
+      // binds the source record to the durable
+      // task notification
+      // delivery; Trace only decides which logical research node receives it.
+      // This keeps the trace agent's status authentically live in the
       // Agents panel (otherwise it would be a permanently-dormant placeholder)
       // and lets the trace agent merge/dedupe across multiple sources, which is
       // exactly the persona we already ship for it.
       const description = String(params.description ?? "");
       const context = String(params.context ?? "");
       const artifacts = (params.artifacts as string[]) ?? [];
+      const inputs = artifactInputs(params.artifact_inputs);
+      const outputs = artifactInputs(params.artifact_outputs);
+      const record: TraceNodeRecord = {
+        sourceAgent: deps.fromAgent,
+        description,
+        ...(context ? { context } : {}),
+        createdAt: new Date().toISOString(),
+      };
       const lines = [`[Trace Event]`, `Description: ${description}`];
       if (context) lines.push(`Context: ${context}`);
+      if (inputs.length) lines.push(`Artifact-Inputs: ${JSON.stringify(inputs)}`);
+      if (outputs.length) lines.push(`Artifact-Outputs: ${JSON.stringify(outputs)}`);
       lines.push("", "Artifacts:");
       if (artifacts.length === 0) {
         lines.push("(none)");
       } else {
         for (const a of artifacts) lines.push(`- ${a}`);
       }
+      lines.push(`Trace-Record: ${JSON.stringify(record)}`);
       const envelope = lines.join("\n");
 
       // Spawn-on-demand: the trace agent is a real Pi session. ensureAgent
@@ -272,32 +340,55 @@ export function createRecordTraceTool(deps: ToolDeps): SystemTool {
 export function createTraceNodeTool(deps: ToolDeps): SystemTool {
   return {
     name: "create_trace_node",
-    description: "Create a node in the Graph of Trace.",
+    description:
+      "Create one new active Graph of Trace node only when the current host-bound record represents a distinct, durable scientific unit that is not already in the active graph. " +
+      "Do not create nodes for coordination, delegation, progress, presentation, reformatting, or repetition. The Host attaches the current source record automatically. " +
+      "The Host also attaches the session root whenever no more specific causal parent has been confirmed; never submit the session root as a parent candidate. " +
+      "One Trace Event may call this tool more than once only when it explicitly contains multiple independently meaningful scientific units with enough content to describe each accurately.",
     parameters: {
       type: "object",
       properties: {
-        title: { type: "string" },
-        type: { type: "string" },
-        status: { type: "string" },
-        description: { type: "string" },
-        parent_id: { type: "string" },
+        title: { type: "string", description: "Concise name of the scientific result, decision, analysis, artifact, or conclusion; not an activity-log title." },
+        type: { type: "string", description: "Optional short presentation label; do not invent a complex ontology." },
+        status: { type: "string", enum: ["completed", "failed"] },
+        description: { type: "string", description: "What was scientifically decided, measured, produced, observed, or concluded." },
+        confidence: { type: "string", enum: ["low", "medium", "high"], description: "Strength of support from accessible records and evidence, not task success or writing detail." },
+        confidence_reason: { type: "string", description: "Name the concrete supporting records/evidence and their limitations; specificity alone does not justify high confidence." },
+        parent_candidates: {
+          type: "array",
+          items: { type: "object", properties: { node_id: { type: "string" }, reason: { type: "string" } }, required: ["node_id", "reason"] },
+          description: "Direct epistemic or computational prerequisites actually consumed by this node. Chronology, delegation, and topic similarity are insufficient. Trace proposes; Auditor confirms.",
+        },
+        artifact_inputs: { type: "array", items: { type: "object", properties: { path: { type: "string" }, type: { type: "string" }, producer_node_id: { type: "string" } }, required: ["path"] } },
+        artifact_outputs: { type: "array", items: { type: "object", properties: { path: { type: "string" }, type: { type: "string" }, blob_hash: { type: "string" } }, required: ["path"] } },
       },
-      required: ["title"],
+      required: ["title", "confidence", "confidence_reason"],
     },
     execute: async (params: Record<string, unknown>) => {
-      // Honour an explicit parent_id; otherwise chain to the most recent node so
-      // the graph stays connected instead of accumulating orphan nodes.
-      const explicitParent = params.parent_id ? String(params.parent_id) : undefined;
-      const parentId = explicitParent ?? deps.trace.getLastNodeId();
-      const relation = explicitParent ? "parent" : "follows";
+      if ((params.confidence !== "low" && params.confidence !== "medium" && params.confidence !== "high") || !String(params.confidence_reason ?? "").trim()) {
+        return { ...ok("confidence and a non-empty confidence_reason are required"), isError: true };
+      }
+      const record = deps.currentTraceRecord?.();
       const node = deps.trace.createNode({
         title: String(params.title ?? ""),
         type: params.type ? String(params.type) : undefined,
-        status: params.status ? String(params.status) : undefined,
+        status: params.status === "failed" ? "failed" : "completed",
+        executionResult: params.status === "failed" ? "failed" : "completed",
         description: params.description ? String(params.description) : undefined,
-        agent: deps.fromAgent,
-        parents: parentId ? [{ id: parentId, relation }] : undefined,
+        confidence: params.confidence === "high" || params.confidence === "medium" ? params.confidence : "low",
+        confidenceReason: String(params.confidence_reason ?? ""),
+        agent: record?.sourceAgent ?? deps.fromAgent,
+        records: record ? [record] : [],
+        changeActor: { type: "agent", name: deps.fromAgent },
+        artifactInputs: artifactInputs(params.artifact_inputs),
+        artifactOutputs: artifactInputs(params.artifact_outputs),
       });
+      for (const value of Array.isArray(params.parent_candidates) ? params.parent_candidates : []) {
+        if (!value || typeof value !== "object") continue;
+        const candidate = value as Record<string, unknown>;
+        if (typeof candidate.node_id !== "string" || typeof candidate.reason !== "string") continue;
+        deps.trace.proposeCausalParent(node.id, candidate.node_id, candidate.reason, { type: "agent", name: deps.fromAgent });
+      }
       return ok(`node ${node.id} created`);
     },
   };
@@ -306,60 +397,55 @@ export function createTraceNodeTool(deps: ToolDeps): SystemTool {
 export function createUpdateTraceNodeTool(deps: ToolDeps): SystemTool {
   return {
     name: "update_trace_node",
-    description: "Update fields of an existing trace node.",
+    description:
+      "Update exactly one existing active Trace node only when the current host-bound record belongs to the same scientific unit and adds evidence, results, a correction, or a meaningful status change. " +
+      "Read the target node first and preserve its valid existing content when supplying replacement text. Do not update merely to rephrase, translate, format, present, or repeat it. " +
+      "The Host attaches the current record automatically; revoked nodes cannot be reused, and confidence must be re-evaluated on every substantive update.",
     parameters: {
       type: "object",
       properties: {
-        node_id: { type: "string" },
-        status: { type: "string" },
+        node_id: { type: "string", description: "Active node representing the exact same scientific unit. Inspect it with get_trace_node before updating." },
+        title: { type: "string", description: "Supply only when the existing title is inaccurate or the same scientific unit now has a clearer stable name." },
+        description: { type: "string", description: "Complete merged scientific description preserving valid prior content; this replaces the stored description." },
+        status: { type: "string", enum: ["completed", "failed"] },
         summary: { type: "string" },
         content: { type: "string" },
+        confidence: { type: "string", enum: ["low", "medium", "high"], description: "Re-evaluated strength of support after incorporating the current record." },
+        confidence_reason: { type: "string", description: "Required concrete re-evaluation after every node update, even when the level is unchanged." },
+        artifact_outputs: { type: "array", items: { type: "object", properties: { path: { type: "string" }, type: { type: "string" } }, required: ["path"] } },
+        parent_candidates: {
+          type: "array",
+          items: { type: "object", properties: { node_id: { type: "string" }, reason: { type: "string" } }, required: ["node_id", "reason"] },
+          description: "New direct epistemic or computational prerequisites revealed by this update; never infer them from chronology.",
+        },
       },
-      required: ["node_id"],
+      required: ["node_id", "confidence", "confidence_reason"],
     },
     execute: async (params: Record<string, unknown>) => {
       const id = String(params.node_id ?? "");
+      if (deps.trace.getNodeV2(id)?.revoked) return { ...ok(`node ${id} is revoked; create a new node instead`), isError: true };
+      if ((params.confidence !== "low" && params.confidence !== "medium" && params.confidence !== "high") || !String(params.confidence_reason ?? "").trim()) {
+        return { ...ok("confidence and a non-empty confidence_reason are required for every node update"), isError: true };
+      }
+      const record = deps.currentTraceRecord?.();
       const updates: Record<string, unknown> = {};
       for (const k of ["status", "summary", "content", "title", "description"]) {
         if (params[k] !== undefined) updates[k] = params[k];
       }
-      const node = deps.trace.updateNode(id, updates);
+      if (params.status === "completed" || params.status === "failed") updates.executionResult = params.status;
+      updates.confidence = params.confidence === "high" || params.confidence === "medium" ? params.confidence : "low";
+      updates.confidenceReason = String(params.confidence_reason ?? "");
+      const outputs = artifactInputs(params.artifact_outputs);
+      if (outputs.length) updates.artifacts = outputs.map((artifact) => ({ path: artifact.path, type: artifact.type }));
+      const node = deps.trace.updateNode(id, updates, { type: "agent", name: deps.fromAgent });
+      if (node && record) deps.trace.appendRecord(id, record, { type: "agent", name: deps.fromAgent });
+      for (const value of Array.isArray(params.parent_candidates) ? params.parent_candidates : []) {
+        if (!value || typeof value !== "object") continue;
+        const candidate = value as Record<string, unknown>;
+        if (typeof candidate.node_id !== "string" || typeof candidate.reason !== "string") continue;
+        deps.trace.proposeCausalParent(id, candidate.node_id, candidate.reason, { type: "agent", name: deps.fromAgent });
+      }
       return node ? ok(`node ${id} updated`) : { ...ok(`node ${id} not found`), isError: true };
-    },
-  };
-}
-
-export function createAddTraceRelationTool(deps: ToolDeps): SystemTool {
-  return {
-    name: "add_trace_relation",
-    description:
-      "Add a directed dependency edge between two trace nodes. DIRECTION MATTERS: " +
-      "`from_id` is the PREREQUISITE (the earlier source work that must exist first), " +
-      "`to_id` is the DEPENDENT (the later downstream work that relies on it). The " +
-      "edge points from_id ──▶ to_id, read as \"to_id depends_on from_id\". " +
-      "Example: a librarian survey is the prerequisite of an experimentalist synthesis, " +
-      "so call add_trace_relation(from_id=<survey>, to_id=<synthesis>) — NOT the reverse. " +
-      "Rule of thumb: the prerequisite (from_id) is almost always the node that was " +
-      "created earlier; if you find yourself pointing from a later node to an earlier " +
-      "one, you have the arguments backwards.",
-    parameters: {
-      type: "object",
-      properties: {
-        from_id: { type: "string", description: "Prerequisite / earlier source node." },
-        to_id: { type: "string", description: "Dependent / later downstream node." },
-        explanation: { type: "string" },
-      },
-      required: ["from_id", "to_id", "explanation"],
-    },
-    execute: async (params: Record<string, unknown>) => {
-      const okEdge = deps.trace.addRelation(
-        String(params.from_id ?? ""),
-        String(params.to_id ?? ""),
-        String(params.explanation ?? ""),
-      );
-      return okEdge
-        ? ok("relation added")
-        : { ...ok("relation failed: node not found"), isError: true };
     },
   };
 }
@@ -367,9 +453,199 @@ export function createAddTraceRelationTool(deps: ToolDeps): SystemTool {
 export function createGetTraceGraphTool(deps: ToolDeps): SystemTool {
   return {
     name: "get_trace_graph",
-    description: "Get the current Graph of Trace as JSON.",
+    description:
+      "Get the compact active Graph of Trace for curation. Returns concise node metadata and embedded causal parents only; use get_trace_node or get_trace_neighborhood for evidence details.",
     parameters: { type: "object", properties: {} },
-    execute: async () => ok(JSON.stringify(deps.trace.getGraph())),
+    execute: async () => {
+      const graph = deps.trace.getGraphV2();
+      const rootId = graph.meta.rootNodeId;
+      const activeIds = new Set(
+        graph.nodes
+          .filter((node) => !node.revoked && node.id !== rootId)
+          .map((node) => node.id),
+      );
+      return ok(JSON.stringify({
+        schemaVersion: graph.schemaVersion,
+        revision: graph.revision,
+        nodes: graph.nodes
+          .filter((node) => activeIds.has(node.id))
+          .map((node) => ({
+            id: node.id,
+            title: node.title,
+            type: node.type,
+            status: node.status,
+            ...(node.description
+              ? { description: node.description.length > 400 ? `${node.description.slice(0, 399)}…` : node.description }
+              : {}),
+            confidence: node.confidence,
+            reviewConclusion: node.reviewConclusion,
+            updatedAt: node.updatedAt,
+            parents: node.parents
+              .filter((parent) => parent.nodeId !== rootId && activeIds.has(parent.nodeId))
+              .map((parent) => ({
+                nodeId: parent.nodeId,
+                conclusion: parent.conclusion,
+                ...(parent.reason ? { reason: parent.reason } : {}),
+              })),
+          })),
+      }));
+    },
+  };
+}
+
+/** Principal-only bounded trace readers; no Principal full-graph tool exists. */
+export function createGetTraceNodeTool(deps: ToolDeps): SystemTool {
+  return {
+    name: "get_trace_node",
+    description: "Read one Trace node with its official/candidate dependencies, semantic links, episode, and artifacts.",
+    parameters: { type: "object", properties: { node_id: { type: "string" } }, required: ["node_id"] },
+    execute: async (params) => {
+      const detail = deps.trace.getNodeDetail(String(params.node_id ?? ""));
+      return detail ? ok(cappedJson(detail)) : { ...ok("trace node not found"), isError: true };
+    },
+  };
+}
+
+export function createGetTraceNeighborhoodTool(deps: ToolDeps): SystemTool {
+  return {
+    name: "get_trace_neighborhood",
+    description: "Read a bounded local Trace neighborhood around one node; use this instead of a full graph.",
+    parameters: { type: "object", properties: { node_id: { type: "string" }, depth: { type: "number", minimum: 0, maximum: 4 } }, required: ["node_id"] },
+    execute: async (params) => {
+      const neighborhood = deps.trace.getNeighborhood(String(params.node_id ?? ""), typeof params.depth === "number" ? params.depth : 1);
+      return neighborhood ? ok(cappedJson(neighborhood)) : { ...ok("trace node not found"), isError: true };
+    },
+  };
+}
+
+/** Auditor-only discovery surface for outstanding node and parent reviews. */
+export function createListPendingTraceReviewsTool(deps: ToolDeps): SystemTool {
+  return {
+    name: "list_pending_trace_reviews",
+    description:
+      "List active Trace nodes whose node review is unreviewed and causal parent candidates that still need a conclusion. " +
+      "This is read-only and does not bind or change the current audit target.",
+    parameters: {
+      type: "object",
+      properties: {
+        limit: { type: "number", minimum: 1, maximum: 100, description: "Maximum combined pending targets to return." },
+      },
+    },
+    execute: async (params) => {
+      const limit = typeof params.limit === "number"
+        ? Math.max(1, Math.min(100, Math.trunc(params.limit)))
+        : 50;
+      const targets = deps.trace.listPendingAuditTargets();
+      const selected = targets.slice(0, limit);
+      const nodes: Array<Record<string, unknown>> = [];
+      const parentRelations: Array<Record<string, unknown>> = [];
+      for (const target of selected) {
+        const node = deps.trace.getNodeV2(target.nodeId);
+        if (!node) continue;
+        if (!target.parentNodeId) {
+          nodes.push({
+            nodeId: node.id,
+            title: node.title,
+            updatedAt: node.updatedAt,
+            reviewConclusion: node.reviewConclusion,
+            ...(node.confidence ? { confidence: node.confidence } : {}),
+          });
+          continue;
+        }
+        const parent = deps.trace.getNodeV2(target.parentNodeId);
+        const relation = node.parents.find((item) => item.nodeId === target.parentNodeId);
+        parentRelations.push({
+          nodeId: node.id,
+          title: node.title,
+          parentNodeId: target.parentNodeId,
+          ...(parent ? { parentTitle: parent.title } : {}),
+          conclusion: relation?.conclusion ?? "candidate",
+          ...(relation?.reason ? { reason: relation.reason } : {}),
+        });
+      }
+      return ok(cappedJson({
+        nodes,
+        parentRelations,
+        total: targets.length,
+        returned: selected.length,
+        truncated: targets.length > selected.length,
+      }));
+    },
+  };
+}
+
+export function createSearchTraceTool(deps: ToolDeps): SystemTool {
+  return {
+    name: "search_trace",
+    description: "Search concise agent reports and node metadata in Trace; returns a bounded set of matching details.",
+    parameters: { type: "object", properties: { query: { type: "string" }, limit: { type: "number", minimum: 1, maximum: 100 } }, required: ["query"] },
+    execute: async (params) => ok(cappedJson(deps.trace.search(String(params.query ?? ""), typeof params.limit === "number" ? params.limit : 12))),
+  };
+}
+
+/** Auditor-only mutation surface: append one bounded node/parent conclusion. */
+export function createEditTraceReviewTool(deps: ToolDeps): SystemTool {
+  return {
+    name: "edit_trace_review",
+    description: "Review one Trace node or one proposed causal parent. Only conclusion and reason may be changed.",
+    parameters: {
+      type: "object",
+      properties: {
+        conclusion: { type: "string", enum: ["approve", "reject", "uncertain"] },
+        reason: { type: "string" },
+      },
+      required: ["conclusion", "reason"],
+    },
+    execute: async (params) => {
+      const conclusion = params.conclusion;
+      if (conclusion !== "approve" && conclusion !== "reject" && conclusion !== "uncertain") {
+        return { ...ok("invalid review conclusion"), isError: true };
+      }
+      const target = deps.currentTraceAuditTarget?.();
+      if (!target) return { ...ok("no host-bound trace audit target for this turn"), isError: true };
+      const success = deps.trace.review(
+        target.nodeId,
+        conclusion,
+        String(params.reason ?? ""),
+        { type: "agent", name: deps.fromAgent },
+        target.parentNodeId,
+        target.fingerprint,
+      );
+      return success ? ok("trace review recorded") : { ...ok("review rejected: target changed, missing, revoked, or cyclic; it will be re-queued"), isError: true };
+    },
+  };
+}
+
+export function createSubmitAuditReportTool(deps: ToolDeps): SystemTool {
+  return {
+    name: "submit_audit_report",
+    description: "Persist the completed audit for the user. This never notifies PI.",
+    parameters: {
+      type: "object",
+      properties: {
+        risk: { type: "string", enum: ["low", "medium", "high"] },
+        summary: { type: "string" },
+        report: { type: "string", description: "Complete Markdown audit report with concrete evidence." },
+      },
+      required: ["risk", "summary", "report"],
+    },
+    execute: async (params) => {
+      if (params.risk !== "low" && params.risk !== "medium" && params.risk !== "high") {
+        return { ...ok("invalid audit risk"), isError: true };
+      }
+      const summary = String(params.summary ?? "").trim();
+      const reportBody = String(params.report ?? "").trim();
+      if (!summary || !reportBody) return { ...ok("summary and report are required"), isError: true };
+      const target = deps.currentTraceAuditTarget?.();
+      const report = deps.trace.submitAuditReport({
+        kind: target ? "trace" : "deliverable",
+        ...(target ? { target: { nodeId: target.nodeId, ...(target.parentNodeId ? { parentNodeId: target.parentNodeId } : {}) } } : {}),
+        risk: params.risk,
+        summary,
+        report: reportBody,
+      });
+      return ok(`audit report ${report.id} saved for the user`);
+    },
   };
 }
 
@@ -400,8 +676,16 @@ export function allSystemTools(
     createRecordTraceTool(deps),
     createTraceNodeTool(deps),
     createUpdateTraceNodeTool(deps),
-    createAddTraceRelationTool(deps),
     createGetTraceGraphTool(deps),
+    createGetTraceNodeTool(deps),
+    createGetTraceNeighborhoodTool(deps),
+    createListPendingTraceReviewsTool(deps),
+    // Temporarily disabled: the current substring matcher is not reliable
+    // enough to expose as an Agent tool. Keep the implementation above so it
+    // can be re-enabled after tokenized/ranked search is implemented.
+    // createSearchTraceTool(deps),
+    createEditTraceReviewTool(deps),
+    createSubmitAuditReportTool(deps),
   ];
   if (isToolEnabled(toggles, "skill_search")) {
     tools.push(createSkillSearchTool(deps));
@@ -439,7 +723,14 @@ export const AGENT_TOOL_CONFIG: Record<string, string[]> = {
     "get_domain_knowledge_local",
     "search_papers_local",
   ],
-  trace: ["create_trace_node", "update_trace_node", "add_trace_relation", "get_trace_graph"],
+  trace: [
+    "create_trace_node",
+    "update_trace_node",
+    "get_trace_graph",
+    "get_trace_node",
+    "get_trace_neighborhood",
+    // "search_trace", // temporarily disabled; see allSystemTools above
+  ],
   expert: [
     "dispatch_task",
     "complete_task",
@@ -448,15 +739,15 @@ export const AGENT_TOOL_CONFIG: Record<string, string[]> = {
     "get_domain_knowledge_local",
     "search_papers_local",
   ],
-  // Auditor: comms + self-trace only. Deliberately NO `get_trace_graph` —
-  // evidence is restricted to the session workspace; the audit must not
-  // dredge the trace graph or other agents' internal state. skill_search and
-  // the local KB tools are included so an audit can resolve a methodology
-  // skill referenced in a draft and verify a cited claim against the KB.
+  // Auditor gets bounded Trace readers and one review-only mutation tool.
   auditor: [
-    "dispatch_task",
     "complete_task",
-    "record_trace",
+    "list_pending_trace_reviews",
+    "get_trace_node",
+    "get_trace_neighborhood",
+    // "search_trace", // temporarily disabled; see allSystemTools above
+    "edit_trace_review",
+    "submit_audit_report",
     "skill_search",
     "get_domain_knowledge_local",
     "search_papers_local",
@@ -509,11 +800,12 @@ export const BUILTIN_TOOL_CONFIG_BY_NAME: Record<string, string[]> = {
   experimentalist: ["read", "write", "edit", "bash", "grep", "find", "glob", "ls"],
   writer: ["read", "write", "edit", "grep", "find", "glob", "ls"],
   librarian: ["read", "write", "grep", "find", "glob"],
-  // Auditor: read-only inspection + `write` for its own audit report. NO `edit`
-  // (must not modify other agents' artefacts). `bash` is included for
+  // Auditor: read-only inspection. Reports are persisted through the
+  // user-gated submit_audit_report tool; no workspace write/edit access.
+  // `bash` is included for
   // grep/awk/jq/diff style filesystem inspection — its read-only discipline is
   // enforced by the auditor persona, not by the tool whitelist.
-  auditor: ["read", "grep", "find", "glob", "bash", "write"],
+  auditor: ["read", "grep", "find", "glob", "bash"],
 };
 
 export function systemToolNamesForRole(role: AgentRole, agentName: string): string[] {

--- a/packages/runtime/src/trace.ts
+++ b/packages/runtime/src/trace.ts
@@ -1,9 +1,9 @@
 /**
  * TraceGraphV2 — canonical Graph of Trace storage.
  *
- * Nodes own their causal parent references. Legacy dependency/semantic-link
- * collections are compatibility projections only and are never persisted by
- * new writes. `getGraph()` still materializes the old shape for older clients.
+ * Nodes own their causal parent references. The legacy dependency collection
+ * is a compatibility projection only and is never persisted by new writes.
+ * `getGraph()` still materializes the old shape for older clients.
  */
 import { appendFile, copyFile, mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { createHash, randomUUID } from "node:crypto";
@@ -28,8 +28,6 @@ import type {
   TraceNodeRecord,
   TraceNodeReviewConclusion,
   TraceNodeV2,
-  TraceSemanticLink,
-  TraceSemanticLinkType,
   TraceDeltaV2,
 } from "@brainpilot/protocol";
 function now(): string {
@@ -88,18 +86,6 @@ function isDeterministicHostEvidence(evidence: readonly TraceDependencyEvidence[
   );
 }
 
-function semanticTypeForLegacyRelation(relation: string | undefined): TraceSemanticLinkType {
-  switch (relation) {
-    case "follows": return "sequence_after";
-    case "restored_from": return "restored_from";
-    case "supports": return "supports";
-    case "contradicts": return "contradicts";
-    case "supersedes": return "supersedes";
-    case "references": return "references";
-    default: return "legacy";
-  }
-}
-
 /** Legacy callback operation retained for older hosting code and tests. */
 export type TraceChangeOp = "created" | "updated";
 
@@ -134,7 +120,6 @@ export interface TraceArtifactInput {
 export interface TraceNodeDetail {
   node: TraceNodeV2;
   dependencies: { incoming: TraceDependency[]; outgoing: TraceDependency[] };
-  semanticLinks: { incoming: TraceSemanticLink[]; outgoing: TraceSemanticLink[] };
   episode?: TraceEpisode;
   artifacts: TraceArtifactV2[];
 }
@@ -163,7 +148,6 @@ type TraceChangeDraft = Omit<TraceChange, "id" | "revision" | "createdAt">;
 export class GraphOfTrace {
   private readonly nodes = new Map<string, TraceNodeV2>();
   private readonly dependencies = new Map<string, TraceDependency>();
-  private readonly semanticLinks = new Map<string, TraceSemanticLink>();
   private readonly episodes = new Map<string, TraceEpisode>();
   private readonly artifacts = new Map<string, TraceArtifactV2>();
   private readonly changes: TraceChange[] = [];
@@ -297,7 +281,7 @@ export class GraphOfTrace {
     return this.getNode(id)!;
   }
 
-  /** Creates a sequence semantic link, not an implied dependency. */
+  /** Creates the next presentation milestone without manufacturing causality. */
   createChainedNode(input: {
     title: string;
     type?: string;
@@ -306,14 +290,12 @@ export class GraphOfTrace {
     description?: string;
     metadata?: Record<string, unknown>;
   }): TraceNode {
-    const parent = this.lastNodeId ? this.nodes.get(this.lastNodeId) : undefined;
     return this.createNode({
       title: input.title,
       type: input.type ?? "milestone",
       status: input.status ?? "completed",
       agent: input.agent,
       description: input.description,
-      parents: parent ? [{ id: parent.id, relation: "follows" }] : undefined,
       metadata: { auto: true, ...input.metadata },
     });
   }
@@ -626,23 +608,7 @@ export class GraphOfTrace {
         evidence: [{ source: "legacy", kind: relation, detail: explanation }],
       }).ok;
     }
-    const link = this.addSemanticLink(fromId, toId, semanticTypeForLegacyRelation(relation), explanation);
-    return Boolean(link);
-  }
-
-  addSemanticLink(fromId: string, toId: string, type: TraceSemanticLinkType, reason?: string): TraceSemanticLink | undefined {
-    if (!this.nodes.has(fromId) || !this.nodes.has(toId)) return undefined;
-    const id = stableId("semantic", fromId, toId, type);
-    const existing = this.semanticLinks.get(id);
-    if (existing) {
-      if (reason) existing.reason = reason;
-      this.commit("updated", toId);
-      return clone(existing);
-    }
-    const link: TraceSemanticLink = { id, fromId, toId, type, ...(reason ? { reason } : {}), createdAt: now() };
-    this.semanticLinks.set(id, link);
-    this.commit("updated", toId);
-    return clone(link);
+    return false;
   }
 
   createEpisode(input: { title: string; description?: string; id?: string }): TraceEpisode {
@@ -728,12 +694,9 @@ export class GraphOfTrace {
     if (!node || (!includeRevoked && node.revoked)) return undefined;
     const incoming = [...this.dependencies.values()].filter((edge) => edge.dependentId === id);
     const outgoing = [...this.dependencies.values()].filter((edge) => edge.prerequisiteId === id);
-    const semanticIncoming = [...this.semanticLinks.values()].filter((edge) => edge.toId === id);
-    const semanticOutgoing = [...this.semanticLinks.values()].filter((edge) => edge.fromId === id);
     return {
       node: clone(node),
       dependencies: { incoming: clone(incoming), outgoing: clone(outgoing) },
-      semanticLinks: { incoming: clone(semanticIncoming), outgoing: clone(semanticOutgoing) },
       ...(node.primaryEpisodeId && this.episodes.get(node.primaryEpisodeId)
         ? { episode: clone(this.episodes.get(node.primaryEpisodeId)!) }
         : {}),
@@ -741,16 +704,16 @@ export class GraphOfTrace {
     };
   }
 
-  getNeighborhood(id: string, depth = 1): { nodes: TraceNodeV2[]; dependencies: TraceDependency[]; semanticLinks: TraceSemanticLink[] } | undefined {
+  getNeighborhood(id: string, depth = 1): { nodes: TraceNodeV2[]; dependencies: TraceDependency[] } | undefined {
     if (!this.nodes.has(id) || this.nodes.get(id)?.revoked) return undefined;
     const requestedDepth = Math.max(0, Math.min(4, Math.trunc(depth)));
     const seen = new Set<string>([id]);
     let frontier = [id];
     for (let level = 0; level < requestedDepth; level++) {
       const next = new Set<string>();
-      for (const edge of [...this.dependencies.values(), ...this.semanticLinks.values()]) {
-        const from = "prerequisiteId" in edge ? edge.prerequisiteId : edge.fromId;
-        const to = "dependentId" in edge ? edge.dependentId : edge.toId;
+      for (const edge of this.dependencies.values()) {
+        const from = edge.prerequisiteId;
+        const to = edge.dependentId;
         if (frontier.includes(from) && !seen.has(to)) next.add(to);
         if (frontier.includes(to) && !seen.has(from)) next.add(from);
       }
@@ -761,7 +724,6 @@ export class GraphOfTrace {
     return {
       nodes: clone([...this.nodes.values()].filter((node) => seen.has(node.id) && !node.revoked)),
       dependencies: clone([...this.dependencies.values()].filter((edge) => included(edge.prerequisiteId) && included(edge.dependentId) && !this.nodes.get(edge.prerequisiteId)?.revoked && !this.nodes.get(edge.dependentId)?.revoked)),
-      semanticLinks: clone([...this.semanticLinks.values()].filter((edge) => included(edge.fromId) && included(edge.toId))),
     };
   }
 
@@ -790,7 +752,6 @@ export class GraphOfTrace {
       meta: clone(this.meta),
       nodes: [...this.nodes.values()].map((node) => this.materializeNode(node)),
       dependencies: clone([...this.dependencies.values()]),
-      semanticLinks: clone([...this.semanticLinks.values()]),
       episodes: clone([...this.episodes.values()]),
       artifacts: clone([...this.artifacts.values()]),
     };
@@ -808,13 +769,12 @@ export class GraphOfTrace {
         childIds: node.childIds.filter((id) => activeIds.has(id)),
       })),
       dependencies: graph.dependencies?.filter((edge) => activeIds.has(edge.prerequisiteId) && activeIds.has(edge.dependentId)),
-      semanticLinks: [],
       artifacts: graph.artifacts?.filter((artifact) => !artifact.producerNodeId || activeIds.has(artifact.producerNodeId)),
     };
   }
 
-  /** Persisted V2 data. Node.parents is the causal source of truth; legacy
-   * dependency/link collections remain only as a compatibility projection. */
+  /** Persisted V2 data. Node.parents is the causal source of truth; the legacy
+   * dependency collection remains only as a compatibility projection. */
   getGraphV2(): TraceGraphV2 {
     return {
       schemaVersion: "2.0",
@@ -822,7 +782,6 @@ export class GraphOfTrace {
       meta: clone(this.meta),
       nodes: clone([...this.nodes.values()]),
       dependencies: clone([...this.dependencies.values()]),
-      semanticLinks: clone([...this.semanticLinks.values()]),
       episodes: clone([...this.episodes.values()]),
       artifacts: clone([...this.artifacts.values()]),
     };
@@ -830,7 +789,7 @@ export class GraphOfTrace {
 
   /** Disk shape: embedded parents are canonical; legacy edge collections stay out. */
   private getPersistedGraph(pendingChanges: TraceChange[] = []): TraceDocumentV2 {
-    const { dependencies: _dependencies, semanticLinks: _semanticLinks, ...canonical } = this.getGraphV2();
+    const { dependencies: _dependencies, ...canonical } = this.getGraphV2();
     return {
       ...canonical,
       ...(pendingChanges.length ? { pendingChanges: clone(pendingChanges) } : {}),
@@ -845,44 +804,46 @@ export class GraphOfTrace {
   async recoverChanges(): Promise<void> {
     const path = this.changeLogPath();
     if (!path) return;
+    let raw = "";
     try {
-      const raw = await readFile(path, "utf8");
-      this.changes.length = 0;
-      const ids = new Set<string>();
-      for (const line of raw.split("\n")) {
-        if (!line.trim()) continue;
+      raw = await readFile(path, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") return;
+      await mkdir(dirname(path), { recursive: true }).catch(() => {});
+    }
+
+    this.changes.length = 0;
+    const ids = new Set<string>();
+    for (const line of raw.split("\n")) {
+      if (!line.trim()) continue;
+      try {
+        const value = JSON.parse(line) as TraceChange;
+        if (value?.id && typeof value.revision === "number" && !ids.has(value.id)) {
+          ids.add(value.id);
+          this.changes.push(value);
+        }
+      } catch {
+        // JSONL is intentionally record-oriented: preserve valid entries
+        // before and after a torn/corrupt append.
+      }
+    }
+    for (const change of this.pendingChanges) {
+      if (!ids.has(change.id)) {
         try {
-          const value = JSON.parse(line) as TraceChange;
-          if (value?.id && typeof value.revision === "number" && !ids.has(value.id)) {
-            ids.add(value.id);
-            this.changes.push(value);
-          }
+          await appendFile(path, `${JSON.stringify(change)}\n`, "utf8");
+          ids.add(change.id);
         } catch {
-          // JSONL is intentionally record-oriented: preserve valid entries
-          // before and after a torn/corrupt append.
+          // Keep this and every later record embedded in trace.json. A future
+          // mutation or restart can retry without losing the audit trail.
+          break;
         }
       }
-      for (const change of this.pendingChanges) {
-        if (ids.has(change.id)) continue;
-        await appendFile(path, `${JSON.stringify(change)}\n`, "utf8");
-        ids.add(change.id);
-        this.changes.push(clone(change));
-      }
-      if (this.pendingChanges.length > 0 && this.persistPath) {
-        this.pendingChanges = [];
-        await this.writeSnapshot(this.getPersistedGraph());
-      }
-    } catch {
-      // A missing audit log must not make the materialized graph unavailable.
-      if (this.pendingChanges.length > 0) {
-        await mkdir(dirname(path), { recursive: true }).catch(() => {});
-        for (const change of this.pendingChanges) {
-          await appendFile(path, `${JSON.stringify(change)}\n`, "utf8").catch(() => {});
-          this.changes.push(clone(change));
-        }
-        this.pendingChanges = [];
-        if (this.persistPath) await this.writeSnapshot(this.getPersistedGraph()).catch(() => {});
-      }
+      if (!this.changes.some((item) => item.id === change.id)) this.changes.push(clone(change));
+    }
+    const remaining = this.pendingChanges.filter((change) => !ids.has(change.id));
+    if (remaining.length !== this.pendingChanges.length && this.persistPath) {
+      this.pendingChanges = remaining;
+      await this.writeSnapshot(this.getPersistedGraph(this.pendingChanges)).catch(() => {});
     }
   }
 
@@ -967,7 +928,6 @@ export class GraphOfTrace {
   private clear(): void {
     this.nodes.clear();
     this.dependencies.clear();
-    this.semanticLinks.clear();
     this.episodes.clear();
     this.artifacts.clear();
     this.changes.length = 0;
@@ -1049,20 +1009,7 @@ export class GraphOfTrace {
       const id = asString(edge.id, stableId("dependency", prerequisiteId, dependentId));
       const state = edge.state === "active" || edge.state === "rejected" ? edge.state : "proposed";
       // Never hydrate a malformed persisted cycle into the canonical graph.
-      // Retain a non-authoritative historical hint rather than manufacturing an
-      // official edge from corrupt external JSON.
       if (state !== "rejected" && this.wouldCreateCycle(prerequisiteId, dependentId)) {
-        const legacyId = stableId("semantic", prerequisiteId, dependentId, "legacy");
-        if (!this.semanticLinks.has(legacyId)) {
-          this.semanticLinks.set(legacyId, {
-            id: legacyId,
-            fromId: prerequisiteId,
-            toId: dependentId,
-            type: "legacy",
-            ...(typeof edge.reason === "string" ? { reason: edge.reason } : {}),
-            createdAt: now(),
-          });
-        }
         continue;
       }
       const dependency: TraceDependency = {
@@ -1084,18 +1031,6 @@ export class GraphOfTrace {
         this.syncParentFromDependency(dependency);
       }
     }
-    for (const item of Array.isArray(raw.semanticLinks) ? raw.semanticLinks : []) {
-      const link = asRecord(item);
-      const fromId = asString(link.fromId);
-      const toId = asString(link.toId);
-      if (!fromId || !toId || !this.nodes.has(fromId) || !this.nodes.has(toId)) continue;
-      const type = this.validSemanticType(link.type);
-      const id = asString(link.id, stableId("semantic", fromId, toId, type));
-      this.semanticLinks.set(id, { id, fromId, toId, type, ...(typeof link.reason === "string" ? { reason: link.reason } : {}), ...(typeof link.createdAt === "string" ? { createdAt: link.createdAt } : {}) });
-    }
-    // Semantic links are not causal and are intentionally not part of the new
-    // graph. The untouched legacy file/one-time backup remains their archive.
-    this.semanticLinks.clear();
     this.normalizeCausalGraph();
     for (const item of Array.isArray(raw.episodes) ? raw.episodes : []) {
       const episode = asRecord(item);
@@ -1218,16 +1153,9 @@ export class GraphOfTrace {
         seen.add(key);
         this.addLegacyRelationInternal(prerequisiteId, dependentId, relation, typeof parent.explanation === "string" ? parent.explanation : undefined, "legacy");
       }
-      // Some very old files only carried parentIds. Preserve their existence as
-      // an explicitly legacy semantic relation rather than inventing a fact.
-      for (const prerequisiteId of asStringArray(source.parentIds)) {
-        const key = `${prerequisiteId}\u0000legacy`;
-        if (!prerequisiteId || seen.has(key)) continue;
-        seen.add(key);
-        this.addLegacyRelationInternal(prerequisiteId, dependentId, "legacy", undefined, "legacy");
-      }
+      // parentIds without a typed relation are intentionally ignored: they do
+      // not carry enough evidence to manufacture a causal claim.
     }
-    this.semanticLinks.clear();
     this.normalizeCausalGraph();
     this.revision = 0;
   }
@@ -1265,13 +1193,6 @@ export class GraphOfTrace {
           reason,
           evidence: [{ source: "trace", kind: relation, ...(reason ? { detail: reason } : {}) }],
         });
-      } else {
-        const type = semanticTypeForLegacyRelation(relation);
-        const id = stableId("semantic", prerequisiteId, dependentId, type);
-        if (!this.semanticLinks.has(id)) {
-          const stamp = this.nodes.get(dependentId)?.createdAt;
-          this.semanticLinks.set(id, { id, fromId: prerequisiteId, toId: dependentId, type, ...(reason ? { reason } : {}), ...(stamp ? { createdAt: stamp } : {}) });
-        }
       }
       return;
     }
@@ -1281,13 +1202,6 @@ export class GraphOfTrace {
       this.upsertMigrationDependency(prerequisiteId, dependentId, "host", "high", "active", reason, "delegation");
     } else if (relation === "necessitated_by" || relation === "used") {
       this.upsertMigrationDependency(prerequisiteId, dependentId, "legacy", "medium", "proposed", reason, relation);
-    } else {
-      const type = semanticTypeForLegacyRelation(relation);
-      const id = stableId("semantic", prerequisiteId, dependentId, type);
-      if (!this.semanticLinks.has(id)) {
-        const stamp = this.nodes.get(dependentId)?.createdAt;
-        this.semanticLinks.set(id, { id, fromId: prerequisiteId, toId: dependentId, type, ...(reason ? { reason } : {}), ...(stamp ? { createdAt: stamp } : {}) });
-      }
     }
   }
 
@@ -1300,16 +1214,7 @@ export class GraphOfTrace {
     reason: string | undefined,
     kind: string,
   ): void {
-    if (this.wouldCreateCycle(prerequisiteId, dependentId)) {
-      // A corrupt V1 cycle must not become a V2 dependency cycle. Keep the
-      // historical hint as a semantic legacy edge instead of dropping it.
-      const id = stableId("semantic", prerequisiteId, dependentId, "legacy");
-      if (!this.semanticLinks.has(id)) {
-        const stamp = this.nodes.get(dependentId)?.createdAt;
-        this.semanticLinks.set(id, { id, fromId: prerequisiteId, toId: dependentId, type: "legacy", ...(reason ? { reason } : {}), ...(stamp ? { createdAt: stamp } : {}) });
-      }
-      return;
-    }
+    if (this.wouldCreateCycle(prerequisiteId, dependentId)) return;
     const id = stableId("dependency", prerequisiteId, dependentId);
     const existing = this.dependencies.get(id);
     if (existing) {
@@ -1372,7 +1277,10 @@ export class GraphOfTrace {
     const conclusion: TraceCausalParent["conclusion"] = dependency.state === "active" && (
       dependency.origin === "user" ||
       dependency.origin === "explicit" ||
-      (dependency.origin === "host" && isDeterministicHostEvidence(dependency.evidence))
+      (dependency.origin === "host" && isDeterministicHostEvidence(dependency.evidence)) ||
+      (dependency.origin === "legacy" && dependency.evidence.some((item) =>
+        item.source === "v1" && item.kind === "legacy_depends_on"
+      ))
     )
       ? "confirmed"
       : dependency.state === "rejected"
@@ -1788,10 +1696,6 @@ export class GraphOfTrace {
     return value === "agent_report" || value === "explicit" || value === "host" || value === "user" || value === "legacy" ? value : "trace";
   }
 
-  private validSemanticType(value: unknown): TraceSemanticLinkType {
-    return value === "sequence_after" || value === "restored_from" || value === "supports" || value === "contradicts" || value === "supersedes" || value === "references" ? value : "legacy";
-  }
-
   private coerceEvidence(value: unknown): TraceDependencyEvidence[] {
     if (!Array.isArray(value)) return [];
     return value.map(asRecord).map((item) => ({
@@ -1836,11 +1740,14 @@ export class GraphOfTrace {
 
   private persist(change?: TraceChange): void {
     if (!this.persistPath) return;
-    // Capture both states now. Using live in-memory state after an awaited
-    // append could otherwise persist a later revision before its own journal
-    // tail has been embedded.
-    const cleanGraph = this.getPersistedGraph();
-    const graph = change ? { ...cleanGraph, pendingChanges: [clone(change)] } : cleanGraph;
+    if (change && !this.pendingChanges.some((item) => item.id === change.id)) {
+      this.pendingChanges.push(clone(change));
+    }
+    // Every snapshot carries the complete non-durable journal tail. If an
+    // earlier append failed, a later mutation therefore cannot overwrite and
+    // lose that older change.
+    const pending = clone(this.pendingChanges);
+    const graph = this.getPersistedGraph(pending);
     this.writeChain = this.writeChain
       .then(async () => {
         await mkdir(dirname(this.persistPath!), { recursive: true });
@@ -1858,11 +1765,33 @@ export class GraphOfTrace {
           this.wroteV2AfterV1 = true;
         }
         await this.writeSnapshot(graph);
-        if (change) {
-          await appendFile(this.changeLogPath()!, `${JSON.stringify(change)}\n`, "utf8");
-          // Clear the embedded journal only after the append succeeds. A crash
-          // before this rewrite is repaired idempotently by recoverChanges().
-          await this.writeSnapshot(cleanGraph);
+        if (pending.length > 0) {
+          const journalPath = this.changeLogPath()!;
+          let journal = "";
+          try {
+            journal = await readFile(journalPath, "utf8");
+          } catch (error) {
+            if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+          }
+          const durableIds = new Set<string>();
+          for (const line of journal.split("\n")) {
+            try {
+              const value = JSON.parse(line) as TraceChange;
+              if (typeof value?.id === "string") durableIds.add(value.id);
+            } catch {
+              // Ignore torn/corrupt records; valid records remain deduplicated.
+            }
+          }
+          for (const item of pending) {
+            if (!durableIds.has(item.id)) {
+              await appendFile(journalPath, `${JSON.stringify(item)}\n`, "utf8");
+              durableIds.add(item.id);
+            }
+          }
+          this.pendingChanges = this.pendingChanges.filter((item) => !durableIds.has(item.id));
+          // Use the current in-memory graph so a queued later mutation stays
+          // embedded while this earlier write finishes.
+          await this.writeSnapshot(this.getPersistedGraph(this.pendingChanges));
         }
       })
       // Persistence is best-effort by historical contract. The in-memory graph

--- a/packages/runtime/src/trace.ts
+++ b/packages/runtime/src/trace.ts
@@ -1,38 +1,204 @@
 /**
- * GraphOfTrace (GoT) — the reasoning DAG (§9, ports legacy graph_of_trace.py).
+ * TraceGraphV2 — canonical Graph of Trace storage.
  *
- * Nodes + relations are persisted to `.bp/{sid}/trace.json` as a `TraceGraph`
- * (protocol schema). System tools (create/update node, add relation, get graph)
- * mutate this; the Trace agent is the primary writer.
+ * Nodes own their causal parent references. Legacy dependency/semantic-link
+ * collections are compatibility projections only and are never persisted by
+ * new writes. `getGraph()` still materializes the old shape for older clients.
  */
-import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { randomUUID } from "node:crypto";
+import { appendFile, copyFile, mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { createHash, randomUUID } from "node:crypto";
 import { dirname } from "node:path";
-import type { TraceGraph, TraceNode } from "@brainpilot/protocol";
-
+import type {
+  AuditReport,
+  TraceArtifact,
+  TraceArtifactV2,
+  TraceCheckpointRef,
+  TraceChange,
+  TraceCausalParent,
+  TraceDependency,
+  TraceDependencyEvidence,
+  TraceDependencyOrigin,
+  TraceDependencyState,
+  TraceEpisode,
+  TraceGraph,
+  TraceDocumentV2,
+  TraceGraphV2,
+  TraceNode,
+  TraceNodeConfidence,
+  TraceNodeRecord,
+  TraceNodeReviewConclusion,
+  TraceNodeV2,
+  TraceSemanticLink,
+  TraceSemanticLinkType,
+  TraceDeltaV2,
+} from "@brainpilot/protocol";
 function now(): string {
   return new Date().toISOString();
 }
 
-/** Mutation kind reported to the `onChange` listener. */
+function stableId(prefix: string, ...parts: Array<string | undefined>): string {
+  const hash = createHash("sha256").update(parts.map((part) => part ?? "").join("\u0000")).digest("hex").slice(0, 20);
+  return `${prefix}_${hash}`;
+}
+
+function clone<T>(value: T): T {
+  // Trace records are JSON-only by design. JSON cloning makes returned views
+  // safe for HTTP consumers without leaking mutable Map values.
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {};
+}
+
+function asString(value: unknown, fallback = ""): string {
+  return typeof value === "string" ? value : fallback;
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function evidenceKey(evidence: TraceDependencyEvidence): string {
+  return JSON.stringify([
+    evidence.source,
+    evidence.kind,
+    evidence.detail ?? "",
+    evidence.artifactId ?? "",
+    evidence.reportId ?? "",
+    evidence.path ?? "",
+    evidence.checkpointId ?? "",
+    evidence.baseBlobId ?? "",
+    evidence.resultBlobId ?? "",
+    evidence.deterministic ?? false,
+  ]);
+}
+
+function isDeterministicHostEvidence(evidence: readonly TraceDependencyEvidence[]): boolean {
+  return evidence.some((item) =>
+    item.deterministic === true ||
+    item.kind === "artifact_producer_consumer" ||
+    item.kind === "delegation",
+  );
+}
+
+function semanticTypeForLegacyRelation(relation: string | undefined): TraceSemanticLinkType {
+  switch (relation) {
+    case "follows": return "sequence_after";
+    case "restored_from": return "restored_from";
+    case "supports": return "supports";
+    case "contradicts": return "contradicts";
+    case "supersedes": return "supersedes";
+    case "references": return "references";
+    default: return "legacy";
+  }
+}
+
+function legacyRelationForSemantic(type: TraceSemanticLinkType): string {
+  switch (type) {
+    case "sequence_after": return "follows";
+    default: return type;
+  }
+}
+
+/** Legacy callback operation retained for older hosting code and tests. */
 export type TraceChangeOp = "created" | "updated";
 
+export interface TraceDependencyInput {
+  prerequisiteId: string;
+  dependentId: string;
+  reason?: string;
+  origin?: TraceDependencyOrigin;
+  evidence?: TraceDependencyEvidence[];
+}
+
+export interface TraceArtifactInput {
+  id?: string;
+  path: string;
+  kind?: string;
+  type?: string;
+  producerNodeId?: string | null;
+  checkpointId?: string;
+  checkpoint?: TraceCheckpointRef;
+  blobHash?: string;
+  changeStatus?: "added" | "modified" | "deleted" | "renamed";
+  previousPath?: string;
+  exists?: "unknown" | "present" | "missing";
+  verificationStatus?: "unverified" | "reserved" | "verified" | "missing";
+  role?: "input" | "output" | "checkpoint" | "reference";
+  createdAt?: string;
+  updatedAt?: string;
+  /** Used only by V1 normalization so an absent historical time stays absent. */
+  preserveUnknownTimestamps?: boolean;
+}
+
+export interface TraceNodeDetail {
+  node: TraceNodeV2;
+  dependencies: { incoming: TraceDependency[]; outgoing: TraceDependency[] };
+  semanticLinks: { incoming: TraceSemanticLink[]; outgoing: TraceSemanticLink[] };
+  episode?: TraceEpisode;
+  artifacts: TraceArtifactV2[];
+}
+
+export interface TraceChangeActor {
+  type: "user" | "agent" | "host";
+  name?: string;
+}
+
+export interface TraceAuditTarget {
+  nodeId: string;
+  parentNodeId?: string;
+  fingerprint: string;
+}
+
+type TraceChangeDraft = Omit<TraceChange, "id" | "revision" | "createdAt">;
+
+/**
+ * Canonical V2 storage with a deliberately narrow mutation surface.
+ *
+ * A Trace dependency starts proposed/low. It can only become active/high by a
+ * user decision, an explicit direct declaration, or deterministic Host
+ * evidence. Trace-generated repetition never raises confidence; independent
+ * non-Trace reports may only raise it to medium.
+ */
 export class GraphOfTrace {
-  private readonly nodes = new Map<string, TraceNode>();
+  private readonly nodes = new Map<string, TraceNodeV2>();
+  private readonly dependencies = new Map<string, TraceDependency>();
+  private readonly semanticLinks = new Map<string, TraceSemanticLink>();
+  private readonly episodes = new Map<string, TraceEpisode>();
+  private readonly artifacts = new Map<string, TraceArtifactV2>();
+  private readonly changes: TraceChange[] = [];
+  /** Journal tail embedded in trace.json until its JSONL append is durable. */
+  private pendingChanges: TraceChange[] = [];
+  private meta: TraceGraphV2["meta"];
+  private revision = 0;
   private writeChain: Promise<void> = Promise.resolve();
-  /** Id of the most recently created node — used to chain auto-captured nodes. */
+  /** Id of the most recently created node — only a presentation-chain helper. */
   private lastNodeId: string | undefined;
+  /** True only after V1 was loaded; controls one-time backup on first mutation. */
+  private loadedV1 = false;
+  private wroteV2AfterV1 = false;
 
   /**
-   * @param onChange invoked after every node create/update/relation mutation so
-   *   a hosting layer (SessionManager) can push a live `CUSTOM:trace_node` event.
-   *   Kept decoupled from the EventBus so the store stays unit-testable on its own.
+   * @param onChange legacy V1 projection event. Kept during the transition.
+   * @param onDelta canonical V2 snapshot event. The manager emits it as
+   * `CUSTOM:trace_delta`; snapshot events favor correctness during rollout.
    */
   constructor(
     readonly sessionId: string,
     private readonly persistPath?: string,
     private readonly onChange?: (op: TraceChangeOp, node: TraceNode) => void,
-  ) {}
+    private readonly onDelta?: (delta: TraceDeltaV2) => void,
+  ) {
+    this.meta = { sessionId, createdAt: now() };
+    this.ensureSessionRoot();
+  }
 
   createNode(input: {
     title: string;
@@ -42,48 +208,103 @@ export class GraphOfTrace {
     description?: string;
     summary?: string;
     content?: string;
+    reason?: string;
+    context?: string;
     parents?: Array<{ id: string; relation?: string; explanation?: string }>;
     artifacts?: Array<{ path: string; type?: string }>;
+    artifactInputs?: TraceArtifactInput[];
+    artifactOutputs?: TraceArtifactInput[];
     metadata?: Record<string, unknown>;
+    checkpoints?: TraceCheckpointRef[];
     id?: string;
+    primaryEpisodeId?: string;
+    episodeTags?: string[];
+    records?: TraceNodeRecord[];
+    causalParents?: TraceCausalParent[];
+    executionResult?: "completed" | "failed";
+    revoked?: boolean;
+    reviewConclusion?: TraceNodeReviewConclusion;
+    reviewReason?: string;
+    confidence?: TraceNodeConfidence;
+    confidenceReason?: string;
+    changeActor?: TraceChangeActor;
   }): TraceNode {
+    this.ensureSessionRoot();
     const id = input.id ?? `node_${randomUUID()}`;
-    const parents = input.parents ?? [];
-    const node: TraceNode = {
+    if (this.nodes.has(id)) throw new Error(`trace node already exists: ${id}`);
+    const createdAt = now();
+    const report = input.summary !== undefined || input.content !== undefined
+      ? { kind: "agent_report" as const, summary: input.summary, content: input.content, author: input.agent }
+      : undefined;
+    const node: TraceNodeV2 = {
       id,
       title: input.title,
       type: input.type ?? "task",
-      status: input.status ?? "pending",
+      status: input.status ?? input.executionResult ?? "completed",
       agent: input.agent,
       description: input.description,
-      summary: input.summary,
-      content: input.content,
-      parents,
-      artifacts: input.artifacts ?? [],
-      parentIds: parents.map((p) => p.id),
-      childIds: [],
-      createdAt: now(),
-      updatedAt: now(),
+      reason: input.reason,
+      context: input.context,
+      ...(report ? { report } : {}),
+      createdAt,
+      updatedAt: createdAt,
       toolCalls: [],
-      ...(input.metadata ? { metadata: input.metadata } : {}),
+      artifactIds: [],
+      ...(input.primaryEpisodeId ? { primaryEpisodeId: input.primaryEpisodeId } : {}),
+      ...(input.episodeTags?.length ? { episodeTags: unique(input.episodeTags) } : { episodeTags: [] }),
+      ...(input.metadata ? { metadata: clone(input.metadata) } : {}),
+      records: clone(input.records ?? []),
+      parents: clone(input.causalParents ?? []),
+      executionResult: input.executionResult ?? (input.status === "error" || input.status === "failed" ? "failed" : "completed"),
+      revoked: input.revoked ?? false,
+      ...(input.confidence ? { confidence: input.confidence } : {}),
+      ...(input.confidenceReason ? { confidenceReason: input.confidenceReason } : {}),
+      reviewConclusion: input.reviewConclusion ?? "unreviewed",
+      ...(input.reviewReason ? { reviewReason: input.reviewReason } : {}),
     };
     this.nodes.set(id, node);
-    // Maintain reverse edges.
-    for (const p of parents) {
-      const parent = this.nodes.get(p.id);
-      if (parent && !parent.childIds.includes(id)) parent.childIds.push(id);
+
+    for (const artifact of input.artifacts ?? []) {
+      this.registerArtifactInternal(id, { path: artifact.path, type: artifact.type, kind: artifact.type ?? "file", role: "output" });
     }
+    for (const artifact of input.artifactOutputs ?? []) {
+      this.registerArtifactInternal(id, { ...artifact, role: "output" });
+    }
+    for (const artifact of input.artifactInputs ?? []) {
+      this.attachArtifactInputInternal(id, artifact);
+    }
+    for (const checkpoint of input.checkpoints ?? []) {
+      this.registerArtifactInternal(id, {
+        path: `checkpoint:${checkpoint.id}`,
+        kind: "checkpoint",
+        type: "checkpoint",
+        checkpointId: checkpoint.id,
+        checkpoint,
+        exists: checkpoint.status === "ready" || checkpoint.status === "partial" ? "present" : "unknown",
+        verificationStatus: "reserved",
+        role: "checkpoint",
+      });
+    }
+    for (const parent of input.parents ?? []) {
+      this.addLegacyRelationInternal(parent.id, id, parent.relation, parent.explanation, "trace");
+    }
+    this.normalizeCausalGraph();
     this.lastNodeId = id;
-    this.persist();
-    this.onChange?.("created", node);
-    return node;
+    this.commit("created", id, {
+      actor: input.changeActor ?? { type: "host" },
+      action: "node_created",
+      target: { nodeId: id },
+      after: {
+        title: node.title,
+        executionResult: node.executionResult,
+        confidence: node.confidence,
+        confidenceReason: node.confidenceReason,
+      },
+    });
+    return this.getNode(id)!;
   }
 
-  /**
-   * Create a node automatically chained to the most recent node (deterministic
-   * hook capture, §8). When no prior node exists it becomes a root. `metadata.auto`
-   * is set so the UI can distinguish infra-captured milestones from LLM traces.
-   */
+  /** Creates a sequence semantic link, not an implied dependency. */
   createChainedNode(input: {
     title: string;
     type?: string;
@@ -104,86 +325,1567 @@ export class GraphOfTrace {
     });
   }
 
-  updateNode(id: string, updates: Partial<TraceNode>): TraceNode | undefined {
+  /**
+   * Legacy-shaped update. Parent/child fields are intentionally ignored: they
+   * are derived from the canonical relation collections at read time.
+   */
+  updateNode(id: string, updates: Partial<TraceNode>, actor: TraceChangeActor = { type: "host" }): TraceNode | undefined {
     const node = this.nodes.get(id);
-    if (!node) return undefined;
-    Object.assign(node, updates, { id, updatedAt: now() });
-    this.persist();
-    this.onChange?.("updated", node);
-    return node;
+    if (!node || this.isSessionRoot(id)) return undefined;
+    const patch = updates as Record<string, unknown>;
+    const before = {
+      confidence: node.confidence,
+      confidenceReason: node.confidenceReason,
+      reviewConclusion: node.reviewConclusion,
+    };
+    for (const key of ["title", "type", "status", "agent", "description", "reason", "context", "durationMs", "errorMessage", "timestamp"]) {
+      if (patch[key] !== undefined) (node as Record<string, unknown>)[key] = clone(patch[key]);
+    }
+    if (Array.isArray(patch.toolCalls)) node.toolCalls = asStringArray(patch.toolCalls);
+    if (patch.metadata && typeof patch.metadata === "object") node.metadata = clone(patch.metadata as Record<string, unknown>);
+    if (patch.executionResult === "completed" || patch.executionResult === "failed") {
+      node.executionResult = patch.executionResult;
+      node.status = patch.executionResult;
+    }
+    if (typeof patch.revoked === "boolean") node.revoked = patch.revoked;
+    if (patch.confidence === "low" || patch.confidence === "medium" || patch.confidence === "high") {
+      node.confidence = patch.confidence;
+    }
+    if (typeof patch.confidenceReason === "string") node.confidenceReason = patch.confidenceReason;
+    if (patch.reviewConclusion === "unreviewed" || patch.reviewConclusion === "approved" || patch.reviewConclusion === "rejected" || patch.reviewConclusion === "uncertain") {
+      node.reviewConclusion = patch.reviewConclusion;
+    }
+    if (typeof patch.reviewReason === "string") node.reviewReason = patch.reviewReason;
+    if (patch.summary !== undefined || patch.content !== undefined) {
+      node.report = {
+        kind: "agent_report",
+        summary: patch.summary !== undefined ? asString(patch.summary) : node.report?.summary,
+        content: patch.content !== undefined ? asString(patch.content) : node.report?.content,
+        author: node.agent,
+      };
+    }
+    if (Array.isArray(patch.artifacts)) {
+      for (const raw of patch.artifacts) {
+        const artifact = asRecord(raw);
+        const path = asString(artifact.path);
+        if (path) this.registerArtifactInternal(id, { path, type: asString(artifact.type) || undefined, kind: asString(artifact.type, "file"), role: "output" });
+      }
+    }
+    if (Array.isArray(patch.checkpoints)) {
+      for (const raw of patch.checkpoints) {
+        const checkpoint = raw as TraceCheckpointRef;
+        if (checkpoint?.id) {
+          this.registerArtifactInternal(id, {
+            path: `checkpoint:${checkpoint.id}`,
+            kind: "checkpoint",
+            type: "checkpoint",
+            checkpointId: checkpoint.id,
+            checkpoint,
+            role: "checkpoint",
+          });
+        }
+      }
+    }
+    // Any substantive Trace edit invalidates the previous independent review.
+    // Its old conclusion/reason remain available in trace-changes.jsonl.
+    if (actor.type === "agent" && actor.name === "trace") {
+      node.reviewConclusion = "unreviewed";
+      delete node.reviewReason;
+    }
+    this.normalizeCausalGraph();
+    node.updatedAt = now();
+    this.commit("updated", id, {
+      actor,
+      action: "node_updated",
+      target: { nodeId: id },
+      before,
+      after: clone(updates),
+      ...(node.confidenceReason ? { reason: node.confidenceReason } : {}),
+    });
+    return this.getNode(id);
   }
 
-  /** Id of the most recently created node, if any. */
+  appendRecord(id: string, record: TraceNodeRecord, actor: TraceChangeActor): TraceNode | undefined {
+    const node = this.nodes.get(id);
+    if (!node || node.revoked || this.isSessionRoot(id)) return undefined;
+    const duplicate = node.records.some((item) =>
+      item.sourceAgent === record.sourceAgent &&
+      item.createdAt === record.createdAt &&
+      item.description === record.description,
+    );
+    if (!duplicate) node.records.push(clone(record));
+    node.updatedAt = now();
+    this.commit("updated", id, {
+      actor,
+      action: "record_attached",
+      target: { nodeId: id },
+      after: { sourceAgent: record.sourceAgent, checkpointId: record.checkpointId },
+    });
+    return this.getNode(id);
+  }
+
+  proposeCausalParent(childNodeId: string, parentNodeId: string, reason: string, actor: TraceChangeActor): boolean {
+    const child = this.nodes.get(childNodeId);
+    const parent = this.nodes.get(parentNodeId);
+    if (!child || !parent || child.revoked || parent.revoked || this.isSessionRoot(childNodeId) || this.isSessionRoot(parentNodeId) || childNodeId === parentNodeId) return false;
+    const existing = child.parents.find((item) => item.nodeId === parentNodeId);
+    if (existing?.conclusion === "rejected") return false;
+    const before = existing ? clone(existing) : undefined;
+    if (existing) {
+      if (existing.conclusion === "confirmed" && existing.reason === reason) return true;
+      existing.conclusion = "candidate";
+      existing.reason = reason;
+    } else {
+      child.parents.push({ nodeId: parentNodeId, conclusion: "candidate", ...(reason ? { reason } : {}) });
+    }
+    this.syncCompatibilityDependency(parentNodeId, childNodeId, "candidate", reason);
+    child.updatedAt = now();
+    this.commit("updated", childNodeId, {
+      actor,
+      action: "parent_proposed",
+      target: { nodeId: childNodeId, parentNodeId },
+      before,
+      after: { conclusion: "candidate" },
+      reason,
+    });
+    return true;
+  }
+
+  review(
+    nodeId: string,
+    conclusion: "approve" | "reject" | "uncertain",
+    reason: string,
+    actor: TraceChangeActor,
+    parentNodeId?: string,
+    expectedFingerprint?: string,
+  ): boolean {
+    const node = this.nodes.get(nodeId);
+    if (!node || node.revoked || this.isSessionRoot(nodeId)) return false;
+    if (expectedFingerprint && this.auditFingerprint(nodeId, parentNodeId) !== expectedFingerprint) return false;
+    if (!parentNodeId) {
+      const before = node.reviewConclusion;
+      node.reviewConclusion = conclusion === "approve" ? "approved" : conclusion === "reject" ? "rejected" : "uncertain";
+      node.reviewReason = reason;
+      node.updatedAt = now();
+      this.commit("updated", nodeId, {
+        actor,
+        action: "node_reviewed",
+        target: { nodeId },
+        before,
+        after: node.reviewConclusion,
+        reason,
+      });
+      return true;
+    }
+    if (this.isSessionRoot(parentNodeId)) return false;
+    const parent = this.nodes.get(parentNodeId);
+    const ref = node.parents.find((item) => item.nodeId === parentNodeId);
+    if (!parent || parent.revoked || !ref) return false;
+    if (conclusion === "approve" && parent.reviewConclusion === "rejected") return false;
+    if (conclusion === "approve" && this.wouldCreateConfirmedCycle(parentNodeId, nodeId)) return false;
+    const before = ref.conclusion;
+    ref.conclusion = conclusion === "approve" ? "confirmed" : conclusion === "reject" ? "rejected" : "uncertain";
+    ref.reason = reason;
+    this.normalizeCausalGraph();
+    node.updatedAt = now();
+    this.commit("updated", nodeId, {
+      actor,
+      action: "parent_reviewed",
+      target: { nodeId, parentNodeId },
+      before,
+      after: ref.conclusion,
+      reason,
+    });
+    return true;
+  }
+
+  listPendingAuditTargets(nodeIds?: Iterable<string>): TraceAuditTarget[] {
+    const selected = nodeIds ? new Set(nodeIds) : undefined;
+    const targets: TraceAuditTarget[] = [];
+    for (const node of this.nodes.values()) {
+      if (node.revoked || this.isSessionRoot(node.id) || (selected && !selected.has(node.id))) continue;
+      if (node.reviewConclusion === "unreviewed") {
+        targets.push({ nodeId: node.id, fingerprint: this.auditFingerprint(node.id)! });
+      }
+      for (const parent of node.parents) {
+        if (parent.conclusion !== "candidate") continue;
+        const fingerprint = this.auditFingerprint(node.id, parent.nodeId);
+        if (fingerprint) targets.push({ nodeId: node.id, parentNodeId: parent.nodeId, fingerprint });
+      }
+    }
+    return targets;
+  }
+
+  auditFingerprint(nodeId: string, parentNodeId?: string): string | undefined {
+    const node = this.nodes.get(nodeId);
+    if (!node || node.revoked) return undefined;
+    const payload = parentNodeId
+      ? {
+          child: this.auditNodeEvidence(node),
+          parent: this.nodes.get(parentNodeId) ? this.auditNodeEvidence(this.nodes.get(parentNodeId)!) : undefined,
+          relation: node.parents.find((parent) => parent.nodeId === parentNodeId),
+        }
+      : this.auditNodeEvidence(node);
+    return createHash("sha256").update(JSON.stringify(payload)).digest("hex");
+  }
+
+  /** Register an artifact and attach it to a node. IDs are stable across V1 migration. */
+  registerArtifact(nodeId: string, input: TraceArtifactInput): TraceArtifactV2 | undefined {
+    if (!this.nodes.has(nodeId) || !input.path) return undefined;
+    const artifact = this.registerArtifactInternal(nodeId, input);
+    this.nodes.get(nodeId)!.updatedAt = now();
+    this.commit("updated", nodeId);
+    return clone(artifact);
+  }
+
+  /** Attach an existing artifact to a consumer and infer a deterministic Host edge. */
+  referenceArtifact(nodeId: string, artifactId: string, role: "input" | "reference" = "input"): boolean {
+    const node = this.nodes.get(nodeId);
+    const artifact = this.artifacts.get(artifactId);
+    if (!node || !artifact) return false;
+    node.artifactIds = unique([...node.artifactIds, artifactId]);
+    node.updatedAt = now();
+    if (!artifact.role) artifact.role = role;
+    this.commit("updated", nodeId);
+    return true;
+  }
+
+  /** Register/reference an input artifact and infer producer -> consumer only from Host evidence. */
+  attachArtifactInput(nodeId: string, input: TraceArtifactInput): TraceArtifactV2 | undefined {
+    if (!this.nodes.has(nodeId) || !input.path) return undefined;
+    const artifact = this.attachArtifactInputInternal(nodeId, input);
+    this.nodes.get(nodeId)!.updatedAt = now();
+    this.commit("updated", nodeId);
+    return clone(artifact);
+  }
+
+  /**
+   * Trace-facing dependency proposal. Returns false for missing nodes, cycles,
+   * and rejected tombstones. The method never uses timestamps to alter edges.
+   */
+  proposeDependency(input: TraceDependencyInput): { ok: boolean; dependency?: TraceDependency; reason?: string; error?: string } {
+    const result = this.proposeDependencyInternal(input);
+    if (!result.ok) return { ...result, error: result.reason };
+    this.normalizeCausalGraph();
+    this.commit("updated", input.dependentId);
+    return { ok: true, dependency: clone(result.dependency!) };
+  }
+
+  /** User decision endpoint: accepted -> active/high; rejected is a tombstone. */
+  decideDependency(id: string, decision: "accept" | "reject", reason?: string): TraceDependency | undefined {
+    const dependency = this.dependencies.get(id);
+    if (!dependency || this.isSessionRoot(dependency.prerequisiteId) || this.isSessionRoot(dependency.dependentId)) return undefined;
+    if (decision === "accept" && this.wouldCreateConfirmedCycle(dependency.prerequisiteId, dependency.dependentId)) return undefined;
+    dependency.state = decision === "accept" ? "active" : "rejected";
+    dependency.confidence = decision === "accept" ? "high" : dependency.confidence;
+    dependency.evidence = this.mergeEvidence(dependency.evidence, [{
+      source: "user",
+      kind: decision === "accept" ? "accepted" : "rejected",
+      detail: reason,
+      deterministic: true,
+    }]);
+    if (reason) dependency.reason = reason;
+    dependency.updatedAt = now();
+    const child = this.nodes.get(dependency.dependentId);
+    const parentRef = child?.parents.find((parent) => parent.nodeId === dependency.prerequisiteId);
+    if (parentRef) {
+      parentRef.conclusion = decision === "accept" ? "confirmed" : "rejected";
+      if (reason) parentRef.reason = reason;
+    }
+    this.normalizeCausalGraph();
+    this.commit("updated", dependency.dependentId, {
+      actor: { type: "user" },
+      action: "parent_reviewed",
+      target: { nodeId: dependency.dependentId, parentNodeId: dependency.prerequisiteId },
+      after: dependency.state === "active" ? "confirmed" : "rejected",
+      reason,
+    });
+    return clone(dependency);
+  }
+
+  /** Compatibility wrapper for V1 callers. `depends_on` now stays proposed. */
+  addRelation(fromId: string, toId: string, explanation: string, relation = "depends_on"): boolean {
+    if (!this.nodes.has(fromId) || !this.nodes.has(toId)) return false;
+    if (relation === "depends_on") {
+      return this.proposeDependency({
+        prerequisiteId: fromId,
+        dependentId: toId,
+        reason: explanation,
+        origin: "trace",
+        evidence: [{ source: "trace", kind: "trace_inference", detail: explanation }],
+      }).ok;
+    }
+    if (relation === "delegated") {
+      return this.proposeDependency({
+        prerequisiteId: fromId,
+        dependentId: toId,
+        reason: explanation,
+        origin: "host",
+        evidence: [{ source: "host", kind: "delegation", detail: explanation, deterministic: true }],
+      }).ok;
+    }
+    if (relation === "necessitated_by" || relation === "used") {
+      return this.proposeDependency({
+        prerequisiteId: fromId,
+        dependentId: toId,
+        reason: explanation,
+        origin: "legacy",
+        evidence: [{ source: "legacy", kind: relation, detail: explanation }],
+      }).ok;
+    }
+    const link = this.addSemanticLink(fromId, toId, semanticTypeForLegacyRelation(relation), explanation);
+    return Boolean(link);
+  }
+
+  addSemanticLink(fromId: string, toId: string, type: TraceSemanticLinkType, reason?: string): TraceSemanticLink | undefined {
+    if (!this.nodes.has(fromId) || !this.nodes.has(toId)) return undefined;
+    const id = stableId("semantic", fromId, toId, type);
+    const existing = this.semanticLinks.get(id);
+    if (existing) {
+      if (reason) existing.reason = reason;
+      this.commit("updated", toId);
+      return clone(existing);
+    }
+    const link: TraceSemanticLink = { id, fromId, toId, type, ...(reason ? { reason } : {}), createdAt: now() };
+    this.semanticLinks.set(id, link);
+    this.commit("updated", toId);
+    return clone(link);
+  }
+
+  createEpisode(input: { title: string; description?: string; id?: string }): TraceEpisode {
+    const id = input.id ?? `episode_${randomUUID()}`;
+    const stamp = now();
+    const episode: TraceEpisode = { id, title: input.title, ...(input.description ? { description: input.description } : {}), createdAt: stamp, updatedAt: stamp };
+    this.episodes.set(id, episode);
+    this.commit("updated");
+    return clone(episode);
+  }
+
+  renameEpisode(id: string, title: string, description?: string): TraceEpisode | undefined {
+    const episode = this.episodes.get(id);
+    if (!episode) return undefined;
+    episode.title = title;
+    if (description !== undefined) episode.description = description;
+    episode.updatedAt = now();
+    this.commit("updated");
+    return clone(episode);
+  }
+
+  assignEpisode(nodeId: string, episodeId?: string, tags?: string[]): TraceNode | undefined {
+    const node = this.nodes.get(nodeId);
+    if (!node || (episodeId && !this.episodes.has(episodeId))) return undefined;
+    node.primaryEpisodeId = episodeId;
+    node.episodeTags = unique(tags ?? node.episodeTags);
+    node.updatedAt = now();
+    this.commit("updated", nodeId);
+    return this.getNode(nodeId);
+  }
+
+  mergeEpisodes(targetId: string, sourceIds: string[]): TraceEpisode | undefined {
+    const target = this.episodes.get(targetId);
+    if (!target) return undefined;
+    const sources = unique(sourceIds).filter((id) => id !== targetId && this.episodes.has(id));
+    for (const node of this.nodes.values()) {
+      if (node.primaryEpisodeId && sources.includes(node.primaryEpisodeId)) node.primaryEpisodeId = targetId;
+      node.episodeTags = unique(node.episodeTags.map((tag) => sources.includes(tag) ? targetId : tag));
+    }
+    for (const id of sources) this.episodes.delete(id);
+    target.updatedAt = now();
+    this.commit("updated");
+    return clone(target);
+  }
+
+  /** Split is a presentation-only reassignment; it cannot touch dependencies. */
+  splitEpisode(sourceId: string, splits: Array<{ title: string; nodeIds: string[] }>): TraceEpisode[] | undefined {
+    if (!this.episodes.has(sourceId) || splits.length === 0) return undefined;
+    const created = splits.map((split) => this.createEpisode({ title: split.title }));
+    const reassigned = new Map<string, string>();
+    for (let index = 0; index < splits.length; index++) {
+      for (const nodeId of unique(splits[index]!.nodeIds)) {
+        const node = this.nodes.get(nodeId);
+        if (node?.primaryEpisodeId === sourceId) node.primaryEpisodeId = created[index]!.id;
+        if (node) reassigned.set(nodeId, created[index]!.id);
+      }
+    }
+    for (const node of this.nodes.values()) {
+      const replacement = reassigned.get(node.id);
+      if (node.primaryEpisodeId === sourceId) node.primaryEpisodeId = replacement;
+      node.episodeTags = unique(node.episodeTags.flatMap((tag) => {
+        if (tag !== sourceId) return [tag];
+        return replacement ? [replacement] : [];
+      }));
+    }
+    this.episodes.delete(sourceId);
+    this.commit("updated");
+    return created;
+  }
+
+  getNode(id: string): TraceNode | undefined {
+    const node = this.nodes.get(id);
+    return node ? this.materializeNode(node) : undefined;
+  }
+
+  getNodeV2(id: string): TraceNodeV2 | undefined {
+    const node = this.nodes.get(id);
+    return node ? clone(node) : undefined;
+  }
+
+  getNodeDetail(id: string, includeRevoked = false): TraceNodeDetail | undefined {
+    const node = this.nodes.get(id);
+    if (!node || (!includeRevoked && node.revoked)) return undefined;
+    const incoming = [...this.dependencies.values()].filter((edge) => edge.dependentId === id);
+    const outgoing = [...this.dependencies.values()].filter((edge) => edge.prerequisiteId === id);
+    const semanticIncoming = [...this.semanticLinks.values()].filter((edge) => edge.toId === id);
+    const semanticOutgoing = [...this.semanticLinks.values()].filter((edge) => edge.fromId === id);
+    return {
+      node: clone(node),
+      dependencies: { incoming: clone(incoming), outgoing: clone(outgoing) },
+      semanticLinks: { incoming: clone(semanticIncoming), outgoing: clone(semanticOutgoing) },
+      ...(node.primaryEpisodeId && this.episodes.get(node.primaryEpisodeId)
+        ? { episode: clone(this.episodes.get(node.primaryEpisodeId)!) }
+        : {}),
+      artifacts: clone(node.artifactIds.map((artifactId) => this.artifacts.get(artifactId)).filter((item): item is TraceArtifactV2 => Boolean(item))),
+    };
+  }
+
+  getNeighborhood(id: string, depth = 1): { nodes: TraceNodeV2[]; dependencies: TraceDependency[]; semanticLinks: TraceSemanticLink[] } | undefined {
+    if (!this.nodes.has(id) || this.nodes.get(id)?.revoked) return undefined;
+    const requestedDepth = Math.max(0, Math.min(4, Math.trunc(depth)));
+    const seen = new Set<string>([id]);
+    let frontier = [id];
+    for (let level = 0; level < requestedDepth; level++) {
+      const next = new Set<string>();
+      for (const edge of [...this.dependencies.values(), ...this.semanticLinks.values()]) {
+        const from = "prerequisiteId" in edge ? edge.prerequisiteId : edge.fromId;
+        const to = "dependentId" in edge ? edge.dependentId : edge.toId;
+        if (frontier.includes(from) && !seen.has(to)) next.add(to);
+        if (frontier.includes(to) && !seen.has(from)) next.add(from);
+      }
+      frontier = [...next];
+      for (const nextId of frontier) seen.add(nextId);
+    }
+    const included = (nodeId: string) => seen.has(nodeId);
+    return {
+      nodes: clone([...this.nodes.values()].filter((node) => seen.has(node.id) && !node.revoked)),
+      dependencies: clone([...this.dependencies.values()].filter((edge) => included(edge.prerequisiteId) && included(edge.dependentId) && !this.nodes.get(edge.prerequisiteId)?.revoked && !this.nodes.get(edge.dependentId)?.revoked)),
+      semanticLinks: clone([...this.semanticLinks.values()].filter((edge) => included(edge.fromId) && included(edge.toId))),
+    };
+  }
+
+  search(query: string, limit = 20): TraceNodeV2[] {
+    const needle = query.trim().toLocaleLowerCase();
+    const max = Math.max(1, Math.min(50, Math.trunc(limit)));
+    const results = [...this.nodes.values()].filter((node) => {
+      if (node.revoked || this.isSessionRoot(node.id)) return false;
+      if (!needle) return true;
+      const text = [node.title, node.description, node.reason, node.context, node.report?.summary, node.report?.content]
+        .filter(Boolean).join("\n").toLocaleLowerCase();
+      return text.includes(needle);
+    });
+    return clone(results.slice(0, max));
+  }
+
   getLastNodeId(): string | undefined {
     return this.lastNodeId;
   }
 
-  addRelation(fromId: string, toId: string, explanation: string, relation = "depends_on"): boolean {
-    let from = this.nodes.get(fromId);
-    let to = this.nodes.get(toId);
-    if (!from || !to) return false;
-    // Chronology guard (#110): a `depends_on` edge must point prerequisite → dependent,
-    // i.e. the source (`from`) is created no later than the dependent (`to`). The Trace
-    // agent (an LLM) sometimes passes the arguments reversed ("synthesis depends_on
-    // survey" written as from=synthesis,to=survey), producing edges that point backward
-    // in time. Time is a hard fact, so when a depends_on edge would run later→earlier we
-    // swap the endpoints to restore the semantic direction. Other relation kinds
-    // (parent/follows/produced/…) are left untouched.
-    if (
-      relation === "depends_on" &&
-      from.createdAt &&
-      to.createdAt &&
-      from.createdAt > to.createdAt
-    ) {
-      [from, to] = [to, from];
-      [fromId, toId] = [toId, fromId];
-    }
-    if (!to.parents.some((p) => p.id === fromId)) {
-      to.parents.push({ id: fromId, relation, explanation });
-      to.parentIds.push(fromId);
-    }
-    if (!from.childIds.includes(toId)) from.childIds.push(toId);
-    to.updatedAt = now();
-    this.persist();
-    this.onChange?.("updated", to);
-    return true;
-  }
-
-  getNode(id: string): TraceNode | undefined {
-    return this.nodes.get(id);
-  }
-
+  /** Backwards-compatible materialized view. Never persisted as V2. */
   getGraph(): TraceGraph {
     return {
-      meta: { sessionId: this.sessionId, createdAt: now() },
-      nodes: [...this.nodes.values()],
+      schemaVersion: "2.0",
+      revision: this.revision,
+      meta: clone(this.meta),
+      nodes: [...this.nodes.values()].map((node) => this.materializeNode(node)),
+      dependencies: clone([...this.dependencies.values()]),
+      semanticLinks: clone([...this.semanticLinks.values()]),
+      episodes: clone([...this.episodes.values()]),
+      artifacts: clone([...this.artifacts.values()]),
     };
   }
 
-  load(graph: TraceGraph): void {
-    this.nodes.clear();
-    for (const n of graph.nodes) this.nodes.set(n.id, n);
-    // Resume chaining from the last-created node (by createdAt, falling back to
-    // insertion order) so post-restore auto nodes link to existing history.
-    let last: TraceNode | undefined;
-    for (const n of this.nodes.values()) {
-      if (!last || (n.createdAt ?? "") >= (last.createdAt ?? "")) last = n;
-    }
-    this.lastNodeId = last?.id;
+  getActiveGraph(): TraceGraph {
+    const activeIds = new Set([...this.nodes.values()].filter((node) => !node.revoked).map((node) => node.id));
+    const graph = this.getGraph();
+    return {
+      ...graph,
+      nodes: graph.nodes.filter((node) => activeIds.has(node.id)).map((node) => ({
+        ...node,
+        parents: node.parents.filter((parent) => activeIds.has(parent.id)),
+        parentIds: node.parentIds.filter((id) => activeIds.has(id)),
+        childIds: node.childIds.filter((id) => activeIds.has(id)),
+      })),
+      dependencies: graph.dependencies?.filter((edge) => activeIds.has(edge.prerequisiteId) && activeIds.has(edge.dependentId)),
+      semanticLinks: [],
+      artifacts: graph.artifacts?.filter((artifact) => !artifact.producerNodeId || activeIds.has(artifact.producerNodeId)),
+    };
   }
 
-  private persist(): void {
-    if (!this.persistPath) return;
-    const graph = this.getGraph();
-    this.writeChain = this.writeChain
-      .then(async () => {
-        await mkdir(dirname(this.persistPath!), { recursive: true });
-        await writeFile(this.persistPath!, JSON.stringify(graph, null, 2), "utf8");
-      })
-      .catch(() => {});
+  /** Persisted V2 data. Node.parents is the causal source of truth; legacy
+   * dependency/link collections remain only as a compatibility projection. */
+  getGraphV2(): TraceGraphV2 {
+    return {
+      schemaVersion: "2.0",
+      revision: this.revision,
+      meta: clone(this.meta),
+      nodes: clone([...this.nodes.values()]),
+      dependencies: clone([...this.dependencies.values()]),
+      semanticLinks: clone([...this.semanticLinks.values()]),
+      episodes: clone([...this.episodes.values()]),
+      artifacts: clone([...this.artifacts.values()]),
+    };
+  }
+
+  /** Disk shape: embedded parents are canonical; legacy edge collections stay out. */
+  private getPersistedGraph(pendingChanges: TraceChange[] = []): TraceDocumentV2 {
+    const { dependencies: _dependencies, semanticLinks: _semanticLinks, ...canonical } = this.getGraphV2();
+    return {
+      ...canonical,
+      ...(pendingChanges.length ? { pendingChanges: clone(pendingChanges) } : {}),
+    };
+  }
+
+  getChanges(limit = 200): TraceChange[] {
+    const max = Math.max(1, Math.min(2_000, Math.trunc(limit)));
+    return clone(this.changes.slice(-max));
+  }
+
+  async recoverChanges(): Promise<void> {
+    const path = this.changeLogPath();
+    if (!path) return;
+    try {
+      const raw = await readFile(path, "utf8");
+      this.changes.length = 0;
+      const ids = new Set<string>();
+      for (const line of raw.split("\n")) {
+        if (!line.trim()) continue;
+        try {
+          const value = JSON.parse(line) as TraceChange;
+          if (value?.id && typeof value.revision === "number" && !ids.has(value.id)) {
+            ids.add(value.id);
+            this.changes.push(value);
+          }
+        } catch {
+          // JSONL is intentionally record-oriented: preserve valid entries
+          // before and after a torn/corrupt append.
+        }
+      }
+      for (const change of this.pendingChanges) {
+        if (ids.has(change.id)) continue;
+        await appendFile(path, `${JSON.stringify(change)}\n`, "utf8");
+        ids.add(change.id);
+        this.changes.push(clone(change));
+      }
+      if (this.pendingChanges.length > 0 && this.persistPath) {
+        this.pendingChanges = [];
+        await this.writeSnapshot(this.getPersistedGraph());
+      }
+    } catch {
+      // A missing audit log must not make the materialized graph unavailable.
+      if (this.pendingChanges.length > 0) {
+        await mkdir(dirname(path), { recursive: true }).catch(() => {});
+        for (const change of this.pendingChanges) {
+          await appendFile(path, `${JSON.stringify(change)}\n`, "utf8").catch(() => {});
+          this.changes.push(clone(change));
+        }
+        this.pendingChanges = [];
+        if (this.persistPath) await this.writeSnapshot(this.getPersistedGraph()).catch(() => {});
+      }
+    }
+  }
+
+  recordChange(draft: TraceChangeDraft): TraceChange {
+    this.revision++;
+    const change: TraceChange = {
+      id: `change_${randomUUID()}`,
+      revision: this.revision,
+      createdAt: now(),
+      ...clone(draft),
+    };
+    this.changes.push(change);
+    this.persist(change);
+    this.onDelta?.({ schemaVersion: "2.0", revision: this.revision, op: "snapshot", graph: this.getGraphV2() });
+    return clone(change);
+  }
+
+  submitAuditReport(input: Omit<AuditReport, "id" | "createdAt" | "sharedWithPiAt">): AuditReport {
+    const report: AuditReport = {
+      id: `audit_${randomUUID()}`,
+      ...clone(input),
+      createdAt: now(),
+    };
+    this.recordChange({
+      actor: { type: "agent", name: "auditor" },
+      action: "audit_report_submitted",
+      target: report.target ?? {},
+      reason: report.summary,
+      metadata: { auditReport: report },
+    });
+    return clone(report);
+  }
+
+  getAuditReports(): AuditReport[] {
+    const reports = new Map<string, AuditReport>();
+    const shared = new Map<string, string>();
+    for (const change of this.changes) {
+      if (change.action === "audit_report_submitted") {
+        const raw = change.metadata?.auditReport;
+        if (!raw || typeof raw !== "object") continue;
+        const report = raw as AuditReport;
+        if (typeof report.id === "string" && typeof report.summary === "string" && typeof report.report === "string") {
+          reports.set(report.id, clone(report));
+        }
+      } else if (change.action === "audit_report_shared_with_pi") {
+        const reportId = change.metadata?.auditReportId;
+        if (typeof reportId === "string") shared.set(reportId, change.createdAt);
+      }
+    }
+    return [...reports.values()].map((report) => ({
+      ...report,
+      ...(shared.has(report.id) ? { sharedWithPiAt: shared.get(report.id)! } : {}),
+    }));
+  }
+
+  /**
+   * Loads V1 without writing. A pure read/restore never migrates the file. The
+   * first V2 mutation later makes `trace.v1.json.bak` and atomically replaces
+   * trace.json with the canonical V2 representation.
+   */
+  load(graph: TraceGraph | TraceGraphV2 | TraceDocumentV2 | unknown): void {
+    const raw = asRecord(graph);
+    this.clear();
+    if (raw.schemaVersion === "2.0") {
+      const needsCanonicalRewrite = Array.isArray(raw.dependencies) || Array.isArray(raw.semanticLinks);
+      this.loadV2(raw);
+      this.loadedV1 = needsCanonicalRewrite;
+      this.wroteV2AfterV1 = !needsCanonicalRewrite;
+    } else {
+      this.loadV1(raw);
+      this.loadedV1 = true;
+      this.wroteV2AfterV1 = false;
+    }
+    this.normalizeCausalGraph();
+    this.refreshLastNode();
   }
 
   async flush(): Promise<void> {
     await this.writeChain;
+  }
+
+  private clear(): void {
+    this.nodes.clear();
+    this.dependencies.clear();
+    this.semanticLinks.clear();
+    this.episodes.clear();
+    this.artifacts.clear();
+    this.changes.length = 0;
+    this.pendingChanges = [];
+    this.revision = 0;
+    this.meta = { sessionId: this.sessionId, createdAt: now() };
+    this.lastNodeId = undefined;
+  }
+
+  private loadV2(raw: Record<string, unknown>): void {
+    const meta = asRecord(raw.meta);
+    this.meta = { ...clone(meta), sessionId: asString(meta.sessionId, this.sessionId) };
+    this.revision = typeof raw.revision === "number" && Number.isFinite(raw.revision) ? Math.max(0, Math.trunc(raw.revision)) : 0;
+    this.pendingChanges = (Array.isArray(raw.pendingChanges) ? raw.pendingChanges : []).flatMap((value) => {
+      const parsed = value as TraceChange;
+      return parsed && typeof parsed.id === "string" && typeof parsed.revision === "number" ? [clone(parsed)] : [];
+    });
+    for (const item of Array.isArray(raw.nodes) ? raw.nodes : []) {
+      const node = asRecord(item);
+      const id = asString(node.id);
+      if (!id) continue;
+      this.nodes.set(id, {
+        id,
+        title: asString(node.title, id),
+        type: asString(node.type, "task"),
+        status: asString(node.status, "pending"),
+        ...(typeof node.agent === "string" ? { agent: node.agent } : {}),
+        ...(typeof node.description === "string" ? { description: node.description } : {}),
+        ...(typeof node.reason === "string" ? { reason: node.reason } : {}),
+        ...(typeof node.context === "string" ? { context: node.context } : {}),
+        ...(node.report && typeof node.report === "object" ? { report: clone(node.report) as TraceNodeV2["report"] } : {}),
+        ...(typeof node.createdAt === "string" ? { createdAt: node.createdAt } : {}),
+        ...(typeof node.updatedAt === "string" ? { updatedAt: node.updatedAt } : {}),
+        ...(node.timestamp && typeof node.timestamp === "object" ? { timestamp: clone(node.timestamp) as TraceNodeV2["timestamp"] } : {}),
+        ...(typeof node.durationMs === "number" ? { durationMs: node.durationMs } : {}),
+        ...(typeof node.errorMessage === "string" ? { errorMessage: node.errorMessage } : {}),
+        toolCalls: asStringArray(node.toolCalls),
+        artifactIds: unique(asStringArray(node.artifactIds)),
+        ...(typeof node.primaryEpisodeId === "string" ? { primaryEpisodeId: node.primaryEpisodeId } : {}),
+        episodeTags: unique(asStringArray(node.episodeTags)),
+        ...(node.metadata && typeof node.metadata === "object" ? { metadata: clone(node.metadata) as Record<string, unknown> } : {}),
+        records: (Array.isArray(node.records) ? node.records : []).flatMap((value) => {
+          const record = asRecord(value);
+          if (typeof record.sourceAgent !== "string" || typeof record.description !== "string") return [];
+          return [{
+            sourceAgent: record.sourceAgent,
+            description: record.description,
+            ...(typeof record.context === "string" ? { context: record.context } : {}),
+            ...(typeof record.checkpointId === "string" ? { checkpointId: record.checkpointId } : {}),
+            createdAt: asString(record.createdAt, asString(node.createdAt, now())),
+          }];
+        }),
+        parents: (Array.isArray(node.parents) ? node.parents : []).flatMap((value) => {
+          const parent = asRecord(value);
+          const nodeId = asString(parent.nodeId);
+          if (!nodeId) return [];
+          const conclusion = parent.conclusion === "confirmed" || parent.conclusion === "rejected" || parent.conclusion === "uncertain"
+            ? parent.conclusion
+            : "candidate";
+          return [{ nodeId, conclusion, ...(typeof parent.reason === "string" ? { reason: parent.reason } : {}) }];
+        }),
+        executionResult: node.executionResult === "failed" || node.status === "failed" || node.status === "error" ? "failed" : "completed",
+        revoked: node.revoked === true || node.status === "rolled_back" || node.status === "inactive",
+        ...(node.confidence === "low" || node.confidence === "medium" || node.confidence === "high"
+          ? { confidence: node.confidence }
+          : {}),
+        ...(typeof node.confidenceReason === "string" ? { confidenceReason: node.confidenceReason } : {}),
+        reviewConclusion: node.reviewConclusion === "approved" || node.reviewConclusion === "rejected" || node.reviewConclusion === "uncertain"
+          ? node.reviewConclusion
+          : "unreviewed",
+        ...(typeof node.reviewReason === "string" ? { reviewReason: node.reviewReason } : {}),
+      });
+    }
+    for (const item of Array.isArray(raw.dependencies) ? raw.dependencies : []) {
+      const edge = asRecord(item);
+      const prerequisiteId = asString(edge.prerequisiteId);
+      const dependentId = asString(edge.dependentId);
+      if (!prerequisiteId || !dependentId || !this.nodes.has(prerequisiteId) || !this.nodes.has(dependentId)) continue;
+      const id = asString(edge.id, stableId("dependency", prerequisiteId, dependentId));
+      const state = edge.state === "active" || edge.state === "rejected" ? edge.state : "proposed";
+      // Never hydrate a malformed persisted cycle into the canonical graph.
+      // Retain a non-authoritative historical hint rather than manufacturing an
+      // official edge from corrupt external JSON.
+      if (state !== "rejected" && this.wouldCreateCycle(prerequisiteId, dependentId)) {
+        const legacyId = stableId("semantic", prerequisiteId, dependentId, "legacy");
+        if (!this.semanticLinks.has(legacyId)) {
+          this.semanticLinks.set(legacyId, {
+            id: legacyId,
+            fromId: prerequisiteId,
+            toId: dependentId,
+            type: "legacy",
+            ...(typeof edge.reason === "string" ? { reason: edge.reason } : {}),
+            createdAt: now(),
+          });
+        }
+        continue;
+      }
+      const dependency: TraceDependency = {
+        id,
+        prerequisiteId,
+        dependentId,
+        origin: this.validOrigin(edge.origin),
+        confidence: edge.confidence === "high" || edge.confidence === "medium" ? edge.confidence : "low",
+        state,
+        ...(typeof edge.reason === "string" ? { reason: edge.reason } : {}),
+        evidence: this.coerceEvidence(edge.evidence),
+        ...(typeof edge.createdAt === "string" ? { createdAt: edge.createdAt } : {}),
+        ...(typeof edge.updatedAt === "string" ? { updatedAt: edge.updatedAt } : {}),
+      };
+      // Old V2 files may only have the collection form. Migrate it once, but
+      // never let it overwrite an embedded parent that already exists.
+      const child = this.nodes.get(dependentId);
+      if (child && !child.parents.some((parent) => parent.nodeId === prerequisiteId)) {
+        this.syncParentFromDependency(dependency);
+      }
+    }
+    for (const item of Array.isArray(raw.semanticLinks) ? raw.semanticLinks : []) {
+      const link = asRecord(item);
+      const fromId = asString(link.fromId);
+      const toId = asString(link.toId);
+      if (!fromId || !toId || !this.nodes.has(fromId) || !this.nodes.has(toId)) continue;
+      const type = this.validSemanticType(link.type);
+      const id = asString(link.id, stableId("semantic", fromId, toId, type));
+      this.semanticLinks.set(id, { id, fromId, toId, type, ...(typeof link.reason === "string" ? { reason: link.reason } : {}), ...(typeof link.createdAt === "string" ? { createdAt: link.createdAt } : {}) });
+    }
+    // Semantic links are not causal and are intentionally not part of the new
+    // graph. The untouched legacy file/one-time backup remains their archive.
+    this.semanticLinks.clear();
+    this.normalizeCausalGraph();
+    for (const item of Array.isArray(raw.episodes) ? raw.episodes : []) {
+      const episode = asRecord(item);
+      const id = asString(episode.id);
+      if (!id) continue;
+      this.episodes.set(id, { id, title: asString(episode.title, id), ...(typeof episode.description === "string" ? { description: episode.description } : {}), ...(typeof episode.createdAt === "string" ? { createdAt: episode.createdAt } : {}), ...(typeof episode.updatedAt === "string" ? { updatedAt: episode.updatedAt } : {}) });
+    }
+    for (const item of Array.isArray(raw.artifacts) ? raw.artifacts : []) {
+      const artifact = asRecord(item);
+      const id = asString(artifact.id);
+      const path = asString(artifact.path);
+      if (!id || !path) continue;
+      this.artifacts.set(id, {
+        id,
+        ...(typeof artifact.producerNodeId === "string" || artifact.producerNodeId === null ? { producerNodeId: artifact.producerNodeId } : {}),
+        path,
+        kind: asString(artifact.kind, "file"),
+        ...(typeof artifact.type === "string" ? { type: artifact.type } : {}),
+        ...(typeof artifact.checkpointId === "string" ? { checkpointId: artifact.checkpointId } : {}),
+        ...(artifact.checkpoint && typeof artifact.checkpoint === "object" ? { checkpoint: clone(artifact.checkpoint) as TraceCheckpointRef } : {}),
+        ...(typeof artifact.blobHash === "string" ? { blobHash: artifact.blobHash } : {}),
+        exists: artifact.exists === "present" || artifact.exists === "missing" ? artifact.exists : "unknown",
+        verificationStatus: artifact.verificationStatus === "unverified" || artifact.verificationStatus === "verified" || artifact.verificationStatus === "missing" ? artifact.verificationStatus : "reserved",
+        ...(artifact.role === "input" || artifact.role === "output" || artifact.role === "checkpoint" || artifact.role === "reference" ? { role: artifact.role } : {}),
+        ...(typeof artifact.createdAt === "string" ? { createdAt: artifact.createdAt } : {}),
+        ...(typeof artifact.updatedAt === "string" ? { updatedAt: artifact.updatedAt } : {}),
+      });
+    }
+    // Defensively add any registered producer artifact ids missing from a
+    // malformed V2 file, without serializing parent/child duplicates.
+    for (const artifact of this.artifacts.values()) {
+      if (artifact.producerNodeId && this.nodes.has(artifact.producerNodeId)) {
+        const node = this.nodes.get(artifact.producerNodeId)!;
+        node.artifactIds = unique([...node.artifactIds, artifact.id]);
+      }
+    }
+  }
+
+  private loadV1(raw: Record<string, unknown>): void {
+    const rawMeta = asRecord(raw.meta);
+    this.meta = { ...clone(rawMeta), sessionId: asString(rawMeta.sessionId, this.sessionId) };
+    const legacyNodes = Array.isArray(raw.nodes) ? raw.nodes.map(asRecord) : [];
+    // First pass creates every node, so relation migration is independent of
+    // array order and can preserve multiple roots.
+    for (const source of legacyNodes) {
+      const id = asString(source.id);
+      if (!id) continue;
+      const report = source.summary !== undefined || source.content !== undefined
+        ? { kind: "agent_report" as const, ...(typeof source.summary === "string" ? { summary: source.summary } : {}), ...(typeof source.content === "string" ? { content: source.content } : {}), ...(typeof source.agent === "string" ? { author: source.agent } : {}) }
+        : undefined;
+      const node: TraceNodeV2 = {
+        id,
+        title: asString(source.title, id),
+        type: asString(source.type ?? source.nodeType, "task"),
+        status: asString(source.status, "pending"),
+        ...(typeof source.agent === "string" ? { agent: source.agent } : {}),
+        ...(typeof source.description === "string" ? { description: source.description } : {}),
+        ...(typeof source.reason === "string" ? { reason: source.reason } : {}),
+        ...(typeof source.context === "string" ? { context: source.context } : {}),
+        ...(report ? { report } : {}),
+        ...(typeof source.createdAt === "string" ? { createdAt: source.createdAt } : {}),
+        ...(typeof source.updatedAt === "string" ? { updatedAt: source.updatedAt } : {}),
+        ...(source.timestamp && typeof source.timestamp === "object" ? { timestamp: clone(source.timestamp) as TraceNodeV2["timestamp"] } : {}),
+        ...(typeof source.durationMs === "number" ? { durationMs: source.durationMs } : {}),
+        ...(typeof source.errorMessage === "string" ? { errorMessage: source.errorMessage } : {}),
+        toolCalls: asStringArray(source.toolCalls),
+        artifactIds: [],
+        episodeTags: [],
+        ...(source.metadata && typeof source.metadata === "object" ? { metadata: clone(source.metadata) as Record<string, unknown> } : {}),
+        records: (typeof source.description === "string" || report?.summary || report?.content) ? [{
+          sourceAgent: asString(source.agent, "legacy"),
+          description: asString(source.description, report?.summary ?? report?.content ?? "Legacy trace node"),
+          ...(typeof source.context === "string" ? { context: source.context } : {}),
+          createdAt: asString(source.createdAt, now()),
+        }] : [],
+        parents: [],
+        executionResult: source.status === "failed" || source.status === "error" ? "failed" : "completed",
+        revoked: source.revoked === true || source.status === "rolled_back" || source.status === "inactive",
+        ...(source.confidence === "low" || source.confidence === "medium" || source.confidence === "high"
+          ? { confidence: source.confidence }
+          : {}),
+        ...(typeof source.confidenceReason === "string" ? { confidenceReason: source.confidenceReason } : {}),
+        reviewConclusion: "unreviewed",
+      };
+      this.nodes.set(id, node);
+      for (const rawArtifact of Array.isArray(source.artifacts) ? source.artifacts : []) {
+        const artifact = asRecord(rawArtifact);
+        const path = asString(artifact.path);
+        if (path) this.registerArtifactInternal(id, {
+          path,
+          type: asString(artifact.type) || undefined,
+          kind: asString(artifact.type, "file"),
+          role: "output",
+          preserveUnknownTimestamps: true,
+          ...(typeof source.createdAt === "string" ? { createdAt: source.createdAt } : {}),
+          ...(typeof source.updatedAt === "string" ? { updatedAt: source.updatedAt } : {}),
+        });
+      }
+      for (const rawCheckpoint of Array.isArray(source.checkpoints) ? source.checkpoints : []) {
+        const checkpoint = rawCheckpoint as TraceCheckpointRef;
+        if (checkpoint?.id) this.registerArtifactInternal(id, {
+          path: `checkpoint:${checkpoint.id}`, kind: "checkpoint", type: "checkpoint", checkpointId: checkpoint.id, checkpoint, role: "checkpoint",
+          preserveUnknownTimestamps: true,
+          ...(typeof source.createdAt === "string" ? { createdAt: source.createdAt } : {}),
+          ...(typeof source.updatedAt === "string" ? { updatedAt: source.updatedAt } : {}),
+        });
+      }
+    }
+    // Second pass maps V1 relation semantics. Relation arrays are not copied.
+    for (const source of legacyNodes) {
+      const dependentId = asString(source.id);
+      if (!this.nodes.has(dependentId)) continue;
+      const parents = Array.isArray(source.parents) ? source.parents.map(asRecord) : [];
+      const seen = new Set<string>();
+      for (const parent of parents) {
+        const prerequisiteId = asString(parent.id);
+        const relation = asString(parent.relation, "legacy");
+        const key = `${prerequisiteId}\u0000${relation}`;
+        if (!prerequisiteId || seen.has(key)) continue;
+        seen.add(key);
+        this.addLegacyRelationInternal(prerequisiteId, dependentId, relation, typeof parent.explanation === "string" ? parent.explanation : undefined, "legacy");
+      }
+      // Some very old files only carried parentIds. Preserve their existence as
+      // an explicitly legacy semantic relation rather than inventing a fact.
+      for (const prerequisiteId of asStringArray(source.parentIds)) {
+        const key = `${prerequisiteId}\u0000legacy`;
+        if (!prerequisiteId || seen.has(key)) continue;
+        seen.add(key);
+        this.addLegacyRelationInternal(prerequisiteId, dependentId, "legacy", undefined, "legacy");
+      }
+    }
+    this.semanticLinks.clear();
+    this.normalizeCausalGraph();
+    this.revision = 0;
+  }
+
+  private addLegacyRelationInternal(
+    prerequisiteId: string,
+    dependentId: string,
+    relation: string | undefined,
+    reason: string | undefined,
+    source: "trace" | "legacy",
+  ): void {
+    if (!this.nodes.has(prerequisiteId) || !this.nodes.has(dependentId)) return;
+    if (source === "trace") {
+      if (relation === "depends_on") {
+        this.proposeDependencyInternal({
+          prerequisiteId,
+          dependentId,
+          origin: "trace",
+          reason,
+          evidence: [{ source: "trace", kind: "trace_inference", ...(reason ? { detail: reason } : {}) }],
+        });
+      } else if (relation === "delegated") {
+        this.proposeDependencyInternal({
+          prerequisiteId,
+          dependentId,
+          origin: "host",
+          reason,
+          evidence: [{ source: "host", kind: "delegation", ...(reason ? { detail: reason } : {}), deterministic: true }],
+        });
+      } else if (relation === "necessitated_by" || relation === "used") {
+        this.proposeDependencyInternal({
+          prerequisiteId,
+          dependentId,
+          origin: "trace",
+          reason,
+          evidence: [{ source: "trace", kind: relation, ...(reason ? { detail: reason } : {}) }],
+        });
+      } else {
+        const type = semanticTypeForLegacyRelation(relation);
+        const id = stableId("semantic", prerequisiteId, dependentId, type);
+        if (!this.semanticLinks.has(id)) {
+          const stamp = this.nodes.get(dependentId)?.createdAt;
+          this.semanticLinks.set(id, { id, fromId: prerequisiteId, toId: dependentId, type, ...(reason ? { reason } : {}), ...(stamp ? { createdAt: stamp } : {}) });
+        }
+      }
+      return;
+    }
+    if (relation === "depends_on") {
+      this.upsertMigrationDependency(prerequisiteId, dependentId, "legacy", "medium", "active", reason, "legacy_depends_on");
+    } else if (relation === "delegated") {
+      this.upsertMigrationDependency(prerequisiteId, dependentId, "host", "high", "active", reason, "delegation");
+    } else if (relation === "necessitated_by" || relation === "used") {
+      this.upsertMigrationDependency(prerequisiteId, dependentId, "legacy", "medium", "proposed", reason, relation);
+    } else {
+      const type = semanticTypeForLegacyRelation(relation);
+      const id = stableId("semantic", prerequisiteId, dependentId, type);
+      if (!this.semanticLinks.has(id)) {
+        const stamp = this.nodes.get(dependentId)?.createdAt;
+        this.semanticLinks.set(id, { id, fromId: prerequisiteId, toId: dependentId, type, ...(reason ? { reason } : {}), ...(stamp ? { createdAt: stamp } : {}) });
+      }
+    }
+  }
+
+  private upsertMigrationDependency(
+    prerequisiteId: string,
+    dependentId: string,
+    origin: TraceDependencyOrigin,
+    confidence: "medium" | "high",
+    state: TraceDependencyState,
+    reason: string | undefined,
+    kind: string,
+  ): void {
+    if (this.wouldCreateCycle(prerequisiteId, dependentId)) {
+      // A corrupt V1 cycle must not become a V2 dependency cycle. Keep the
+      // historical hint as a semantic legacy edge instead of dropping it.
+      const id = stableId("semantic", prerequisiteId, dependentId, "legacy");
+      if (!this.semanticLinks.has(id)) {
+        const stamp = this.nodes.get(dependentId)?.createdAt;
+        this.semanticLinks.set(id, { id, fromId: prerequisiteId, toId: dependentId, type: "legacy", ...(reason ? { reason } : {}), ...(stamp ? { createdAt: stamp } : {}) });
+      }
+      return;
+    }
+    const id = stableId("dependency", prerequisiteId, dependentId);
+    const existing = this.dependencies.get(id);
+    if (existing) {
+      existing.evidence = this.mergeEvidence(existing.evidence, [{ source: "v1", kind, detail: reason }]);
+      this.syncParentFromDependency(existing);
+      return;
+    }
+    const stamp = this.nodes.get(dependentId)?.createdAt;
+    const dependency: TraceDependency = {
+      id, prerequisiteId, dependentId, origin, confidence, state,
+      ...(reason ? { reason } : {}),
+      evidence: [{ source: "v1", kind, detail: reason }],
+      ...(stamp ? { createdAt: stamp, updatedAt: stamp } : {}),
+    };
+    this.dependencies.set(id, dependency);
+    this.syncParentFromDependency(dependency);
+  }
+
+  private proposeDependencyInternal(input: TraceDependencyInput): { ok: boolean; dependency?: TraceDependency; reason?: string } {
+    const prerequisiteId = input.prerequisiteId;
+    const dependentId = input.dependentId;
+    if (!this.nodes.has(prerequisiteId) || !this.nodes.has(dependentId)) return { ok: false, reason: "node not found" };
+    if (this.isSessionRoot(prerequisiteId) || this.isSessionRoot(dependentId)) return { ok: false, reason: "session root relations are Host-managed" };
+    if (prerequisiteId === dependentId || this.wouldCreateCycle(prerequisiteId, dependentId)) return { ok: false, reason: "dependency cycle rejected" };
+    const id = stableId("dependency", prerequisiteId, dependentId);
+    const existing = this.dependencies.get(id);
+    if (existing?.state === "rejected") return { ok: false, reason: "dependency was rejected" };
+    const origin = input.origin ?? "trace";
+    const evidence = this.mergeEvidence([], input.evidence ?? [{ source: origin, kind: origin === "trace" ? "trace_inference" : "reported", detail: input.reason }]);
+    if (existing) {
+      existing.evidence = this.mergeEvidence(existing.evidence, evidence);
+      if (input.reason) existing.reason = input.reason;
+      this.applyConfidencePolicy(existing, origin, evidence);
+      this.syncParentFromDependency(existing);
+      existing.updatedAt = now();
+      return { ok: true, dependency: existing };
+    }
+    const stamp = now();
+    const dependency: TraceDependency = {
+      id,
+      prerequisiteId,
+      dependentId,
+      origin,
+      confidence: "low",
+      state: "proposed",
+      ...(input.reason ? { reason: input.reason } : {}),
+      evidence,
+      createdAt: stamp,
+      updatedAt: stamp,
+    };
+    this.applyConfidencePolicy(dependency, origin, evidence);
+    this.dependencies.set(id, dependency);
+    this.syncParentFromDependency(dependency);
+    return { ok: true, dependency };
+  }
+
+  private syncParentFromDependency(dependency: TraceDependency): void {
+    const node = this.nodes.get(dependency.dependentId);
+    if (!node) return;
+    const conclusion: TraceCausalParent["conclusion"] = dependency.state === "active" && (
+      dependency.origin === "user" ||
+      dependency.origin === "explicit" ||
+      (dependency.origin === "host" && isDeterministicHostEvidence(dependency.evidence))
+    )
+      ? "confirmed"
+      : dependency.state === "rejected"
+        ? "rejected"
+        : dependency.state === "active"
+          ? "uncertain"
+          : "candidate";
+    const existing = node.parents.find((item) => item.nodeId === dependency.prerequisiteId);
+    if (existing) {
+      existing.conclusion = conclusion;
+      if (dependency.reason) existing.reason = dependency.reason;
+    } else {
+      node.parents.push({
+        nodeId: dependency.prerequisiteId,
+        conclusion,
+        ...(dependency.reason ? { reason: dependency.reason } : {}),
+      });
+    }
+  }
+
+  private applyConfidencePolicy(
+    dependency: TraceDependency,
+    incomingOrigin: TraceDependencyOrigin,
+    incomingEvidence: TraceDependencyEvidence[],
+  ): void {
+    // Trace inference stays proposed/low forever. Repeating the same LLM view
+    // is not independent corroboration.
+    if (incomingOrigin === "trace") return;
+    if (incomingOrigin === "user" || incomingOrigin === "explicit" || (incomingOrigin === "host" && isDeterministicHostEvidence(incomingEvidence))) {
+      dependency.confidence = "high";
+      dependency.state = "active";
+      return;
+    }
+    if (dependency.state === "active") return;
+    // Only distinct non-Trace report sources can lift a candidate to medium;
+    // they still cannot make it official.
+    const sources = new Set(
+      dependency.evidence
+        .filter((item) => item.source !== "trace" && item.kind !== "trace_inference")
+        .map((item) => item.source),
+    );
+    if (sources.size >= 2) dependency.confidence = "medium";
+    dependency.state = "proposed";
+  }
+
+  /**
+   * Create the one Host-owned structural root for this session. The root is a
+   * container/initial condition, not a scientific claim, so it is pre-approved
+   * and never enters the Auditor queue.
+   */
+  private ensureSessionRoot(): TraceNodeV2 {
+    const configured = typeof this.meta.rootNodeId === "string" ? this.meta.rootNodeId : undefined;
+    const baseId = configured ?? stableId("node_session_start", this.sessionId);
+    let id = baseId;
+    let suffix = 0;
+    while (this.nodes.has(id) && this.nodes.get(id)?.type !== "session_start") {
+      suffix++;
+      id = `${baseId}_${suffix}`;
+    }
+    this.meta.rootNodeId = id;
+    const existing = this.nodes.get(id);
+    const stamp = existing?.createdAt ?? this.meta.createdAt ?? now();
+    const root: TraceNodeV2 = existing ?? {
+      id,
+      title: "Session Start",
+      type: "session_start",
+      status: "completed",
+      agent: "host",
+      description: "Initial context and structural root for this session.",
+      createdAt: stamp,
+      updatedAt: stamp,
+      toolCalls: [],
+      artifactIds: [],
+      episodeTags: [],
+      records: [],
+      parents: [],
+      executionResult: "completed",
+      revoked: false,
+      confidence: "high",
+      confidenceReason: "Created deterministically by the Host for this session.",
+      reviewConclusion: "approved",
+      reviewReason: "System structural node; no scientific review required.",
+    };
+    root.title = "Session Start";
+    root.type = "session_start";
+    root.status = "completed";
+    root.agent = "host";
+    root.parents = [];
+    root.executionResult = "completed";
+    root.revoked = false;
+    root.reviewConclusion = "approved";
+    this.nodes.set(id, root);
+    return root;
+  }
+
+  private isSessionRoot(nodeId: string): boolean {
+    return nodeId === this.meta.rootNodeId;
+  }
+
+  /**
+   * Enforce the official active DAG after creates, reviews, restores and loads.
+   * Candidate/rejected relations remain review history; only confirmed active
+   * parents participate in cycle and reachability checks.
+   */
+  private normalizeCausalGraph(): void {
+    const root = this.ensureSessionRoot();
+
+    // Remove malformed references and duplicate parent entries first. A
+    // rejected tombstone wins ties so a malformed duplicate cannot silently
+    // resurrect a relation that was explicitly rejected.
+    for (const node of this.nodes.values()) {
+      if (node.id === root.id) {
+        node.parents = [];
+        continue;
+      }
+      const deduplicated = new Map<string, TraceCausalParent>();
+      for (const parent of node.parents) {
+        if (!this.nodes.has(parent.nodeId) || parent.nodeId === node.id) continue;
+        const current = deduplicated.get(parent.nodeId);
+        if (!current || parent.conclusion === "rejected") deduplicated.set(parent.nodeId, parent);
+      }
+      node.parents = [...deduplicated.values()];
+    }
+
+    // Accept confirmed edges in stable insertion order, demoting only the edge
+    // that would close a cycle. This also repairs manually edited/corrupt V2.
+    const outgoing = new Map<string, Set<string>>();
+    const hasPath = (fromId: string, targetId: string): boolean => {
+      const seen = new Set<string>();
+      const visit = (id: string): boolean => {
+        if (id === targetId) return true;
+        if (seen.has(id)) return false;
+        seen.add(id);
+        for (const childId of outgoing.get(id) ?? []) {
+          if (visit(childId)) return true;
+        }
+        return false;
+      };
+      return visit(fromId);
+    };
+    for (const node of this.nodes.values()) {
+      if (node.revoked || node.id === root.id) continue;
+      for (const parent of node.parents) {
+        if (parent.conclusion !== "confirmed") continue;
+        const parentNode = this.nodes.get(parent.nodeId);
+        if (!parentNode || parentNode.revoked) continue;
+        if (hasPath(node.id, parent.nodeId)) {
+          parent.conclusion = "uncertain";
+          parent.reason = parent.reason
+            ? `${parent.reason} (Demoted by Host: confirmed cycle rejected.)`
+            : "Demoted by Host: confirmed cycle rejected.";
+          continue;
+        }
+        const children = outgoing.get(parent.nodeId) ?? new Set<string>();
+        children.add(node.id);
+        outgoing.set(parent.nodeId, children);
+      }
+    }
+
+    // A real confirmed parent replaces the temporary root link. Otherwise the
+    // Host supplies the root as an immediately confirmed fallback.
+    for (const node of this.nodes.values()) {
+      if (node.revoked || node.id === root.id) continue;
+      const hasRealConfirmedParent = node.parents.some((parent) => {
+        const parentNode = this.nodes.get(parent.nodeId);
+        return parent.nodeId !== root.id && parent.conclusion === "confirmed" && parentNode && !parentNode.revoked;
+      });
+      if (hasRealConfirmedParent) {
+        node.parents = node.parents.filter((parent) => parent.nodeId !== root.id);
+      } else {
+        const rootRef = node.parents.find((parent) => parent.nodeId === root.id);
+        if (rootRef) {
+          rootRef.conclusion = "confirmed";
+          rootRef.reason = "No more specific confirmed causal parent; attached to the session root by the Host.";
+        } else {
+          node.parents.unshift({
+            nodeId: root.id,
+            conclusion: "confirmed",
+            reason: "No more specific confirmed causal parent; attached to the session root by the Host.",
+          });
+        }
+      }
+    }
+    this.rebuildCompatibilityDependencies();
+  }
+
+  private wouldCreateCycle(prerequisiteId: string, dependentId: string): boolean {
+    if (prerequisiteId === dependentId) return true;
+    const seen = new Set<string>();
+    const visit = (id: string): boolean => {
+      if (id === prerequisiteId) return true;
+      if (seen.has(id)) return false;
+      seen.add(id);
+      for (const edge of this.dependencies.values()) {
+        if (edge.state !== "rejected" && edge.prerequisiteId === id && visit(edge.dependentId)) return true;
+      }
+      return false;
+    };
+    return visit(dependentId);
+  }
+
+  private wouldCreateConfirmedCycle(parentNodeId: string, childNodeId: string): boolean {
+    if (parentNodeId === childNodeId) return true;
+    const seen = new Set<string>();
+    const visit = (id: string): boolean => {
+      if (id === parentNodeId) return true;
+      if (seen.has(id)) return false;
+      seen.add(id);
+      for (const node of this.nodes.values()) {
+        if (node.revoked) continue;
+        if (node.parents.some((parent) => parent.nodeId === id && parent.conclusion === "confirmed") && visit(node.id)) return true;
+      }
+      return false;
+    };
+    return visit(childNodeId);
+  }
+
+  private syncCompatibilityDependency(
+    prerequisiteId: string,
+    dependentId: string,
+    conclusion: "candidate" | "confirmed" | "rejected" | "uncertain",
+    reason?: string,
+    stampOverride?: string,
+  ): void {
+    const id = stableId("dependency", prerequisiteId, dependentId);
+    const existing = this.dependencies.get(id);
+    const stamp = stampOverride ?? now();
+    const state: TraceDependencyState = conclusion === "confirmed" ? "active" : conclusion === "rejected" ? "rejected" : "proposed";
+    if (existing) {
+      existing.state = state;
+      if (conclusion === "confirmed") existing.confidence = "high";
+      else if (conclusion === "uncertain") existing.confidence = "low";
+      if (reason) existing.reason = reason;
+      existing.updatedAt = stamp;
+      return;
+    }
+    this.dependencies.set(id, {
+      id,
+      prerequisiteId,
+      dependentId,
+      origin: "trace",
+      confidence: conclusion === "confirmed" ? "high" : "low",
+      state,
+      ...(reason ? { reason } : {}),
+      evidence: [],
+      createdAt: stamp,
+      updatedAt: stamp,
+    });
+  }
+
+  /** Rebuild the legacy read model exclusively from embedded node parents. */
+  private rebuildCompatibilityDependencies(): void {
+    const retained = new Set<string>();
+    for (const node of this.nodes.values()) {
+      for (const parent of node.parents) {
+        if (!this.nodes.has(parent.nodeId) || parent.nodeId === node.id) continue;
+        retained.add(stableId("dependency", parent.nodeId, node.id));
+        this.syncCompatibilityDependency(parent.nodeId, node.id, parent.conclusion, parent.reason, node.updatedAt ?? node.createdAt);
+      }
+    }
+    for (const id of this.dependencies.keys()) {
+      if (!retained.has(id)) this.dependencies.delete(id);
+    }
+  }
+
+  private auditNodeEvidence(node: TraceNodeV2): unknown {
+    return {
+      id: node.id,
+      title: node.title,
+      type: node.type,
+      description: node.description,
+      report: node.report,
+      records: node.records,
+      artifactIds: node.artifactIds,
+      executionResult: node.executionResult,
+      confidence: node.confidence,
+      confidenceReason: node.confidenceReason,
+    };
+  }
+
+  private registerArtifactInternal(nodeId: string, input: TraceArtifactInput): TraceArtifactV2 {
+    const id = input.id ?? stableId("artifact", input.producerNodeId ?? nodeId, input.path, input.type ?? input.kind, input.role);
+    const stamp = now();
+    const existing = this.artifacts.get(id);
+    const createdAt = input.createdAt ?? existing?.createdAt ?? (input.preserveUnknownTimestamps ? undefined : stamp);
+    const updatedAt = input.updatedAt ?? existing?.updatedAt ?? (input.preserveUnknownTimestamps ? undefined : stamp);
+    const artifact: TraceArtifactV2 = {
+      id,
+      producerNodeId: input.producerNodeId === undefined ? nodeId : input.producerNodeId,
+      path: input.path,
+      kind: input.kind ?? input.type ?? "file",
+      ...(input.type ? { type: input.type } : {}),
+      ...(input.checkpointId ? { checkpointId: input.checkpointId } : {}),
+      ...(input.checkpoint ? { checkpoint: clone(input.checkpoint) } : {}),
+      ...(input.blobHash ? { blobHash: input.blobHash } : {}),
+      ...(input.changeStatus ? { changeStatus: input.changeStatus } : {}),
+      ...(input.previousPath ? { previousPath: input.previousPath } : {}),
+      exists: input.exists ?? existing?.exists ?? "unknown",
+      verificationStatus: input.verificationStatus ?? existing?.verificationStatus ?? "reserved",
+      ...(input.role ? { role: input.role } : existing?.role ? { role: existing.role } : {}),
+      ...(createdAt ? { createdAt } : {}),
+      ...(updatedAt ? { updatedAt } : {}),
+    };
+    this.artifacts.set(id, artifact);
+    const node = this.nodes.get(nodeId);
+    if (node) node.artifactIds = unique([...node.artifactIds, id]);
+    return artifact;
+  }
+
+  private attachArtifactInputInternal(nodeId: string, input: TraceArtifactInput): TraceArtifactV2 {
+    const existing = input.id ? this.artifacts.get(input.id) : undefined;
+    if (existing) {
+      const node = this.nodes.get(nodeId)!;
+      node.artifactIds = unique([...node.artifactIds, existing.id]);
+      return existing;
+    }
+    const artifact = this.registerArtifactInternal(nodeId, { ...input, producerNodeId: input.producerNodeId ?? null, role: "input" });
+    return artifact;
+  }
+
+  private mergeEvidence(existing: TraceDependencyEvidence[], incoming: TraceDependencyEvidence[]): TraceDependencyEvidence[] {
+    const seen = new Set(existing.map(evidenceKey));
+    const out = [...existing];
+    for (const item of incoming) {
+      const normal: TraceDependencyEvidence = {
+        source: item.source || "unknown",
+        kind: item.kind || "reported",
+        ...(item.detail ? { detail: item.detail } : {}),
+        ...(item.artifactId ? { artifactId: item.artifactId } : {}),
+        ...(item.reportId ? { reportId: item.reportId } : {}),
+        ...(item.path ? { path: item.path } : {}),
+        ...(item.checkpointId ? { checkpointId: item.checkpointId } : {}),
+        ...(item.baseBlobId ? { baseBlobId: item.baseBlobId } : {}),
+        ...(item.resultBlobId ? { resultBlobId: item.resultBlobId } : {}),
+        ...(item.deterministic !== undefined ? { deterministic: item.deterministic } : {}),
+      };
+      const key = evidenceKey(normal);
+      if (!seen.has(key)) {
+        seen.add(key);
+        out.push(normal);
+      }
+    }
+    return out;
+  }
+
+  private materializeNode(node: TraceNodeV2): TraceNode {
+    const parentRefs: Array<{ id: string; relation?: string; explanation?: string; edgeType?: string }> = node.parents
+      .filter((parent) => parent.conclusion === "confirmed" && this.nodes.has(parent.nodeId))
+      .map((parent) => ({
+        id: parent.nodeId,
+        relation: "depends_on",
+        ...(parent.reason ? { explanation: parent.reason } : {}),
+        edgeType: "confirmed",
+      }));
+    const parentIds = unique(parentRefs.map((item) => item.id));
+    const childIds = unique([...this.nodes.values()]
+      .filter((child) => child.parents.some((parent) => parent.nodeId === node.id && parent.conclusion === "confirmed"))
+      .map((child) => child.id));
+    const nodeArtifacts = node.artifactIds
+      .map((id) => this.artifacts.get(id))
+      .filter((item): item is TraceArtifactV2 => Boolean(item));
+    const artifacts: TraceArtifact[] = nodeArtifacts.map((artifact) => ({ path: artifact.path, ...(artifact.type ? { type: artifact.type } : { type: artifact.kind }) }));
+    const checkpoints = nodeArtifacts
+      .map((artifact) => artifact.checkpoint)
+      .filter((checkpoint): checkpoint is TraceCheckpointRef => Boolean(checkpoint));
+    return {
+      id: node.id,
+      title: node.title,
+      type: node.type,
+      status: node.status,
+      ...(node.agent ? { agent: node.agent } : {}),
+      ...(node.description ? { description: node.description } : {}),
+      ...(node.report?.summary ? { summary: node.report.summary } : {}),
+      ...(node.report?.content ? { content: node.report.content } : {}),
+      ...(node.reason ? { reason: node.reason } : {}),
+      ...(node.context ? { context: node.context } : {}),
+      parents: parentRefs,
+      artifacts,
+      parentIds,
+      childIds,
+      ...(node.createdAt ? { createdAt: node.createdAt } : {}),
+      ...(node.updatedAt ? { updatedAt: node.updatedAt } : {}),
+      ...(node.timestamp ? { timestamp: clone(node.timestamp) } : {}),
+      ...(node.durationMs !== undefined ? { durationMs: node.durationMs } : {}),
+      ...(node.errorMessage ? { errorMessage: node.errorMessage } : {}),
+      toolCalls: clone(node.toolCalls),
+      ...(checkpoints.length ? { checkpoints } : {}),
+      artifactIds: clone(node.artifactIds),
+      ...(node.primaryEpisodeId ? { primaryEpisodeId: node.primaryEpisodeId } : {}),
+      ...(node.episodeTags.length ? { episodeTags: clone(node.episodeTags) } : {}),
+      ...(node.metadata ? { metadata: clone(node.metadata) } : {}),
+      records: clone(node.records),
+      causalParents: clone(node.parents),
+      executionResult: node.executionResult,
+      revoked: node.revoked,
+      ...(node.confidence ? { confidence: node.confidence } : {}),
+      ...(node.confidenceReason ? { confidenceReason: node.confidenceReason } : {}),
+      reviewConclusion: node.reviewConclusion,
+      ...(node.reviewReason ? { reviewReason: node.reviewReason } : {}),
+    };
+  }
+
+  private refreshLastNode(): void {
+    let last: TraceNodeV2 | undefined;
+    for (const node of this.nodes.values()) {
+      if (this.isSessionRoot(node.id)) continue;
+      if (!last || (node.createdAt ?? "") >= (last.createdAt ?? "")) last = node;
+    }
+    this.lastNodeId = last?.id;
+  }
+
+  private validOrigin(value: unknown): TraceDependencyOrigin {
+    return value === "agent_report" || value === "explicit" || value === "host" || value === "user" || value === "legacy" ? value : "trace";
+  }
+
+  private validSemanticType(value: unknown): TraceSemanticLinkType {
+    return value === "sequence_after" || value === "restored_from" || value === "supports" || value === "contradicts" || value === "supersedes" || value === "references" ? value : "legacy";
+  }
+
+  private coerceEvidence(value: unknown): TraceDependencyEvidence[] {
+    if (!Array.isArray(value)) return [];
+    return value.map(asRecord).map((item) => ({
+      source: asString(item.source, "unknown"),
+      kind: asString(item.kind, "reported"),
+      ...(typeof item.detail === "string" ? { detail: item.detail } : {}),
+      ...(typeof item.artifactId === "string" ? { artifactId: item.artifactId } : {}),
+      ...(typeof item.reportId === "string" ? { reportId: item.reportId } : {}),
+      ...(typeof item.deterministic === "boolean" ? { deterministic: item.deterministic } : {}),
+    }));
+  }
+
+  private commit(op: TraceChangeOp, nodeId?: string, draft?: TraceChangeDraft): void {
+    this.revision++;
+    const change: TraceChange = {
+      id: `change_${randomUUID()}`,
+      revision: this.revision,
+      actor: draft?.actor ?? { type: "host" },
+      action: draft?.action ?? (op === "created" ? "node_created" : "node_updated"),
+      target: draft?.target ?? (nodeId ? { nodeId } : {}),
+      ...(draft?.before !== undefined ? { before: clone(draft.before) } : {}),
+      ...(draft?.after !== undefined ? { after: clone(draft.after) } : {}),
+      ...(draft?.reason ? { reason: draft.reason } : {}),
+      ...(draft?.metadata ? { metadata: clone(draft.metadata) } : {}),
+      createdAt: now(),
+    };
+    this.changes.push(change);
+    this.persist(change);
+    if (nodeId) {
+      const node = this.getNode(nodeId);
+      if (node) this.onChange?.(op, node);
+    }
+    this.onDelta?.({ schemaVersion: "2.0", revision: this.revision, op: "snapshot", graph: this.getGraphV2() });
+  }
+
+  private changeLogPath(): string | undefined {
+    if (!this.persistPath) return undefined;
+    return this.persistPath.endsWith("trace.json")
+      ? `${this.persistPath.slice(0, -"trace.json".length)}trace-changes.jsonl`
+      : `${this.persistPath}.changes.jsonl`;
+  }
+
+  private persist(change?: TraceChange): void {
+    if (!this.persistPath) return;
+    // Capture both states now. Using live in-memory state after an awaited
+    // append could otherwise persist a later revision before its own journal
+    // tail has been embedded.
+    const cleanGraph = this.getPersistedGraph();
+    const graph = change ? { ...cleanGraph, pendingChanges: [clone(change)] } : cleanGraph;
+    this.writeChain = this.writeChain
+      .then(async () => {
+        await mkdir(dirname(this.persistPath!), { recursive: true });
+        if (this.loadedV1 && !this.wroteV2AfterV1) {
+          const backupPath = this.persistPath!.endsWith("trace.json")
+            ? `${this.persistPath!.slice(0, -"trace.json".length)}trace.v1.json.bak`
+            : `${this.persistPath!}.v1.json.bak`;
+          try {
+            await stat(backupPath);
+          } catch {
+            // Backup is made immediately before the first replacement, never on
+            // pure V1 reads and never overwritten on later V2 writes.
+            await copyFile(this.persistPath!, backupPath).catch(() => {});
+          }
+          this.wroteV2AfterV1 = true;
+        }
+        await this.writeSnapshot(graph);
+        if (change) {
+          await appendFile(this.changeLogPath()!, `${JSON.stringify(change)}\n`, "utf8");
+          // Clear the embedded journal only after the append succeeds. A crash
+          // before this rewrite is repaired idempotently by recoverChanges().
+          await this.writeSnapshot(cleanGraph);
+        }
+      })
+      // Persistence is best-effort by historical contract. The in-memory graph
+      // and live event remain authoritative for this running session.
+      .catch(() => {});
+  }
+
+  private async writeSnapshot(graph: Record<string, unknown>): Promise<void> {
+    if (!this.persistPath) return;
+    const tempPath = `${this.persistPath}.${process.pid}.${randomUUID()}.tmp`;
+    try {
+      await writeFile(tempPath, JSON.stringify(graph, null, 2), "utf8");
+      await rename(tempPath, this.persistPath);
+    } catch (error) {
+      await rm(tempPath, { force: true }).catch(() => {});
+      throw error;
+    }
   }
 }

--- a/packages/runtime/src/trace.ts
+++ b/packages/runtime/src/trace.ts
@@ -100,13 +100,6 @@ function semanticTypeForLegacyRelation(relation: string | undefined): TraceSeman
   }
 }
 
-function legacyRelationForSemantic(type: TraceSemanticLinkType): string {
-  switch (type) {
-    case "sequence_after": return "follows";
-    default: return type;
-  }
-}
-
 /** Legacy callback operation retained for older hosting code and tests. */
 export type TraceChangeOp = "created" | "updated";
 


### PR DESCRIPTION
## Summary

Introduces the GoT v2 canonical model and the independent Trace/Auditor delivery loop.

- stores causal authority only in nodes[].parents and exposes confirmed depends_on edges through the V1 materialized view
- adds Session Start, candidate/confirmed/rejected/uncertain review states, cycle repair, revoked nodes, and an append-only change log
- binds Trace records and Auditor targets in the Host
- rebuilds Auditor deduplication after restart, preserves unconcluded reviews, and requeues a stale fingerprint exactly once
- exposes a compact active graph to Trace and removes legacy relation/episode mutation tools

## V1 migration boundary

- valid V1 depends_on relations migrate to confirmed causal parents; actual cycles are repaired
- non-causal V1 relation types such as follows and supports are intentionally not part of GoT v2 and are not migrated or exposed as semantic links
- this is an intentional compatibility break: deployments that need those historical non-causal records should archive/export the V1 trace before upgrading
- there is no automatic causal replacement for discarded semantic relations because promoting them would change their meaning

## Deliberately excluded

- Principal GoT context injection and PI GoT view changes
- workspace checkpoint and restore execution
- Web UI
- plugins, subagents, trace search, semantic links, and legacy episode/relation tools

## Validation

- full production build passed
- full repository test suite passed at this stack layer
- focused GoT core/audit tests cover canonical persistence, migration, cycles, audit restart dedupe, unconcluded review durability, and stale fingerprint requeue
- diff contains protocol/runtime files only

## Stack

1. This PR
2. Workspace checkpoints and causal restore
3. GoT Web UI