### PR TITLE
feat(got): add workspace checkpoints and causal restore

### DIFF
--- a/docker/main/Dockerfile
+++ b/docker/main/Dockerfile
@@ -39,7 +39,7 @@ RUN if [ -n "$APT_MIRROR" ]; then \
       sed -i "s|http://deb.debian.org|$APT_MIRROR|g" /etc/apt/sources.list.d/*.sources 2>/dev/null || true; \
     fi \
     && apt-get update \
-    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && apt-get install -y --no-install-recommends curl ca-certificates git \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -43,8 +43,8 @@ RUN if [ -n "$NPM_REGISTRY" ]; then npm config set registry "$NPM_REGISTRY"; fi 
 # (protocol ← runtime), not the whole monorepo (web/cli/backend-core).
 RUN npx tsc -b packages/runtime
 
-# ---- python-baseline: node + python3 + pip + curl + 镜像源 ----
-#   cpu 链的根，也是 gpu-base 的父（python+curl 层只构建一次，被两条链复用）。
+# ---- python-baseline: node + python3 + pip + curl + Git + 镜像源 ----
+#   cpu 链的根，也是 gpu-base 的父（共享运行时依赖只构建一次，被两条链复用）。
 FROM node:22-slim AS python-baseline
 ARG APT_MIRROR=""
 ARG PIP_INDEX_URL=""

--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -75,6 +75,8 @@ CMD ["node", "packages/runtime/dist/server.js"]
 #   不在此安装 → monorepo 代码变更只重建下面的业务层，base 层完全复用。
 #   ⚠️ base tag 写死（经典构建器不支持 FROM ${ARG}）；升级须同步三处（见文件头）。
 FROM ghcr.io/neuroaihub/brainpilot-gpu-base:cu124-torch2.6.0 AS gpu
+# Older published GPU base tags may predate workspace checkpoints.
+RUN command -v git >/dev/null 2>&1 || (apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*)
 WORKDIR /app
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/packages ./packages

--- a/docker/sandbox/_python-base.sh
+++ b/docker/sandbox/_python-base.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# _python-base.sh — cpu/gpu sandbox 共享的 python3 + pip + curl + 镜像源安装段。
+# _python-base.sh — cpu/gpu sandbox 共享的 python3 + pip + curl + Git + 镜像源安装段。
 # 由 Dockerfile 的 python-baseline stage 直接 RUN（gpu-base 继承该 stage，无需重跑）。
-# curl/ca-certificates 供 HEALTHCHECK 探活用，cpu/gpu 都需要，故装在此共享层。
+# curl/ca-certificates 供 HEALTHCHECK 探活；Git 供 GoT workspace checkpoint
+# 捕获、diff 与恢复使用。它们都是 cpu/gpu 运行时依赖，故装在此共享层。
 # 镜像源来自 ENV（Dockerfile 经 build-arg 透传），为空则用镜像自带官方源
 # （pypi.org / deb.debian.org）。
 set -euo pipefail
@@ -10,8 +11,12 @@ set -euo pipefail
 [ -n "${APT_MIRROR:-}" ] && sed -i "s|http://deb.debian.org|$APT_MIRROR|g" \
   /etc/apt/sources.list.d/*.sources /etc/apt/sources.list 2>/dev/null || true
 apt-get update && apt-get install -y --no-install-recommends \
-  python3 python3-pip python3-venv curl ca-certificates
+  python3 python3-pip python3-venv curl ca-certificates git
 rm -rf /var/lib/apt/lists/*
+
+# Fail the image build rather than shipping a runtime whose checkpoint feature
+# can only report unavailable.
+git --version >/dev/null
 
 # pip 源：PIP_INDEX_URL 注入则固化 /etc/pip.conf，否则用 pip 官方默认
 if [ -n "${PIP_INDEX_URL:-}" ]; then

--- a/packages/backend-core/src/app.ts
+++ b/packages/backend-core/src/app.ts
@@ -190,6 +190,29 @@ export function createApp(options: CreateAppOptions): Hono {
   api.delete("/sessions/:id", forward("deleteSession", { idParam: "id" }));
   api.get("/sessions/:id/state", forward("getSessionState", { idParam: "id" }));
   api.get("/sessions/:id/trace", forward("getTrace", { idParam: "id" }));
+  api.get("/sessions/:id/trace/changes", forward("getTraceChanges", { idParam: "id", withQuery: true }));
+  api.get("/sessions/:id/audits", forward("getAuditReports", { idParam: "id" }));
+  api.post("/sessions/:id/trace/dependencies/:dependencyId/decision", forward("decideTraceDependency", {
+    params: { id: "id", dependencyId: "dependencyId" }, withBody: true,
+  }));
+  api.get("/sessions/:id/trace/nodes/:nodeId/checkpoints", forward("getTraceNodeCheckpoints", {
+    params: { id: "id", nodeId: "nodeId" },
+  }));
+  api.get("/sessions/:id/trace/nodes/:nodeId/rollback-preview", forward("getTraceCausalRollbackPreview", {
+    params: { id: "id", nodeId: "nodeId" },
+  }));
+  api.post("/sessions/:id/trace/nodes/:nodeId/rollback", forward("rollbackTraceNode", {
+    params: { id: "id", nodeId: "nodeId" }, withBody: true,
+  }));
+  api.get("/sessions/:id/trace/checkpoints/:checkpointId/diff", forward("getTraceCheckpointDiff", {
+    params: { id: "id", checkpointId: "checkpointId" }, withQuery: true,
+  }));
+  api.get("/sessions/:id/trace/checkpoints/:checkpointId/restore-preview", forward("getTraceRestorePreview", {
+    params: { id: "id", checkpointId: "checkpointId" },
+  }));
+  api.post("/sessions/:id/trace/checkpoints/:checkpointId/restore", forward("restoreTraceCheckpoint", {
+    params: { id: "id", checkpointId: "checkpointId" }, withBody: true,
+  }));
   api.get("/sessions/:id/stats", forward("getSessionStats", { idParam: "id" }));
   // Persisted event tail for chat rehydrate after a restart. SSE replays only
   // the in-memory ring; this endpoint reads events.jsonl on disk. Carries the
@@ -781,12 +804,15 @@ export function createApp(options: CreateAppOptions): Hono {
 
   function forward(
     route: keyof typeof RUNTIME_ROUTES,
-    opts: { idParam?: string; withBody?: boolean; withQuery?: boolean } = {},
+    opts: { idParam?: string; params?: Record<string, string>; withBody?: boolean; withQuery?: boolean } = {},
   ) {
     return async (c: import("hono").Context) => {
       const rc = await getClient(c);
       const params: Record<string, string> = {};
       if (opts.idParam) params.id = c.req.param(opts.idParam) ?? "";
+      for (const [runtimeKey, requestKey] of Object.entries(opts.params ?? {})) {
+        params[runtimeKey] = c.req.param(requestKey) ?? "";
+      }
       const body = opts.withBody ? await c.req.text() : undefined;
       const headers: Record<string, string> = {};
       const ct = c.req.header("content-type");

--- a/packages/protocol/src/domain.ts
+++ b/packages/protocol/src/domain.ts
@@ -350,7 +350,6 @@ export type TraceRestorePreview = z.infer<typeof TraceRestorePreviewSchema>;
 
 export const TraceRestoreResultSchema = z.object({
   restoredCheckpointId: z.string(),
-  recoveryCheckpointId: z.string(),
   auditNodeId: z.string().optional(),
   changeId: z.string().optional(),
 });
@@ -377,7 +376,6 @@ export type TraceCausalRollbackPreview = z.infer<typeof TraceCausalRollbackPrevi
 export const TraceCausalRollbackResultSchema = z.object({
   nodeId: z.string(),
   affectedNodeIds: z.array(z.string()),
-  recoveryCheckpointId: z.string(),
   auditNodeId: z.string().optional(),
   changeId: z.string().optional(),
 });

--- a/packages/protocol/src/domain.ts
+++ b/packages/protocol/src/domain.ts
@@ -316,6 +316,73 @@ export const TraceCheckpointRefSchema = z.object({
 });
 export type TraceCheckpointRef = z.infer<typeof TraceCheckpointRefSchema>;
 
+export const TraceCheckpointFileChangeSchema = z.object({
+  path: z.string(),
+  previousPath: z.string().optional(),
+  status: z.enum(["added", "modified", "deleted", "renamed"]),
+  additions: z.number().int().nonnegative().optional(),
+  deletions: z.number().int().nonnegative().optional(),
+  binary: z.boolean().default(false),
+});
+export type TraceCheckpointFileChange = z.infer<typeof TraceCheckpointFileChangeSchema>;
+
+export const TraceCheckpointSkippedFileSchema = z.object({
+  path: z.string(),
+  reason: z.enum(["ignored", "too_large", "total_limit", "internal", "unsupported"]),
+  size: z.number().int().nonnegative().optional(),
+});
+export type TraceCheckpointSkippedFile = z.infer<typeof TraceCheckpointSkippedFileSchema>;
+
+export const TraceCheckpointDetailSchema = z.object({
+  checkpoint: TraceCheckpointRefSchema,
+  files: z.array(TraceCheckpointFileChangeSchema),
+  skipped: z.array(TraceCheckpointSkippedFileSchema),
+});
+export type TraceCheckpointDetail = z.infer<typeof TraceCheckpointDetailSchema>;
+
+export const TraceRestorePreviewSchema = z.object({
+  checkpointId: z.string(),
+  stateToken: z.string(),
+  files: z.array(TraceCheckpointFileChangeSchema),
+  skipped: z.array(TraceCheckpointSkippedFileSchema),
+});
+export type TraceRestorePreview = z.infer<typeof TraceRestorePreviewSchema>;
+
+export const TraceRestoreResultSchema = z.object({
+  restoredCheckpointId: z.string(),
+  recoveryCheckpointId: z.string(),
+  auditNodeId: z.string().optional(),
+  changeId: z.string().optional(),
+});
+export type TraceRestoreResult = z.infer<typeof TraceRestoreResultSchema>;
+
+export const TraceCausalRollbackConflictSchema = z.object({
+  path: z.string(),
+  checkpointIds: z.array(z.string()),
+  reason: z.string(),
+});
+export type TraceCausalRollbackConflict = z.infer<typeof TraceCausalRollbackConflictSchema>;
+
+export const TraceCausalRollbackPreviewSchema = z.object({
+  nodeId: z.string(),
+  stateToken: z.string(),
+  affectedNodeIds: z.array(z.string()),
+  affectedCheckpointIds: z.array(z.string()),
+  files: z.array(TraceCheckpointFileChangeSchema),
+  skipped: z.array(TraceCheckpointSkippedFileSchema),
+  conflicts: z.array(TraceCausalRollbackConflictSchema),
+});
+export type TraceCausalRollbackPreview = z.infer<typeof TraceCausalRollbackPreviewSchema>;
+
+export const TraceCausalRollbackResultSchema = z.object({
+  nodeId: z.string(),
+  affectedNodeIds: z.array(z.string()),
+  recoveryCheckpointId: z.string(),
+  auditNodeId: z.string().optional(),
+  changeId: z.string().optional(),
+});
+export type TraceCausalRollbackResult = z.infer<typeof TraceCausalRollbackResultSchema>;
+
 export const TraceParentConclusionSchema = z.enum(["candidate", "confirmed", "rejected", "uncertain"]);
 export type TraceParentConclusion = z.infer<typeof TraceParentConclusionSchema>;
 

--- a/packages/protocol/src/http.ts
+++ b/packages/protocol/src/http.ts
@@ -30,6 +30,7 @@ import {
   SessionSchema,
   SessionStateSnapshotSchema,
   SessionStatsSchema,
+  TraceDependencySchema,
 } from "./domain.js";
 
 export type HttpMethod = "GET" | "POST" | "PUT" | "DELETE";
@@ -130,6 +131,16 @@ export type GetSessionStateResponse = z.infer<typeof GetSessionStateResponseSche
  */
 export const GetSessionStatsResponseSchema = SessionStatsSchema;
 export type GetSessionStatsResponse = z.infer<typeof GetSessionStatsResponseSchema>;
+
+export const TraceDependencyDecisionRequestSchema = z.object({
+  decision: z.enum(["accept", "reject"]),
+  reason: z.string().optional(),
+});
+export type TraceDependencyDecisionRequest = z.infer<typeof TraceDependencyDecisionRequestSchema>;
+export const TraceDependencyDecisionResponseSchema = TraceDependencySchema;
+export type TraceDependencyDecisionResponse = z.infer<typeof TraceDependencyDecisionResponseSchema>;
+export const TraceStateTokenRequestSchema = z.object({ stateToken: z.string().min(1) });
+export type TraceStateTokenRequest = z.infer<typeof TraceStateTokenRequestSchema>;
 
 /* ------------------------------------------------------------------ *
  * POST /sessions/:id/messages  (inject user message)
@@ -288,6 +299,15 @@ export const RUNTIME_ROUTES = {
   getSessionStats: { method: "GET", path: "/sessions/:id/stats" },
   /** Graph of Trace (reasoning DAG) for a session. */
   getTrace: { method: "GET", path: "/sessions/:id/trace" },
+  getTraceChanges: { method: "GET", path: "/sessions/:id/trace/changes" },
+  getAuditReports: { method: "GET", path: "/sessions/:id/audits" },
+  decideTraceDependency: { method: "POST", path: "/sessions/:id/trace/dependencies/:dependencyId/decision" },
+  getTraceNodeCheckpoints: { method: "GET", path: "/sessions/:id/trace/nodes/:nodeId/checkpoints" },
+  getTraceCausalRollbackPreview: { method: "GET", path: "/sessions/:id/trace/nodes/:nodeId/rollback-preview" },
+  rollbackTraceNode: { method: "POST", path: "/sessions/:id/trace/nodes/:nodeId/rollback" },
+  getTraceCheckpointDiff: { method: "GET", path: "/sessions/:id/trace/checkpoints/:checkpointId/diff" },
+  getTraceRestorePreview: { method: "GET", path: "/sessions/:id/trace/checkpoints/:checkpointId/restore-preview" },
+  restoreTraceCheckpoint: { method: "POST", path: "/sessions/:id/trace/checkpoints/:checkpointId/restore" },
   sendMessage: { method: "POST", path: "/sessions/:id/messages" },
   /** Canonical AG-UI event stream (§15.4). */
   sessionEvents: { method: "GET", path: "/sse/:id" },

--- a/packages/runtime/src/__tests__/server.test.ts
+++ b/packages/runtime/src/__tests__/server.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { mkdtemp, mkdir, writeFile, readFile, readdir } from "node:fs/promises";
+import { mkdtemp, mkdir, writeFile, readFile, readdir, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createServer, startServer } from "../server.js";
 import { SessionManager } from "../session-manager.js";
 import { PERSISTENT_LAYOUT_MARKER } from "../persistent-layout.js";
 import { mockAgentFactory } from "../agent-factory.js";
+import { WorkspaceCheckpointStore } from "../workspace-checkpoints.js";
 
 /**
  * HTTP surface smoke test. Drives every non-SSE RUNTIME_ROUTE via app.request
@@ -37,6 +38,33 @@ describe("HTTP server (RUNTIME_ROUTES)", () => {
     // Opt-in budget unset by default → null (single-user / no throttle).
     expect(body.memLimitBytes).toBeNull();
     expect(body.memRatio).toBeNull();
+  });
+
+  it("serves checkpoint diff/preview and restores through the trace API", async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), "bp-checkpoint-api-"));
+    try {
+      const manager = new SessionManager({ dataRoot, persist: true, agentFactory: mockAgentFactory });
+      await manager.createSession({ id: "checkpoint-api" });
+      const workspace = join(dataRoot, "workspaces", "checkpoint-api");
+      const store = new WorkspaceCheckpointStore("checkpoint-api", workspace, join(dataRoot, ".bp", "checkpoint-api"));
+      await writeFile(join(workspace, "value.txt"), "old\n", "utf8");
+      const checkpoint = await store.capture("principal");
+      await writeFile(join(workspace, "value.txt"), "new\n", "utf8");
+      const a = createServer({ manager }).app;
+
+      const diff = await a.request(`/sessions/checkpoint-api/trace/checkpoints/${checkpoint.id}/diff?path=value.txt`);
+      expect(diff.status).toBe(200);
+      expect((await diff.json()) as { diff: string }).toMatchObject({ diff: expect.stringContaining("+old") });
+      const preview = await a.request(`/sessions/checkpoint-api/trace/checkpoints/${checkpoint.id}/restore-preview`);
+      const body = await preview.json() as { stateToken: string };
+      const restored = await a.request(`/sessions/checkpoint-api/trace/checkpoints/${checkpoint.id}/restore`, {
+        method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ stateToken: body.stateToken }),
+      });
+      expect(restored.status).toBe(200);
+      expect(await readFile(join(workspace, "value.txt"), "utf8")).toBe("old\n");
+    } finally {
+      await rm(dataRoot, { recursive: true, force: true });
+    }
   });
 
   it("returns a truthful terminal response for an unknown tool call", async () => {

--- a/packages/runtime/src/__tests__/task-ledger.test.ts
+++ b/packages/runtime/src/__tests__/task-ledger.test.ts
@@ -111,6 +111,20 @@ describe("TaskLedger", () => {
     expect(ledger.peekBatch("engineer")).toEqual([]);
   });
 
+  it("cancels pending tasks and clears every queued notification before rollback", async () => {
+    const ledger = new TaskLedger("s");
+    const pending = await ledger.dispatch("principal", "engineer", "uses the old workspace");
+    const completed = await ledger.dispatch("principal", "writer", "finished work");
+    await ledger.complete(completed.id, "writer", "done");
+    await ledger.pauseDelivery();
+
+    const cancelled = await ledger.cancelAllPending("workspace rolled back");
+    expect(cancelled.map((task) => task.id)).toEqual([pending.id]);
+    expect(ledger.get(pending.id)).toMatchObject({ status: "cancelled", reply: "workspace rolled back" });
+    expect(ledger.get(completed.id)).toMatchObject({ status: "completed" });
+    expect(ledger.notificationTargets()).toEqual([]);
+  });
+
   it("treats a missing ledger as empty but rejects corruption without overwriting it", async () => {
     const dir = await mkdtemp(join(tmpdir(), "task-ledger-corrupt-"));
     dirs.push(dir);

--- a/packages/runtime/src/__tests__/tool-access.test.ts
+++ b/packages/runtime/src/__tests__/tool-access.test.ts
@@ -202,6 +202,7 @@ describe("tool access control (§9)", () => {
         "list_pending_trace_reviews",
         "get_trace_node",
         "get_trace_neighborhood",
+        "get_trace_diff",
         "edit_trace_review",
         "submit_audit_report",
         "skill_search",

--- a/packages/runtime/src/__tests__/workspace-checkpoints.test.ts
+++ b/packages/runtime/src/__tests__/workspace-checkpoints.test.ts
@@ -60,9 +60,12 @@ describe("WorkspaceCheckpointStore", () => {
 
     const preview = await store.preview(old.id);
     expect(preview?.files.some((item) => item.path === "later.txt" && item.status === "deleted")).toBe(true);
-    let prepared = 0;
-    await store.restore(old.id, preview!.stateToken, async () => { prepared++; });
-    expect(prepared).toBe(1);
+    let committed = 0;
+    await store.restore(old.id, preview!.stateToken, async () => {
+      expect(await readFile(join(workspace, "tracked.txt"), "utf8")).toBe("old\n");
+      committed++;
+    });
+    expect(committed).toBe(1);
     expect(await readFile(join(workspace, "tracked.txt"), "utf8")).toBe("old\n");
     await expect(readFile(join(workspace, "later.txt"), "utf8")).rejects.toThrow();
     expect(await readFile(join(workspace, "keep.local"), "utf8")).toBe("untouched\n");
@@ -87,6 +90,44 @@ describe("WorkspaceCheckpointStore", () => {
     let prepared = false;
     await expect(store.restore(target.id, preview!.stateToken, async () => { prepared = true; })).rejects.toMatchObject({ code: "STALE_WORKSPACE" });
     expect(prepared).toBe(false);
+  });
+
+  it("does not commit caller state when the target Git tree cannot materialize", async () => {
+    const { workspace, state, store } = await fixture();
+    await writeFile(join(workspace, "value.txt"), "old\n", "utf8");
+    const target = await store.capture("principal");
+    await writeFile(join(workspace, "value.txt"), "current\n", "utf8");
+    await store.capture("principal");
+    const preview = await store.preview(target.id);
+    const index = JSON.parse(await readFile(join(state, "workspace-checkpoints.json"), "utf8")) as {
+      checkpoints: Record<string, { treeId: string }>;
+    };
+    const treeId = index.checkpoints[target.id]!.treeId;
+    await rm(join(state, "workspace-checkpoints.git", "objects", treeId.slice(0, 2), treeId.slice(2)), { force: true });
+
+    let committed = false;
+    await expect(store.restore(target.id, preview!.stateToken, async () => { committed = true; })).rejects.toThrow();
+    expect(committed).toBe(false);
+    expect(await readFile(join(workspace, "value.txt"), "utf8")).toBe("current\n");
+  });
+
+  it("restores the original workspace when the final commit callback fails", async () => {
+    const { workspace, store } = await fixture();
+    await writeFile(join(workspace, "value.txt"), "old\n", "utf8");
+    const target = await store.capture("principal");
+    await writeFile(join(workspace, "value.txt"), "current\n", "utf8");
+    await store.capture("principal");
+    const preview = await store.preview(target.id);
+
+    await expect(store.restore(target.id, preview!.stateToken, async () => {
+      expect(await readFile(join(workspace, "value.txt"), "utf8")).toBe("old\n");
+      throw new Error("ledger commit failed");
+    })).rejects.toThrow("ledger commit failed");
+    expect(await readFile(join(workspace, "value.txt"), "utf8")).toBe("current\n");
+
+    await writeFile(join(workspace, "after-failure.txt"), "after\n", "utf8");
+    const next = await store.capture("writer");
+    expect(next.stats).toMatchObject({ files: 1, added: 1, modified: 0, deleted: 0 });
   });
 
   it("marks oversized and binary files correctly and reloads its index after restart", async () => {

--- a/packages/runtime/src/__tests__/workspace-checkpoints.test.ts
+++ b/packages/runtime/src/__tests__/workspace-checkpoints.test.ts
@@ -46,8 +46,8 @@ describe("WorkspaceCheckpointStore", () => {
     expect(detail?.skipped.some((item) => item.path === "ignored.txt" && item.reason === "ignored")).toBe(true);
   });
 
-  it("restores managed files and can restore the generated recovery checkpoint", async () => {
-    const { workspace, store } = await fixture();
+  it("restores managed files and makes the restored tree the next checkpoint baseline", async () => {
+    const { workspace, state, store } = await fixture();
     await writeFile(join(workspace, ".gitignore"), "keep.local\n", "utf8");
     await writeFile(join(workspace, "tracked.txt"), "old\n", "utf8");
     await writeFile(join(workspace, "keep.local"), "untouched\n", "utf8");
@@ -60,15 +60,19 @@ describe("WorkspaceCheckpointStore", () => {
 
     const preview = await store.preview(old.id);
     expect(preview?.files.some((item) => item.path === "later.txt" && item.status === "deleted")).toBe(true);
-    const restored = await store.restore(old.id, preview!.stateToken);
+    await store.restore(old.id, preview!.stateToken);
     expect(await readFile(join(workspace, "tracked.txt"), "utf8")).toBe("old\n");
     await expect(readFile(join(workspace, "later.txt"), "utf8")).rejects.toThrow();
     expect(await readFile(join(workspace, "keep.local"), "utf8")).toBe("untouched\n");
 
-    const undoPreview = await store.preview(restored.recoveryCheckpointId);
-    await store.restore(restored.recoveryCheckpointId, undoPreview!.stateToken);
-    expect(await readFile(join(workspace, "tracked.txt"), "utf8")).toBe("new\n");
-    expect(await readFile(join(workspace, "later.txt"), "utf8")).toBe("later\n");
+    await writeFile(join(workspace, "after-restore.txt"), "after\n", "utf8");
+    const next = await store.capture("writer");
+    expect(next.stats).toMatchObject({ files: 1, added: 1, modified: 0, deleted: 0 });
+    const index = JSON.parse(await readFile(join(state, "workspace-checkpoints.json"), "utf8")) as {
+      checkpoints: Record<string, { kind: string }>;
+    };
+    expect(next.baseCheckpointId).toBeTruthy();
+    expect(index.checkpoints[next.baseCheckpointId!]?.kind).toBe("baseline");
   });
 
   it("rejects a restore when the workspace changed after preview", async () => {
@@ -174,11 +178,13 @@ describe("WorkspaceCheckpointStore", () => {
       expect.objectContaining({ path: "b.txt", status: "deleted" }),
       expect.objectContaining({ path: "shared.txt", status: "modified" }),
     ]));
-    const result = await store.restoreCausal([a2.id, b.id], preview.stateToken);
-    expect(result.recoveryCheckpointId).toBeTruthy();
+    await store.restoreCausal([a2.id, b.id], preview.stateToken);
     expect(await readFile(join(workspace, "shared.txt"), "utf8")).toBe("A\n");
     await expect(readFile(join(workspace, "a2.txt"), "utf8")).rejects.toThrow();
     await expect(readFile(join(workspace, "b.txt"), "utf8")).rejects.toThrow();
+    await writeFile(join(workspace, "after.txt"), "after\n", "utf8");
+    const next = await store.capture("writer");
+    expect(next.stats).toMatchObject({ files: 1, added: 1, modified: 0, deleted: 0 });
   });
 
   it("reports a conflict instead of overwriting a later independent edit", async () => {

--- a/packages/runtime/src/__tests__/workspace-checkpoints.test.ts
+++ b/packages/runtime/src/__tests__/workspace-checkpoints.test.ts
@@ -60,7 +60,9 @@ describe("WorkspaceCheckpointStore", () => {
 
     const preview = await store.preview(old.id);
     expect(preview?.files.some((item) => item.path === "later.txt" && item.status === "deleted")).toBe(true);
-    await store.restore(old.id, preview!.stateToken);
+    let prepared = 0;
+    await store.restore(old.id, preview!.stateToken, async () => { prepared++; });
+    expect(prepared).toBe(1);
     expect(await readFile(join(workspace, "tracked.txt"), "utf8")).toBe("old\n");
     await expect(readFile(join(workspace, "later.txt"), "utf8")).rejects.toThrow();
     expect(await readFile(join(workspace, "keep.local"), "utf8")).toBe("untouched\n");
@@ -82,7 +84,9 @@ describe("WorkspaceCheckpointStore", () => {
     await writeFile(join(workspace, "a.txt"), "b\n", "utf8");
     const preview = await store.preview(target.id);
     await writeFile(join(workspace, "a.txt"), "c\n", "utf8");
-    await expect(store.restore(target.id, preview!.stateToken)).rejects.toMatchObject({ code: "STALE_WORKSPACE" });
+    let prepared = false;
+    await expect(store.restore(target.id, preview!.stateToken, async () => { prepared = true; })).rejects.toMatchObject({ code: "STALE_WORKSPACE" });
+    expect(prepared).toBe(false);
   });
 
   it("marks oversized and binary files correctly and reloads its index after restart", async () => {
@@ -112,10 +116,17 @@ describe("WorkspaceCheckpointStore", () => {
     const { workspace, state } = await fixture();
     await writeFile(join(workspace, "value.txt"), "one\n", "utf8");
     const store = new WorkspaceCheckpointStore("s1", workspace, state, { maxRepositoryBytes: 1024 });
-    expect((await store.capture("principal")).status).toBe("ready");
+    const first = await store.capture("principal");
+    expect(first.status).toBe("ready");
     const blocked = await store.capture("principal");
     expect(blocked.status).toBe("failed");
     expect(blocked.error).toContain("repository quota exceeded");
+
+    // A full history quota must never prevent restoring an existing point.
+    await writeFile(join(workspace, "value.txt"), "two\n", "utf8");
+    const preview = await store.preview(first.id);
+    await store.restore(first.id, preview!.stateToken);
+    expect(await readFile(join(workspace, "value.txt"), "utf8")).toBe("one\n");
   });
 
   it("migrates a V1 index without retaining duplicated file lists", async () => {
@@ -200,7 +211,9 @@ describe("WorkspaceCheckpointStore", () => {
     expect(preview.conflicts).toEqual([
       expect.objectContaining({ path: "shared.txt", checkpointIds: [branchA.id] }),
     ]);
-    await expect(store.restoreCausal([branchA.id], preview.stateToken)).rejects.toMatchObject({ code: "CAUSAL_CONFLICT" });
+    let prepared = false;
+    await expect(store.restoreCausal([branchA.id], preview.stateToken, async () => { prepared = true; })).rejects.toMatchObject({ code: "CAUSAL_CONFLICT" });
+    expect(prepared).toBe(false);
     expect(await readFile(join(workspace, "shared.txt"), "utf8")).toBe("independent-current\n");
   });
 });

--- a/packages/runtime/src/__tests__/workspace-checkpoints.test.ts
+++ b/packages/runtime/src/__tests__/workspace-checkpoints.test.ts
@@ -1,0 +1,200 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, describe, expect, it } from "vitest";
+import { WorkspaceCheckpointStore } from "../workspace-checkpoints.js";
+
+const roots: string[] = [];
+
+async function fixture() {
+  const root = await mkdtemp(join(tmpdir(), "bp-checkpoints-test-"));
+  roots.push(root);
+  const workspace = join(root, "workspaces", "s1");
+  const state = join(root, ".bp", "s1");
+  await mkdir(workspace, { recursive: true });
+  return { root, workspace, state, store: new WorkspaceCheckpointStore("s1", workspace, state) };
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+describe("WorkspaceCheckpointStore", () => {
+  it("captures ordered commits, honours gitignore, and returns per-file diffs", async () => {
+    const { workspace, store } = await fixture();
+    await writeFile(join(workspace, ".gitignore"), "ignored.txt\n", "utf8");
+    await writeFile(join(workspace, "note.txt"), "one\n", "utf8");
+    await writeFile(join(workspace, "ignored.txt"), "secret\n", "utf8");
+
+    const first = await store.capture("principal");
+    expect(first.status).toBe("partial");
+    expect(first.commitId).toMatch(/^[a-f0-9]{40}$/);
+    expect(first.stats?.added).toBe(2);
+
+    await writeFile(join(workspace, "note.txt"), "one\ntwo\n", "utf8");
+    await writeFile(join(workspace, "new.txt"), "new\n", "utf8");
+    const second = await store.capture("engineer");
+    expect(second.baseCheckpointId).toBe(first.id);
+    expect(second.commitId).not.toBe(first.commitId);
+    expect(second.stats).toMatchObject({ added: 1, modified: 1 });
+
+    const detail = await store.detail(second.id);
+    expect(detail?.files.map((item) => [item.path, item.status])).toEqual([
+      ["new.txt", "added"],
+      ["note.txt", "modified"],
+    ]);
+    expect(await store.diff(second.id, "note.txt")).toContain("+two");
+    expect(detail?.skipped.some((item) => item.path === "ignored.txt" && item.reason === "ignored")).toBe(true);
+  });
+
+  it("restores managed files and can restore the generated recovery checkpoint", async () => {
+    const { workspace, store } = await fixture();
+    await writeFile(join(workspace, ".gitignore"), "keep.local\n", "utf8");
+    await writeFile(join(workspace, "tracked.txt"), "old\n", "utf8");
+    await writeFile(join(workspace, "keep.local"), "untouched\n", "utf8");
+    const old = await store.capture("principal");
+
+    await writeFile(join(workspace, "tracked.txt"), "new\n", "utf8");
+    await writeFile(join(workspace, "later.txt"), "later\n", "utf8");
+    const current = await store.capture("principal");
+    expect(current.commitId).toBeTruthy();
+
+    const preview = await store.preview(old.id);
+    expect(preview?.files.some((item) => item.path === "later.txt" && item.status === "deleted")).toBe(true);
+    const restored = await store.restore(old.id, preview!.stateToken);
+    expect(await readFile(join(workspace, "tracked.txt"), "utf8")).toBe("old\n");
+    await expect(readFile(join(workspace, "later.txt"), "utf8")).rejects.toThrow();
+    expect(await readFile(join(workspace, "keep.local"), "utf8")).toBe("untouched\n");
+
+    const undoPreview = await store.preview(restored.recoveryCheckpointId);
+    await store.restore(restored.recoveryCheckpointId, undoPreview!.stateToken);
+    expect(await readFile(join(workspace, "tracked.txt"), "utf8")).toBe("new\n");
+    expect(await readFile(join(workspace, "later.txt"), "utf8")).toBe("later\n");
+  });
+
+  it("rejects a restore when the workspace changed after preview", async () => {
+    const { workspace, store } = await fixture();
+    await writeFile(join(workspace, "a.txt"), "a\n", "utf8");
+    const target = await store.capture("principal");
+    await writeFile(join(workspace, "a.txt"), "b\n", "utf8");
+    const preview = await store.preview(target.id);
+    await writeFile(join(workspace, "a.txt"), "c\n", "utf8");
+    await expect(store.restore(target.id, preview!.stateToken)).rejects.toMatchObject({ code: "STALE_WORKSPACE" });
+  });
+
+  it("marks oversized and binary files correctly and reloads its index after restart", async () => {
+    const { workspace, state, store } = await fixture();
+    await writeFile(join(workspace, "large.bin"), Buffer.alloc(10 * 1024 * 1024 + 1, 1));
+    await writeFile(join(workspace, "binary.dat"), Buffer.from([0, 1, 2, 3]));
+    const first = await store.capture("principal");
+    expect((await store.detail(first.id))?.skipped).toContainEqual(expect.objectContaining({ path: "large.bin", reason: "too_large" }));
+
+    await writeFile(join(workspace, "binary.dat"), Buffer.from([0, 9, 2, 3]));
+    const [second, third] = await Promise.all([store.capture("engineer"), store.capture("auditor")]);
+    expect(second.id).not.toBe(third.id);
+    expect(third.baseCheckpointId).toBe(second.id);
+    expect((await store.detail(second.id))?.files.find((item) => item.path === "binary.dat")?.binary).toBe(true);
+
+    const reloaded = new WorkspaceCheckpointStore("s1", workspace, state);
+    expect((await reloaded.refs([first.id, second.id, third.id])).map((item) => item.id)).toEqual([first.id, second.id, third.id]);
+    const index = JSON.parse(await readFile(join(state, "workspace-checkpoints.json"), "utf8")) as {
+      version: number;
+      checkpoints: Record<string, Record<string, unknown>>;
+    };
+    expect(index.version).toBe(2);
+    expect(Object.values(index.checkpoints).every((record) => !("files" in record))).toBe(true);
+  });
+
+  it("stops adding snapshots after the repository quota is reached", async () => {
+    const { workspace, state } = await fixture();
+    await writeFile(join(workspace, "value.txt"), "one\n", "utf8");
+    const store = new WorkspaceCheckpointStore("s1", workspace, state, { maxRepositoryBytes: 1024 });
+    expect((await store.capture("principal")).status).toBe("ready");
+    const blocked = await store.capture("principal");
+    expect(blocked.status).toBe("failed");
+    expect(blocked.error).toContain("repository quota exceeded");
+  });
+
+  it("migrates a V1 index without retaining duplicated file lists", async () => {
+    const { workspace, state, store } = await fixture();
+    await writeFile(join(workspace, "value.txt"), "old\n", "utf8");
+    const target = await store.capture("principal");
+    const indexPath = join(state, "workspace-checkpoints.json");
+    const legacy = JSON.parse(await readFile(indexPath, "utf8")) as {
+      version: number;
+      checkpoints: Record<string, Record<string, unknown>>;
+    };
+    legacy.version = 1;
+    legacy.checkpoints[target.id]!.files = ["value.txt"];
+    await writeFile(indexPath, JSON.stringify(legacy, null, 2), "utf8");
+    await writeFile(join(workspace, "value.txt"), "new\n", "utf8");
+
+    const reloaded = new WorkspaceCheckpointStore("s1", workspace, state);
+    const preview = await reloaded.preview(target.id);
+    await reloaded.restore(target.id, preview!.stateToken);
+    expect(await readFile(join(workspace, "value.txt"), "utf8")).toBe("old\n");
+    const migrated = JSON.parse(await readFile(indexPath, "utf8")) as {
+      version: number;
+      checkpoints: Record<string, Record<string, unknown>>;
+    };
+    expect(migrated.version).toBe(2);
+    expect(Object.values(migrated.checkpoints).every((record) => !("files" in record))).toBe(true);
+  });
+
+  it("never overwrites a path that is ignored at restore time", async () => {
+    const { workspace, store } = await fixture();
+    await mkdir(join(workspace, "local"));
+    await writeFile(join(workspace, ".gitignore"), "", "utf8");
+    await writeFile(join(workspace, "local", "state.txt"), "checkpoint\n", "utf8");
+    const target = await store.capture("principal");
+
+    await writeFile(join(workspace, ".gitignore"), "local/\n", "utf8");
+    await writeFile(join(workspace, "local", "state.txt"), "keep-current\n", "utf8");
+    const preview = await store.preview(target.id);
+    expect(preview?.files.some((item) => item.path === "local/state.txt")).toBe(false);
+    await store.restore(target.id, preview!.stateToken);
+    expect(await readFile(join(workspace, "local", "state.txt"), "utf8")).toBe("keep-current\n");
+  });
+
+  it("reverses only selected checkpoint patches for causal rollback", async () => {
+    const { workspace, store } = await fixture();
+    await writeFile(join(workspace, "shared.txt"), "A\n", "utf8");
+    await store.capture("principal");
+
+    await writeFile(join(workspace, "a2.txt"), "A2\n", "utf8");
+    const a2 = await store.capture("engineer");
+
+    await writeFile(join(workspace, "shared.txt"), "B\n", "utf8");
+    await writeFile(join(workspace, "b.txt"), "B\n", "utf8");
+    const b = await store.capture("engineer");
+
+    const preview = await store.previewCausal([a2.id, b.id]);
+    expect(preview.conflicts).toEqual([]);
+    expect(preview.files).toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: "a2.txt", status: "deleted" }),
+      expect.objectContaining({ path: "b.txt", status: "deleted" }),
+      expect.objectContaining({ path: "shared.txt", status: "modified" }),
+    ]));
+    const result = await store.restoreCausal([a2.id, b.id], preview.stateToken);
+    expect(result.recoveryCheckpointId).toBeTruthy();
+    expect(await readFile(join(workspace, "shared.txt"), "utf8")).toBe("A\n");
+    await expect(readFile(join(workspace, "a2.txt"), "utf8")).rejects.toThrow();
+    await expect(readFile(join(workspace, "b.txt"), "utf8")).rejects.toThrow();
+  });
+
+  it("reports a conflict instead of overwriting a later independent edit", async () => {
+    const { workspace, store } = await fixture();
+    await writeFile(join(workspace, "shared.txt"), "base\n", "utf8");
+    await store.capture("principal");
+
+    await writeFile(join(workspace, "shared.txt"), "branch-a\n", "utf8");
+    const branchA = await store.capture("engineer");
+
+    await writeFile(join(workspace, "shared.txt"), "independent-current\n", "utf8");
+    const preview = await store.previewCausal([branchA.id]);
+    expect(preview.conflicts).toEqual([
+      expect.objectContaining({ path: "shared.txt", checkpointIds: [branchA.id] }),
+    ]);
+    await expect(store.restoreCausal([branchA.id], preview.stateToken)).rejects.toMatchObject({ code: "CAUSAL_CONFLICT" });
+    expect(await readFile(join(workspace, "shared.txt"), "utf8")).toBe("independent-current\n");
+  });
+});

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -80,6 +80,13 @@ export { makeRouterSkillGuardExt } from "./extensions/router-skill-guard.js";
 export { materializeSkills, resolveBundledSkillsDir } from "./materialize-skills.js";
 export type { MaterializeSkillsResult } from "./materialize-skills.js";
 
+export { WorkspaceCheckpointStore } from "./workspace-checkpoints.js";
+export type {
+  WorkspaceCheckpointOptions,
+  CheckpointFileProvenance,
+  CausalWorkspacePreview,
+} from "./workspace-checkpoints.js";
+
 export {
   materializeKb,
   resolveBundledKbDir,

--- a/packages/runtime/src/server.ts
+++ b/packages/runtime/src/server.ts
@@ -18,6 +18,8 @@ import {
   CreateSessionRequestSchema,
   SendMessageRequestSchema,
   InterruptRequestSchema,
+  TraceDependencyDecisionRequestSchema,
+  TraceStateTokenRequestSchema,
   WriteFileRequestSchema,
 } from "@brainpilot/protocol";
 import { SessionManager, type SessionManagerOptions } from "./session-manager.js";
@@ -77,6 +79,95 @@ export function createServer(opts: SessionManagerOptions & { manager?: SessionMa
     await manager.ensureLoaded(id);
     const graph = manager.getTrace(id);
     return graph ? c.json(graph) : c.json({ error: "not found" }, 404);
+  });
+
+  app.get("/sessions/:id/trace/changes", async (c) => {
+    const id = c.req.param("id");
+    await manager.ensureLoaded(id);
+    const limit = Number(c.req.query("limit") ?? 200);
+    const changes = manager.getTraceChanges(id, Number.isFinite(limit) ? limit : 200);
+    return changes ? c.json({ changes }) : c.json({ error: "not found" }, 404);
+  });
+
+  app.get("/sessions/:id/audits", async (c) => {
+    const id = c.req.param("id");
+    await manager.ensureLoaded(id);
+    const reports = manager.getAuditReports(id);
+    return reports ? c.json({ reports }) : c.json({ error: "not found" }, 404);
+  });
+
+  app.post("/sessions/:id/trace/dependencies/:dependencyId/decision", async (c) => {
+    const id = c.req.param("id");
+    await manager.ensureLoaded(id);
+    const parsed = TraceDependencyDecisionRequestSchema.safeParse(await c.req.json().catch(() => ({})));
+    if (!parsed.success) return c.json({ error: "decision must be accept or reject" }, 400);
+    const dependency = manager.decideTraceDependency(id, c.req.param("dependencyId"), parsed.data.decision, parsed.data.reason);
+    return dependency ? c.json(dependency) : c.json({ error: "dependency not found" }, 404);
+  });
+
+  app.get("/sessions/:id/trace/nodes/:nodeId/checkpoints", async (c) => {
+    const id = c.req.param("id");
+    await manager.ensureLoaded(id);
+    const checkpoints = await manager.getTraceNodeCheckpoints(id, c.req.param("nodeId"));
+    return checkpoints ? c.json({ checkpoints }) : c.json({ error: "not found" }, 404);
+  });
+
+  app.get("/sessions/:id/trace/nodes/:nodeId/rollback-preview", async (c) => {
+    const id = c.req.param("id");
+    await manager.ensureLoaded(id);
+    try {
+      const preview = await manager.getTraceCausalRollbackPreview(id, c.req.param("nodeId"));
+      return preview ? c.json(preview) : c.json({ error: "not found" }, 404);
+    } catch (error) { return c.json({ error: (error as Error).message }, 400); }
+  });
+
+  app.post("/sessions/:id/trace/nodes/:nodeId/rollback", async (c) => {
+    const id = c.req.param("id");
+    const parsed = TraceStateTokenRequestSchema.safeParse(await c.req.json().catch(() => ({})));
+    if (!parsed.success) return c.json({ error: "stateToken required" }, 400);
+    await manager.ensureLoaded(id);
+    try {
+      const result = await manager.rollbackTraceNode(id, c.req.param("nodeId"), parsed.data.stateToken);
+      return result ? c.json(result) : c.json({ error: "not found" }, 404);
+    } catch (error) {
+      const typed = error as Error & { code?: string; conflicts?: unknown };
+      const status = typed.code === "SESSION_ACTIVE" || typed.code === "STALE_WORKSPACE" || typed.code === "CAUSAL_CONFLICT" ? 409 : 400;
+      return c.json({ error: typed.message, code: typed.code, conflicts: typed.conflicts }, status);
+    }
+  });
+
+  app.get("/sessions/:id/trace/checkpoints/:checkpointId/diff", async (c) => {
+    const path = c.req.query("path");
+    if (!path) return c.json({ error: "path required" }, 400);
+    const id = c.req.param("id");
+    await manager.ensureLoaded(id);
+    try {
+      const diff = await manager.getTraceCheckpointDiff(id, c.req.param("checkpointId"), path);
+      return diff === undefined ? c.json({ error: "not found" }, 404) : c.json({ diff });
+    } catch (error) { return c.json({ error: (error as Error).message }, 400); }
+  });
+
+  app.get("/sessions/:id/trace/checkpoints/:checkpointId/restore-preview", async (c) => {
+    const id = c.req.param("id");
+    await manager.ensureLoaded(id);
+    try {
+      const preview = await manager.getTraceRestorePreview(id, c.req.param("checkpointId"));
+      return preview ? c.json(preview) : c.json({ error: "not found" }, 404);
+    } catch (error) { return c.json({ error: (error as Error).message }, 400); }
+  });
+
+  app.post("/sessions/:id/trace/checkpoints/:checkpointId/restore", async (c) => {
+    const id = c.req.param("id");
+    const parsed = TraceStateTokenRequestSchema.safeParse(await c.req.json().catch(() => ({})));
+    if (!parsed.success) return c.json({ error: "stateToken required" }, 400);
+    await manager.ensureLoaded(id);
+    try {
+      const result = await manager.restoreTraceCheckpoint(id, c.req.param("checkpointId"), parsed.data.stateToken);
+      return result ? c.json(result) : c.json({ error: "not found" }, 404);
+    } catch (error) {
+      const code = (error as Error & { code?: string }).code;
+      return c.json({ error: (error as Error).message, code }, code === "SESSION_ACTIVE" || code === "STALE_WORKSPACE" ? 409 : 400);
+    }
   });
 
   // Per-run + per-session usage stats — see RUNTIME_ROUTES.getSessionStats.

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -2800,6 +2800,7 @@ export class SessionManager {
     const entry = this.sessions.get(sessionId);
     if (!entry) return undefined;
     this.beginWorkspaceOperation(entry, "roll back");
+    let releaseWorkspace = true;
     try {
       const plan = entry.trace.getCausalRollbackPlan(nodeId);
       if (!plan) return undefined;
@@ -2817,8 +2818,11 @@ export class SessionManager {
         metadata: { affectedNodeIds: plan.affectedNodeIds },
       });
       return { nodeId, affectedNodeIds: plan.affectedNodeIds, changeId: change.id };
+    } catch (error) {
+      if ((error as Error & { code?: string }).code === "WORKSPACE_RECOVERY_FAILED") releaseWorkspace = false;
+      throw error;
     } finally {
-      this.endWorkspaceOperation(entry);
+      if (releaseWorkspace) this.endWorkspaceOperation(entry);
     }
   }
 
@@ -2826,6 +2830,7 @@ export class SessionManager {
     const entry = this.sessions.get(sessionId);
     if (!entry) return undefined;
     this.beginWorkspaceOperation(entry, "restore");
+    let releaseWorkspace = true;
     try {
       const restored = await entry.checkpoints.restore(checkpointId, stateToken, async () => {
         await entry.taskLedger.cancelAllPending("Cancelled because the workspace was restored to an earlier checkpoint.");
@@ -2842,8 +2847,11 @@ export class SessionManager {
         metadata: { restoredCheckpointId: checkpointId },
       });
       return { ...restored, changeId: change.id };
+    } catch (error) {
+      if ((error as Error & { code?: string }).code === "WORKSPACE_RECOVERY_FAILED") releaseWorkspace = false;
+      throw error;
     } finally {
-      this.endWorkspaceOperation(entry);
+      if (releaseWorkspace) this.endWorkspaceOperation(entry);
     }
   }
 

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -2666,14 +2666,13 @@ export class SessionManager {
     return false;
   }
 
-  /** Restore gate includes Trace, queued work, and active tool execution. */
+  /** Restore gate blocks live execution; durable queued work is cancelled after restore. */
   private hasAnyAgentActivity(entry: SessionEntry): boolean {
     if (entry.runActive || entry.userInputs.active || entry.userInputs.queue.length > 0) return true;
     for (const agent of entry.agents.values()) {
       if (agent.status === "running" || agent.isStreaming || agent.hasActiveTools()) return true;
     }
-    if ([...this.deliveryLoops].some((key) => key.startsWith(`${entry.id}:`))) return true;
-    return entry.taskLedger.notificationTargets().some((agent) => !entry.taskLedger.isPaused(agent));
+    return [...this.deliveryLoops].some((key) => key.startsWith(`${entry.id}:`));
   }
 
   private beginWorkspaceOperation(entry: SessionEntry, action: "restore" | "roll back"): void {
@@ -2685,7 +2684,7 @@ export class SessionManager {
     entry.workspaceOperationActive = true;
     if (this.hasAnyAgentActivity(entry)) {
       entry.workspaceOperationActive = false;
-      const error = new Error(`cannot ${action} while an agent or queued task is active`);
+      const error = new Error(`cannot ${action} while an agent is active`);
       (error as Error & { code?: string }).code = "SESSION_ACTIVE";
       throw error;
     }
@@ -2805,16 +2804,18 @@ export class SessionManager {
       const plan = entry.trace.getCausalRollbackPlan(nodeId);
       if (!plan) return undefined;
       const checkpointIds = (await entry.checkpoints.refs(plan.checkpointIds)).map((ref) => ref.id);
-      const restored = await entry.checkpoints.restoreCausal(checkpointIds, stateToken);
-      const previousStatuses = entry.trace.markNodesRolledBack(plan.affectedNodeIds, nodeId);
+      await entry.checkpoints.restoreCausal(checkpointIds, stateToken);
+      await entry.taskLedger.cancelAllPending("Cancelled because the workspace was rolled back.");
+      this.emitTaskSnapshot(entry);
+      entry.trace.markNodesRolledBack(plan.affectedNodeIds, nodeId);
       const change = entry.trace.recordChange({
         actor: { type: "user" },
         action: "causal_rollback",
         target: { nodeId },
         reason: `Revoked ${plan.affectedNodeIds.length} causal descendants.`,
-        metadata: { affectedNodeIds: plan.affectedNodeIds, previousRevoked: previousStatuses, recoveryCheckpointId: restored.recoveryCheckpointId },
+        metadata: { affectedNodeIds: plan.affectedNodeIds },
       });
-      return { nodeId, affectedNodeIds: plan.affectedNodeIds, recoveryCheckpointId: restored.recoveryCheckpointId, changeId: change.id };
+      return { nodeId, affectedNodeIds: plan.affectedNodeIds, changeId: change.id };
     } finally {
       this.endWorkspaceOperation(entry);
     }
@@ -2826,21 +2827,17 @@ export class SessionManager {
     this.beginWorkspaceOperation(entry, "restore");
     try {
       const restored = await entry.checkpoints.restore(checkpointId, stateToken);
+      await entry.taskLedger.cancelAllPending("Cancelled because the workspace was restored to an earlier checkpoint.");
+      this.emitTaskSnapshot(entry);
       const [checkpoint] = await entry.checkpoints.refs([checkpointId]);
       if (!checkpoint) throw new Error("restored checkpoint disappeared");
       const targetNode = entry.trace.getGraph().nodes.find((node) => node.checkpoints?.some((item) => item.id === checkpointId));
-      const rollbackChange = [...entry.trace.getChanges(2_000)].reverse().find((change) =>
-        change.action === "causal_rollback" && change.metadata?.recoveryCheckpointId === checkpointId);
-      const causalStatuses = rollbackChange?.metadata?.previousRevoked && typeof rollbackChange.metadata.previousRevoked === "object"
-        ? rollbackChange.metadata.previousRevoked as Record<string, boolean>
-        : undefined;
-      if (causalStatuses) entry.trace.restoreNodeStatuses(causalStatuses);
       const change = entry.trace.recordChange({
         actor: { type: "user" },
-        action: causalStatuses ? "causal_rollback_undo" : "workspace_restore",
+        action: "workspace_restore",
         target: targetNode ? { nodeId: targetNode.id } : {},
         reason: `Restored workspace checkpoint ${checkpointId}.`,
-        metadata: { restoredCheckpointId: checkpointId, recoveryCheckpointId: restored.recoveryCheckpointId, ...(rollbackChange ? { rollbackChangeId: rollbackChange.id } : {}) },
+        metadata: { restoredCheckpointId: checkpointId },
       });
       return { ...restored, changeId: change.id };
     } finally {

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -2804,9 +2804,10 @@ export class SessionManager {
       const plan = entry.trace.getCausalRollbackPlan(nodeId);
       if (!plan) return undefined;
       const checkpointIds = (await entry.checkpoints.refs(plan.checkpointIds)).map((ref) => ref.id);
-      await entry.checkpoints.restoreCausal(checkpointIds, stateToken);
-      await entry.taskLedger.cancelAllPending("Cancelled because the workspace was rolled back.");
-      this.emitTaskSnapshot(entry);
+      await entry.checkpoints.restoreCausal(checkpointIds, stateToken, async () => {
+        await entry.taskLedger.cancelAllPending("Cancelled because the workspace was rolled back.");
+        this.emitTaskSnapshot(entry);
+      });
       entry.trace.markNodesRolledBack(plan.affectedNodeIds, nodeId);
       const change = entry.trace.recordChange({
         actor: { type: "user" },
@@ -2826,9 +2827,10 @@ export class SessionManager {
     if (!entry) return undefined;
     this.beginWorkspaceOperation(entry, "restore");
     try {
-      const restored = await entry.checkpoints.restore(checkpointId, stateToken);
-      await entry.taskLedger.cancelAllPending("Cancelled because the workspace was restored to an earlier checkpoint.");
-      this.emitTaskSnapshot(entry);
+      const restored = await entry.checkpoints.restore(checkpointId, stateToken, async () => {
+        await entry.taskLedger.cancelAllPending("Cancelled because the workspace was restored to an earlier checkpoint.");
+        this.emitTaskSnapshot(entry);
+      });
       const [checkpoint] = await entry.checkpoints.refs([checkpointId]);
       if (!checkpoint) throw new Error("restored checkpoint disappeared");
       const targetNode = entry.trace.getGraph().nodes.find((node) => node.checkpoints?.some((item) => item.id === checkpointId));

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -30,6 +30,11 @@ import {
   type SessionTokenUsage,
   type TokenUsage,
   type TraceGraph,
+  type TraceCausalRollbackPreview,
+  type TraceCausalRollbackResult,
+  type TraceCheckpointDetail,
+  type TraceRestorePreview,
+  type TraceRestoreResult,
   type TraceNodeRecord,
   type UserInputCancellationReason,
 } from "@brainpilot/protocol";
@@ -41,6 +46,7 @@ import {
   type TaskRecord,
 } from "./task-ledger.js";
 import { GraphOfTrace, type TraceAuditTarget } from "./trace.js";
+import { WorkspaceCheckpointStore } from "./workspace-checkpoints.js";
 import { MasAgent, addUsage, emptyTokenUsage } from "./mas-agent.js";
 import {
   addStatsDelta,
@@ -270,6 +276,8 @@ interface SessionEntry {
   bus: EventBus;
   taskLedger: TaskLedger;
   trace: GraphOfTrace;
+  checkpoints: WorkspaceCheckpointStore;
+  workspaceOperationActive: boolean;
   /** Host-bound source record while Trace processes one durable event. */
   currentTraceRecord?: TraceNodeRecord;
   /** Host-bound immutable target for one Auditor turn. */
@@ -944,6 +952,9 @@ export class SessionManager {
     await this.ensureLayoutForPath(rel);
     const { abs, prefix } = this.resolveManagedPath(sid, rel);
     this.assertWritable(prefix, rel); // #261: the shared root is read-only
+    if (prefix === "/workspace" && this.sessions.get(sid)?.workspaceOperationActive) {
+      throw new Error("workspace restore is in progress");
+    }
     try {
       await rm(abs, { recursive: true });
       return true;
@@ -992,6 +1003,9 @@ export class SessionManager {
     await this.ensureLayoutForPath(rel);
     const { abs, root, prefix } = this.resolveManagedPath(sid, rel);
     this.assertWritable(prefix, rel); // #261: the shared root is read-only
+    if (prefix === "/workspace" && this.sessions.get(sid)?.workspaceOperationActive) {
+      throw new Error("workspace restore is in progress");
+    }
     await mkdir(dirname(abs), { recursive: true });
     await writeFile(abs, buf);
     return { path: this.relManagedPath(abs, root, prefix), size: buf.byteLength };
@@ -1021,6 +1035,9 @@ export class SessionManager {
     await this.ensureLayoutForPath(rel);
     const { abs, root, prefix } = this.resolveManagedPath(sid, rel);
     this.assertWritable(prefix, rel); // #261: the shared root is read-only
+    if (prefix === "/workspace" && this.sessions.get(sid)?.workspaceOperationActive) {
+      throw new Error("workspace restore is in progress");
+    }
     await mkdir(dirname(abs), { recursive: true });
 
     // Normalize either stream flavor to a Node Readable.
@@ -1275,6 +1292,11 @@ export class SessionManager {
         bus.emit(ev.custom({ sessionId: id }, CUSTOM_EVENT.TRACE_DELTA, delta));
       },
     );
+    const checkpoints = new WorkspaceCheckpointStore(
+      id,
+      this.workspaceDir(id),
+      persistBase ?? join(this.dataRoot, ".bp", id),
+    );
 
     const entry: SessionEntry = {
       id,
@@ -1285,6 +1307,8 @@ export class SessionManager {
       bus,
       taskLedger,
       trace,
+      checkpoints,
+      workspaceOperationActive: false,
       currentTraceRecord: undefined,
       currentTraceAuditTarget: undefined,
       traceAuditQueued: new Set(),
@@ -1479,6 +1503,7 @@ export class SessionManager {
   ): Promise<{ accepted: boolean; runId?: string; queued?: boolean }> {
     const entry = this.sessions.get(sessionId);
     if (!entry) throw new Error(`session not found: ${sessionId}`);
+    if (entry.workspaceOperationActive) return { accepted: false };
     this.touch(entry);
     // §R-4: refuse new runs past the soft memory threshold. The HTTP `accepted`
     // flag alone isn't surfaced by the web, so also emit a system message.
@@ -2048,6 +2073,7 @@ export class SessionManager {
       sessionId,
       fromAgent: name,
       trace: entry.trace,
+      checkpoints: entry.checkpoints,
       currentTraceRecord: () => entry.currentTraceRecord,
       currentTraceAuditTarget: () => entry.currentTraceAuditTarget,
       dispatchTask: async (target, content) => {
@@ -2291,7 +2317,7 @@ export class SessionManager {
    */
   private wakeAgent(sessionId: string, name: string): void {
     const current = this.sessions.get(sessionId);
-    if (!current || current.taskLedger.isPaused(name)) return;
+    if (!current || current.workspaceOperationActive || current.taskLedger.isPaused(name)) return;
     const key = `${sessionId}:${name}`;
     if (this.deliveryLoops.has(key)) return;
     this.deliveryLoops.add(key);
@@ -2640,6 +2666,36 @@ export class SessionManager {
     return false;
   }
 
+  /** Restore gate includes Trace, queued work, and active tool execution. */
+  private hasAnyAgentActivity(entry: SessionEntry): boolean {
+    if (entry.runActive || entry.userInputs.active || entry.userInputs.queue.length > 0) return true;
+    for (const agent of entry.agents.values()) {
+      if (agent.status === "running" || agent.isStreaming || agent.hasActiveTools()) return true;
+    }
+    if ([...this.deliveryLoops].some((key) => key.startsWith(`${entry.id}:`))) return true;
+    return entry.taskLedger.notificationTargets().some((agent) => !entry.taskLedger.isPaused(agent));
+  }
+
+  private beginWorkspaceOperation(entry: SessionEntry, action: "restore" | "roll back"): void {
+    if (entry.workspaceOperationActive) {
+      const error = new Error(`cannot ${action} while another workspace operation is active`);
+      (error as Error & { code?: string }).code = "SESSION_ACTIVE";
+      throw error;
+    }
+    entry.workspaceOperationActive = true;
+    if (this.hasAnyAgentActivity(entry)) {
+      entry.workspaceOperationActive = false;
+      const error = new Error(`cannot ${action} while an agent or queued task is active`);
+      (error as Error & { code?: string }).code = "SESSION_ACTIVE";
+      throw error;
+    }
+  }
+
+  private endWorkspaceOperation(entry: SessionEntry): void {
+    entry.workspaceOperationActive = false;
+    for (const agent of entry.taskLedger.notificationTargets()) this.wakeAgent(entry.id, agent);
+  }
+
   /**
    * #70/#76: emit the authoritative live snapshot as a `CUSTOM:session_state`
    * event. This is the wholesale source the web Agents panel replaces its
@@ -2705,6 +2761,91 @@ export class SessionManager {
 
   getAuditReports(sessionId: string): AuditReport[] | undefined {
     return this.sessions.get(sessionId)?.trace.getAuditReports();
+  }
+
+  decideTraceDependency(
+    sessionId: string,
+    dependencyId: string,
+    decision: "accept" | "reject",
+    reason?: string,
+  ): import("@brainpilot/protocol").TraceDependency | undefined {
+    return this.sessions.get(sessionId)?.trace.decideDependency(dependencyId, decision, reason);
+  }
+
+  async getTraceNodeCheckpoints(sessionId: string, nodeId: string): Promise<TraceCheckpointDetail[] | undefined> {
+    const entry = this.sessions.get(sessionId);
+    const node = entry?.trace.getNode(nodeId);
+    if (!entry || !node) return undefined;
+    const details = await Promise.all((node.checkpoints ?? []).map((checkpoint) => entry.checkpoints.detail(checkpoint.id)));
+    return details.filter((item): item is TraceCheckpointDetail => Boolean(item));
+  }
+
+  async getTraceCheckpointDiff(sessionId: string, checkpointId: string, path: string): Promise<string | undefined> {
+    return this.sessions.get(sessionId)?.checkpoints.diff(checkpointId, path);
+  }
+
+  async getTraceRestorePreview(sessionId: string, checkpointId: string): Promise<TraceRestorePreview | undefined> {
+    return this.sessions.get(sessionId)?.checkpoints.preview(checkpointId);
+  }
+
+  async getTraceCausalRollbackPreview(sessionId: string, nodeId: string): Promise<TraceCausalRollbackPreview | undefined> {
+    const entry = this.sessions.get(sessionId);
+    const plan = entry?.trace.getCausalRollbackPlan(nodeId);
+    if (!entry || !plan) return undefined;
+    const checkpointIds = (await entry.checkpoints.refs(plan.checkpointIds)).map((ref) => ref.id);
+    const preview = await entry.checkpoints.previewCausal(checkpointIds);
+    return { nodeId, affectedNodeIds: plan.affectedNodeIds, affectedCheckpointIds: checkpointIds, ...preview };
+  }
+
+  async rollbackTraceNode(sessionId: string, nodeId: string, stateToken: string): Promise<TraceCausalRollbackResult | undefined> {
+    const entry = this.sessions.get(sessionId);
+    if (!entry) return undefined;
+    this.beginWorkspaceOperation(entry, "roll back");
+    try {
+      const plan = entry.trace.getCausalRollbackPlan(nodeId);
+      if (!plan) return undefined;
+      const checkpointIds = (await entry.checkpoints.refs(plan.checkpointIds)).map((ref) => ref.id);
+      const restored = await entry.checkpoints.restoreCausal(checkpointIds, stateToken);
+      const previousStatuses = entry.trace.markNodesRolledBack(plan.affectedNodeIds, nodeId);
+      const change = entry.trace.recordChange({
+        actor: { type: "user" },
+        action: "causal_rollback",
+        target: { nodeId },
+        reason: `Revoked ${plan.affectedNodeIds.length} causal descendants.`,
+        metadata: { affectedNodeIds: plan.affectedNodeIds, previousRevoked: previousStatuses, recoveryCheckpointId: restored.recoveryCheckpointId },
+      });
+      return { nodeId, affectedNodeIds: plan.affectedNodeIds, recoveryCheckpointId: restored.recoveryCheckpointId, changeId: change.id };
+    } finally {
+      this.endWorkspaceOperation(entry);
+    }
+  }
+
+  async restoreTraceCheckpoint(sessionId: string, checkpointId: string, stateToken: string): Promise<TraceRestoreResult | undefined> {
+    const entry = this.sessions.get(sessionId);
+    if (!entry) return undefined;
+    this.beginWorkspaceOperation(entry, "restore");
+    try {
+      const restored = await entry.checkpoints.restore(checkpointId, stateToken);
+      const [checkpoint] = await entry.checkpoints.refs([checkpointId]);
+      if (!checkpoint) throw new Error("restored checkpoint disappeared");
+      const targetNode = entry.trace.getGraph().nodes.find((node) => node.checkpoints?.some((item) => item.id === checkpointId));
+      const rollbackChange = [...entry.trace.getChanges(2_000)].reverse().find((change) =>
+        change.action === "causal_rollback" && change.metadata?.recoveryCheckpointId === checkpointId);
+      const causalStatuses = rollbackChange?.metadata?.previousRevoked && typeof rollbackChange.metadata.previousRevoked === "object"
+        ? rollbackChange.metadata.previousRevoked as Record<string, boolean>
+        : undefined;
+      if (causalStatuses) entry.trace.restoreNodeStatuses(causalStatuses);
+      const change = entry.trace.recordChange({
+        actor: { type: "user" },
+        action: causalStatuses ? "causal_rollback_undo" : "workspace_restore",
+        target: targetNode ? { nodeId: targetNode.id } : {},
+        reason: `Restored workspace checkpoint ${checkpointId}.`,
+        metadata: { restoredCheckpointId: checkpointId, recoveryCheckpointId: restored.recoveryCheckpointId, ...(rollbackChange ? { rollbackChangeId: rollbackChange.id } : {}) },
+      });
+      return { ...restored, changeId: change.id };
+    } finally {
+      this.endWorkspaceOperation(entry);
+    }
   }
 
   /**

--- a/packages/runtime/src/task-ledger.ts
+++ b/packages/runtime/src/task-ledger.ts
@@ -260,6 +260,24 @@ export class TaskLedger {
     });
   }
 
+  /** Destructively clear work that must not survive a workspace rollback. */
+  async cancelAllPending(reason: string): Promise<TaskRecord[]> {
+    return this.mutate(() => {
+      const cancelled: TaskRecord[] = [];
+      for (const task of this.tasks) {
+        if (task.status !== "pending") continue;
+        task.status = "cancelled";
+        task.reply = reason;
+        task.completed_at = Date.now();
+        cancelled.push(this.publicTask(task));
+      }
+      // Terminal and system notifications can also carry assumptions about
+      // the pre-rollback workspace, so the entire delivery queue is discarded.
+      this.notifications = [];
+      return cancelled;
+    });
+  }
+
   async enqueueTrace(fromAgent: string, content: string): Promise<void> {
     await this.mutate(() => { this.enqueue("trace", "trace", fromAgent, content); });
   }

--- a/packages/runtime/src/tools/system-tools.ts
+++ b/packages/runtime/src/tools/system-tools.ts
@@ -9,6 +9,7 @@
  */
 import type { TraceNodeRecord } from "@brainpilot/protocol";
 import type { GraphOfTrace, TraceArtifactInput, TraceAuditTarget } from "../trace.js";
+import type { WorkspaceCheckpointStore } from "../workspace-checkpoints.js";
 import { TaskQueueFullError, type TaskRecord } from "../task-ledger.js";
 import type { AgentRole, SystemTool } from "../types.js";
 import { createSkillSearchTool } from "./skill-search.js";
@@ -22,6 +23,7 @@ export interface ToolDeps {
   sessionId: string;
   fromAgent: string;
   trace: GraphOfTrace;
+  checkpoints?: WorkspaceCheckpointStore;
   dispatchTask: (to: string, content: string) => Promise<TaskRecord>;
   completeTask: (taskId: string, reply: string) => Promise<TaskRecord>;
   dispatchTrace: (content: string) => Promise<void>;
@@ -90,6 +92,15 @@ function artifactInputs(value: unknown): TraceArtifactInput[] {
       ...(typeof input.blobHash === "string" ? { blobHash: input.blobHash } : {}),
     }];
   });
+}
+
+async function attachCheckpointWithGitEvidence(deps: ToolDeps, nodeId: string, checkpointId: string): Promise<void> {
+  if (!deps.checkpoints) return;
+  const [[checkpoint], files] = await Promise.all([
+    deps.checkpoints.refs([checkpointId]),
+    deps.checkpoints.provenance(checkpointId),
+  ]);
+  if (checkpoint) deps.trace.attachCheckpoint(nodeId, checkpoint, files ?? []);
 }
 
 export function createDispatchTaskTool(deps: ToolDeps): SystemTool {
@@ -301,16 +312,23 @@ export function createRecordTraceTool(deps: ToolDeps): SystemTool {
         : [];
       const inputs = artifactInputs(params.artifact_inputs);
       const outputs = artifactInputs(params.artifact_outputs);
+      const checkpoint = await deps.checkpoints?.capture(deps.fromAgent);
+      const gitEvidence = checkpoint
+        ? await deps.checkpoints?.provenance(checkpoint.id).catch(() => undefined)
+        : undefined;
       const record: TraceNodeRecord = {
         sourceAgent: deps.fromAgent,
         description,
         ...(context ? { context } : {}),
+        ...(checkpoint ? { checkpointId: checkpoint.id } : {}),
         createdAt: new Date().toISOString(),
       };
       const lines = [`[Trace Event]`, `Description: ${description}`];
       if (context) lines.push(`Context: ${context}`);
+      if (checkpoint) lines.push(`Checkpoint-ID: ${checkpoint.id}`);
       if (inputs.length) lines.push(`Artifact-Inputs: ${JSON.stringify(inputs)}`);
       if (outputs.length) lines.push(`Artifact-Outputs: ${JSON.stringify(outputs)}`);
+      if (gitEvidence?.length) lines.push(`Git-Evidence: ${JSON.stringify(gitEvidence)}`);
       lines.push("", "Artifacts:");
       if (artifacts.length === 0) {
         lines.push("(none)");
@@ -344,7 +362,7 @@ export function createTraceNodeTool(deps: ToolDeps): SystemTool {
     name: "create_trace_node",
     description:
       "Create one new active Graph of Trace node only when the current host-bound record represents a distinct, durable scientific unit that is not already in the active graph. " +
-      "Do not create nodes for coordination, delegation, progress, presentation, reformatting, or repetition. The Host attaches the current source record automatically. " +
+      "Do not create nodes for coordination, delegation, progress, presentation, reformatting, or repetition. The Host attaches the current source record and checkpoint automatically. " +
       "The Host also attaches the session root whenever no more specific causal parent has been confirmed; never submit the session root as a parent candidate. " +
       "One Trace Event may call this tool more than once only when it explicitly contains multiple independently meaningful scientific units with enough content to describe each accurately.",
     parameters: {
@@ -391,6 +409,8 @@ export function createTraceNodeTool(deps: ToolDeps): SystemTool {
         if (typeof candidate.node_id !== "string" || typeof candidate.reason !== "string") continue;
         deps.trace.proposeCausalParent(node.id, candidate.node_id, candidate.reason, { type: "agent", name: deps.fromAgent });
       }
+      const checkpointId = record?.checkpointId;
+      if (checkpointId) await attachCheckpointWithGitEvidence(deps, node.id, checkpointId);
       return ok(`node ${node.id} created`);
     },
   };
@@ -402,7 +422,7 @@ export function createUpdateTraceNodeTool(deps: ToolDeps): SystemTool {
     description:
       "Update exactly one existing active Trace node only when the current host-bound record belongs to the same scientific unit and adds evidence, results, a correction, or a meaningful status change. " +
       "Read the target node first and preserve its valid existing content when supplying replacement text. Do not update merely to rephrase, translate, format, present, or repeat it. " +
-      "The Host attaches the current record automatically; revoked nodes cannot be reused, and confidence must be re-evaluated on every substantive update.",
+      "The Host attaches the current record and checkpoint automatically; revoked nodes cannot be reused, and confidence must be re-evaluated on every substantive update.",
     parameters: {
       type: "object",
       properties: {
@@ -447,6 +467,8 @@ export function createUpdateTraceNodeTool(deps: ToolDeps): SystemTool {
         if (typeof candidate.node_id !== "string" || typeof candidate.reason !== "string") continue;
         deps.trace.proposeCausalParent(id, candidate.node_id, candidate.reason, { type: "agent", name: deps.fromAgent });
       }
+      const checkpointId = record?.checkpointId;
+      if (node && checkpointId) await attachCheckpointWithGitEvidence(deps, id, checkpointId);
       return node ? ok(`node ${id} updated`) : { ...ok(`node ${id} not found`), isError: true };
     },
   };
@@ -516,6 +538,29 @@ export function createGetTraceNeighborhoodTool(deps: ToolDeps): SystemTool {
     execute: async (params) => {
       const neighborhood = deps.trace.getNeighborhood(String(params.node_id ?? ""), typeof params.depth === "number" ? params.depth : 1);
       return neighborhood ? ok(cappedJson(neighborhood)) : { ...ok("trace node not found"), isError: true };
+    },
+  };
+}
+
+export function createGetTraceDiffTool(deps: ToolDeps): SystemTool {
+  return {
+    name: "get_trace_diff",
+    description: "Read the latest checkpoint diff for one active Trace node, optionally limited to one path.",
+    parameters: {
+      type: "object",
+      properties: { node_id: { type: "string" }, path: { type: "string" } },
+      required: ["node_id"],
+    },
+    execute: async (params) => {
+      if (!deps.checkpoints) return { ...ok("checkpoint store unavailable"), isError: true };
+      const node = deps.trace.getNode(String(params.node_id ?? ""));
+      if (!node || node.revoked) return { ...ok("trace node not found"), isError: true };
+      const checkpoint = node.checkpoints?.at(-1);
+      if (!checkpoint) return { ...ok("node has no checkpoint"), isError: true };
+      if (typeof params.path === "string" && params.path) {
+        return ok(await deps.checkpoints.diff(checkpoint.id, params.path) ?? "");
+      }
+      return ok(cappedJson(await deps.checkpoints.detail(checkpoint.id)));
     },
   };
 }
@@ -681,6 +726,7 @@ export function allSystemTools(
     createGetTraceGraphTool(deps),
     createGetTraceNodeTool(deps),
     createGetTraceNeighborhoodTool(deps),
+    createGetTraceDiffTool(deps),
     createListPendingTraceReviewsTool(deps),
     // Temporarily disabled: the current substring matcher is not reliable
     // enough to expose as an Agent tool. Keep the implementation above so it
@@ -747,6 +793,7 @@ export const AGENT_TOOL_CONFIG: Record<string, string[]> = {
     "list_pending_trace_reviews",
     "get_trace_node",
     "get_trace_neighborhood",
+    "get_trace_diff",
     // "search_trace", // temporarily disabled; see allSystemTools above
     "edit_trace_review",
     "submit_audit_report",

--- a/packages/runtime/src/trace.ts
+++ b/packages/runtime/src/trace.ts
@@ -30,6 +30,16 @@ import type {
   TraceNodeV2,
   TraceDeltaV2,
 } from "@brainpilot/protocol";
+interface CheckpointFileProvenance {
+  path: string;
+  previousPath?: string;
+  status: "added" | "modified" | "deleted" | "renamed";
+  additions?: number;
+  deletions?: number;
+  binary: boolean;
+  baseBlobId?: string;
+  resultBlobId?: string;
+}
 function now(): string {
   return new Date().toISOString();
 }
@@ -502,6 +512,79 @@ export class GraphOfTrace {
         }
       : this.auditNodeEvidence(node);
     return createHash("sha256").update(JSON.stringify(payload)).digest("hex");
+  }
+
+  attachCheckpoint(id: string, checkpoint: TraceCheckpointRef, files: CheckpointFileProvenance[] = []): TraceNode | undefined {
+    if (!this.nodes.has(id)) return undefined;
+    this.registerArtifactInternal(id, {
+      path: `checkpoint:${checkpoint.id}`,
+      kind: "checkpoint",
+      type: "checkpoint",
+      checkpointId: checkpoint.id,
+      checkpoint,
+      exists: checkpoint.status === "ready" || checkpoint.status === "partial" ? "present" : "unknown",
+      verificationStatus: "reserved",
+      role: "checkpoint",
+    });
+    this.attachCheckpointFilesInternal(id, checkpoint, files);
+    this.nodes.get(id)!.updatedAt = now();
+    this.commit("updated", id);
+    return this.getNode(id);
+  }
+
+  getCausalRollbackPlan(targetNodeId: string): { affectedNodeIds: string[]; checkpointIds: string[] } | undefined {
+    if (!this.nodes.has(targetNodeId) || this.nodes.get(targetNodeId)?.revoked || this.isSessionRoot(targetNodeId)) return undefined;
+    const visited = new Set<string>([targetNodeId]);
+    const queue = [targetNodeId];
+    const affected: string[] = [];
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      const children = [...this.nodes.values()]
+        .filter((node) => !node.revoked && node.parents.some((parent) => parent.nodeId === current && parent.conclusion === "confirmed"))
+        .map((node) => node.id);
+      for (const child of children) {
+        if (visited.has(child)) continue;
+        visited.add(child);
+        queue.push(child);
+        affected.push(child);
+      }
+    }
+    const checkpointIds = unique(affected.flatMap((nodeId) => this.nodes.get(nodeId)?.artifactIds.flatMap((artifactId) => {
+      const id = this.artifacts.get(artifactId)?.checkpointId;
+      return id ? [id] : [];
+    }) ?? []));
+    return { affectedNodeIds: affected, checkpointIds };
+  }
+
+  markNodesRolledBack(nodeIds: string[], targetNodeId: string): Record<string, boolean> {
+    const previous: Record<string, boolean> = {};
+    for (const id of nodeIds) {
+      const node = this.nodes.get(id);
+      if (!node || this.isSessionRoot(id)) continue;
+      previous[id] = node.revoked;
+      node.revoked = true;
+      this.normalizeCausalGraph();
+      node.updatedAt = now();
+      this.commit("updated", id, {
+        actor: { type: "user" }, action: "node_revoked", target: { nodeId: id },
+        before: false, after: true, reason: `Causal rollback to ${targetNodeId}`,
+      });
+    }
+    return previous;
+  }
+
+  restoreNodeStatuses(statuses: Record<string, boolean>): void {
+    for (const [id, revoked] of Object.entries(statuses)) {
+      const node = this.nodes.get(id);
+      if (!node || this.isSessionRoot(id)) continue;
+      node.revoked = revoked;
+      this.normalizeCausalGraph();
+      node.updatedAt = now();
+      this.commit("updated", id, {
+        actor: { type: "user" }, action: "node_revocation_undone", target: { nodeId: id },
+        before: !revoked, after: revoked,
+      });
+    }
   }
 
   /** Register an artifact and attach it to a node. IDs are stable across V1 migration. */
@@ -1568,6 +1651,29 @@ export class GraphOfTrace {
     const node = this.nodes.get(nodeId);
     if (node) node.artifactIds = unique([...node.artifactIds, id]);
     return artifact;
+  }
+
+  private attachCheckpointFilesInternal(
+    nodeId: string,
+    checkpoint: TraceCheckpointRef,
+    files: CheckpointFileProvenance[],
+  ): void {
+    for (const file of files) {
+      this.registerArtifactInternal(nodeId, {
+        path: file.path,
+        previousPath: file.previousPath,
+        kind: file.binary ? "binary" : "file",
+        type: file.binary ? "binary" : "file",
+        checkpointId: checkpoint.id,
+        blobHash: file.resultBlobId,
+        changeStatus: file.status,
+        exists: file.status === "deleted" ? "missing" : "present",
+        verificationStatus: file.status === "deleted" ? "missing" : "verified",
+        role: "output",
+        createdAt: checkpoint.capturedAt,
+        updatedAt: checkpoint.capturedAt,
+      });
+    }
   }
 
   private attachArtifactInputInternal(nodeId: string, input: TraceArtifactInput): TraceArtifactV2 {

--- a/packages/runtime/src/trace.ts
+++ b/packages/runtime/src/trace.ts
@@ -556,33 +556,16 @@ export class GraphOfTrace {
     return { affectedNodeIds: affected, checkpointIds };
   }
 
-  markNodesRolledBack(nodeIds: string[], targetNodeId: string): Record<string, boolean> {
-    const previous: Record<string, boolean> = {};
+  markNodesRolledBack(nodeIds: string[], targetNodeId: string): void {
     for (const id of nodeIds) {
       const node = this.nodes.get(id);
       if (!node || this.isSessionRoot(id)) continue;
-      previous[id] = node.revoked;
       node.revoked = true;
       this.normalizeCausalGraph();
       node.updatedAt = now();
       this.commit("updated", id, {
         actor: { type: "user" }, action: "node_revoked", target: { nodeId: id },
         before: false, after: true, reason: `Causal rollback to ${targetNodeId}`,
-      });
-    }
-    return previous;
-  }
-
-  restoreNodeStatuses(statuses: Record<string, boolean>): void {
-    for (const [id, revoked] of Object.entries(statuses)) {
-      const node = this.nodes.get(id);
-      if (!node || this.isSessionRoot(id)) continue;
-      node.revoked = revoked;
-      this.normalizeCausalGraph();
-      node.updatedAt = now();
-      this.commit("updated", id, {
-        actor: { type: "user" }, action: "node_revocation_undone", target: { nodeId: id },
-        before: !revoked, after: revoked,
       });
     }
   }

--- a/packages/runtime/src/workspace-checkpoints.ts
+++ b/packages/runtime/src/workspace-checkpoints.ts
@@ -52,6 +52,11 @@ interface TreeSnapshot {
   skipped: Skipped[];
 }
 
+interface PreparedTree {
+  tempDir: string;
+  sourceRoot: string;
+}
+
 export interface CheckpointFileProvenance extends TraceCheckpointFileChange {
   baseBlobId?: string;
   resultBlobId?: string;
@@ -646,7 +651,7 @@ export class WorkspaceCheckpointStore {
   restoreCausal(
     checkpointIds: string[],
     expectedStateToken: string,
-    onPrepared?: () => Promise<void>,
+    onCommitted?: () => Promise<void>,
   ): Promise<void> {
     return this.exclusive(async () => {
       const plan = await this.synthesizeCausalTree(checkpointIds);
@@ -664,19 +669,43 @@ export class WorkspaceCheckpointStore {
       const recoveryRef = await this.captureUnlocked("system", "recovery");
       const index = await this.index();
       const recovery = index.checkpoints[recoveryRef.id];
-      if (!recovery?.ref.commitId) throw new Error("failed to create recovery checkpoint");
-      // All validation and recovery capture have succeeded. Callers can now
-      // commit related destructive state (for example clearing queued tasks)
-      // without risking a predictable checkpoint failure afterwards.
-      await onPrepared?.();
+      if (!recovery?.ref.commitId || !recovery.treeId) throw new Error("failed to create recovery checkpoint");
+      const recoveryTree: TreeSnapshot = {
+        treeId: recovery.treeId,
+        files: await this.treeFiles(recovery.treeId),
+        skipped: recovery.skipped,
+      };
+      let preparedTarget: PreparedTree | undefined;
+      let preparedRecovery: PreparedTree | undefined;
       try {
-        await this.applyTree(plan.target, plan.current);
+        // Materialize both directions before touching the workspace. Missing
+        // or corrupt Git objects therefore cannot consume queued work or leave
+        // a half-applied target without a ready recovery tree.
+        preparedTarget = await this.prepareTree(plan.target);
+        preparedRecovery = await this.prepareTree(recoveryTree);
+        await this.applyPreparedTree(plan.target, plan.current, preparedTarget);
         const baseline = await this.captureUnlocked("system", "baseline");
         if (!baseline.commitId) throw new Error(baseline.error ?? "failed to create post-restore baseline");
+        // The workspace and its new baseline are now committed. Only at this
+        // point may the caller durably cancel work from the old workspace.
+        await onCommitted?.();
       } catch (error) {
         const failedState = await this.buildTree().catch(() => plan.current);
-        await this.applyRecord(recovery, failedState).catch(() => undefined);
+        try {
+          preparedRecovery ??= await this.prepareTree(recoveryTree);
+          await this.applyPreparedTree(recoveryTree, failedState, preparedRecovery);
+          await this.setHeadCheckpoint(recoveryRef.id);
+        } catch (recoveryError) {
+          const fatal = new Error(`workspace restore failed and automatic recovery failed: ${errorText(recoveryError)}`);
+          (fatal as Error & { code?: string; cause?: unknown }).code = "WORKSPACE_RECOVERY_FAILED";
+          (fatal as Error & { cause?: unknown }).cause = error;
+          throw fatal;
+        }
         throw error;
+      } finally {
+        await Promise.all([preparedTarget, preparedRecovery]
+          .filter((tree): tree is PreparedTree => Boolean(tree))
+          .map((tree) => rm(tree.tempDir, { recursive: true, force: true })));
       }
     });
   }
@@ -697,54 +726,58 @@ export class WorkspaceCheckpointStore {
     });
   }
 
-  private async materializeTree(treeish: string): Promise<string> {
+  private async prepareTree(tree: TreeSnapshot): Promise<PreparedTree> {
     const temp = await mkdtemp(join(tmpdir(), `bp-restore-${this.sessionId}-`));
     const indexFile = join(temp, "index");
     const outputDir = join(temp, "tree");
-    await mkdir(outputDir);
-    await this.runGit(["read-tree", this.gitObject(treeish)], undefined, { GIT_INDEX_FILE: indexFile });
-    await this.runGit(["checkout-index", "-a", `--prefix=${outputDir}/`], undefined, { GIT_INDEX_FILE: indexFile });
-    return temp;
-  }
-
-  private async applyTree(target: TreeSnapshot, current: TreeSnapshot): Promise<void> {
-    const temp = await this.materializeTree(target.treeId);
-    const sourceRoot = join(temp, "tree");
-    const targetFiles = new Set(target.files);
-    const protectedEntries = [...target.skipped, ...current.skipped];
     try {
-      for (const path of current.files) {
-        if (!targetFiles.has(path) && !this.isSkipped(path, protectedEntries)) {
-          await rm(this.workspacePath(path), { force: true, recursive: true });
-        }
-      }
-      for (const path of target.files) {
-        if (this.isSkipped(path, protectedEntries)) continue;
-        const source = join(sourceRoot, path);
-        const destination = this.workspacePath(path);
-        const info = await lstat(source);
-        await mkdir(dirname(destination), { recursive: true });
-        await rm(destination, { force: true, recursive: true });
-        if (info.isSymbolicLink()) await symlink(await readlink(source), destination);
-        else {
-          await copyFile(source, destination);
-          await chmod(destination, info.mode & 0o777);
-        }
-      }
-    } finally {
+      await mkdir(outputDir);
+      await this.runGit(["read-tree", this.gitObject(tree.treeId)], undefined, { GIT_INDEX_FILE: indexFile });
+      await this.runGit(["checkout-index", "-a", `--prefix=${outputDir}/`], undefined, { GIT_INDEX_FILE: indexFile });
+      await Promise.all(tree.files
+        .filter((path) => !this.isSkipped(path, tree.skipped))
+        .map((path) => lstat(join(outputDir, path))));
+      return { tempDir: temp, sourceRoot: outputDir };
+    } catch (error) {
       await rm(temp, { recursive: true, force: true });
+      throw error;
     }
   }
 
-  private async applyRecord(record: CheckpointRecord, current: TreeSnapshot): Promise<void> {
-    if (!record.treeId) throw new Error("checkpoint has no Git tree");
-    await this.applyTree({ treeId: record.treeId, files: await this.treeFiles(record.treeId), skipped: record.skipped }, current);
+  private async applyPreparedTree(target: TreeSnapshot, current: TreeSnapshot, prepared: PreparedTree): Promise<void> {
+    const targetFiles = new Set(target.files);
+    const protectedEntries = [...target.skipped, ...current.skipped];
+    for (const path of current.files) {
+      if (!targetFiles.has(path) && !this.isSkipped(path, protectedEntries)) {
+        await rm(this.workspacePath(path), { force: true, recursive: true });
+      }
+    }
+    for (const path of target.files) {
+      if (this.isSkipped(path, protectedEntries)) continue;
+      const source = join(prepared.sourceRoot, path);
+      const destination = this.workspacePath(path);
+      const info = await lstat(source);
+      await mkdir(dirname(destination), { recursive: true });
+      await rm(destination, { force: true, recursive: true });
+      if (info.isSymbolicLink()) await symlink(await readlink(source), destination);
+      else {
+        await copyFile(source, destination);
+        await chmod(destination, info.mode & 0o777);
+      }
+    }
+  }
+
+  private async setHeadCheckpoint(id: string): Promise<void> {
+    const index = await this.index();
+    if (!index.checkpoints[id]) throw new Error(`checkpoint ${id} disappeared`);
+    index.headCheckpointId = id;
+    await this.saveIndex(index);
   }
 
   restore(
     id: string,
     expectedStateToken: string,
-    onPrepared?: () => Promise<void>,
+    onCommitted?: () => Promise<void>,
   ): Promise<{ restoredCheckpointId: string }> {
     return this.exclusive(async () => {
       const index = await this.index();
@@ -758,16 +791,39 @@ export class WorkspaceCheckpointStore {
       }
       const recoveryRef = await this.captureUnlocked("system", "recovery");
       const recovery = index.checkpoints[recoveryRef.id];
-      if (!recovery?.ref.commitId) throw new Error("failed to create recovery checkpoint");
-      await onPrepared?.();
+      if (!recovery?.ref.commitId || !recovery.treeId) throw new Error("failed to create recovery checkpoint");
+      const targetTree: TreeSnapshot = { treeId: target.treeId, files: await this.treeFiles(target.treeId), skipped: target.skipped };
+      const recoveryTree: TreeSnapshot = {
+        treeId: recovery.treeId,
+        files: await this.treeFiles(recovery.treeId),
+        skipped: recovery.skipped,
+      };
+      let preparedTarget: PreparedTree | undefined;
+      let preparedRecovery: PreparedTree | undefined;
       try {
-        await this.applyRecord(target, current);
+        preparedTarget = await this.prepareTree(targetTree);
+        preparedRecovery = await this.prepareTree(recoveryTree);
+        await this.applyPreparedTree(targetTree, current, preparedTarget);
         const baseline = await this.captureUnlocked("system", "baseline");
         if (!baseline.commitId) throw new Error(baseline.error ?? "failed to create post-restore baseline");
+        await onCommitted?.();
       } catch (error) {
         const failedState = await this.buildTree().catch(() => current);
-        await this.applyRecord(recovery, failedState).catch(() => undefined);
+        try {
+          preparedRecovery ??= await this.prepareTree(recoveryTree);
+          await this.applyPreparedTree(recoveryTree, failedState, preparedRecovery);
+          await this.setHeadCheckpoint(recoveryRef.id);
+        } catch (recoveryError) {
+          const fatal = new Error(`workspace restore failed and automatic recovery failed: ${errorText(recoveryError)}`);
+          (fatal as Error & { code?: string; cause?: unknown }).code = "WORKSPACE_RECOVERY_FAILED";
+          (fatal as Error & { cause?: unknown }).cause = error;
+          throw fatal;
+        }
         throw error;
+      } finally {
+        await Promise.all([preparedTarget, preparedRecovery]
+          .filter((tree): tree is PreparedTree => Boolean(tree))
+          .map((tree) => rm(tree.tempDir, { recursive: true, force: true })));
       }
       return { restoredCheckpointId: id };
     });

--- a/packages/runtime/src/workspace-checkpoints.ts
+++ b/packages/runtime/src/workspace-checkpoints.ts
@@ -38,7 +38,7 @@ interface CheckpointRecord {
   ref: TraceCheckpointRef;
   skipped: Skipped[];
   treeId?: string;
-  kind: "trace" | "recovery";
+  kind: "trace" | "recovery" | "baseline";
 }
 interface CheckpointIndex {
   version: 2;
@@ -227,7 +227,7 @@ export class WorkspaceCheckpointStore {
             ref: record.ref,
             skipped: record.skipped ?? [],
             ...(record.treeId ? { treeId: record.treeId } : {}),
-            kind: record.kind === "recovery" ? "recovery" : "trace",
+            kind: record.kind === "recovery" || record.kind === "baseline" ? record.kind : "trace",
           };
         }
         this.loaded = { version: 2, headCheckpointId: parsed.headCheckpointId, checkpoints };
@@ -449,7 +449,7 @@ export class WorkspaceCheckpointStore {
     });
   }
 
-  private async captureUnlocked(sourceAgent: string | undefined, kind: "trace" | "recovery"): Promise<TraceCheckpointRef> {
+  private async captureUnlocked(sourceAgent: string | undefined, kind: "trace" | "recovery" | "baseline"): Promise<TraceCheckpointRef> {
     const id = `checkpoint_${randomUUID()}`;
     const capturedAt = new Date().toISOString();
     const index = await this.index();
@@ -637,7 +637,7 @@ export class WorkspaceCheckpointStore {
   restoreCausal(
     checkpointIds: string[],
     expectedStateToken: string,
-  ): Promise<{ recoveryCheckpointId: string }> {
+  ): Promise<void> {
     return this.exclusive(async () => {
       const plan = await this.synthesizeCausalTree(checkpointIds);
       if (plan.stateToken !== expectedStateToken) {
@@ -657,12 +657,13 @@ export class WorkspaceCheckpointStore {
       if (!recovery?.ref.commitId) throw new Error("failed to create recovery checkpoint");
       try {
         await this.applyTree(plan.target, plan.current);
+        const baseline = await this.captureUnlocked("system", "baseline");
+        if (!baseline.commitId) throw new Error(baseline.error ?? "failed to create post-restore baseline");
       } catch (error) {
         const failedState = await this.buildTree().catch(() => plan.current);
         await this.applyRecord(recovery, failedState).catch(() => undefined);
         throw error;
       }
-      return { recoveryCheckpointId: recoveryRef.id };
     });
   }
 
@@ -726,7 +727,7 @@ export class WorkspaceCheckpointStore {
     await this.applyTree({ treeId: record.treeId, files: await this.treeFiles(record.treeId), skipped: record.skipped }, current);
   }
 
-  restore(id: string, expectedStateToken: string): Promise<{ restoredCheckpointId: string; recoveryCheckpointId: string }> {
+  restore(id: string, expectedStateToken: string): Promise<{ restoredCheckpointId: string }> {
     return this.exclusive(async () => {
       const index = await this.index();
       const target = index.checkpoints[id];
@@ -742,12 +743,14 @@ export class WorkspaceCheckpointStore {
       if (!recovery?.ref.commitId) throw new Error("failed to create recovery checkpoint");
       try {
         await this.applyRecord(target, current);
+        const baseline = await this.captureUnlocked("system", "baseline");
+        if (!baseline.commitId) throw new Error(baseline.error ?? "failed to create post-restore baseline");
       } catch (error) {
         const failedState = await this.buildTree().catch(() => current);
         await this.applyRecord(recovery, failedState).catch(() => undefined);
         throw error;
       }
-      return { restoredCheckpointId: id, recoveryCheckpointId: recoveryRef.id };
+      return { restoredCheckpointId: id };
     });
   }
 }

--- a/packages/runtime/src/workspace-checkpoints.ts
+++ b/packages/runtime/src/workspace-checkpoints.ts
@@ -453,13 +453,21 @@ export class WorkspaceCheckpointStore {
     const id = `checkpoint_${randomUUID()}`;
     const capturedAt = new Date().toISOString();
     const index = await this.index();
+    const previousHeadCheckpointId = index.headCheckpointId;
     const base = index.headCheckpointId ? index.checkpoints[index.headCheckpointId] : undefined;
     try {
-      const repositoryBytes = await this.repositoryBytes();
-      if (repositoryBytes >= this.maxRepositoryBytes) {
-        throw new Error(`checkpoint repository quota exceeded: ${repositoryBytes} bytes >= ${this.maxRepositoryBytes} bytes`);
+      let repositoryBudgetBytes: number | undefined;
+      if (kind === "trace") {
+        const repositoryBytes = await this.repositoryBytes();
+        if (repositoryBytes >= this.maxRepositoryBytes) {
+          throw new Error(`checkpoint repository quota exceeded: ${repositoryBytes} bytes >= ${this.maxRepositoryBytes} bytes`);
+        }
+        repositoryBudgetBytes = this.maxRepositoryBytes - repositoryBytes;
       }
-      const tree = await this.buildTree(this.maxRepositoryBytes - repositoryBytes);
+      // Recovery and post-restore baseline commits are correctness metadata,
+      // not user history growth. They must remain available even when the
+      // ordinary Trace checkpoint quota has been reached.
+      const tree = await this.buildTree(repositoryBudgetBytes);
       const args = ["commit-tree", tree.treeId];
       if (base?.ref.commitId) args.push("-p", this.gitObject(base.ref.commitId));
       const commitId = (await this.runGit(args, `BrainPilot ${kind} checkpoint ${id}\n`, {
@@ -486,6 +494,7 @@ export class WorkspaceCheckpointStore {
       await this.saveIndex(index);
       return ref;
     } catch (error) {
+      index.headCheckpointId = previousHeadCheckpointId;
       const unavailable = error instanceof Error && /ENOENT|spawn git/.test(error.message);
       const ref: TraceCheckpointRef = {
         id,
@@ -637,6 +646,7 @@ export class WorkspaceCheckpointStore {
   restoreCausal(
     checkpointIds: string[],
     expectedStateToken: string,
+    onPrepared?: () => Promise<void>,
   ): Promise<void> {
     return this.exclusive(async () => {
       const plan = await this.synthesizeCausalTree(checkpointIds);
@@ -655,6 +665,10 @@ export class WorkspaceCheckpointStore {
       const index = await this.index();
       const recovery = index.checkpoints[recoveryRef.id];
       if (!recovery?.ref.commitId) throw new Error("failed to create recovery checkpoint");
+      // All validation and recovery capture have succeeded. Callers can now
+      // commit related destructive state (for example clearing queued tasks)
+      // without risking a predictable checkpoint failure afterwards.
+      await onPrepared?.();
       try {
         await this.applyTree(plan.target, plan.current);
         const baseline = await this.captureUnlocked("system", "baseline");
@@ -727,7 +741,11 @@ export class WorkspaceCheckpointStore {
     await this.applyTree({ treeId: record.treeId, files: await this.treeFiles(record.treeId), skipped: record.skipped }, current);
   }
 
-  restore(id: string, expectedStateToken: string): Promise<{ restoredCheckpointId: string }> {
+  restore(
+    id: string,
+    expectedStateToken: string,
+    onPrepared?: () => Promise<void>,
+  ): Promise<{ restoredCheckpointId: string }> {
     return this.exclusive(async () => {
       const index = await this.index();
       const target = index.checkpoints[id];
@@ -741,6 +759,7 @@ export class WorkspaceCheckpointStore {
       const recoveryRef = await this.captureUnlocked("system", "recovery");
       const recovery = index.checkpoints[recoveryRef.id];
       if (!recovery?.ref.commitId) throw new Error("failed to create recovery checkpoint");
+      await onPrepared?.();
       try {
         await this.applyRecord(target, current);
         const baseline = await this.captureUnlocked("system", "baseline");

--- a/packages/runtime/src/workspace-checkpoints.ts
+++ b/packages/runtime/src/workspace-checkpoints.ts
@@ -1,0 +1,753 @@
+import { spawn } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  chmod,
+  copyFile,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readlink,
+  rename,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { dirname, join, posix, resolve, sep } from "node:path";
+import { tmpdir } from "node:os";
+import type {
+  TraceCausalRollbackConflict,
+  TraceCheckpointDetail,
+  TraceCheckpointFileChange,
+  TraceCheckpointRef,
+  TraceCheckpointSkippedFile,
+  TraceRestorePreview,
+} from "@brainpilot/protocol";
+
+const MAX_FILE_BYTES = 10 * 1024 * 1024;
+const MAX_SNAPSHOT_BYTES = 200 * 1024 * 1024;
+const MAX_DIFF_BYTES = 1024 * 1024;
+const DEFAULT_GIT_TIMEOUT_MS = 30_000;
+const DEFAULT_MAX_REPOSITORY_BYTES = 2 * 1024 * 1024 * 1024;
+const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
+const HARD_EXCLUDED_ROOTS = new Set([".attachments", ".truncated"]);
+
+type Skipped = TraceCheckpointSkippedFile;
+
+interface CheckpointRecord {
+  ref: TraceCheckpointRef;
+  skipped: Skipped[];
+  treeId?: string;
+  kind: "trace" | "recovery";
+}
+interface CheckpointIndex {
+  version: 2;
+  headCheckpointId?: string;
+  checkpoints: Record<string, CheckpointRecord>;
+}
+
+interface TreeSnapshot {
+  treeId: string;
+  files: string[];
+  skipped: Skipped[];
+}
+
+export interface CheckpointFileProvenance extends TraceCheckpointFileChange {
+  baseBlobId?: string;
+  resultBlobId?: string;
+}
+
+export interface CausalWorkspacePreview {
+  stateToken: string;
+  files: TraceCheckpointFileChange[];
+  skipped: Skipped[];
+  conflicts: TraceCausalRollbackConflict[];
+}
+
+interface CausalTreeResult extends CausalWorkspacePreview {
+  current: TreeSnapshot;
+  target?: TreeSnapshot;
+}
+
+interface RunResult {
+  stdout: Buffer;
+  stderr: Buffer;
+  truncated?: boolean;
+}
+
+export interface WorkspaceCheckpointOptions {
+  gitTimeoutMs?: number;
+  maxRepositoryBytes?: number;
+}
+
+function safeRelativePath(value: string): string | null {
+  if (value.includes("\0")) return null;
+  const normalized = posix.normalize(value.replaceAll("\\", "/"));
+  if (!normalized || normalized === "." || normalized.startsWith("/") || normalized === ".." || normalized.startsWith("../")) {
+    return null;
+  }
+  return normalized;
+}
+
+function errorText(error: unknown): string {
+  const text = error instanceof Error ? error.message : String(error);
+  return text.slice(0, 500);
+}
+
+/**
+ * Per-session, Git-backed workspace snapshots. The git dir lives under .bp and
+ * is never placed in, nor inferred from, the user's workspace.
+ */
+export class WorkspaceCheckpointStore {
+  private chain: Promise<unknown> = Promise.resolve();
+  private loaded?: CheckpointIndex;
+
+  constructor(
+    private readonly sessionId: string,
+    private readonly workspaceDir: string,
+    private readonly stateDir: string,
+    options: WorkspaceCheckpointOptions = {},
+  ) {
+    this.gitTimeoutMs = Math.max(1, Math.trunc(options.gitTimeoutMs ?? DEFAULT_GIT_TIMEOUT_MS));
+    this.maxRepositoryBytes = Math.max(1, Math.trunc(options.maxRepositoryBytes ?? DEFAULT_MAX_REPOSITORY_BYTES));
+  }
+
+  private readonly gitTimeoutMs: number;
+  private readonly maxRepositoryBytes: number;
+
+  private get gitDir(): string {
+    return join(this.stateDir, "workspace-checkpoints.git");
+  }
+
+  private get indexPath(): string {
+    return join(this.stateDir, "workspace-checkpoints.json");
+  }
+
+  private exclusive<T>(fn: () => Promise<T>): Promise<T> {
+    const next = this.chain.then(fn, fn);
+    this.chain = next.then(() => undefined, () => undefined);
+    return next;
+  }
+
+  private async runGit(
+    args: string[],
+    input?: Buffer | string,
+    extraEnv?: Record<string, string>,
+    maxStdoutBytes?: number,
+  ): Promise<RunResult> {
+    return new Promise((resolvePromise, reject) => {
+      const child = spawn("git", args, {
+        cwd: this.workspaceDir,
+        env: {
+          ...process.env,
+          GIT_DIR: this.gitDir,
+          GIT_WORK_TREE: this.workspaceDir,
+          GIT_CONFIG_NOSYSTEM: "1",
+          GIT_CONFIG_GLOBAL: process.platform === "win32" ? "NUL" : "/dev/null",
+          GIT_CONFIG_COUNT: "0",
+          ...extraEnv,
+        },
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      const stdout: Buffer[] = [];
+      const stderr: Buffer[] = [];
+      let stdoutBytes = 0;
+      let truncated = false;
+      const timer = setTimeout(() => {
+        child.kill("SIGKILL");
+        reject(new Error(`git ${args[0] ?? "command"} timed out after ${this.gitTimeoutMs} ms`));
+      }, this.gitTimeoutMs);
+      child.stdout.on("data", (chunk: Buffer) => {
+        const remaining = maxStdoutBytes === undefined ? chunk.byteLength : Math.max(0, maxStdoutBytes - stdoutBytes);
+        if (remaining > 0) {
+          const kept = chunk.byteLength > remaining ? chunk.subarray(0, remaining) : chunk;
+          stdout.push(kept);
+          stdoutBytes += kept.byteLength;
+        }
+        if (maxStdoutBytes !== undefined && chunk.byteLength > remaining) truncated = true;
+      });
+      child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+      child.on("error", (error) => {
+        clearTimeout(timer);
+        reject(error);
+      });
+      child.on("close", (code) => {
+        clearTimeout(timer);
+        const result = { stdout: Buffer.concat(stdout), stderr: Buffer.concat(stderr), truncated };
+        if (code === 0) resolvePromise(result);
+        else reject(new Error(`git ${args[0] ?? "command"} failed (${code}): ${result.stderr.toString("utf8").trim()}`));
+      });
+      if (input !== undefined) child.stdin.end(input);
+      else child.stdin.end();
+    });
+  }
+
+  private async ensureRepo(): Promise<void> {
+    await mkdir(this.workspaceDir, { recursive: true });
+    await mkdir(this.stateDir, { recursive: true });
+    try {
+      await lstat(join(this.gitDir, "HEAD"));
+    } catch {
+      await new Promise<void>((resolvePromise, reject) => {
+        const child = spawn("git", ["init", "--bare", this.gitDir], { stdio: ["ignore", "pipe", "pipe"] });
+        const stderr: Buffer[] = [];
+        const timer = setTimeout(() => {
+          child.kill("SIGKILL");
+          reject(new Error(`git init timed out after ${this.gitTimeoutMs} ms`));
+        }, this.gitTimeoutMs);
+        child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+        child.on("error", (error) => {
+          clearTimeout(timer);
+          reject(error);
+        });
+        child.on("close", (code) => {
+          clearTimeout(timer);
+          if (code === 0) resolvePromise();
+          else reject(new Error(`git init failed (${code}): ${Buffer.concat(stderr).toString("utf8")}`));
+        });
+      });
+    }
+  }
+
+  private async index(): Promise<CheckpointIndex> {
+    if (this.loaded) return this.loaded;
+    try {
+      const parsed = JSON.parse(await readFile(this.indexPath, "utf8")) as {
+        version?: number;
+        headCheckpointId?: string;
+        checkpoints?: Record<string, CheckpointRecord & { files?: string[] }>;
+      };
+      if ((parsed.version === 1 || parsed.version === 2) && parsed.checkpoints) {
+        // V1 duplicated the complete file list in every record. Tree contents
+        // are already authoritative in Git, so migrate that redundant field
+        // away in memory and on the next ordinary index write.
+        const checkpoints: Record<string, CheckpointRecord> = {};
+        for (const [id, record] of Object.entries(parsed.checkpoints)) {
+          checkpoints[id] = {
+            ref: record.ref,
+            skipped: record.skipped ?? [],
+            ...(record.treeId ? { treeId: record.treeId } : {}),
+            kind: record.kind === "recovery" ? "recovery" : "trace",
+          };
+        }
+        this.loaded = { version: 2, headCheckpointId: parsed.headCheckpointId, checkpoints };
+      }
+    } catch {
+      // First use or a corrupt optional index. Start clean; trace recording must continue.
+    }
+    this.loaded ??= { version: 2, checkpoints: {} };
+    return this.loaded;
+  }
+
+  private async saveIndex(index: CheckpointIndex): Promise<void> {
+    await mkdir(dirname(this.indexPath), { recursive: true });
+    const temp = `${this.indexPath}.${randomUUID()}.tmp`;
+    await writeFile(temp, JSON.stringify(index, null, 2), "utf8");
+    await rename(temp, this.indexPath);
+  }
+
+  private async repositoryBytes(): Promise<number> {
+    await this.ensureRepo();
+    const output = (await this.runGit(["count-objects", "-v"])).stdout.toString("utf8");
+    const values = new Map(output.split("\n").flatMap((line) => {
+      const separator = line.indexOf(":");
+      if (separator < 0) return [];
+      const value = Number(line.slice(separator + 1).trim());
+      return Number.isFinite(value) ? [[line.slice(0, separator), value] as const] : [];
+    }));
+    return ((values.get("size") ?? 0) + (values.get("size-pack") ?? 0) + (values.get("size-garbage") ?? 0)) * 1024;
+  }
+
+  private hardExcluded(path: string): boolean {
+    const parts = path.replace(/\/$/, "").split("/");
+    return parts.includes(".git") || HARD_EXCLUDED_ROOTS.has(parts[0] ?? "");
+  }
+
+  private workspacePath(rawPath: string): string {
+    const path = safeRelativePath(rawPath);
+    if (!path) throw new Error("invalid checkpoint path");
+    const root = resolve(this.workspaceDir);
+    const absolute = resolve(root, path);
+    if (absolute !== root && !absolute.startsWith(`${root}${sep}`)) throw new Error("checkpoint path escapes workspace");
+    return absolute;
+  }
+
+  private gitObject(value: string): string {
+    if (!/^[a-f0-9]{40,64}$/i.test(value)) throw new Error("invalid checkpoint Git object id");
+    return value;
+  }
+
+  private async workspaceFiles(): Promise<{ candidates: Array<{ path: string; size: number }>; skipped: Skipped[] }> {
+    // Let Git apply all nested .gitignore rules and collapse fully ignored
+    // directories (node_modules, datasets, etc.) to one skipped entry. This
+    // avoids walking millions of ignored files merely to discover they are out
+    // of scope.
+    const eligibleOutput = await this.runGit(["ls-files", "--others", "--exclude-standard", "-z"]);
+    const ignoredOutput = await this.runGit([
+      "ls-files", "--others", "--ignored", "--exclude-standard",
+      "--directory", "--no-empty-directory", "-z",
+    ]);
+    const eligible = eligibleOutput.stdout.toString("utf8").split("\0").filter(Boolean).sort();
+    const ignored = ignoredOutput.stdout.toString("utf8").split("\0").filter(Boolean).sort();
+    const skipped: Skipped[] = ignored.map((path) => ({ path, reason: "ignored" }));
+    const candidates: Array<{ path: string; size: number }> = [];
+    for (const path of eligible) {
+      if (this.hardExcluded(path)) {
+        skipped.push({ path, reason: "internal" });
+        continue;
+      }
+      try {
+        const info = await lstat(this.workspacePath(path));
+        if (!info.isFile() && !info.isSymbolicLink()) {
+          skipped.push({ path, reason: "unsupported" });
+          continue;
+        }
+        candidates.push({ path, size: info.isSymbolicLink() ? 0 : info.size });
+      } catch {
+        skipped.push({ path, reason: "unsupported" });
+      }
+    }
+    for (const root of HARD_EXCLUDED_ROOTS) {
+      try {
+        await lstat(join(this.workspaceDir, root));
+        if (!skipped.some((item) => item.path === root || item.path === `${root}/`)) {
+          skipped.push({ path: `${root}/`, reason: "internal" });
+        }
+      } catch {
+        // Absent internal directories are not reported.
+      }
+    }
+    return { candidates, skipped };
+  }
+
+  private async buildTree(repositoryBudgetBytes?: number): Promise<TreeSnapshot> {
+    await this.ensureRepo();
+    const { candidates, skipped } = await this.workspaceFiles();
+    const selected: string[] = [];
+    let total = 0;
+    for (const item of candidates) {
+      if (item.size > MAX_FILE_BYTES) {
+        skipped.push({ path: item.path, reason: "too_large", size: item.size });
+      } else if (total + item.size > MAX_SNAPSHOT_BYTES) {
+        skipped.push({ path: item.path, reason: "total_limit", size: item.size });
+      } else {
+        selected.push(item.path);
+        total += item.size;
+      }
+    }
+    if (repositoryBudgetBytes !== undefined && total > repositoryBudgetBytes) {
+      throw new Error(`checkpoint repository quota exceeded: snapshot needs up to ${total} bytes with ${repositoryBudgetBytes} bytes remaining`);
+    }
+
+    const temp = await mkdtemp(join(tmpdir(), `bp-checkpoint-${this.sessionId}-`));
+    const indexFile = join(temp, "index");
+    const env = { GIT_INDEX_FILE: indexFile };
+    try {
+      await this.runGit(["read-tree", "--empty"], undefined, env);
+      if (selected.length > 0) {
+        await this.runGit(
+          ["add", "--all", "--pathspec-from-file=-", "--pathspec-file-nul"],
+          Buffer.from(`${selected.join("\0")}\0`),
+          env,
+        );
+      }
+      const treeId = (await this.runGit(["write-tree"], undefined, env)).stdout.toString("utf8").trim();
+      return { treeId, files: selected, skipped: skipped.sort((a, b) => a.path.localeCompare(b.path)) };
+    } finally {
+      await rm(temp, { recursive: true, force: true });
+    }
+  }
+
+  private async changesBetween(from: string, to: string): Promise<TraceCheckpointFileChange[]> {
+    from = this.gitObject(from);
+    to = this.gitObject(to);
+    const output = (await this.runGit(["diff", "--name-status", "-z", "--find-renames", from, to])).stdout;
+    const tokens = output.toString("utf8").split("\0").filter(Boolean);
+    const changes: TraceCheckpointFileChange[] = [];
+    for (let i = 0; i < tokens.length;) {
+      const code = tokens[i++]!;
+      if (code.startsWith("R")) {
+        const previousPath = tokens[i++]!;
+        const path = tokens[i++]!;
+        changes.push({ path, previousPath, status: "renamed", binary: false });
+      } else {
+        const path = tokens[i++]!;
+        const status = code[0] === "A" ? "added" : code[0] === "D" ? "deleted" : "modified";
+        changes.push({ path, status, binary: false });
+      }
+    }
+
+    const numstat = (await this.runGit(["diff", "--numstat", "-z", from, to])).stdout.toString("utf8");
+    for (const row of numstat.split("\0").filter(Boolean)) {
+      const [a, d, ...rest] = row.split("\t");
+      const path = rest.join("\t");
+      const match = changes.find((item) => item.path === path);
+      if (!match) continue;
+      if (a === "-" || d === "-") match.binary = true;
+      else {
+        match.additions = Number(a);
+        match.deletions = Number(d);
+      }
+    }
+    return changes;
+  }
+
+  private async treeFiles(treeId: string): Promise<string[]> {
+    const output = await this.runGit(["ls-tree", "-r", "--name-only", "-z", this.gitObject(treeId)]);
+    return output.stdout.toString("utf8").split("\0").filter(Boolean).sort();
+  }
+
+  private async blobAt(treeish: string, rawPath: string): Promise<string | undefined> {
+    const path = safeRelativePath(rawPath);
+    if (!path) return undefined;
+    const output = await this.runGit(["ls-tree", "-z", this.gitObject(treeish), "--", path]);
+    const row = output.stdout.toString("utf8").split("\0").find(Boolean);
+    if (!row) return undefined;
+    const header = row.slice(0, row.indexOf("\t"));
+    const objectId = header.split(" ")[2];
+    return objectId && /^[a-f0-9]{40,64}$/i.test(objectId) ? objectId : undefined;
+  }
+
+  /** File-level Git evidence for binding one checkpoint to its GoT node. */
+  async provenance(id: string): Promise<CheckpointFileProvenance[] | undefined> {
+    const index = await this.index();
+    const record = index.checkpoints[id];
+    if (!record?.ref.commitId) return undefined;
+    const base = record.ref.baseCheckpointId
+      ? index.checkpoints[record.ref.baseCheckpointId]?.ref.commitId ?? EMPTY_TREE
+      : EMPTY_TREE;
+    const changes = (await this.changesBetween(base, record.ref.commitId))
+      .filter((item) => !this.isSkipped(item.path, record.skipped));
+    return Promise.all(changes.map(async (change) => {
+      const basePath = change.previousPath ?? change.path;
+      const [baseBlobId, resultBlobId] = await Promise.all([
+        this.blobAt(base, basePath),
+        this.blobAt(record.ref.commitId!, change.path),
+      ]);
+      return {
+        ...change,
+        ...(baseBlobId ? { baseBlobId } : {}),
+        ...(resultBlobId ? { resultBlobId } : {}),
+      };
+    }));
+  }
+
+  private stats(changes: TraceCheckpointFileChange[]) {
+    return {
+      files: changes.length,
+      added: changes.filter((item) => item.status === "added").length,
+      modified: changes.filter((item) => item.status === "modified").length,
+      deleted: changes.filter((item) => item.status === "deleted").length,
+      renamed: changes.filter((item) => item.status === "renamed").length,
+    };
+  }
+
+  private isSkipped(path: string, skipped: Skipped[]): boolean {
+    return skipped.some((item) => {
+      const skippedPath = item.path.replaceAll("\\", "/");
+      return path === skippedPath || (skippedPath.endsWith("/") && path.startsWith(skippedPath));
+    });
+  }
+
+  private async captureUnlocked(sourceAgent: string | undefined, kind: "trace" | "recovery"): Promise<TraceCheckpointRef> {
+    const id = `checkpoint_${randomUUID()}`;
+    const capturedAt = new Date().toISOString();
+    const index = await this.index();
+    const base = index.headCheckpointId ? index.checkpoints[index.headCheckpointId] : undefined;
+    try {
+      const repositoryBytes = await this.repositoryBytes();
+      if (repositoryBytes >= this.maxRepositoryBytes) {
+        throw new Error(`checkpoint repository quota exceeded: ${repositoryBytes} bytes >= ${this.maxRepositoryBytes} bytes`);
+      }
+      const tree = await this.buildTree(this.maxRepositoryBytes - repositoryBytes);
+      const args = ["commit-tree", tree.treeId];
+      if (base?.ref.commitId) args.push("-p", this.gitObject(base.ref.commitId));
+      const commitId = (await this.runGit(args, `BrainPilot ${kind} checkpoint ${id}\n`, {
+        GIT_AUTHOR_NAME: "BrainPilot",
+        GIT_AUTHOR_EMAIL: "checkpoint@brainpilot.local",
+        GIT_COMMITTER_NAME: "BrainPilot",
+        GIT_COMMITTER_EMAIL: "checkpoint@brainpilot.local",
+      })).stdout.toString("utf8").trim();
+      await this.runGit(["update-ref", `refs/brainpilot/checkpoints/${id}`, commitId]);
+      const changes = (await this.changesBetween(base?.ref.commitId ?? EMPTY_TREE, commitId))
+        .filter((item) => !this.isSkipped(item.path, tree.skipped));
+      const ref: TraceCheckpointRef = {
+        id,
+        commitId,
+        status: tree.skipped.length > 0 ? "partial" : "ready",
+        capturedAt,
+        sourceAgent,
+        baseCheckpointId: base?.ref.id,
+        stats: this.stats(changes),
+        skippedCount: tree.skipped.length,
+      };
+      index.checkpoints[id] = { ref, skipped: tree.skipped, treeId: tree.treeId, kind };
+      index.headCheckpointId = id;
+      await this.saveIndex(index);
+      return ref;
+    } catch (error) {
+      const unavailable = error instanceof Error && /ENOENT|spawn git/.test(error.message);
+      const ref: TraceCheckpointRef = {
+        id,
+        status: unavailable ? "unavailable" : "failed",
+        capturedAt,
+        sourceAgent,
+        skippedCount: 0,
+        error: errorText(error),
+      };
+      index.checkpoints[id] = { ref, skipped: [], kind };
+      await this.saveIndex(index).catch(() => undefined);
+      return ref;
+    }
+  }
+
+  capture(sourceAgent?: string, kind: "trace" | "recovery" = "trace"): Promise<TraceCheckpointRef> {
+    return this.exclusive(() => this.captureUnlocked(sourceAgent, kind));
+  }
+
+  async refs(ids: string[]): Promise<TraceCheckpointRef[]> {
+    const index = await this.index();
+    return ids.map((id) => index.checkpoints[id]?.ref).filter((item): item is TraceCheckpointRef => Boolean(item));
+  }
+
+  async detail(id: string): Promise<TraceCheckpointDetail | undefined> {
+    const index = await this.index();
+    const record = index.checkpoints[id];
+    if (!record) return undefined;
+    const files = record.ref.commitId
+      ? await this.changesBetween(
+          record.ref.baseCheckpointId ? index.checkpoints[record.ref.baseCheckpointId]?.ref.commitId ?? EMPTY_TREE : EMPTY_TREE,
+          record.ref.commitId,
+        )
+      : [];
+    return { checkpoint: record.ref, files: files.filter((item) => !this.isSkipped(item.path, record.skipped)), skipped: record.skipped };
+  }
+
+  async diff(id: string, rawPath: string): Promise<string | undefined> {
+    const path = safeRelativePath(rawPath);
+    if (!path) throw new Error("invalid checkpoint diff path");
+    const index = await this.index();
+    const record = index.checkpoints[id];
+    if (!record?.ref.commitId) return undefined;
+    const base = record.ref.baseCheckpointId ? index.checkpoints[record.ref.baseCheckpointId]?.ref.commitId ?? EMPTY_TREE : EMPTY_TREE;
+    const result = await this.runGit(
+      ["diff", "--no-color", "--no-ext-diff", "--unified=3", this.gitObject(base), this.gitObject(record.ref.commitId), "--", path],
+      undefined,
+      undefined,
+      MAX_DIFF_BYTES,
+    );
+    return `${result.stdout.toString("utf8")}${result.truncated ? `\n\n[diff truncated at ${MAX_DIFF_BYTES} bytes]\n` : ""}`;
+  }
+
+  private stateToken(tree: TreeSnapshot): string {
+    return createHash("sha256")
+      .update(tree.treeId)
+      .update("\0")
+      .update(tree.files.join("\0"))
+      .update("\0")
+      .update(tree.skipped.map((item) => `${item.path}:${item.reason}:${item.size ?? ""}`).join("\0"))
+      .digest("hex");
+  }
+
+  private causalStateToken(tree: TreeSnapshot, checkpointIds: string[]): string {
+    return createHash("sha256")
+      .update(this.stateToken(tree))
+      .update("\0causal\0")
+      .update([...checkpointIds].sort().join("\0"))
+      .digest("hex");
+  }
+
+  private async synthesizeCausalTree(checkpointIds: string[]): Promise<CausalTreeResult> {
+    const index = await this.index();
+    const records = checkpointIds
+      .map((id) => index.checkpoints[id])
+      .filter((record): record is CheckpointRecord => Boolean(record?.ref.commitId && record.treeId))
+      .sort((a, b) => {
+        const byTime = b.ref.capturedAt.localeCompare(a.ref.capturedAt);
+        return byTime || b.ref.id.localeCompare(a.ref.id);
+      });
+    const orderedIds = records.map((record) => record.ref.id);
+    const current = await this.buildTree();
+    const stateToken = this.causalStateToken(current, orderedIds);
+    const skippedByKey = new Map<string, Skipped>();
+    for (const item of [...current.skipped, ...records.flatMap((record) => record.skipped)]) {
+      skippedByKey.set(`${item.reason}:${item.path}`, item);
+    }
+    const skipped = [...skippedByKey.values()].sort((a, b) => a.path.localeCompare(b.path));
+    if (records.length === 0) {
+      return { current, target: current, stateToken, files: [], skipped, conflicts: [] };
+    }
+
+    const temp = await mkdtemp(join(tmpdir(), `bp-causal-${this.sessionId}-`));
+    const indexFile = join(temp, "index");
+    const env = { GIT_INDEX_FILE: indexFile };
+    const conflicts: TraceCausalRollbackConflict[] = [];
+    try {
+      await this.runGit(["read-tree", this.gitObject(current.treeId)], undefined, env);
+      for (const record of records) {
+        const commitId = this.gitObject(record.ref.commitId!);
+        const baseCommit = record.ref.baseCheckpointId
+          ? index.checkpoints[record.ref.baseCheckpointId]?.ref.commitId ?? EMPTY_TREE
+          : EMPTY_TREE;
+        const patch = (await this.runGit([
+          "diff", "--binary", "--full-index", this.gitObject(baseCommit), commitId,
+        ])).stdout;
+        if (patch.length === 0) continue;
+        try {
+          await this.runGit(
+            ["apply", "--reverse", "--3way", "--cached", "--whitespace=nowarn"],
+            patch,
+            env,
+          );
+        } catch (error) {
+          const unmerged = await this.runGit(["ls-files", "-u", "-z"], undefined, env).catch(() => undefined);
+          const unmergedPaths = unmerged?.stdout.toString("utf8").split("\0").filter(Boolean).map((row) => row.slice(row.indexOf("\t") + 1)) ?? [];
+          const fallback = (await this.changesBetween(baseCommit, commitId)).flatMap((change) => [change.previousPath, change.path].filter((path): path is string => Boolean(path)));
+          for (const path of [...new Set(unmergedPaths.length ? unmergedPaths : fallback)]) {
+            conflicts.push({ path, checkpointIds: [record.ref.id], reason: errorText(error) });
+          }
+          break;
+        }
+      }
+      if (conflicts.length > 0) {
+        return { current, stateToken, files: [], skipped, conflicts };
+      }
+      const treeId = (await this.runGit(["write-tree"], undefined, env)).stdout.toString("utf8").trim();
+      const target: TreeSnapshot = { treeId, files: await this.treeFiles(treeId), skipped };
+      const files = (await this.changesBetween(current.treeId, treeId))
+        .filter((item) => !this.isSkipped(item.path, skipped));
+      return { current, target, stateToken, files, skipped, conflicts: [] };
+    } finally {
+      await rm(temp, { recursive: true, force: true });
+    }
+  }
+
+  previewCausal(checkpointIds: string[]): Promise<CausalWorkspacePreview> {
+    return this.exclusive(async () => {
+      const result = await this.synthesizeCausalTree(checkpointIds);
+      return {
+        stateToken: result.stateToken,
+        files: result.files,
+        skipped: result.skipped,
+        conflicts: result.conflicts,
+      };
+    });
+  }
+
+  restoreCausal(
+    checkpointIds: string[],
+    expectedStateToken: string,
+  ): Promise<{ recoveryCheckpointId: string }> {
+    return this.exclusive(async () => {
+      const plan = await this.synthesizeCausalTree(checkpointIds);
+      if (plan.stateToken !== expectedStateToken) {
+        const error = new Error("workspace or causal rollback scope changed after preview");
+        (error as Error & { code?: string }).code = "STALE_WORKSPACE";
+        throw error;
+      }
+      if (plan.conflicts.length > 0 || !plan.target) {
+        const error = new Error("causal rollback has file conflicts; resolve or change the rollback scope");
+        (error as Error & { code?: string; conflicts?: TraceCausalRollbackConflict[] }).code = "CAUSAL_CONFLICT";
+        (error as Error & { conflicts?: TraceCausalRollbackConflict[] }).conflicts = plan.conflicts;
+        throw error;
+      }
+      const recoveryRef = await this.captureUnlocked("system", "recovery");
+      const index = await this.index();
+      const recovery = index.checkpoints[recoveryRef.id];
+      if (!recovery?.ref.commitId) throw new Error("failed to create recovery checkpoint");
+      try {
+        await this.applyTree(plan.target, plan.current);
+      } catch (error) {
+        const failedState = await this.buildTree().catch(() => plan.current);
+        await this.applyRecord(recovery, failedState).catch(() => undefined);
+        throw error;
+      }
+      return { recoveryCheckpointId: recoveryRef.id };
+    });
+  }
+
+  preview(id: string): Promise<TraceRestorePreview | undefined> {
+    return this.exclusive(async () => {
+      const index = await this.index();
+      const target = index.checkpoints[id];
+      if (!target?.ref.commitId || !target.treeId) return undefined;
+      const current = await this.buildTree();
+      const files = await this.changesBetween(current.treeId, target.treeId);
+      return {
+        checkpointId: id,
+        stateToken: this.stateToken(current),
+        files: files.filter((item) => !this.isSkipped(item.path, [...target.skipped, ...current.skipped])),
+        skipped: target.skipped,
+      };
+    });
+  }
+
+  private async materializeTree(treeish: string): Promise<string> {
+    const temp = await mkdtemp(join(tmpdir(), `bp-restore-${this.sessionId}-`));
+    const indexFile = join(temp, "index");
+    const outputDir = join(temp, "tree");
+    await mkdir(outputDir);
+    await this.runGit(["read-tree", this.gitObject(treeish)], undefined, { GIT_INDEX_FILE: indexFile });
+    await this.runGit(["checkout-index", "-a", `--prefix=${outputDir}/`], undefined, { GIT_INDEX_FILE: indexFile });
+    return temp;
+  }
+
+  private async applyTree(target: TreeSnapshot, current: TreeSnapshot): Promise<void> {
+    const temp = await this.materializeTree(target.treeId);
+    const sourceRoot = join(temp, "tree");
+    const targetFiles = new Set(target.files);
+    const protectedEntries = [...target.skipped, ...current.skipped];
+    try {
+      for (const path of current.files) {
+        if (!targetFiles.has(path) && !this.isSkipped(path, protectedEntries)) {
+          await rm(this.workspacePath(path), { force: true, recursive: true });
+        }
+      }
+      for (const path of target.files) {
+        if (this.isSkipped(path, protectedEntries)) continue;
+        const source = join(sourceRoot, path);
+        const destination = this.workspacePath(path);
+        const info = await lstat(source);
+        await mkdir(dirname(destination), { recursive: true });
+        await rm(destination, { force: true, recursive: true });
+        if (info.isSymbolicLink()) await symlink(await readlink(source), destination);
+        else {
+          await copyFile(source, destination);
+          await chmod(destination, info.mode & 0o777);
+        }
+      }
+    } finally {
+      await rm(temp, { recursive: true, force: true });
+    }
+  }
+
+  private async applyRecord(record: CheckpointRecord, current: TreeSnapshot): Promise<void> {
+    if (!record.treeId) throw new Error("checkpoint has no Git tree");
+    await this.applyTree({ treeId: record.treeId, files: await this.treeFiles(record.treeId), skipped: record.skipped }, current);
+  }
+
+  restore(id: string, expectedStateToken: string): Promise<{ restoredCheckpointId: string; recoveryCheckpointId: string }> {
+    return this.exclusive(async () => {
+      const index = await this.index();
+      const target = index.checkpoints[id];
+      if (!target?.ref.commitId || !target.treeId) throw new Error("checkpoint is not restorable");
+      const current = await this.buildTree();
+      if (this.stateToken(current) !== expectedStateToken) {
+        const error = new Error("workspace changed after restore preview");
+        (error as Error & { code?: string }).code = "STALE_WORKSPACE";
+        throw error;
+      }
+      const recoveryRef = await this.captureUnlocked("system", "recovery");
+      const recovery = index.checkpoints[recoveryRef.id];
+      if (!recovery?.ref.commitId) throw new Error("failed to create recovery checkpoint");
+      try {
+        await this.applyRecord(target, current);
+      } catch (error) {
+        const failedState = await this.buildTree().catch(() => current);
+        await this.applyRecord(recovery, failedState).catch(() => undefined);
+        throw error;
+      }
+      return { restoredCheckpointId: id, recoveryCheckpointId: recoveryRef.id };
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Adds the checkpoint and irreversible restore layer on top of GoT v2.

- captures per-session Git-backed workspace snapshots when record_trace runs
- attaches checkpoint and file provenance to Trace nodes
- provides bounded diff, restore preview, restore, causal rollback preview, and causal rollback APIs
- rolls back only Auditor-confirmed causal descendants
- blocks restore while agents, tools, user input, or delivery loops are active
- materializes and validates both target and recovery trees before changing workspace files
- applies the target and creates its post-restore baseline before cancelling pending tasks and clearing the delivery list
- restores the original workspace and preserves queued work if target application, baseline creation, or queue persistence fails
- keeps a session locked if both the restore and automatic recovery fail, so old work cannot run against an uncertain workspace
- uses internal recovery checkpoints only for transaction recovery
- adds Git to the shared runtime baseline used by the default CPU sandbox

## Restore semantics

Restore and causal rollback are intentionally irreversible after success. Completed task history remains available; pending tasks are then cancelled and all queued notifications are cleared. A failed restore preserves the old workspace and queue whenever automatic recovery succeeds. Recovery checkpoint IDs are not exposed and no Undo operation is provided.

## Deliberately excluded

- Web UI
- Undo
- Principal GoT context injection
- plugins, subagents, and neuroscience preview changes

## Validation

- typecheck passed
- full runtime suite passed: 51 files / 508 tests
- focused checkpoint and TaskLedger suite passed: 21 tests
- regressions cover corrupt target materialization, callback persistence failure, automatic recovery, quota-saturated restore, conflicts, and post-restore baselines

## Stack

- Depends on #401, which follows merged #398
- Followed by #400