### PR TITLE
[AI-assisted] docs: align harness architecture descriptions

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -38,7 +38,7 @@ body:
       description: Which area of the project does this relate to?
       options:
         - CLI / launch (brainpilot up, init)
-        - Agents / orchestration (Principal, specialists, mailbox)
+        - Agents / orchestration (Principal, specialists, task ledger, subagents)
         - Web UI
         - MCP / tools
         - Skills library

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/):
 Examples:
 
 ```
-feat(runtime): add result_deliver mailbox message type
+feat(runtime): add task completion notifications
 fix(web): stop trace panel from resetting on session switch
 docs: add bilingual README and CONTRIBUTING
 ```
@@ -160,19 +160,22 @@ AI-assisted PRs are held to the same quality standard as any other PR.
 
 ## Project Structure
 
-BrainPilot is a TypeScript monorepo of six packages under `packages/`:
+BrainPilot is a TypeScript monorepo of 10 packages under `packages/`:
 
 ```
 BrainPilot/
 ├── packages/
 │   ├── protocol/        # zod wire SSOT: AG-UI events, domain types, HTTP route contract
-│   ├── runtime/         # Pi SDK orchestration, SessionManager, mailbox, system tools,
-│   │                    #   MCP bridge, Hono + SSE server
+│   ├── plugin-sdk/      # Plugin schemas, authoring helpers, and CLI tooling
+│   ├── runtime/         # Pi SDK orchestration, state authority, task ledger, isolated
+│   │                    #   subagents, GoT/checkpoints, tools, MCP bridge, Hono + SSE
 │   ├── backend-core/    # Hono REST + SSE passthrough, Orchestrator (Local/Static/Docker)
 │   ├── web/             # React/Vite SPA (AG-UI consumer)
 │   ├── cli/             # @brainpilot/app — `brainpilot` / `bnpt` Docker-free launch
 │   ├── client-cli/      # @brainpilot/client-cli — headless verification client (private)
-│   └── skills/          # @brainpilot/skills — built-in skills content library
+│   ├── skills/          # @brainpilot/skills — built-in skills content library
+│   ├── kb-scripts/      # Publishable knowledge-base build and indexing scripts
+│   └── docs/            # Static public documentation site (private workspace package)
 ├── docker/              # Dockerfiles & sandbox build hooks
 ├── scripts/            # smoke tests, release tooling
 └── .github/            # issue/PR templates, CI workflows
@@ -202,10 +205,10 @@ The `contribute-skills-via-pr` and `verify-skill` Meta-Skills document the full 
 npm login                 # account with @brainpilot scope access
 npm run version:check     # verify all workspace package versions are aligned
 npm run release:dry       # pack-preview all public packages (no upload)
-npm run release           # version-sync, build, then publish protocol → runtime → backend-core → web → app
+npm run release           # version-sync, build, then publish all eight public packages in dependency order
 ```
 
-`@brainpilot/client-cli` stays private and is never published.
+`@brainpilot/client-cli` and `@brainpilot/docs` stay private and are never published.
 
 ### Docker images
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -59,6 +59,7 @@ BrainPilot 是一个面向脑科学的开源人工智能研究工作台，帮助
 
 - **🧠 面向脑科学研究** — 支持从文献综述、假设细化、实验设计到数据分析、论文写作和科学审查的完整科研流程。
 - **🤝 PI 智能体协调专业智能体团队** — PI 智能体统一理解用户需求、规划任务，并协调文献、实验、工程、写作和审查智能体协同工作。
+- **⚙️ 持久且有界的编排机制** — 长期专业智能体通过 session 级任务账本协作，并可启动数量受限、上下文隔离的子智能体，并行完成检索与验证。
 - **📚 整合领域知识与科研技能** — 集成脑科学相关知识、研究方法、分析流程、写作规范和工具接口，使智能体能够调用专业知识完成具体科研任务。
 - **🛡️ 审查智能体提升科研可靠性** — 审查科学结论、证据链、引用来源、幻觉风险、遗漏信息和缺乏支撑的推理，帮助研究者发现潜在问题。
 - **🔭 [Graph of Trace](https://aclanthology.org/2026.acl-demo.29/) 展示研究过程** — 将任务结构、智能体行为、工具调用、证据流向和关键决策点可视化，方便研究者检查、回溯和干预。
@@ -507,16 +508,18 @@ harness–model 组合。ALE 显示出明确的成本优势，而 BrainPilotBenc
 完整指南（开发环境、分支模型、从源码运行、测试、发布流程）见
 **[CONTRIBUTING.md](CONTRIBUTING.md)**；私下报告安全漏洞见 **[SECURITY.md](SECURITY.md)**。
 
-BrainPilot 是一个 8 包的 TypeScript monorepo：
+BrainPilot 是一个包含 10 个包的 TypeScript monorepo：
 
 | 包 | 角色 |
 |---------|------|
 | `@brainpilot/protocol` | zod 线协议 SSOT：AG-UI 事件联合、领域类型、HTTP 路由契约 |
-| `@brainpilot/runtime` | Pi SDK 编排、SessionManager（状态权威）、mailbox、系统工具、MCP bridge、Hono+SSE 服务 |
+| `@brainpilot/plugin-sdk` | 插件 manifest schema、创作辅助接口与 CLI 工具 |
+| `@brainpilot/runtime` | Pi SDK 编排、SessionManager（状态权威）、持久化任务账本、隔离 subagent、GoT、系统工具、MCP bridge、Hono+SSE 服务 |
 | `@brainpilot/backend-core` | Hono REST + SSE 字节透传、Orchestrator 抽象（Local / Static / Docker） |
 | `@brainpilot/web` | React/Vite SPA（AG-UI 消费端） |
 | `@brainpilot/app` | `brainpilot` / `bnpt` —— 免 Docker 本地启动 |
 | `@brainpilot/skills` | 内置技能内容库（物化到数据目录，经 Pi 原生 skill 流水线加载） |
+| `@brainpilot/kb-scripts` | 可发布的知识库构建与索引脚本 |
 | `@brainpilot/client-cli` | `bp-client` —— 无头端到端验证客户端 |
 | `@brainpilot/docs` | 面向 `brainpilot.chat/docs` 的静态公开文档站点 |
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ BrainPilot is an open-source AI research workspace for brain science. It helps r
 
 - 🧠 Built for brain science research — supports workflows across literature review, hypothesis refinement, experiment design, data analysis, writing, and audit.
 - 🤝 PI Agent + specialist agents — the coordinating PI works with a librarian, experimentalist, engineer, writer, and auditor.
+- ⚙️ Durable, bounded orchestration — persistent specialists coordinate through a session-scoped task ledger and can fan out bounded, context-isolated leaf workers for parallel research and verification.
 - 📚 Integrated domain knowledge and skills — brings together brain-science knowledge, methodological skills, analysis procedures, writing conventions, and tool interfaces.
 - 🛡️ Auditor Agent for scientific reliability — reviews claims, evidence chains, citations, hallucination risks, omitted information, and unsupported reasoning.
 - 🔭 Traceable research process — represents each session as an inspectable [Graph of Trace](https://aclanthology.org/2026.acl-demo.29/), making task structure, agent actions, evidence flow, and decision points visible.
@@ -548,16 +549,18 @@ See **[CONTRIBUTING.md](CONTRIBUTING.md)** for the full guide (dev setup, branch
 running from source, tests, and the release process), and
 **[SECURITY.md](SECURITY.md)** to report a vulnerability privately.
 
-BrainPilot is an 8-package TypeScript monorepo:
+BrainPilot is a 10-package TypeScript monorepo:
 
 | Package | Role |
 |---------|------|
 | `@brainpilot/protocol` | zod wire SSOT: AG-UI event union, domain types, HTTP route contract |
-| `@brainpilot/runtime` | Pi SDK orchestration, SessionManager (state authority), mailbox, system tools, MCP bridge, Hono+SSE server |
+| `@brainpilot/plugin-sdk` | plugin manifest schemas, authoring helpers, and CLI tooling |
+| `@brainpilot/runtime` | Pi SDK orchestration, SessionManager (state authority), durable task ledger, isolated subagents, GoT, system tools, MCP bridge, Hono+SSE server |
 | `@brainpilot/backend-core` | Hono REST + SSE byte-passthrough, Orchestrator abstraction (Local / Static / Docker) |
 | `@brainpilot/web` | React/Vite SPA (AG-UI consumer) |
 | `@brainpilot/app` | `brainpilot` / `bnpt` — Docker-free local launch |
 | `@brainpilot/skills` | built-in skills content library (materialized into the data dir, loaded via Pi's native skill pipeline) |
+| `@brainpilot/kb-scripts` | publishable knowledge-base build and indexing scripts |
 | `@brainpilot/client-cli` | `bp-client` — headless end-to-end verification client |
 | `@brainpilot/docs` | static public documentation site for `brainpilot.chat/docs` |
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,8 +2,9 @@
 
 **BrainPilot** is an open-source, single-user multi-agent collaboration platform
 built with TypeScript + the [Pi SDK](https://pi.dev) — a Principal agent
-coordinating specialist agents through a durable flat task ledger, served as a Hono
-backend + React SPA. It runs as a local process; **no Docker required**.
+coordinating persistent specialists through a durable flat task ledger. Specialists
+can launch bounded, context-isolated leaf workers for parallel work. The system is
+served as a Hono backend + React SPA and runs as a local process; **no Docker required**.
 
 This package (`@brainpilot/app`) is the CLI. It installs the `brainpilot`
 command (`bnpt` is a built-in short alias).

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -14,10 +14,28 @@ byte-passthrough) and, in hosted deployments, by the platform layer.
 - `SessionManager` — session lifecycle, agent registry, **state authority**
   (`status = idle | running | error | stopped`), `metrics()`.
 - `MasAgent` — per-agent wrapper over a Pi `AgentSession`; emits AG-UI events.
-- System tools + access control, the external-MCP bridge, Graph-of-Trace.
+- `TaskLedger` — durable, session-scoped expert assignments and completion delivery.
+- `SubagentManager` — bounded, short-lived leaf workers with isolated context and scratch space.
+- Graph-of-Trace V2, workspace checkpoints, system tools + access control, and the external-MCP bridge.
 - The Hono server (`./server`) with the SSE event stream.
 
 All wire types come from `@brainpilot/protocol` (the zod SSOT).
+
+## Coordination model
+
+BrainPilot has two execution tiers:
+
+1. **Persistent specialists** keep their own Pi conversation history and coordinate
+   through `dispatch_task` / `complete_task`. The flat task ledger persists task state,
+   notification delivery, and reminders in `.bp/<sessionId>/tasks.json`.
+2. **Isolated subagents** are bounded leaf workers launched by a specialist for parallel,
+   self-contained work. Each child gets a fresh conversation and scratch workspace, has a
+   profile-controlled tool allowlist, cannot message agents or users, and returns exactly
+   one structured result through `submit_result`.
+
+Both tiers are owned by `SessionManager` and share the per-session provider concurrency
+budget. See [`docs/plan/task-ledger.md`](../../docs/plan/task-ledger.md) and
+[`docs/plan/subagents.md`](../../docs/plan/subagents.md) for the detailed contracts.
 
 ## Persistent storage contract
 

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -1929,7 +1929,7 @@ export class SessionManager {
   /**
    * Interrupt a session (or a specific agent).
    *
-   * Targeted (`agentName` given): abort just that agent. Mailboxes and the
+   * Targeted (`agentName` given): abort just that agent. The task ledger and
    * principal are left untouched — a narrow "stop this one expert" contract.
    *
    * Whole-session (`agentName` omitted, the Stop button — #90 / #327): abort

--- a/packages/skills/skills/01_Meta-Skills/repo-to-skill/SKILL.md
+++ b/packages/skills/skills/01_Meta-Skills/repo-to-skill/SKILL.md
@@ -97,13 +97,20 @@ Skim test files to discover edge cases, expected behaviors, and usage patterns t
 
 ### Exploration Strategy
 
-Use the Agent tool with `subagent_type=Explore` for broad exploration, or launch multiple parallel subagents to cover different areas simultaneously:
+When `repo-scout` appears in `list_subagent_profiles`, use `spawn_subagent` to run independent exploration slices in parallel. Pass the repository path and all required background explicitly because leaf workers do not inherit the parent conversation. For example:
 
 ```
-Agent 1: Explore top-level structure + README + core __init__.py files
-Agent 2: Explore tutorials/ and examples/ directories, read representative files
-Agent 3: Explore docs/ for API reference, read key module documentation
+spawn_subagent(
+  context="Repository root: <path>. Explore read-only and cite file paths.",
+  tasks=[
+    {name: "api-map", profile: "repo-scout", task: "Map top-level structure, README, and public entry points."},
+    {name: "examples", profile: "repo-scout", task: "Inspect tutorials and examples; extract representative usage patterns."},
+    {name: "docs", profile: "repo-scout", task: "Inspect API documentation and identify key module references."}
+  ]
+)
 ```
+
+If `repo-scout` is unavailable, explore with your own read/search tools or delegate a self-contained repository-mapping task to the engineer through `dispatch_task`.
 
 The goal is to collect:
 - Complete list of public API (classes, functions, constants)


### PR DESCRIPTION
## Summary

Align current documentation with the durable task-ledger and isolated-subagent harness now on `main`.

## Related Issues

None.

## Changes

- replace current-architecture mailbox references with the task-ledger/subagent model
- document the two runtime execution tiers and their state/concurrency ownership
- update `repo-to-skill` from the obsolete `Agent(subagent_type=Explore)` workflow to `spawn_subagent` with `repo-scout`
- correct the monorepo inventory from 8/6 packages to the current 10 and list the missing plugin/KB packages
- preserve mailbox mentions that explicitly document historical migration behavior

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] New skill (added under `packages/skills-mcp/skills/`)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### How to test

1. Run `npm run docs:check`.
2. Run `npm run docs:build`.
3. Run `npm run build -w @brainpilot/skills` and `git diff --check main...HEAD`.

### What you personally verified

- current docs/templates no longer describe mailbox or the generic Agent tool as the active harness
- explicit historical mailbox migration notes remain intact
- runtime README links resolve and the documented package count matches root workspaces
- Standards and Spec self-review found no remaining substantive issue
- `npm run typecheck` was attempted but is currently blocked by existing plugin-sdk errors: missing `semver` declarations and unresolved `@brainpilot/plugin-sdk` imports; this PR does not touch those paths

### Checks

- [ ] `npm run typecheck` passes
- [ ] `BP_MOCK=1 npx vitest run` passes
- [ ] Web build passes (`cd packages/web && npm test && npm run build`) — if web changed
- [x] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] This PR is AI-assisted, and I have self-reviewed the generated code
- [x] My code follows the project style
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings