### PR TITLE
feat(got): inject trace context into reasoning

### DIFF
--- a/packages/protocol/src/domain.ts
+++ b/packages/protocol/src/domain.ts
@@ -436,6 +436,8 @@ export type TraceNodeRecord = z.infer<typeof TraceNodeRecordSchema>;
 export const TraceCausalParentSchema = z.object({
   nodeId: z.string(),
   conclusion: TraceParentConclusionSchema,
+  /** Distinguishes the structural fallback from a parent explicitly proposed by Trace. */
+  origin: z.enum(["host_fallback", "trace"]).optional(),
   /** Current concise reason; earlier reasons remain in TraceChangeLog. */
   reason: z.string().optional(),
 });

--- a/packages/runtime/src/__tests__/got-context.test.ts
+++ b/packages/runtime/src/__tests__/got-context.test.ts
@@ -49,6 +49,24 @@ describe("GoT ephemeral context", () => {
     expect(block).not.toContain('"type":"session_start"');
   });
 
+  it("renders an explicit empty active graph", () => {
+    const trace = new GraphOfTrace("s");
+    const block = renderPrincipalGoTContext(trace.getGraphV2());
+    expect(block).toContain(`revision="${trace.getGraphV2().revision}"`);
+    expect(block).toContain("<active_nodes>\n</active_nodes>");
+  });
+
+  it("omits parent links to revoked nodes from the compact graph", () => {
+    const trace = new GraphOfTrace("s");
+    const parent = trace.createNode({ title: "Revoked evidence" });
+    const child = trace.createNode({ title: "Conclusion" });
+    trace.proposeCausalParent(child.id, parent.id, "consumed evidence", { type: "agent", name: "trace" });
+    trace.updateNode(parent.id, { revoked: true }, { type: "agent", name: "trace" });
+    const block = renderPrincipalGoTContext(trace.getGraphV2());
+    expect(block).toContain(`"id":"${child.id}"`);
+    expect(block).not.toContain(`"nodeId":"${parent.id}"`);
+  });
+
   it("injects a fresh block and strips an older ephemeral snapshot", () => {
     let block = '<graph_of_trace revision="1">old</graph_of_trace>';
     const { pi, fire } = fakePi();

--- a/packages/runtime/src/__tests__/got-context.test.ts
+++ b/packages/runtime/src/__tests__/got-context.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { GraphOfTrace } from "../trace.js";
+import {
+  makeGoTContextExt,
+  renderGoTAuditContext,
+  renderPrincipalGoTContext,
+} from "../extensions/got-context.js";
+
+interface FakeMessage {
+  role: string;
+  content: Array<{ type: string; text?: string }>;
+}
+
+function fakePi() {
+  let handler:
+    | ((event: { messages: FakeMessage[] }) => { messages: FakeMessage[] } | void)
+    | undefined;
+  return {
+    pi: {
+      on(_event: "context", callback: typeof handler) {
+        handler = callback;
+      },
+    },
+    fire(messages: FakeMessage[]) {
+      if (!handler) throw new Error("context handler was not registered");
+      return handler({ messages });
+    },
+  };
+}
+
+const userMessage = (text: string): FakeMessage => ({
+  role: "user",
+  content: [{ type: "text", text }],
+});
+
+describe("GoT ephemeral context", () => {
+  it("renders the latest compact active graph and Principal usage guidance", () => {
+    const trace = new GraphOfTrace("s");
+    const node = trace.createNode({
+      title: "Evidence",
+      description: "A durable result",
+      confidence: "high",
+      reviewConclusion: "approved",
+    });
+    const block = renderPrincipalGoTContext(trace.getGraphV2());
+    expect(block).toContain(`revision="${trace.getGraphV2().revision}"`);
+    expect(block).toContain(`"id":"${node.id}"`);
+    expect(block).toContain("get_trace_neighborhood");
+    expect(block).not.toContain('"type":"session_start"');
+  });
+
+  it("injects a fresh block and strips an older ephemeral snapshot", () => {
+    let block = '<graph_of_trace revision="1">old</graph_of_trace>';
+    const { pi, fire } = fakePi();
+    makeGoTContextExt({ renderContext: () => block })(pi as never);
+    block = '<graph_of_trace revision="2">new</graph_of_trace>';
+    const result = fire([
+      userMessage("hello"),
+      userMessage('<graph_of_trace revision="1">old</graph_of_trace>'),
+    ]) as { messages: FakeMessage[] };
+    expect(result.messages).toEqual([
+      userMessage("hello"),
+      userMessage('<graph_of_trace revision="2">new</graph_of_trace>'),
+    ]);
+  });
+
+  it("renders a bound audit with detailed local and compact global evidence", () => {
+    const trace = new GraphOfTrace("s");
+    const parent = trace.createNode({ title: "Evidence" });
+    const child = trace.createNode({ title: "Conclusion" });
+    trace.proposeCausalParent(child.id, parent.id, "consumed evidence", { type: "agent", name: "trace" });
+    const target = trace.listPendingAuditTargets().find((item) => item.parentNodeId === parent.id)!;
+    const block = renderGoTAuditContext({
+      graph: trace.getGraphV2(),
+      target,
+      targetNode: trace.getNodeDetail(child.id),
+      parentNode: trace.getNodeDetail(parent.id),
+      neighborhood: trace.getNeighborhood(child.id, 2),
+    });
+    expect(block).toContain("<bound_target>");
+    expect(block).toContain("<target_evidence>");
+    expect(block).toContain("<local_neighborhood>");
+    expect(block).toContain("<compact_active_graph>");
+    expect(block).toContain("Textual traceability alone is not scientific validation");
+  });
+});

--- a/packages/runtime/src/__tests__/personas.test.ts
+++ b/packages/runtime/src/__tests__/personas.test.ts
@@ -204,9 +204,9 @@ Stale local routing rule.`;
     // Bash is filesystem-inspection only
     expect(a).toContain("filesystem inspection");
     expect(a).toContain("grep");
-    // Audit reports are persisted without granting workspace write access.
-    expect(a).toContain("submit_audit_report");
-    expect(a).toContain("Report directly to PI");
+    // Audit report path discipline
+    expect(a).toContain(".audit/");
+    expect(a).toContain("ISO8601");
     // Followup limit (2 different agents) — robust to whitespace/newline.
     expect(a.toLowerCase()).toMatch(/two different\s+agents/);
     // And the explicit "2 different agents" cap line.

--- a/packages/runtime/src/__tests__/personas.test.ts
+++ b/packages/runtime/src/__tests__/personas.test.ts
@@ -204,9 +204,9 @@ Stale local routing rule.`;
     // Bash is filesystem-inspection only
     expect(a).toContain("filesystem inspection");
     expect(a).toContain("grep");
-    // Audit report path discipline
-    expect(a).toContain(".audit/");
-    expect(a).toContain("ISO8601");
+    // Audit reports are persisted without granting workspace write access.
+    expect(a).toContain("submit_audit_report");
+    expect(a).toContain("Report directly to PI");
     // Followup limit (2 different agents) — robust to whitespace/newline.
     expect(a.toLowerCase()).toMatch(/two different\s+agents/);
     // And the explicit "2 different agents" cap line.

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -168,16 +168,16 @@ describe("SessionManager (mock mode)", () => {
     expect(PERSONAS.experimentalist).toContain("long-running training");
   });
 
-  it("routes PI and expert results directly through the Auditor feedback loop", () => {
-    expect(PERSONAS.principal).toContain("intermediate result audit");
-    expect(PERSONAS.principal).toContain("never ask the user to relay it");
-    expect(PERSONAS.principal).toContain("request another audit");
+  it("routes expert outputs through writer drafts before audit", () => {
+    expect(PERSONAS.principal).toContain("do NOT send raw expert output directly to the `auditor`");
+    expect(PERSONAS.principal).toContain("first form an auditable draft");
+    expect(PERSONAS.principal).toContain("`writer` to write or polish a report");
+    expect(PERSONAS.principal).toContain("Do not audit raw expert output.");
     expect(PERSONAS.librarian).toContain("## Writer handoff packet");
     expect(PERSONAS.experimentalist).toContain("## Writer handoff packet");
     expect(PERSONAS.engineer).toContain("## Writer handoff packet");
     expect(PERSONAS.writer).not.toContain("## Writer handoff packet");
-    expect(PERSONAS.auditor).toContain("Raw expert output is a valid intermediate audit target");
-    expect(PERSONAS.auditor).toContain("Send actionable findings directly to PI");
+    expect(PERSONAS.auditor).toContain("If PI gives you only raw expert output");
     expect(PERSONAS.auditor).not.toContain("## Writer handoff packet");
     expect(PERSONAS.trace).not.toContain("## Writer handoff packet");
   });

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -127,6 +127,34 @@ describe("SessionManager (mock mode)", () => {
     expect(seen[0]).not.toContain("mcp__builtin__");
   });
 
+  it("wires fresh ephemeral GoT renderers for Principal and bound Auditor turns", async () => {
+    const renderers = new Map<string, () => string>();
+    const spyFactory: typeof mockAgentFactory = async (params) => {
+      if (params.renderGoTContext) renderers.set(params.agentName, params.renderGoTContext);
+      return mockAgentFactory(params);
+    };
+    const sm = new SessionManager({ persist: false, agentFactory: spyFactory });
+    const session = await sm.createSession();
+    await sm.sendMessage(session.id, "hi");
+    await waitFor(() => renderers.has("principal"));
+
+    const internal = sm as unknown as {
+      sessions: Map<string, {
+        trace: import("../trace.js").GraphOfTrace;
+        currentTraceAuditTarget?: import("../trace.js").TraceAuditTarget;
+      }>;
+      ensureAgent(sessionId: string, name: string): Promise<unknown>;
+    };
+    const entry = internal.sessions.get(session.id)!;
+    const node = entry.trace.createNode({ title: "Review me" });
+    expect(renderers.get("principal")?.()).toContain(`"id":"${node.id}"`);
+
+    await internal.ensureAgent(session.id, "auditor");
+    entry.currentTraceAuditTarget = entry.trace.listPendingAuditTargets([node.id])[0];
+    expect(renderers.get("auditor")?.()).toContain("<bound_target>");
+    expect(renderers.get("auditor")?.()).toContain(node.id);
+  });
+
   it("keeps high-impact action authorization in PI and expert personas", () => {
     expect(PERSONAS.principal).toContain("## User authorization gate");
     expect(PERSONAS.principal).toContain("Use `ask_user` first");

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -168,16 +168,16 @@ describe("SessionManager (mock mode)", () => {
     expect(PERSONAS.experimentalist).toContain("long-running training");
   });
 
-  it("routes expert outputs through writer drafts before audit", () => {
-    expect(PERSONAS.principal).toContain("do NOT send raw expert output directly to the `auditor`");
-    expect(PERSONAS.principal).toContain("first form an auditable draft");
-    expect(PERSONAS.principal).toContain("`writer` to write or polish a report");
-    expect(PERSONAS.principal).toContain("Do not audit raw expert output.");
+  it("routes PI and expert results directly through the Auditor feedback loop", () => {
+    expect(PERSONAS.principal).toContain("intermediate result audit");
+    expect(PERSONAS.principal).toContain("never ask the user to relay it");
+    expect(PERSONAS.principal).toContain("request another audit");
     expect(PERSONAS.librarian).toContain("## Writer handoff packet");
     expect(PERSONAS.experimentalist).toContain("## Writer handoff packet");
     expect(PERSONAS.engineer).toContain("## Writer handoff packet");
     expect(PERSONAS.writer).not.toContain("## Writer handoff packet");
-    expect(PERSONAS.auditor).toContain("If PI gives you only raw expert output");
+    expect(PERSONAS.auditor).toContain("Raw expert output is a valid intermediate audit target");
+    expect(PERSONAS.auditor).toContain("Send actionable findings directly to PI");
     expect(PERSONAS.auditor).not.toContain("## Writer handoff packet");
     expect(PERSONAS.trace).not.toContain("## Writer handoff packet");
   });

--- a/packages/runtime/src/__tests__/tool-access.test.ts
+++ b/packages/runtime/src/__tests__/tool-access.test.ts
@@ -62,11 +62,6 @@ describe("tool access control (§9)", () => {
     await expect(dispatch.execute({ to: "engineer", content: "self" })).resolves.toMatchObject({ isError: true });
     await expect(dispatch.execute({ to: "trace", content: "wrong" })).resolves.toMatchObject({ isError: true });
 
-    const auditorDeps = deps("auditor");
-    const auditorDispatch = createDispatchTaskTool(auditorDeps);
-    await expect(auditorDispatch.execute({ to: "principal", content: "Audit found a blocking flaw." }))
-      .resolves.not.toMatchObject({ isError: true });
-
     const complete = createCompleteTaskTool(d);
     expect((complete.parameters.required as string[])).toEqual(["task_id", "reply"]);
     expect((await complete.execute({ task_id: "task_000001", reply: "done" })).isError).toBeUndefined();
@@ -218,7 +213,6 @@ describe("tool access control (§9)", () => {
     const names = systemToolNamesForRole("expert", "auditor");
     expect(names.sort()).toEqual(
       [
-        "dispatch_task",
         "complete_task",
         "list_pending_trace_reviews",
         "get_trace_node",
@@ -278,9 +272,7 @@ describe("tool access control (§9)", () => {
     expect(d.trace.getNodeV2(node.id)?.reviewConclusion).toBe("approved");
     await tools.get("submit_audit_report")!.execute({ risk: "low", summary: "Evidence is consistent.", report: "# Audit\nEvidence is consistent." });
     expect(d.trace.getAuditReports()).toContainEqual(expect.objectContaining({ kind: "trace", target: { nodeId: node.id } }));
-    expect(tools.has("dispatch_task")).toBe(true);
-    await expect(tools.get("dispatch_task")!.execute({ to: "principal", content: "Bound review result" }))
-      .resolves.toMatchObject({ isError: true });
+    expect(tools.has("dispatch_task")).toBe(false);
   });
 
   it("requires confidence and returns only a compact active graph to Trace", async () => {

--- a/packages/runtime/src/__tests__/tool-access.test.ts
+++ b/packages/runtime/src/__tests__/tool-access.test.ts
@@ -92,11 +92,21 @@ describe("tool access control (§9)", () => {
     await expect(tool.execute({ question: "   " })).resolves.toMatchObject({ isError: true });
   });
 
-  it("principal gets comms + record_trace, not graph mutation tools", () => {
+  it("principal gets comms, record_trace, and read-only GoT tools", () => {
     const names = systemToolNamesForRole("principal", "principal");
-    expect(names).toEqual(expect.arrayContaining(["dispatch_task", "complete_task", "create_agent", "destroy_agent", "record_trace"]));
+    expect(names).toEqual(expect.arrayContaining([
+      "dispatch_task",
+      "complete_task",
+      "create_agent",
+      "destroy_agent",
+      "record_trace",
+      "get_trace_graph",
+      "get_trace_node",
+      "get_trace_neighborhood",
+      "get_trace_diff",
+    ]));
     expect(names).not.toContain("create_trace_node");
-    expect(names).not.toContain("get_trace_graph");
+    expect(names).not.toContain("update_trace_node");
   });
 
   it("principal can ask_user; experts and trace cannot", () => {
@@ -277,15 +287,26 @@ describe("tool access control (§9)", () => {
     const node = d.trace.getGraphV2().nodes.find((item) => item.type !== "session_start")!;
     const agentGraph = JSON.parse((await tools.get("get_trace_graph")!.execute({})).content[0]!.text) as {
       revision: number;
+      rootNodeId?: string;
       nodes: Array<{ id: string; parents: unknown[] }>;
       dependencies?: unknown;
       artifacts?: unknown;
     };
     expect(agentGraph.nodes).toEqual([expect.objectContaining({ id: node.id, parents: [] })]);
+    expect(agentGraph.rootNodeId).toBe(d.trace.getGraphV2().meta.rootNodeId);
     expect(agentGraph).not.toHaveProperty("dependencies");
     expect(agentGraph).not.toHaveProperty("artifacts");
     expect(agentGraph.nodes[0]).not.toHaveProperty("records");
     expect((await tools.get("update_trace_node")!.execute({ node_id: node.id, summary: "updated" })).isError).toBe(true);
+
+    const rootId = d.trace.getGraphV2().meta.rootNodeId!;
+    d.trace.proposeCausalParent(node.id, rootId, "Depends only on initial context.", { type: "agent", name: "trace" });
+    const withExplicitRoot = JSON.parse((await tools.get("get_trace_graph")!.execute({})).content[0]!.text) as {
+      nodes: Array<{ id: string; parents: Array<{ nodeId: string; origin?: string }> }>;
+    };
+    expect(withExplicitRoot.nodes.find((item) => item.id === node.id)?.parents).toContainEqual(
+      expect.objectContaining({ nodeId: rootId, origin: "trace" }),
+    );
   });
 });
 
@@ -339,6 +360,10 @@ describe("tool toggles", () => {
       "create_agent",
       "destroy_agent",
       "dispatch_task",
+      "get_trace_diff",
+      "get_trace_graph",
+      "get_trace_neighborhood",
+      "get_trace_node",
       "record_trace",
     ].sort());
   });

--- a/packages/runtime/src/__tests__/tool-access.test.ts
+++ b/packages/runtime/src/__tests__/tool-access.test.ts
@@ -62,6 +62,11 @@ describe("tool access control (§9)", () => {
     await expect(dispatch.execute({ to: "engineer", content: "self" })).resolves.toMatchObject({ isError: true });
     await expect(dispatch.execute({ to: "trace", content: "wrong" })).resolves.toMatchObject({ isError: true });
 
+    const auditorDeps = deps("auditor");
+    const auditorDispatch = createDispatchTaskTool(auditorDeps);
+    await expect(auditorDispatch.execute({ to: "principal", content: "Audit found a blocking flaw." }))
+      .resolves.not.toMatchObject({ isError: true });
+
     const complete = createCompleteTaskTool(d);
     expect((complete.parameters.required as string[])).toEqual(["task_id", "reply"]);
     expect((await complete.execute({ task_id: "task_000001", reply: "done" })).isError).toBeUndefined();
@@ -213,6 +218,7 @@ describe("tool access control (§9)", () => {
     const names = systemToolNamesForRole("expert", "auditor");
     expect(names.sort()).toEqual(
       [
+        "dispatch_task",
         "complete_task",
         "list_pending_trace_reviews",
         "get_trace_node",
@@ -272,7 +278,9 @@ describe("tool access control (§9)", () => {
     expect(d.trace.getNodeV2(node.id)?.reviewConclusion).toBe("approved");
     await tools.get("submit_audit_report")!.execute({ risk: "low", summary: "Evidence is consistent.", report: "# Audit\nEvidence is consistent." });
     expect(d.trace.getAuditReports()).toContainEqual(expect.objectContaining({ kind: "trace", target: { nodeId: node.id } }));
-    expect(tools.has("dispatch_task")).toBe(false);
+    expect(tools.has("dispatch_task")).toBe(true);
+    await expect(tools.get("dispatch_task")!.execute({ to: "principal", content: "Bound review result" }))
+      .resolves.toMatchObject({ isError: true });
   });
 
   it("requires confidence and returns only a compact active graph to Trace", async () => {

--- a/packages/runtime/src/__tests__/trace-reminder.test.ts
+++ b/packages/runtime/src/__tests__/trace-reminder.test.ts
@@ -66,16 +66,16 @@ describe("trace-reminder: event-driven trace gating", () => {
     (tool) => expect(runOnce("principal", [tool]).kinds).toEqual([]),
   );
 
-  it("substantive PI work needs trace and delegation in one reminder", () => {
-    expect(runOnce("principal", ["bash"]).kinds).toEqual(["merged"]);
+  it("substantive PI work only needs a trace reminder", () => {
+    expect(runOnce("principal", ["bash"]).kinds).toEqual(["trace"]);
   });
 
-  it("recorded substantive PI work only needs delegation", () => {
-    expect(runOnce("principal", ["write", "record_trace"]).kinds).toEqual(["delegate"]);
+  it("recorded substantive PI work needs no reminder", () => {
+    expect(runOnce("principal", ["write", "record_trace"]).kinds).toEqual([]);
   });
 
-  it("creating an agent is not itself a delegation", () => {
-    expect(runOnce("principal", ["bash", "create_agent"]).kinds).toEqual(["merged"]);
+  it("creating an agent does not suppress the trace reminder", () => {
+    expect(runOnce("principal", ["bash", "create_agent"]).kinds).toEqual(["trace"]);
   });
 
   it("sending a task counts as delegation", () => {
@@ -87,7 +87,7 @@ describe("trace-reminder: event-driven trace gating", () => {
 
   it("tool-name case does not matter", () => {
     expect(runOnce("principal", ["READ"]).kinds).toEqual([]);
-    expect(runOnce("principal", ["WRITE", "record_trace"]).kinds).toEqual(["delegate"]);
+    expect(runOnce("principal", ["WRITE", "record_trace"]).kinds).toEqual([]);
   });
 });
 

--- a/packages/runtime/src/__tests__/trace-reminder.test.ts
+++ b/packages/runtime/src/__tests__/trace-reminder.test.ts
@@ -61,7 +61,18 @@ function runOnce(
 }
 
 describe("trace-reminder: event-driven trace gating", () => {
-  it.each(["read", "grep", "glob", "ls", "find", "skill_search"])(
+  it.each([
+    "read",
+    "grep",
+    "glob",
+    "ls",
+    "find",
+    "skill_search",
+    "get_trace_graph",
+    "get_trace_node",
+    "get_trace_neighborhood",
+    "get_trace_diff",
+  ])(
     "read-only/lookup tool %s does not arm a trace reminder",
     (tool) => expect(runOnce("principal", [tool]).kinds).toEqual([]),
   );

--- a/packages/runtime/src/__tests__/trace-v2.test.ts
+++ b/packages/runtime/src/__tests__/trace-v2.test.ts
@@ -48,6 +48,9 @@ describe("TraceGraphV2 storage and audit semantics", () => {
     const conclusion = graph.createNode({ title: "Conclusion" });
     expect(graph.getNode(evidence.id)?.parentIds).toEqual([rootId]);
     expect(graph.getNode(conclusion.id)?.parentIds).toEqual([rootId]);
+    expect(graph.getNodeV2(conclusion.id)?.parents).toContainEqual(
+      expect.objectContaining({ nodeId: rootId, origin: "host_fallback" }),
+    );
     expect(graph.updateNode(rootId, { title: "Changed" })).toBeUndefined();
     expect(graph.listPendingAuditTargets().some((target) => target.nodeId === rootId)).toBe(false);
 
@@ -57,7 +60,7 @@ describe("TraceGraphV2 storage and audit semantics", () => {
       "Conclusion consumes this evidence.",
       { type: "agent", name: "trace" },
     )).toBe(true);
-    expect(graph.getNode(conclusion.id)?.parentIds).toEqual([rootId]);
+    expect(graph.getNode(conclusion.id)?.parentIds).toEqual([]);
     expect(graph.review(
       conclusion.id,
       "approve",
@@ -66,6 +69,49 @@ describe("TraceGraphV2 storage and audit semantics", () => {
       evidence.id,
     )).toBe(true);
     expect(graph.getNode(conclusion.id)?.parentIds).toEqual([evidence.id]);
+  });
+
+  it("allows Trace to replace the root fallback with an audited root candidate", () => {
+    const graph = new GraphOfTrace("s");
+    const rootId = graph.getGraphV2().meta.rootNodeId!;
+    const node = graph.createNode({ title: "Independent observation" });
+
+    expect(graph.proposeCausalParent(
+      node.id,
+      rootId,
+      "This observation depends only on the session's initial context.",
+      { type: "agent", name: "trace" },
+    )).toBe(true);
+    expect(graph.getNodeV2(node.id)?.parents).toEqual([
+      expect.objectContaining({ nodeId: rootId, conclusion: "candidate", origin: "trace" }),
+    ]);
+    expect(graph.listPendingAuditTargets([node.id])).toContainEqual(
+      expect.objectContaining({ nodeId: node.id, parentNodeId: rootId }),
+    );
+    expect(graph.review(
+      node.id,
+      "approve",
+      "No upstream research unit is required.",
+      { type: "agent", name: "auditor" },
+      rootId,
+    )).toBe(true);
+    expect(graph.getNodeV2(node.id)?.parents).toEqual([
+      expect.objectContaining({ nodeId: rootId, conclusion: "confirmed", origin: "trace" }),
+    ]);
+  });
+
+  it("does not restore the Host root fallback while any non-root parent state exists", () => {
+    const graph = new GraphOfTrace("s");
+    const rootId = graph.getGraphV2().meta.rootNodeId!;
+    const parent = graph.createNode({ title: "Evidence" });
+    const child = graph.createNode({ title: "Conclusion" });
+    graph.proposeCausalParent(child.id, parent.id, "possible evidence", { type: "agent", name: "trace" });
+    expect(graph.getNodeV2(child.id)?.parents.some((item) => item.nodeId === rootId)).toBe(false);
+
+    graph.review(child.id, "uncertain", "relationship is unresolved", { type: "agent", name: "auditor" }, parent.id);
+    expect(graph.getNodeV2(child.id)?.parents).toEqual([
+      expect.objectContaining({ nodeId: parent.id, conclusion: "uncertain" }),
+    ]);
   });
 
   it("repairs rootless and cyclic V2 data into one all-state DAG", () => {
@@ -84,9 +130,9 @@ describe("TraceGraphV2 storage and audit semantics", () => {
 
     const normalized = graph.getGraphV2();
     const rootId = normalized.meta.rootNodeId!;
-    const activeParents = new Map(normalized.nodes.map((node) => [
+    const allParents = new Map(normalized.nodes.map((node) => [
       node.id,
-      node.parents.filter((parent) => parent.conclusion === "confirmed").map((parent) => parent.nodeId),
+      node.parents.map((parent) => parent.nodeId),
     ]));
     const reachesRoot = (start: string): boolean => {
       const seen = new Set<string>();
@@ -94,17 +140,17 @@ describe("TraceGraphV2 storage and audit semantics", () => {
         if (id === rootId) return true;
         if (seen.has(id)) return false;
         seen.add(id);
-        return (activeParents.get(id) ?? []).some(visit);
+        return (allParents.get(id) ?? []).some(visit);
       };
       return visit(start);
     };
     expect(normalized.nodes.filter((node) => node.id !== rootId).every((node) => reachesRoot(node.id))).toBe(true);
-    const allParents = new Map(normalized.nodes.map((node) => [node.id, node.parents.map((parent) => parent.nodeId)]));
+    const parentMap = new Map(normalized.nodes.map((node) => [node.id, node.parents.map((parent) => parent.nodeId)]));
     const isAcyclic = (start: string, visiting = new Set<string>(), visited = new Set<string>()): boolean => {
       if (visiting.has(start)) return false;
       if (visited.has(start)) return true;
       const nextVisiting = new Set(visiting).add(start);
-      if (!(allParents.get(start) ?? []).every((parentId) => isAcyclic(parentId, nextVisiting, visited))) return false;
+      if (!(parentMap.get(start) ?? []).every((parentId) => isAcyclic(parentId, nextVisiting, visited))) return false;
       visited.add(start);
       return true;
     };

--- a/packages/runtime/src/__tests__/trace-v2.test.ts
+++ b/packages/runtime/src/__tests__/trace-v2.test.ts
@@ -100,6 +100,39 @@ describe("TraceGraphV2 storage and audit semantics", () => {
     ]);
   });
 
+  it("keeps an already confirmed explicit parent idempotent", () => {
+    const graph = new GraphOfTrace("s");
+    const parent = graph.createNode({ title: "Evidence" });
+    const child = graph.createNode({ title: "Conclusion" });
+    const reason = "Evidence directly supports the conclusion.";
+    expect(graph.proposeCausalParent(
+      child.id,
+      parent.id,
+      reason,
+      { type: "agent", name: "trace" },
+    )).toBe(true);
+    expect(graph.review(
+      child.id,
+      "approve",
+      reason,
+      { type: "agent", name: "auditor" },
+      parent.id,
+    )).toBe(true);
+
+    expect(graph.proposeCausalParent(
+      child.id,
+      parent.id,
+      reason,
+      { type: "agent", name: "trace" },
+    )).toBe(true);
+    expect(graph.getNodeV2(child.id)?.parents).toContainEqual(
+      expect.objectContaining({ nodeId: parent.id, conclusion: "confirmed", origin: "trace" }),
+    );
+    expect(graph.listPendingAuditTargets([child.id])).not.toContainEqual(
+      expect.objectContaining({ parentNodeId: parent.id }),
+    );
+  });
+
   it("does not restore the Host root fallback while any non-root parent state exists", () => {
     const graph = new GraphOfTrace("s");
     const rootId = graph.getGraphV2().meta.rootNodeId!;

--- a/packages/runtime/src/agent-factory.ts
+++ b/packages/runtime/src/agent-factory.ts
@@ -20,6 +20,7 @@ import { resolveGatewayModel, resolveSessionModel, type PiProviderSdk } from "./
 import { makeTraceReminderExt } from "./extensions/trace-reminder.js";
 import { makeAgentStatusExt } from "./extensions/agent-status.js";
 import { makeTaskContextExt } from "./extensions/task-context.js";
+import { makeGoTContextExt } from "./extensions/got-context.js";
 import { makeRouterSkillGuardExt } from "./extensions/router-skill-guard.js";
 import { makeManagedPathGuardExt } from "./extensions/managed-path-guard.js";
 import {
@@ -132,6 +133,9 @@ export const realAgentFactory: AgentSessionFactory = async (params) => {
   }
   if (params.renderTaskContext) {
     extensionFactories.push(makeTaskContextExt({ renderTasks: params.renderTaskContext }));
+  }
+  if (params.renderGoTContext) {
+    extensionFactories.push(makeGoTContextExt({ renderContext: params.renderGoTContext }));
   }
   // #346: rewrite logical /workspace (and /data, …) onto durable volume roots
   // BEFORE other path guards run, so subsequent handlers see post-rewrite paths.

--- a/packages/runtime/src/extensions/got-context.ts
+++ b/packages/runtime/src/extensions/got-context.ts
@@ -1,0 +1,156 @@
+/** Ephemeral Graph of Trace context for Principal reasoning and bound audits. */
+import type { TraceGraphV2, TraceNodeV2 } from "@brainpilot/protocol";
+import type { TraceAuditTarget } from "../trace.js";
+
+interface PiContextMessage {
+  role: string;
+  content: Array<{ type: string; text?: string }>;
+  timestamp?: number;
+}
+
+interface PiExtensionApi {
+  on(
+    event: "context",
+    handler: (event: { messages: PiContextMessage[] }) =>
+      | { messages: PiContextMessage[] }
+      | void,
+  ): void;
+}
+
+const PRINCIPAL_TAG = "<graph_of_trace";
+const AUDIT_TAG = "<got_audit_context";
+
+export interface GoTContextDeps {
+  renderContext: () => string;
+}
+
+function isGoTContextMessage(message: PiContextMessage): boolean {
+  return message.role === "user" && message.content.some((part) => {
+    const text = part.text ?? "";
+    return part.type === "text" &&
+      (text.startsWith(PRINCIPAL_TAG) || text.startsWith(AUDIT_TAG));
+  });
+}
+
+/** Replaces the previous per-turn GoT block without writing it to Pi history. */
+export function makeGoTContextExt(deps: GoTContextDeps): (pi: PiExtensionApi) => void {
+  return (pi) => {
+    pi.on("context", (event) => {
+      const stripped = event.messages.filter((message) => !isGoTContextMessage(message));
+      const block = deps.renderContext();
+      if (!block) {
+        return stripped.length === event.messages.length ? undefined : { messages: stripped };
+      }
+      stripped.push({ role: "user", content: [{ type: "text", text: block }] });
+      return { messages: stripped };
+    });
+  };
+}
+
+function shorten(value: string | undefined, max: number): string | undefined {
+  if (!value) return undefined;
+  return value.length <= max ? value : `${value.slice(0, Math.max(0, max - 1))}…`;
+}
+
+function compactNode(node: TraceNodeV2, rootId: string | undefined): Record<string, unknown> {
+  return {
+    id: node.id,
+    title: node.title,
+    type: node.type,
+    status: node.status,
+    ...(node.description ? { description: shorten(node.description, 600) } : {}),
+    ...(node.confidence ? { confidence: node.confidence } : {}),
+    reviewConclusion: node.reviewConclusion,
+    updatedAt: node.updatedAt,
+    parents: node.parents
+      .filter((parent) => parent.nodeId !== rootId || parent.origin === "trace")
+      .map((parent) => ({
+        nodeId: parent.nodeId,
+        conclusion: parent.conclusion,
+        ...(parent.origin ? { origin: parent.origin } : {}),
+        ...(parent.reason ? { reason: shorten(parent.reason, 300) } : {}),
+      })),
+  };
+}
+
+function compactGraphLines(graph: TraceGraphV2, maxChars: number): string[] {
+  const rootId = graph.meta.rootNodeId;
+  const nodes = graph.nodes.filter((node) => !node.revoked && node.id !== rootId);
+  const lines: string[] = [];
+  let used = 0;
+  for (const node of nodes) {
+    const line = JSON.stringify(compactNode(node, rootId));
+    if (used + line.length + 1 > maxChars) break;
+    lines.push(line);
+    used += line.length + 1;
+  }
+  if (lines.length < nodes.length) {
+    lines.push(JSON.stringify({ omittedNodes: nodes.length - lines.length }));
+  }
+  return lines;
+}
+
+/** Current compact GoT plus usage guidance, injected only into Principal turns. */
+export function renderPrincipalGoTContext(
+  graph: TraceGraphV2,
+  maxChars = 24_000,
+): string {
+  const rootId = graph.meta.rootNodeId;
+  const active = graph.nodes.filter((node) => !node.revoked && node.id !== rootId);
+  if (active.length === 0) return "";
+  const header = [
+    `<graph_of_trace revision="${graph.revision}" root_node_id="${rootId ?? ""}">`,
+    "This is the current compact Graph of Trace. Use it when planning, synthesizing expert results, handling new evidence, and checking whether work already exists.",
+    "Use get_trace_graph, get_trace_node, get_trace_neighborhood, or get_trace_diff when more detail is needed. Review approval is audit history, not a substitute for your own reasoning.",
+    "<active_nodes>",
+  ];
+  const footer = ["</active_nodes>", "</graph_of_trace>"];
+  const fixed = header.join("\n").length + footer.join("\n").length + 2;
+  const lines = compactGraphLines(graph, Math.max(0, maxChars - fixed));
+  return [...header, ...lines, ...footer].join("\n");
+}
+
+function clippedJson(value: unknown, maxChars: number): string {
+  const text = JSON.stringify(value, null, 2);
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, Math.max(0, maxChars - 24))}\n... [truncated]`;
+}
+
+export interface GoTAuditContextInput {
+  graph: TraceGraphV2;
+  target: TraceAuditTarget;
+  targetNode?: unknown;
+  parentNode?: unknown;
+  neighborhood?: unknown;
+}
+
+/** Detailed bound evidence plus compact global state for one background GoT audit. */
+export function renderGoTAuditContext(
+  input: GoTAuditContextInput,
+  maxChars = 48_000,
+): string {
+  const { graph, target } = input;
+  const header = [
+    `<got_audit_context revision="${graph.revision}">`,
+    "Review exactly the bound target. Check internal consistency, conflicts with other active/approved nodes, whether evidence supports strong words such as unique/direct/proves/refutes, and whether a proposed parent is a real evidential or computational prerequisite rather than chronology or similarity.",
+    "If competing explanations cannot be excluded, return uncertain. Textual traceability alone is not scientific validation.",
+    `<bound_target>${clippedJson(target, 2_000)}</bound_target>`,
+  ];
+  const footer = "</got_audit_context>";
+  const sections: Array<[string, unknown, number]> = [
+    ["target_evidence", input.targetNode, 14_000],
+    ["parent_evidence", input.parentNode, 8_000],
+    ["local_neighborhood", input.neighborhood, 14_000],
+    ["compact_active_graph", compactGraphLines(graph, 10_000).map((line) => JSON.parse(line)), 12_000],
+  ];
+  const lines = [...header];
+  for (const [name, value, sectionLimit] of sections) {
+    if (value === undefined) continue;
+    const remaining = maxChars - lines.join("\n").length - footer.length - name.length * 2 - 16;
+    if (remaining <= 80) break;
+    const content = clippedJson(value, Math.min(sectionLimit, remaining));
+    lines.push(`<${name}>${content}</${name}>`);
+  }
+  lines.push(footer);
+  return lines.join("\n");
+}

--- a/packages/runtime/src/extensions/got-context.ts
+++ b/packages/runtime/src/extensions/got-context.ts
@@ -52,7 +52,11 @@ function shorten(value: string | undefined, max: number): string | undefined {
   return value.length <= max ? value : `${value.slice(0, Math.max(0, max - 1))}…`;
 }
 
-function compactNode(node: TraceNodeV2, rootId: string | undefined): Record<string, unknown> {
+function compactNode(
+  node: TraceNodeV2,
+  rootId: string | undefined,
+  activeIds: ReadonlySet<string>,
+): Record<string, unknown> {
   return {
     id: node.id,
     title: node.title,
@@ -63,7 +67,10 @@ function compactNode(node: TraceNodeV2, rootId: string | undefined): Record<stri
     reviewConclusion: node.reviewConclusion,
     updatedAt: node.updatedAt,
     parents: node.parents
-      .filter((parent) => parent.nodeId !== rootId || parent.origin === "trace")
+      .filter((parent) =>
+        activeIds.has(parent.nodeId) ||
+        (parent.nodeId === rootId && parent.origin === "trace"),
+      )
       .map((parent) => ({
         nodeId: parent.nodeId,
         conclusion: parent.conclusion,
@@ -76,10 +83,11 @@ function compactNode(node: TraceNodeV2, rootId: string | undefined): Record<stri
 function compactGraphLines(graph: TraceGraphV2, maxChars: number): string[] {
   const rootId = graph.meta.rootNodeId;
   const nodes = graph.nodes.filter((node) => !node.revoked && node.id !== rootId);
+  const activeIds = new Set(nodes.map((node) => node.id));
   const lines: string[] = [];
   let used = 0;
   for (const node of nodes) {
-    const line = JSON.stringify(compactNode(node, rootId));
+    const line = JSON.stringify(compactNode(node, rootId, activeIds));
     if (used + line.length + 1 > maxChars) break;
     lines.push(line);
     used += line.length + 1;
@@ -96,8 +104,6 @@ export function renderPrincipalGoTContext(
   maxChars = 24_000,
 ): string {
   const rootId = graph.meta.rootNodeId;
-  const active = graph.nodes.filter((node) => !node.revoked && node.id !== rootId);
-  if (active.length === 0) return "";
   const header = [
     `<graph_of_trace revision="${graph.revision}" root_node_id="${rootId ?? ""}">`,
     "This is the current compact Graph of Trace. Use it when planning, synthesizing expert results, handling new evidence, and checking whether work already exists.",

--- a/packages/runtime/src/extensions/trace-reminder.ts
+++ b/packages/runtime/src/extensions/trace-reminder.ts
@@ -1,4 +1,4 @@
-/** Event-driven reminders for trace capture, expert replies, and PI delegation. */
+/** Event-driven reminders for trace capture and expert task replies. */
 import type { AgentRole } from "../types.js";
 
 interface ToolStartLike {
@@ -79,21 +79,9 @@ const MERGED_REMINDER = SYS(
   "Before finishing, record the substantive milestone with record_trace and complete the pending task " +
     "with complete_task using its exact ID.",
 );
-const DELEGATE_REMINDER = SYS(
-  "delegate",
-  "As the Principal, delegate substantive execution to an expert before finishing.",
-);
-const PI_MERGED_REMINDER = SYS(
-  "merged",
-  "As the Principal, record this substantive step with record_trace and delegate the execution " +
-    "to an expert before finishing.",
-);
-
 interface RunState {
   traced: boolean;
-  delegated: boolean;
   traceWorthy: boolean;
-  didSubstantiveWork: boolean;
   dispatched: boolean;
   reminded: boolean;
 }
@@ -101,9 +89,7 @@ interface RunState {
 function freshState(): RunState {
   return {
     traced: false,
-    delegated: false,
     traceWorthy: false,
-    didSubstantiveWork: false,
     dispatched: false,
     reminded: false,
   };
@@ -111,7 +97,7 @@ function freshState(): RunState {
 
 /**
  * A reminder starts one internal follow-up agent loop. State survives that one
- * loop so a satisfied reply/trace/delegation is observed and no second reminder
+ * loop so a satisfied reply/trace is observed and no second reminder
  * is injected. The next external run starts clean.
  */
 export function makeTraceReminderExt(deps: TraceReminderDeps): (pi: PiExtensionApi) => void {
@@ -155,14 +141,12 @@ export function makeTraceReminderExt(deps: TraceReminderDeps): (pi: PiExtensionA
 
       if (tool === "dispatch_task") {
         state.dispatched = true;
-        state.delegated = true;
         state.traceWorthy = true;
         return;
       }
 
       if (!NON_TRACE_TOOLS.has(tool)) {
         state.traceWorthy = true;
-        if (deps.role === "principal") state.didSubstantiveWork = true;
       }
     });
 
@@ -178,21 +162,16 @@ export function makeTraceReminderExt(deps: TraceReminderDeps): (pi: PiExtensionA
       const needReply =
         (deps.hasPendingTasks?.() ?? false) &&
         !state.dispatched;
-      const needDelegate =
-        deps.role === "principal" && state.didSubstantiveWork && !state.delegated;
-
       const sendReminder = (reminder: string): void => {
         state.reminded = true;
         continuingFollowUp = true;
         pi.sendUserMessage(reminder, { deliverAs: "followUp" });
       };
 
-      if (!state.reminded && (needTrace || needReply || needDelegate)) {
+      if (!state.reminded && (needTrace || needReply)) {
         let reminder: string;
         if (needReply && needTrace) reminder = MERGED_REMINDER;
         else if (needReply) reminder = REPLY_REMINDER;
-        else if (needTrace && needDelegate) reminder = PI_MERGED_REMINDER;
-        else if (needDelegate) reminder = DELEGATE_REMINDER;
         else reminder = TRACE_REMINDER;
 
         if (needReply && deps.claimTaskReminder) {

--- a/packages/runtime/src/extensions/trace-reminder.ts
+++ b/packages/runtime/src/extensions/trace-reminder.ts
@@ -59,6 +59,9 @@ const NON_TRACE_TOOLS = new Set([
   "create_agent",
   "destroy_agent",
   "get_trace_graph",
+  "get_trace_node",
+  "get_trace_neighborhood",
+  "get_trace_diff",
 ]);
 
 const SYS = (kind: string, body: string): string =>

--- a/packages/runtime/src/personas.ts
+++ b/packages/runtime/src/personas.ts
@@ -366,9 +366,9 @@ When you finish substantive work for the Principal, structure your result so the
 key claims that may appear in a report, evidence pointers (file paths, command
 outputs, search result names, citation details, or other places the writer and
 auditor can inspect), important caveats or uncertainties, and the report angle
-you recommend. Do not ask the auditor to review raw expert output; the Principal
-will route your handoff to the writer first when a report-like deliverable is
-needed.`;
+you recommend. The Principal may send this packet directly to the auditor for an
+intermediate reliability check, or route it to the writer first when a polished
+report is needed.`;
 
 /* ------------------------------- principal ------------------------------- */
 
@@ -448,11 +448,13 @@ Review each primary file against the task, expected output, completion criteria,
 constraints, and stated gaps. Return incomplete work to the same expert; use
 \`ask_user\` only when resolving the gap requires user preference.
 
-Do NOT personally perform fabrication/reliability audit on expert claims. Also
-do NOT send raw expert output directly to the \`auditor\`. For report-like work,
-first form an auditable draft: ask the \`writer\` to write or polish a report
-from the expert files, or draft a very small answer yourself. Then follow the
-Pre-delivery audit below when the draft contains hard claims.
+Do NOT personally perform fabrication/reliability audit on expert claims. Use
+the \`auditor\` as your independent reviewer instead. You may send it either an
+expert's result/evidence packet for an intermediate check or your synthesized
+draft for a pre-delivery check. When an audit finds a problem, revise your own
+synthesis or return concrete findings to the responsible expert, then re-audit
+the revised result when the correction affects substantive claims. The audit
+feedback returns directly to you; never ask the user to relay it.
 
 ## Recording decisions in the Graph of Trace
 
@@ -462,7 +464,18 @@ deliverable. Do NOT record what an expert did; each expert logs its own outputs,
 and the Trace Agent merges your delegation with their completion into one node.
 Recording both yourself just adds noise.
 
-## Pre-delivery audit (mandatory)
+## Auditor review loop
+
+You may ask the \`auditor\` to inspect your own reasoning or draft, any expert's
+result, or a synthesis across several experts. Include the original user need,
+delegated task, the exact result/draft under review, relevant workspace paths,
+and cited evidence. State whether this is an intermediate result audit or the
+final pre-delivery audit. Stop after \`dispatch_task(to="auditor", ...)\`; its
+completion is delivered directly to you. Apply the findings, send correction
+work to the responsible expert when needed, and request another audit if the
+substantive result changes.
+
+### Pre-delivery audit (mandatory)
 
 Before approving an expert deliverable or sending a final answer containing
 numeric results, file/artifact claims, external citations, datasets, benchmarks,
@@ -471,11 +484,9 @@ or analysis/modelling results, you MUST send an auditable draft to the
 cross-validation, baseline/chance comparisons, and risks such as data/label
 leakage or metric misuse.
 
-Do not audit raw expert output. Send the auditor the original user need,
-delegated task, draft/report path, expert files, and cited evidence. For
-analysis work, include pipeline code and data-split logic. Stop after
-\`dispatch_task(to="auditor", ...)\`; when its completion event arrives, read the
-audit report and revise, qualify, or reject unsupported claims before delivery.
+For analysis work, include pipeline code and data-split logic. When the
+completion event arrives, read the audit findings and revise, qualify, or reject
+unsupported claims before delivery.
 
 **Exemption:** for purely conversational replies with no hard claims (greeting,
 clarification, "I'll start by ...", asking the user a question), skip the audit.
@@ -877,11 +888,12 @@ ${A2A_EXPERT}`;
 
 const AUDITOR = `# Auditor
 
-You are an **independent reliability auditor**. You review the Principal
-Investigator's (PI) draft response before it is delivered to the user, and check
-two things: (1) that its factual claims are backed by evidence the session
-actually produced, and (2) that the analysis behind those claims is not
-undermined by a scientific-validity defect the workspace evidence reveals.
+You are an **independent reliability auditor**. The Principal Investigator (PI)
+may ask you to review its own reasoning or draft, one expert's result, or a
+synthesis across multiple experts. You check two things: (1) that factual claims
+are backed by evidence the session actually produced, and (2) that the analysis
+behind those claims is not undermined by a scientific-validity defect the
+workspace evidence reveals.
 
 ## Mission
 
@@ -990,10 +1002,10 @@ not something you compute or assume away.
 
 ## Inputs available to you
 
-PI assigns you a task containing the full draft response,
-and — for modelling/analysis deliverables — should point you at the pipeline code
-and split logic. You also have read access to the session workspace (your cwd)
-via \`read\`, \`grep\`, \`bash\`, and \`glob\`.
+PI assigns you a task containing the result, reasoning, or draft to review and —
+for modelling/analysis work — should point you at the pipeline code and split
+logic. You also have read access to the session workspace (your cwd) via \`read\`,
+\`grep\`, \`bash\`, and \`glob\`.
 
 You do **NOT** have access to:
 
@@ -1003,10 +1015,10 @@ You do **NOT** have access to:
 
 If the evidence isn't reachable from the workspace, a claim is \`unverified\` and
 a reliability check whose evidence you cannot find is a \`concern\`.
-If PI gives you only raw expert output without a draft/report or report path, do
-not construct the report yourself and do not audit the raw output as the
-deliverable. Send PI a concise message asking for an auditable draft/report
-first, then end your turn.
+Raw expert output is a valid intermediate audit target. Audit its claims and
+evidence as presented, but do not turn it into the final user response. Clearly
+tell PI what is supported, what needs correction, and which expert should revise
+which part.
 
 ## Procedure
 
@@ -1081,16 +1093,12 @@ Each reliability check (Dimension 2) that applies gets exactly one status:
 Never mark a finding \`confirmed\` / \`pass\` because it "sounds plausible". A verdict
 without a concrete file path or grep hit is itself fabrication on your part.
 
-### 5. Write the audit report
+### 5. Submit the audit report
 
-Use \`write\` to save a Markdown report to a path of this form, **relative to your
-cwd (the session workspace)**:
-
-    .audit/<ISO8601-timestamp>-audit.md
-
-The timestamp prevents collisions if PI re-audits a revised draft. Example:
-\`.audit/2026-06-18T14-32-11Z-audit.md\`. Create the \`.audit/\` directory if it
-doesn't exist.
+Build the complete Markdown report below, then persist it with
+\`submit_audit_report(risk=..., summary=..., report=...)\`. This keeps the full
+audit available for inspection without giving you ordinary workspace write
+access.
 
 Required structure (SHAPE ONLY — the headings below are in English to show the
 layout; **translate every heading, label, column header, and status word into the
@@ -1137,13 +1145,14 @@ split.>
 - \`high\` — at least one \`disputed\` claim, at least one reliability \`flaw\`, or
   several \`unverified\` / \`concern\` in critical results.
 
-### 6. Notify PI
+### 6. Report directly to PI
 
-Send a **short** message to PI — path and summary only. Do **NOT** embed the full
-report in the message; PI reads the file.
+Complete the assigned task with the risk, verdict, concrete evidence, and the
+specific corrections PI or an expert should make. Keep it concise but include
+enough detail for PI to act without asking the user to relay the audit.
 
     complete_task(task_id="<assigned audit task ID>",
-                  reply="Audit complete. Risk: <low|medium|high>. Report at: .audit/<filename>. Summary: <one or two lines on what to look at>.")
+                  reply="Audit complete. Risk: <low|medium|high>. Findings: <supported and unsupported claims with evidence>. Required corrections: <actionable list>.")
 
 After sending, **end your turn**. Do not continue tool calls.
 
@@ -1170,8 +1179,8 @@ Do not delegate a bound GoT review or message PI directly.
   is a \`concern\`.
 - **Cite concrete evidence in every verdict** — a file path or grep hit. A verdict
   with no evidence is itself fabrication.
-- **The notification to PI carries path + summary only.** Never the full report
-  body.
+- **Send actionable findings directly to PI.** Never require the user to relay
+  an audit or expert correction.
 - **End your turn after \`complete_task\`.** Do not keep acting.
 - **At most 2 followups per audit pass, to 2 different agents.**
 

--- a/packages/runtime/src/personas.ts
+++ b/packages/runtime/src/personas.ts
@@ -366,9 +366,9 @@ When you finish substantive work for the Principal, structure your result so the
 key claims that may appear in a report, evidence pointers (file paths, command
 outputs, search result names, citation details, or other places the writer and
 auditor can inspect), important caveats or uncertainties, and the report angle
-you recommend. The Principal may send this packet directly to the auditor for an
-intermediate reliability check, or route it to the writer first when a polished
-report is needed.`;
+you recommend. Do not ask the auditor to review raw expert output; the Principal
+will route your handoff to the writer first when a report-like deliverable is
+needed.`;
 
 /* ------------------------------- principal ------------------------------- */
 
@@ -448,13 +448,11 @@ Review each primary file against the task, expected output, completion criteria,
 constraints, and stated gaps. Return incomplete work to the same expert; use
 \`ask_user\` only when resolving the gap requires user preference.
 
-Do NOT personally perform fabrication/reliability audit on expert claims. Use
-the \`auditor\` as your independent reviewer instead. You may send it either an
-expert's result/evidence packet for an intermediate check or your synthesized
-draft for a pre-delivery check. When an audit finds a problem, revise your own
-synthesis or return concrete findings to the responsible expert, then re-audit
-the revised result when the correction affects substantive claims. The audit
-feedback returns directly to you; never ask the user to relay it.
+Do NOT personally perform fabrication/reliability audit on expert claims. Also
+do NOT send raw expert output directly to the \`auditor\`. For report-like work,
+first form an auditable draft: ask the \`writer\` to write or polish a report
+from the expert files, or draft a very small answer yourself. Then follow the
+Pre-delivery audit below when the draft contains hard claims.
 
 ## Recording decisions in the Graph of Trace
 
@@ -464,18 +462,7 @@ deliverable. Do NOT record what an expert did; each expert logs its own outputs,
 and the Trace Agent merges your delegation with their completion into one node.
 Recording both yourself just adds noise.
 
-## Auditor review loop
-
-You may ask the \`auditor\` to inspect your own reasoning or draft, any expert's
-result, or a synthesis across several experts. Include the original user need,
-delegated task, the exact result/draft under review, relevant workspace paths,
-and cited evidence. State whether this is an intermediate result audit or the
-final pre-delivery audit. Stop after \`dispatch_task(to="auditor", ...)\`; its
-completion is delivered directly to you. Apply the findings, send correction
-work to the responsible expert when needed, and request another audit if the
-substantive result changes.
-
-### Pre-delivery audit (mandatory)
+## Pre-delivery audit (mandatory)
 
 Before approving an expert deliverable or sending a final answer containing
 numeric results, file/artifact claims, external citations, datasets, benchmarks,
@@ -484,9 +471,11 @@ or analysis/modelling results, you MUST send an auditable draft to the
 cross-validation, baseline/chance comparisons, and risks such as data/label
 leakage or metric misuse.
 
-For analysis work, include pipeline code and data-split logic. When the
-completion event arrives, read the audit findings and revise, qualify, or reject
-unsupported claims before delivery.
+Do not audit raw expert output. Send the auditor the original user need,
+delegated task, draft/report path, expert files, and cited evidence. For
+analysis work, include pipeline code and data-split logic. Stop after
+\`dispatch_task(to="auditor", ...)\`; when its completion event arrives, read the
+audit report and revise, qualify, or reject unsupported claims before delivery.
 
 **Exemption:** for purely conversational replies with no hard claims (greeting,
 clarification, "I'll start by ...", asking the user a question), skip the audit.
@@ -888,12 +877,11 @@ ${A2A_EXPERT}`;
 
 const AUDITOR = `# Auditor
 
-You are an **independent reliability auditor**. The Principal Investigator (PI)
-may ask you to review its own reasoning or draft, one expert's result, or a
-synthesis across multiple experts. You check two things: (1) that factual claims
-are backed by evidence the session actually produced, and (2) that the analysis
-behind those claims is not undermined by a scientific-validity defect the
-workspace evidence reveals.
+You are an **independent reliability auditor**. You review the Principal
+Investigator's (PI) draft response before it is delivered to the user, and check
+two things: (1) that its factual claims are backed by evidence the session
+actually produced, and (2) that the analysis behind those claims is not
+undermined by a scientific-validity defect the workspace evidence reveals.
 
 ## Mission
 
@@ -1002,10 +990,10 @@ not something you compute or assume away.
 
 ## Inputs available to you
 
-PI assigns you a task containing the result, reasoning, or draft to review and —
-for modelling/analysis work — should point you at the pipeline code and split
-logic. You also have read access to the session workspace (your cwd) via \`read\`,
-\`grep\`, \`bash\`, and \`glob\`.
+PI assigns you a task containing the full draft response,
+and — for modelling/analysis deliverables — should point you at the pipeline code
+and split logic. You also have read access to the session workspace (your cwd)
+via \`read\`, \`grep\`, \`bash\`, and \`glob\`.
 
 You do **NOT** have access to:
 
@@ -1015,10 +1003,10 @@ You do **NOT** have access to:
 
 If the evidence isn't reachable from the workspace, a claim is \`unverified\` and
 a reliability check whose evidence you cannot find is a \`concern\`.
-Raw expert output is a valid intermediate audit target. Audit its claims and
-evidence as presented, but do not turn it into the final user response. Clearly
-tell PI what is supported, what needs correction, and which expert should revise
-which part.
+If PI gives you only raw expert output without a draft/report or report path, do
+not construct the report yourself and do not audit the raw output as the
+deliverable. Send PI a concise message asking for an auditable draft/report
+first, then end your turn.
 
 ## Procedure
 
@@ -1093,12 +1081,16 @@ Each reliability check (Dimension 2) that applies gets exactly one status:
 Never mark a finding \`confirmed\` / \`pass\` because it "sounds plausible". A verdict
 without a concrete file path or grep hit is itself fabrication on your part.
 
-### 5. Submit the audit report
+### 5. Write the audit report
 
-Build the complete Markdown report below, then persist it with
-\`submit_audit_report(risk=..., summary=..., report=...)\`. This keeps the full
-audit available for inspection without giving you ordinary workspace write
-access.
+Use \`write\` to save a Markdown report to a path of this form, **relative to your
+cwd (the session workspace)**:
+
+    .audit/<ISO8601-timestamp>-audit.md
+
+The timestamp prevents collisions if PI re-audits a revised draft. Example:
+\`.audit/2026-06-18T14-32-11Z-audit.md\`. Create the \`.audit/\` directory if it
+doesn't exist.
 
 Required structure (SHAPE ONLY — the headings below are in English to show the
 layout; **translate every heading, label, column header, and status word into the
@@ -1145,14 +1137,13 @@ split.>
 - \`high\` — at least one \`disputed\` claim, at least one reliability \`flaw\`, or
   several \`unverified\` / \`concern\` in critical results.
 
-### 6. Report directly to PI
+### 6. Notify PI
 
-Complete the assigned task with the risk, verdict, concrete evidence, and the
-specific corrections PI or an expert should make. Keep it concise but include
-enough detail for PI to act without asking the user to relay the audit.
+Send a **short** message to PI — path and summary only. Do **NOT** embed the full
+report in the message; PI reads the file.
 
     complete_task(task_id="<assigned audit task ID>",
-                  reply="Audit complete. Risk: <low|medium|high>. Findings: <supported and unsupported claims with evidence>. Required corrections: <actionable list>.")
+                  reply="Audit complete. Risk: <low|medium|high>. Report at: .audit/<filename>. Summary: <one or two lines on what to look at>.")
 
 After sending, **end your turn**. Do not continue tool calls.
 
@@ -1179,8 +1170,8 @@ Do not delegate a bound GoT review or message PI directly.
   is a \`concern\`.
 - **Cite concrete evidence in every verdict** — a file path or grep hit. A verdict
   with no evidence is itself fabrication.
-- **Send actionable findings directly to PI.** Never require the user to relay
-  an audit or expert correction.
+- **The notification to PI carries path + summary only.** Never the full report
+  body.
 - **End your turn after \`complete_task\`.** Do not keep acting.
 - **At most 2 followups per audit pass, to 2 different agents.**
 

--- a/packages/runtime/src/personas.ts
+++ b/packages/runtime/src/personas.ts
@@ -1227,8 +1227,9 @@ propose their direct evidence nodes rather than every transitive ancestor.
 Supply possible parents through \`parent_candidates\` on \`create_trace_node\` or
 \`update_trace_node\`. You only propose candidates; Auditor confirms or rejects
 them. Never recreate a rejected candidate without materially new evidence. The
-Host supplies a hidden Session Start parent until a specific parent is
-confirmed; never propose or edit that structural root yourself.
+Host supplies Session Start only while a node has no parent of any conclusion.
+\`get_trace_graph\` exposes its ID; you may propose Session Start when the unit
+directly depends on the session's initial context rather than another research unit.
 
 The Host binds the current source record to your create/update call. Do not pass
 record ids. Revoked nodes are hidden and must never be reused: create a new node

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -68,6 +68,7 @@ import {
 } from "./personas.js";
 import { renderAgentStatusBlock, collectAgentStatusLines } from "./extensions/agent-status.js";
 import { renderTaskListBlock } from "./extensions/task-context.js";
+import { renderGoTAuditContext, renderPrincipalGoTContext } from "./extensions/got-context.js";
 import { McpBridge, loadMcpServersConfig } from "./mcp-bridge.js";
 import { loadToolToggles, isToolEnabled, type ToolToggles } from "./tool-toggles.js";
 import { materializeSkills } from "./materialize-skills.js";
@@ -2336,6 +2337,12 @@ export class SessionManager {
       renderAgentStatus:
         name === "principal" ? () => this.renderAgentStatus(entry) : undefined,
       renderTaskContext: () => this.renderTaskContext(entry, name),
+      renderGoTContext:
+        name === "principal"
+          ? () => renderPrincipalGoTContext(entry.trace.getGraphV2())
+          : name === "auditor"
+            ? () => this.renderGoTAuditContext(entry)
+            : undefined,
     });
 
     const agent = new MasAgent({
@@ -2431,6 +2438,20 @@ export class SessionManager {
       entry.taskLedger.pendingCreatedBy(name),
       TASK_CONTEXT_MAX_CHARS,
     );
+  }
+
+  private renderGoTAuditContext(entry: SessionEntry): string {
+    const target = entry.currentTraceAuditTarget;
+    if (!target) return "";
+    return renderGoTAuditContext({
+      graph: entry.trace.getGraphV2(),
+      target,
+      targetNode: entry.trace.getNodeDetail(target.nodeId),
+      ...(target.parentNodeId
+        ? { parentNode: entry.trace.getNodeDetail(target.parentNodeId) }
+        : {}),
+      neighborhood: entry.trace.getNeighborhood(target.nodeId, 2),
+    });
   }
 
   async destroyAgent(sessionId: string, name: string): Promise<void> {

--- a/packages/runtime/src/tools/system-tools.ts
+++ b/packages/runtime/src/tools/system-tools.ts
@@ -133,9 +133,6 @@ export function createDispatchTaskTool(deps: ToolDeps): SystemTool {
       if (deps.fromAgent === "auditor" && deps.currentTraceAuditTarget?.()) {
         return { ...ok("A bound GoT audit is a single-turn review and cannot delegate tasks"), isError: true };
       }
-      if (deps.fromAgent === "auditor" && to === "principal") {
-        return { ...ok("Auditor reports are user-gated and cannot be sent directly to PI"), isError: true };
-      }
       await deps.ensureAgent(to);
       try {
         const task = await deps.dispatchTask(to, content);
@@ -783,7 +780,7 @@ export function createEditTraceReviewTool(deps: ToolDeps): SystemTool {
 export function createSubmitAuditReportTool(deps: ToolDeps): SystemTool {
   return {
     name: "submit_audit_report",
-    description: "Persist the completed audit for the user. This never notifies PI.",
+    description: "Persist the completed audit for inspection. For an assigned deliverable audit, also use complete_task to send actionable findings directly to PI.",
     parameters: {
       type: "object",
       properties: {
@@ -923,9 +920,11 @@ export const AGENT_TOOL_CONFIG: Record<string, string[]> = {
     "dispatch_task", "complete_task", "record_trace", "spawn_subagent", "wait_subagent", "get_subagent", "cancel_subagent", "list_subagent_profiles", "skill_search",
     "get_domain_knowledge_local", "search_papers_local",
   ],
-  // Auditor gets bounded Trace readers, review-only mutation tools, and
-  // isolated leaf workers. It cannot mutate ordinary Trace nodes.
+  // Auditor gets direct task communication, bounded Trace readers,
+  // review-only mutation tools, and isolated leaf workers. It cannot mutate
+  // ordinary Trace nodes. Bound GoT turns reject dispatch at execution time.
   auditor: [
+    "dispatch_task",
     "complete_task",
     "spawn_subagent",
     "wait_subagent",
@@ -997,7 +996,7 @@ export const BUILTIN_TOOL_CONFIG_BY_NAME: Record<string, string[]> = {
   writer: ["read", "write", "edit", "grep", "find", "glob", "ls"],
   librarian: ["read", "write", "grep", "find", "glob"],
   // Auditor: read-only inspection. Reports are persisted through the
-  // user-gated submit_audit_report tool; no workspace write/edit access.
+  // submit_audit_report tool; no workspace write/edit access.
   // `bash` is included for
   // grep/awk/jq/diff style filesystem inspection — its read-only discipline is
   // enforced by the auditor persona, not by the tool whitelist.

--- a/packages/runtime/src/tools/system-tools.ts
+++ b/packages/runtime/src/tools/system-tools.ts
@@ -474,7 +474,7 @@ export function createTraceNodeTool(deps: ToolDeps): SystemTool {
     description:
       "Create one new active Graph of Trace node only when the current host-bound record represents a distinct, durable scientific unit that is not already in the active graph. " +
       "Do not create nodes for coordination, delegation, progress, presentation, reformatting, or repetition. The Host attaches the current source record and checkpoint automatically. " +
-      "The Host also attaches the session root whenever no more specific causal parent has been confirmed; never submit the session root as a parent candidate. " +
+      "The Host attaches the session root only when no parent is present. The session root ID is exposed by get_trace_graph and may be proposed when the unit directly depends on the session's initial context. " +
       "One Trace Event may call this tool more than once only when it explicitly contains multiple independently meaningful scientific units with enough content to describe each accurately.",
     parameters: {
       type: "object",
@@ -602,6 +602,7 @@ export function createGetTraceGraphTool(deps: ToolDeps): SystemTool {
       return ok(JSON.stringify({
         schemaVersion: graph.schemaVersion,
         revision: graph.revision,
+        rootNodeId: rootId,
         nodes: graph.nodes
           .filter((node) => activeIds.has(node.id))
           .map((node) => ({
@@ -616,10 +617,15 @@ export function createGetTraceGraphTool(deps: ToolDeps): SystemTool {
             reviewConclusion: node.reviewConclusion,
             updatedAt: node.updatedAt,
             parents: node.parents
-              .filter((parent) => parent.nodeId !== rootId && activeIds.has(parent.nodeId))
+              .filter((parent) =>
+                parent.nodeId === rootId
+                  ? parent.origin === "trace"
+                  : activeIds.has(parent.nodeId)
+              )
               .map((parent) => ({
                 nodeId: parent.nodeId,
                 conclusion: parent.conclusion,
+                ...(parent.origin ? { origin: parent.origin } : {}),
                 ...(parent.reason ? { reason: parent.reason } : {}),
               })),
           })),
@@ -628,7 +634,7 @@ export function createGetTraceGraphTool(deps: ToolDeps): SystemTool {
   };
 }
 
-/** Principal-only bounded trace readers; no Principal full-graph tool exists. */
+/** Bounded trace readers shared by Principal, Trace, and Auditor as allowed below. */
 export function createGetTraceNodeTool(deps: ToolDeps): SystemTool {
   return {
     name: "get_trace_node",
@@ -880,6 +886,10 @@ export const AGENT_TOOL_CONFIG: Record<string, string[]> = {
     "create_agent",
     "destroy_agent",
     "record_trace",
+    "get_trace_graph",
+    "get_trace_node",
+    "get_trace_neighborhood",
+    "get_trace_diff",
     "ask_user",
     "skill_search",
     "get_domain_knowledge_local",

--- a/packages/runtime/src/tools/system-tools.ts
+++ b/packages/runtime/src/tools/system-tools.ts
@@ -133,6 +133,9 @@ export function createDispatchTaskTool(deps: ToolDeps): SystemTool {
       if (deps.fromAgent === "auditor" && deps.currentTraceAuditTarget?.()) {
         return { ...ok("A bound GoT audit is a single-turn review and cannot delegate tasks"), isError: true };
       }
+      if (deps.fromAgent === "auditor" && to === "principal") {
+        return { ...ok("Auditor reports are user-gated and cannot be sent directly to PI"), isError: true };
+      }
       await deps.ensureAgent(to);
       try {
         const task = await deps.dispatchTask(to, content);
@@ -780,7 +783,7 @@ export function createEditTraceReviewTool(deps: ToolDeps): SystemTool {
 export function createSubmitAuditReportTool(deps: ToolDeps): SystemTool {
   return {
     name: "submit_audit_report",
-    description: "Persist the completed audit for inspection. For an assigned deliverable audit, also use complete_task to send actionable findings directly to PI.",
+    description: "Persist the completed audit for the user. This never notifies PI.",
     parameters: {
       type: "object",
       properties: {
@@ -920,11 +923,9 @@ export const AGENT_TOOL_CONFIG: Record<string, string[]> = {
     "dispatch_task", "complete_task", "record_trace", "spawn_subagent", "wait_subagent", "get_subagent", "cancel_subagent", "list_subagent_profiles", "skill_search",
     "get_domain_knowledge_local", "search_papers_local",
   ],
-  // Auditor gets direct task communication, bounded Trace readers,
-  // review-only mutation tools, and isolated leaf workers. It cannot mutate
-  // ordinary Trace nodes. Bound GoT turns reject dispatch at execution time.
+  // Auditor gets bounded Trace readers, review-only mutation tools, and
+  // isolated leaf workers. It cannot mutate ordinary Trace nodes.
   auditor: [
-    "dispatch_task",
     "complete_task",
     "spawn_subagent",
     "wait_subagent",
@@ -996,7 +997,7 @@ export const BUILTIN_TOOL_CONFIG_BY_NAME: Record<string, string[]> = {
   writer: ["read", "write", "edit", "grep", "find", "glob", "ls"],
   librarian: ["read", "write", "grep", "find", "glob"],
   // Auditor: read-only inspection. Reports are persisted through the
-  // submit_audit_report tool; no workspace write/edit access.
+  // user-gated submit_audit_report tool; no workspace write/edit access.
   // `bash` is included for
   // grep/awk/jq/diff style filesystem inspection — its read-only discipline is
   // enforced by the auditor persona, not by the tool whitelist.

--- a/packages/runtime/src/trace.ts
+++ b/packages/runtime/src/trace.ts
@@ -412,18 +412,20 @@ export class GraphOfTrace {
   proposeCausalParent(childNodeId: string, parentNodeId: string, reason: string, actor: TraceChangeActor): boolean {
     const child = this.nodes.get(childNodeId);
     const parent = this.nodes.get(parentNodeId);
-    if (!child || !parent || child.revoked || parent.revoked || this.isSessionRoot(childNodeId) || this.isSessionRoot(parentNodeId) || childNodeId === parentNodeId) return false;
+    if (!child || !parent || child.revoked || parent.revoked || this.isSessionRoot(childNodeId) || childNodeId === parentNodeId) return false;
     const existing = child.parents.find((item) => item.nodeId === parentNodeId);
     if (existing?.conclusion === "rejected") return false;
     if (!existing && this.wouldCreateCycle(parentNodeId, childNodeId)) return false;
     const before = existing ? clone(existing) : undefined;
     if (existing) {
-      if (existing.conclusion === "confirmed" && existing.reason === reason) return true;
+      if (existing.conclusion === "candidate" && existing.reason === reason && existing.origin === "trace") return true;
       existing.conclusion = "candidate";
       existing.reason = reason;
+      existing.origin = "trace";
     } else {
-      child.parents.push({ nodeId: parentNodeId, conclusion: "candidate", ...(reason ? { reason } : {}) });
+      child.parents.push({ nodeId: parentNodeId, conclusion: "candidate", origin: "trace", ...(reason ? { reason } : {}) });
     }
+    this.normalizeCausalGraph();
     this.syncCompatibilityDependency(parentNodeId, childNodeId, "candidate", reason);
     child.updatedAt = now();
     this.commit("updated", childNodeId, {
@@ -463,7 +465,6 @@ export class GraphOfTrace {
       });
       return true;
     }
-    if (this.isSessionRoot(parentNodeId)) return false;
     const parent = this.nodes.get(parentNodeId);
     const ref = node.parents.find((item) => item.nodeId === parentNodeId);
     if (!parent || parent.revoked || !ref) return false;
@@ -1053,7 +1054,10 @@ export class GraphOfTrace {
           const conclusion = parent.conclusion === "confirmed" || parent.conclusion === "rejected" || parent.conclusion === "uncertain"
             ? parent.conclusion
             : "candidate";
-          return [{ nodeId, conclusion, ...(typeof parent.reason === "string" ? { reason: parent.reason } : {}) }];
+          const origin = parent.origin === "trace" || parent.origin === "host_fallback"
+            ? parent.origin
+            : undefined;
+          return [{ nodeId, conclusion, ...(origin ? { origin } : {}), ...(typeof parent.reason === "string" ? { reason: parent.reason } : {}) }];
         }),
         executionResult: node.executionResult === "failed" || node.status === "failed" || node.status === "error" ? "failed" : "completed",
         revoked: node.revoked === true || node.status === "rolled_back" || node.status === "inactive",
@@ -1502,28 +1506,30 @@ export class GraphOfTrace {
       node.parents = accepted;
     }
 
-    // A real confirmed parent replaces the temporary root link. Otherwise the
-    // Host supplies the root as an immediately confirmed fallback.
+    // The Host supplies a root fallback only when no parent of any conclusion
+    // exists. A root explicitly proposed by Trace is a normal reviewable edge.
     for (const node of this.nodes.values()) {
       if (node.revoked || node.id === root.id) continue;
-      const hasRealConfirmedParent = node.parents.some((parent) => {
-        const parentNode = this.nodes.get(parent.nodeId);
-        return parent.nodeId !== root.id && parent.conclusion === "confirmed" && parentNode && !parentNode.revoked;
-      });
-      if (hasRealConfirmedParent) {
-        node.parents = node.parents.filter((parent) => parent.nodeId !== root.id);
+      const hasNonRootParent = node.parents.some((parent) => parent.nodeId !== root.id);
+      if (hasNonRootParent) {
+        node.parents = node.parents.filter((parent) =>
+          parent.nodeId !== root.id || parent.origin === "trace"
+        );
+        continue;
+      }
+      const rootRef = node.parents.find((parent) => parent.nodeId === root.id);
+      if (rootRef?.origin === "trace") continue;
+      if (rootRef) {
+        rootRef.conclusion = "confirmed";
+        rootRef.origin = "host_fallback";
+        rootRef.reason = "No parent was proposed; attached to the session root by the Host.";
       } else {
-        const rootRef = node.parents.find((parent) => parent.nodeId === root.id);
-        if (rootRef) {
-          rootRef.conclusion = "confirmed";
-          rootRef.reason = "No more specific confirmed causal parent; attached to the session root by the Host.";
-        } else {
-          node.parents.unshift({
-            nodeId: root.id,
-            conclusion: "confirmed",
-            reason: "No more specific confirmed causal parent; attached to the session root by the Host.",
-          });
-        }
+        node.parents.unshift({
+          nodeId: root.id,
+          conclusion: "confirmed",
+          origin: "host_fallback",
+          reason: "No parent was proposed; attached to the session root by the Host.",
+        });
       }
     }
     this.rebuildCompatibilityDependencies();

--- a/packages/runtime/src/trace.ts
+++ b/packages/runtime/src/trace.ts
@@ -418,6 +418,11 @@ export class GraphOfTrace {
     if (!existing && this.wouldCreateCycle(parentNodeId, childNodeId)) return false;
     const before = existing ? clone(existing) : undefined;
     if (existing) {
+      if (
+        existing.conclusion === "confirmed" &&
+        existing.reason === reason &&
+        existing.origin !== "host_fallback"
+      ) return true;
       if (existing.conclusion === "candidate" && existing.reason === reason && existing.origin === "trace") return true;
       existing.conclusion = "candidate";
       existing.reason = reason;

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -223,6 +223,8 @@ export type AgentSessionFactory = (params: {
   renderAgentStatus?: () => string;
   /** Fresh flat task-list context, injected ephemerally on every turn. */
   renderTaskContext?: () => string;
+  /** Fresh role-specific GoT context, injected ephemerally on every turn. */
+  renderGoTContext?: () => string;
   /**
    * Per-session LLM provider resolved from providers.json. When omitted, the
    * factory falls back to Pi's env-based default (Docker/static compat).


### PR DESCRIPTION
## Summary

- inject the latest compact GoT ephemerally into every Principal model turn without persisting snapshots in chat history
- grant Principal read-only graph, node, neighborhood, and checkpoint-diff tools
- inject bound target evidence, local neighborhood, compact active graph, and consistency guidance into background GoT audits
- attach Session Start only when a node has no parent of any conclusion, while allowing Trace to explicitly propose and audit the root
- remove the intent-blind Principal delegation reminder while preserving trace and expert-reply reminders

## Stack

- stacked on #409 (`codex/fix-session-state-and-shutdown`)
- after #409 merges, this PR can be retargeted to `main`

## Validation

- `npm test`: 83 files / 918 tests passed
- `npm run typecheck`: passed
- `git diff --check`: passed