### PR TITLE
feat(got): curate research episodes and causal trace nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "packages/web",
         "packages/skills",
         "packages/plugin-auditor",
+        "packages/plugin-got",
         "packages/kb-scripts",
         "packages/docs"
       ],
@@ -319,6 +320,10 @@
     },
     "node_modules/@brainpilot/plugin-auditor": {
       "resolved": "packages/plugin-auditor",
+      "link": true
+    },
+    "node_modules/@brainpilot/plugin-got": {
+      "resolved": "packages/plugin-got",
       "link": true
     },
     "node_modules/@brainpilot/plugin-sdk": {
@@ -10533,6 +10538,14 @@
         "node": ">=22"
       }
     },
+    "packages/plugin-got": {
+      "name": "@brainpilot/plugin-got",
+      "version": "0.1.2",
+      "license": "AGPL-3.0-only",
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "packages/plugin-sdk": {
       "name": "@brainpilot/plugin-sdk",
       "version": "0.1.2",
@@ -10577,6 +10590,7 @@
       "dependencies": {
         "@brainpilot/kb-scripts": "^0.1.2",
         "@brainpilot/plugin-auditor": "^0.1.2",
+        "@brainpilot/plugin-got": "^0.1.2",
         "@brainpilot/plugin-sdk": "^0.1.2",
         "@brainpilot/protocol": "^0.1.2",
         "@brainpilot/skills": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "packages/web",
     "packages/skills",
     "packages/plugin-auditor",
+    "packages/plugin-got",
     "packages/kb-scripts",
     "packages/docs"
   ],
@@ -33,7 +34,7 @@
     "version:check": "node scripts/sync-versions.js --check",
     "release:build": "npm run build",
     "release:dry": "npm publish --workspaces --if-present --dry-run --access public",
-    "release": "npm run version:sync && npm run release:build && npm publish --workspace @brainpilot/plugin-sdk --workspace @brainpilot/skills --workspace @brainpilot/plugin-auditor --workspace @brainpilot/kb-scripts --workspace @brainpilot/protocol --workspace @brainpilot/runtime --workspace @brainpilot/backend-core --workspace @brainpilot/web --workspace @brainpilot/app --access public"
+    "release": "npm run version:sync && npm run release:build && npm publish --workspace @brainpilot/plugin-sdk --workspace @brainpilot/skills --workspace @brainpilot/plugin-auditor --workspace @brainpilot/plugin-got --workspace @brainpilot/kb-scripts --workspace @brainpilot/protocol --workspace @brainpilot/runtime --workspace @brainpilot/backend-core --workspace @brainpilot/web --workspace @brainpilot/app --access public"
   },
   "devDependencies": {
     "@types/node": "^22.10.0",

--- a/packages/cli/test/publish-readiness.test.ts
+++ b/packages/cli/test/publish-readiness.test.ts
@@ -126,6 +126,17 @@ describe("targeted publish guards", () => {
     expect(manifest.version).toBe(plugin.version);
     expect(manifest.id).toBe("org.brainpilot.auditor");
   });
+
+  it("ships the GoT system plugin as a pinned Runtime dependency", () => {
+    const runtime = readPkg("../../runtime/package.json");
+    const plugin = readPkg("../../plugin-got/package.json");
+    const manifest = readPkg("../../plugin-got/manifest.json");
+    expect(runtime.dependencies?.["@brainpilot/plugin-got"]).toMatch(/^\^/);
+    expect(plugin.files).toEqual(expect.arrayContaining(["manifest.json", "skills"]));
+    expect(plugin.version).toBe(ROOT.version);
+    expect(manifest.version).toBe(plugin.version);
+    expect(manifest.id).toBe("org.brainpilot.got");
+  });
 });
 
 describe("license is consistent across the repo", () => {
@@ -169,5 +180,9 @@ describe("root scripts", () => {
 
   it("publishes @brainpilot/plugin-auditor in release", () => {
     expect(pkg.scripts?.release).toContain("@brainpilot/plugin-auditor");
+  });
+
+  it("publishes @brainpilot/plugin-got in release", () => {
+    expect(pkg.scripts?.release).toContain("@brainpilot/plugin-got");
   });
 });

--- a/packages/plugin-got/manifest.json
+++ b/packages/plugin-got/manifest.json
@@ -1,0 +1,19 @@
+{
+  "id": "org.brainpilot.got",
+  "version": "0.1.2",
+  "apiVersion": "1",
+  "displayName": "BrainPilot Graph of Trace",
+  "description": "Research-event curation guidance for readable Graph of Trace Episodes and direct dependencies.",
+  "categories": ["analysis", "workflow", "skills"],
+  "engines": { "brainpilot": ">=0.1.2 <0.2.0" },
+  "environments": ["local", "cloud"],
+  "contributes": {
+    "skills": [{
+      "id": "curate-research-trace",
+      "title": "Curate Research Trace",
+      "description": "Organize research reports into Episodes, appropriately granular nodes, and direct dependencies.",
+      "entry": "skills/curate-research-trace/SKILL.md",
+      "targets": ["trace"]
+    }]
+  }
+}

--- a/packages/plugin-got/package.json
+++ b/packages/plugin-got/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@brainpilot/plugin-got",
+  "version": "0.1.2",
+  "engines": { "node": ">=22" },
+  "license": "AGPL-3.0-only",
+  "type": "module",
+  "description": "BrainPilot built-in Graph of Trace curation plugin",
+  "files": [
+    "manifest.json",
+    "skills"
+  ],
+  "exports": {
+    "./package.json": "./package.json",
+    "./manifest.json": "./manifest.json"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/NeuroAIHub/BrainPilot.git",
+    "directory": "packages/plugin-got"
+  },
+  "publishConfig": { "access": "public" }
+}

--- a/packages/plugin-got/skills/curate-research-trace/SKILL.md
+++ b/packages/plugin-got/skills/curate-research-trace/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: curate-research-trace
+description: Curate BrainPilot Trace Events into human-readable research Episodes, appropriately granular nodes, and direct depends_on relationships. Use when a report contains multiple settings, results, analyses, visualizations, findings, or conclusions; when Episode placement is unclear; or when deciding whether new evidence should create parallel/sequential nodes or update an existing node.
+---
+
+# Curate Research Trace
+
+Turn reported research work into a compact derivation graph. Preserve scientific
+units rather than tool chronology.
+
+## Curate one Trace Event
+
+1. Inspect the active graph and reuse established Episode names and nodes.
+2. Extract units that can be inspected, cited, reproduced, or revoked independently.
+3. Assign every new unit to one research work-package Episode.
+4. Update an existing node when the report adds evidence to the same unit.
+5. Create parallel nodes when neither unit consumes the other.
+6. Create sequential dependencies only when the downstream unit consumes or
+   requires the upstream unit.
+7. Add only direct parents. Never copy all transitive ancestors.
+
+## Select an Episode
+
+Treat an Episode as one coherent research subquestion or experiment family, not
+as a time period or causal node.
+
+- Use `Literature Review — <topic>` for evidence synthesis around one question.
+- Use `Method Design — <method>` for reusable method or protocol decisions.
+- Use `Environment & Reproducibility` for shared runtime, dependency, hardware,
+  and reproducibility setup.
+- Use `Data Preparation — <dataset>` for a dataset version, split, or material
+  preprocessing pipeline.
+- Use `Main Experiment — <question>` for settings and outputs testing one main hypothesis.
+- Use `Ablation — <factor>` for all settings, results, comparisons,
+  visualizations, and local findings in one ablation family.
+- Use `Robustness — <factor>` for sensitivity or robustness settings and outputs.
+- Use `Cross-experiment Analysis — <question>` only when an analysis consumes
+  results from multiple experiment families.
+- Use `Final Synthesis` for conclusions that integrate findings across Episodes.
+
+Use the session language. Prefer an existing exact Episode name. Do not create
+Episodes based only on Agent, tool, file, timestamp, or generic lifecycle phase.
+Dependencies may cross Episode boundaries.
+
+## Decide node boundaries
+
+Create separate parallel nodes for:
+
+- distinct settings, conditions, or model variants;
+- the independently inspectable result of each setting;
+- analyses that answer different scientific questions;
+- findings that can independently hold or be refuted.
+
+Create separate sequential nodes when one report contains independently
+reviewable configuration, result, analysis/visualization, finding, and conclusion
+units. Connect them only in the order in which outputs are actually consumed.
+
+Update one existing node for:
+
+- seeds, folds, replicates, and repeated runs of the same setting and outcome;
+- additional evidence or a correction for the same result or finding;
+- multiple export formats of one result or figure;
+- immediate retries, formatting changes, and non-meaningful intermediates.
+
+Keep multiple metrics in one result when they jointly describe one run. Split
+them only when they are reused independently or support independently
+falsifiable findings. Make a visualization a node only when it performs an
+independent analysis or carries an independently cited interpretation; otherwise
+attach it as an artifact.
+
+## Select direct parents
+
+Apply this counterfactual: if the parent disappeared, would the child lose its
+evidence or need recomputation?
+
+- A result depends on the setting and concrete method/data/environment inputs it used.
+- An analysis depends on the result nodes it consumes.
+- A visualization depends on the result or analysis used to generate it.
+- A finding depends on its direct result or analysis evidence.
+- A conclusion depends on direct findings, not every underlying result.
+
+Do not connect nodes because they are adjacent, share an Episode or author, use
+similar words, or occurred in order. Parallel settings share parents and do not
+depend on one another.
+
+Read [references/examples.md](references/examples.md) when a report mixes
+multiple research phases, contains an ablation, or leaves node boundaries unclear.

--- a/packages/plugin-got/skills/curate-research-trace/agents/openai.yaml
+++ b/packages/plugin-got/skills/curate-research-trace/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Curate Research Trace"
+  short_description: "Organize research events into clear causal trace nodes"
+  default_prompt: "Use $curate-research-trace to organize this research report into Episodes, nodes, and direct dependencies."

--- a/packages/plugin-got/skills/curate-research-trace/references/examples.md
+++ b/packages/plugin-got/skills/curate-research-trace/references/examples.md
@@ -1,0 +1,104 @@
+# Research Trace Curation Examples
+
+## Contents
+
+1. Full research path
+2. Three-setting ablation
+3. Mixed report splitting
+4. Metric boundaries
+5. Visualization boundaries
+6. Incorrect graph patterns
+
+## 1. Full research path
+
+Use separate Episodes for reusable prerequisites, then connect their nodes to the
+experiment outputs that actually consume them.
+
+```text
+Episode: Literature Review — regularization
+  Prior evidence synthesis
+
+Episode: Method Design — classifier protocol
+  Evaluation protocol
+
+Episode: Environment & Reproducibility
+  Locked CUDA and Python environment
+
+Episode: Data Preparation — Dataset A
+  Subject-wise train/validation split
+
+Episode: Main Experiment — classifier generalization
+  Baseline setting
+  Baseline validation result
+  Generalization analysis
+  Finding: baseline exceeds the preregistered threshold
+
+Direct dependencies:
+  Prior evidence synthesis -> Evaluation protocol
+  Evaluation protocol -> Baseline validation result
+  Locked environment -> Baseline validation result
+  Subject-wise split -> Baseline validation result
+  Baseline setting -> Baseline validation result
+  Baseline validation result -> Generalization analysis
+  Generalization analysis -> Finding
+```
+
+Do not connect Episodes themselves. They are presentation groups.
+
+## 2. Three-setting ablation
+
+Put the complete local derivation in one Episode.
+
+```text
+Episode: Ablation — dropout
+
+Baseline setting -----------------> Baseline result -------\
+No-dropout setting ---------------> No-dropout result ------> Dropout comparison
+Dropout-0.3 setting --------------> Dropout-0.3 result -----/          |
+                                                                       +-> Ablation figure
+                                                                       +-> Finding: dropout improves generalization
+```
+
+The settings and their results are parallel. Do not create
+`Baseline setting -> No-dropout setting -> Dropout-0.3 setting`.
+
+## 3. Mixed report splitting
+
+Report:
+
+> We evaluated the no-dropout configuration, obtained validation accuracy 0.78,
+> and concluded that removing dropout reduced generalization.
+
+Create three sequential units when each statement is independently inspectable:
+
+1. `No-dropout setting` — the configuration.
+2. `No-dropout validation result` — the measured output.
+3. `Finding: removing dropout reduced generalization` — only if the report also
+   contains an appropriate comparison; otherwise record the result without
+   manufacturing the finding.
+
+## 4. Metric boundaries
+
+Keep accuracy, F1, and AUC from the same evaluation run in one result when they
+jointly characterize performance. Split a fairness metric or robustness score
+when it is produced by a distinct evaluation and later supports a separate analysis.
+
+Repeated seeds update the same result node. Do not create one node per seed.
+
+## 5. Visualization boundaries
+
+- A PNG export of an already-recorded comparison is an artifact of that comparison.
+- A dimensionality-reduction plot that performs a distinct analysis and supports
+  a cluster-separation finding is a visualization node derived from its inputs.
+- Multiple file formats of one figure remain artifacts of one node.
+
+## 6. Incorrect graph patterns
+
+Reject these patterns during curation:
+
+- settings chained by execution time;
+- one node containing several independently reportable settings and results;
+- an Episode name used as if it were a node or parent;
+- a finding connected directly to a setting while skipping the measured result;
+- a conclusion connected to findings and all of their transitive result ancestors;
+- nodes created for file reads, acknowledgements, formatting, or immediate retries.

--- a/packages/protocol/src/domain.ts
+++ b/packages/protocol/src/domain.ts
@@ -436,6 +436,8 @@ export type TraceNodeRecord = z.infer<typeof TraceNodeRecordSchema>;
 export const TraceCausalParentSchema = z.object({
   nodeId: z.string(),
   conclusion: TraceParentConclusionSchema,
+  /** Distinguishes the structural fallback from a parent explicitly proposed by Trace. */
+  origin: z.enum(["host_fallback", "trace"]).optional(),
   /** Current concise reason; earlier reasons remain in TraceChangeLog. */
   reason: z.string().optional(),
 });

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "@brainpilot/kb-scripts": "^0.1.2",
     "@brainpilot/plugin-auditor": "^0.1.2",
+    "@brainpilot/plugin-got": "^0.1.2",
     "@brainpilot/plugin-sdk": "^0.1.2",
     "@brainpilot/protocol": "^0.1.2",
     "@brainpilot/skills": "^0.1.2",

--- a/packages/runtime/src/__tests__/got-context.test.ts
+++ b/packages/runtime/src/__tests__/got-context.test.ts
@@ -49,6 +49,24 @@ describe("GoT ephemeral context", () => {
     expect(block).not.toContain('"type":"session_start"');
   });
 
+  it("renders an explicit empty active graph", () => {
+    const trace = new GraphOfTrace("s");
+    const block = renderPrincipalGoTContext(trace.getGraphV2());
+    expect(block).toContain(`revision="${trace.getGraphV2().revision}"`);
+    expect(block).toContain("<active_nodes>\n</active_nodes>");
+  });
+
+  it("omits parent links to revoked nodes from the compact graph", () => {
+    const trace = new GraphOfTrace("s");
+    const parent = trace.createNode({ title: "Revoked evidence" });
+    const child = trace.createNode({ title: "Conclusion" });
+    trace.proposeCausalParent(child.id, parent.id, "consumed evidence", { type: "agent", name: "trace" });
+    trace.updateNode(parent.id, { revoked: true }, { type: "agent", name: "trace" });
+    const block = renderPrincipalGoTContext(trace.getGraphV2());
+    expect(block).toContain(`"id":"${child.id}"`);
+    expect(block).not.toContain(`"nodeId":"${parent.id}"`);
+  });
+
   it("injects a fresh block and strips an older ephemeral snapshot", () => {
     let block = '<graph_of_trace revision="1">old</graph_of_trace>';
     const { pi, fire } = fakePi();

--- a/packages/runtime/src/__tests__/got-context.test.ts
+++ b/packages/runtime/src/__tests__/got-context.test.ts
@@ -39,12 +39,15 @@ describe("GoT ephemeral context", () => {
     const node = trace.createNode({
       title: "Evidence",
       description: "A durable result",
+      episode: "Ablation — dropout",
       confidence: "high",
       reviewConclusion: "approved",
     });
     const block = renderPrincipalGoTContext(trace.getGraphV2());
     expect(block).toContain(`revision="${trace.getGraphV2().revision}"`);
     expect(block).toContain(`"id":"${node.id}"`);
+    expect(block).toContain('"episode":"Ablation — dropout"');
+    expect(block).not.toContain(String(trace.getNodeV2(node.id)?.primaryEpisodeId));
     expect(block).toContain("get_trace_neighborhood");
     expect(block).not.toContain('"type":"session_start"');
   });
@@ -84,8 +87,8 @@ describe("GoT ephemeral context", () => {
 
   it("renders a bound audit with detailed local and compact global evidence", () => {
     const trace = new GraphOfTrace("s");
-    const parent = trace.createNode({ title: "Evidence" });
-    const child = trace.createNode({ title: "Conclusion" });
+    const parent = trace.createNode({ title: "Evidence", episode: "Main Experiment — accuracy" });
+    const child = trace.createNode({ title: "Conclusion", episode: "Final Synthesis" });
     trace.proposeCausalParent(child.id, parent.id, "consumed evidence", { type: "agent", name: "trace" });
     const target = trace.listPendingAuditTargets().find((item) => item.parentNodeId === parent.id)!;
     const block = renderGoTAuditContext({
@@ -99,6 +102,8 @@ describe("GoT ephemeral context", () => {
     expect(block).toContain("<target_evidence>");
     expect(block).toContain("<local_neighborhood>");
     expect(block).toContain("<compact_active_graph>");
+    expect(block).toContain('"episode": "Final Synthesis"');
     expect(block).toContain("Textual traceability alone is not scientific validation");
+    expect(block).toContain("Episode membership alone never establishes dependency");
   });
 });

--- a/packages/runtime/src/__tests__/got-context.test.ts
+++ b/packages/runtime/src/__tests__/got-context.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+import { GraphOfTrace } from "../trace.js";
+import {
+  makeGoTContextExt,
+  renderGoTAuditContext,
+  renderPrincipalGoTContext,
+} from "../extensions/got-context.js";
+
+interface FakeMessage {
+  role: string;
+  content: Array<{ type: string; text?: string }>;
+}
+
+function fakePi() {
+  let handler:
+    | ((event: { messages: FakeMessage[] }) => { messages: FakeMessage[] } | void)
+    | undefined;
+  return {
+    pi: {
+      on(_event: "context", callback: typeof handler) {
+        handler = callback;
+      },
+    },
+    fire(messages: FakeMessage[]) {
+      if (!handler) throw new Error("context handler was not registered");
+      return handler({ messages });
+    },
+  };
+}
+
+const userMessage = (text: string): FakeMessage => ({
+  role: "user",
+  content: [{ type: "text", text }],
+});
+
+describe("GoT ephemeral context", () => {
+  it("renders the latest compact active graph and Principal usage guidance", () => {
+    const trace = new GraphOfTrace("s");
+    const node = trace.createNode({
+      title: "Evidence",
+      description: "A durable result",
+      confidence: "high",
+      reviewConclusion: "approved",
+    });
+    const block = renderPrincipalGoTContext(trace.getGraphV2());
+    expect(block).toContain(`revision="${trace.getGraphV2().revision}"`);
+    expect(block).toContain(`"id":"${node.id}"`);
+    expect(block).toContain("get_trace_neighborhood");
+    expect(block).not.toContain('"type":"session_start"');
+  });
+
+  it("injects a fresh block and strips an older ephemeral snapshot", () => {
+    let block = '<graph_of_trace revision="1">old</graph_of_trace>';
+    const { pi, fire } = fakePi();
+    makeGoTContextExt({ renderContext: () => block })(pi as never);
+    block = '<graph_of_trace revision="2">new</graph_of_trace>';
+    const result = fire([
+      userMessage("hello"),
+      userMessage('<graph_of_trace revision="1">old</graph_of_trace>'),
+    ]) as { messages: FakeMessage[] };
+    expect(result.messages).toEqual([
+      userMessage("hello"),
+      userMessage('<graph_of_trace revision="2">new</graph_of_trace>'),
+    ]);
+  });
+
+  it("renders a bound audit with detailed local and compact global evidence", () => {
+    const trace = new GraphOfTrace("s");
+    const parent = trace.createNode({ title: "Evidence" });
+    const child = trace.createNode({ title: "Conclusion" });
+    trace.proposeCausalParent(child.id, parent.id, "consumed evidence", { type: "agent", name: "trace" });
+    const target = trace.listPendingAuditTargets().find((item) => item.parentNodeId === parent.id)!;
+    const block = renderGoTAuditContext({
+      graph: trace.getGraphV2(),
+      target,
+      targetNode: trace.getNodeDetail(child.id),
+      parentNode: trace.getNodeDetail(parent.id),
+      neighborhood: trace.getNeighborhood(child.id, 2),
+    });
+    expect(block).toContain("<bound_target>");
+    expect(block).toContain("<target_evidence>");
+    expect(block).toContain("<local_neighborhood>");
+    expect(block).toContain("<compact_active_graph>");
+    expect(block).toContain("Textual traceability alone is not scientific validation");
+  });
+});

--- a/packages/runtime/src/__tests__/personas.test.ts
+++ b/packages/runtime/src/__tests__/personas.test.ts
@@ -89,6 +89,15 @@ describe("personas", () => {
     expect(PERSONAS.trace!).not.toContain("skill_search");
   });
 
+  it("teaches Trace research-unit granularity and direct dependency rules", () => {
+    const trace = PERSONAS.trace!;
+    expect(trace).toContain("curate-research-trace");
+    expect(trace).toContain("setting, its result");
+    expect(trace).toContain("Settings in one ablation are normally parallel");
+    expect(trace).toContain("Episode membership");
+    expect(trace).toContain("only direct parents");
+  });
+
   it("expert personas carry the flat task completion contract", () => {
     for (const name of ["librarian", "engineer", "experimentalist", "writer"]) {
       expect(PERSONAS[name], name).toContain('complete_task(task_id="<exact assigned ID>"');

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -127,6 +127,34 @@ describe("SessionManager (mock mode)", () => {
     expect(seen[0]).not.toContain("mcp__builtin__");
   });
 
+  it("wires fresh ephemeral GoT renderers for Principal and bound Auditor turns", async () => {
+    const renderers = new Map<string, () => string>();
+    const spyFactory: typeof mockAgentFactory = async (params) => {
+      if (params.renderGoTContext) renderers.set(params.agentName, params.renderGoTContext);
+      return mockAgentFactory(params);
+    };
+    const sm = new SessionManager({ persist: false, agentFactory: spyFactory });
+    const session = await sm.createSession();
+    await sm.sendMessage(session.id, "hi");
+    await waitFor(() => renderers.has("principal"));
+
+    const internal = sm as unknown as {
+      sessions: Map<string, {
+        trace: import("../trace.js").GraphOfTrace;
+        currentTraceAuditTarget?: import("../trace.js").TraceAuditTarget;
+      }>;
+      ensureAgent(sessionId: string, name: string): Promise<unknown>;
+    };
+    const entry = internal.sessions.get(session.id)!;
+    const node = entry.trace.createNode({ title: "Review me" });
+    expect(renderers.get("principal")?.()).toContain(`"id":"${node.id}"`);
+
+    await internal.ensureAgent(session.id, "auditor");
+    entry.currentTraceAuditTarget = entry.trace.listPendingAuditTargets([node.id])[0];
+    expect(renderers.get("auditor")?.()).toContain("<bound_target>");
+    expect(renderers.get("auditor")?.()).toContain(node.id);
+  });
+
   it("keeps high-impact action authorization in PI and expert personas", () => {
     expect(PERSONAS.principal).toContain("## User authorization gate");
     expect(PERSONAS.principal).toContain("Use `ask_user` first");

--- a/packages/runtime/src/__tests__/system-plugins.test.ts
+++ b/packages/runtime/src/__tests__/system-plugins.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   AUDITOR_PLUGIN_ID,
+  GOT_PLUGIN_ID,
   loadBundledSystemPlugins,
   snapshotSystemPlugins,
   systemPluginEnabled,
@@ -9,12 +10,15 @@ import {
 } from "../system-plugins.js";
 
 describe("bundled system plugins", () => {
-  it("loads Auditor by default from its npm package", async () => {
+  it("loads Auditor and GoT by default from their npm packages", async () => {
     const plugins = loadBundledSystemPlugins({});
     const snapshot = snapshotSystemPlugins(plugins);
     expect(systemPluginEnabled(snapshot, AUDITOR_PLUGIN_ID)).toBe(true);
+    expect(systemPluginEnabled(snapshot, GOT_PLUGIN_ID)).toBe(true);
     expect(systemPluginSkillPaths(plugins, snapshot, "principal")[0]).toMatch(/plugin-auditor.*audit-feedback-loop/);
     expect(systemPluginSkillPaths(plugins, snapshot, "engineer")).toEqual([]);
+    expect(systemPluginSkillPaths(plugins, snapshot, "trace")[0])
+      .toMatch(/plugin-got.*curate-research-trace/);
     expect((await systemPluginInstructions(plugins, snapshot, "principal")).join("\n"))
       .toContain("Auditor feedback loop");
   });
@@ -49,5 +53,19 @@ describe("bundled system plugins", () => {
     expect(await systemPluginInstructions(plugins, snapshot, "principal")).toEqual([]);
     expect(await systemPluginInstructions(plugins, snapshot, "auditor")).toEqual([]);
     expect(await systemPluginInstructions(plugins, snapshot, "trace")).toEqual([]);
+  });
+
+  it("removes only the targeted GoT skill under its experiment override", () => {
+    const plugins = loadBundledSystemPlugins({
+      BP_EXPERIMENT_DISABLE_PLUGINS: GOT_PLUGIN_ID,
+    });
+    const snapshot = snapshotSystemPlugins(plugins);
+    expect(snapshot).toContainEqual(expect.objectContaining({
+      id: GOT_PLUGIN_ID,
+      enabled: false,
+      reason: "experiment-override",
+    }));
+    expect(systemPluginSkillPaths(plugins, snapshot, "trace")).toEqual([]);
+    expect(systemPluginEnabled(snapshot, AUDITOR_PLUGIN_ID)).toBe(true);
   });
 });

--- a/packages/runtime/src/__tests__/tool-access.test.ts
+++ b/packages/runtime/src/__tests__/tool-access.test.ts
@@ -92,11 +92,21 @@ describe("tool access control (§9)", () => {
     await expect(tool.execute({ question: "   " })).resolves.toMatchObject({ isError: true });
   });
 
-  it("principal gets comms + record_trace, not graph mutation tools", () => {
+  it("principal gets comms, record_trace, and read-only GoT tools", () => {
     const names = systemToolNamesForRole("principal", "principal");
-    expect(names).toEqual(expect.arrayContaining(["dispatch_task", "complete_task", "create_agent", "destroy_agent", "record_trace"]));
+    expect(names).toEqual(expect.arrayContaining([
+      "dispatch_task",
+      "complete_task",
+      "create_agent",
+      "destroy_agent",
+      "record_trace",
+      "get_trace_graph",
+      "get_trace_node",
+      "get_trace_neighborhood",
+      "get_trace_diff",
+    ]));
     expect(names).not.toContain("create_trace_node");
-    expect(names).not.toContain("get_trace_graph");
+    expect(names).not.toContain("update_trace_node");
   });
 
   it("principal can ask_user; experts and trace cannot", () => {
@@ -277,15 +287,26 @@ describe("tool access control (§9)", () => {
     const node = d.trace.getGraphV2().nodes.find((item) => item.type !== "session_start")!;
     const agentGraph = JSON.parse((await tools.get("get_trace_graph")!.execute({})).content[0]!.text) as {
       revision: number;
+      rootNodeId?: string;
       nodes: Array<{ id: string; parents: unknown[] }>;
       dependencies?: unknown;
       artifacts?: unknown;
     };
     expect(agentGraph.nodes).toEqual([expect.objectContaining({ id: node.id, parents: [] })]);
+    expect(agentGraph.rootNodeId).toBe(d.trace.getGraphV2().meta.rootNodeId);
     expect(agentGraph).not.toHaveProperty("dependencies");
     expect(agentGraph).not.toHaveProperty("artifacts");
     expect(agentGraph.nodes[0]).not.toHaveProperty("records");
     expect((await tools.get("update_trace_node")!.execute({ node_id: node.id, summary: "updated" })).isError).toBe(true);
+
+    const rootId = d.trace.getGraphV2().meta.rootNodeId!;
+    d.trace.proposeCausalParent(node.id, rootId, "Depends only on initial context.", { type: "agent", name: "trace" });
+    const withExplicitRoot = JSON.parse((await tools.get("get_trace_graph")!.execute({})).content[0]!.text) as {
+      nodes: Array<{ id: string; parents: Array<{ nodeId: string; origin?: string }> }>;
+    };
+    expect(withExplicitRoot.nodes.find((item) => item.id === node.id)?.parents).toContainEqual(
+      expect.objectContaining({ nodeId: rootId, origin: "trace" }),
+    );
   });
 });
 
@@ -339,6 +360,10 @@ describe("tool toggles", () => {
       "create_agent",
       "destroy_agent",
       "dispatch_task",
+      "get_trace_diff",
+      "get_trace_graph",
+      "get_trace_neighborhood",
+      "get_trace_node",
       "record_trace",
     ].sort());
   });

--- a/packages/runtime/src/__tests__/tool-access.test.ts
+++ b/packages/runtime/src/__tests__/tool-access.test.ts
@@ -281,6 +281,8 @@ describe("tool access control (§9)", () => {
     expect((await tools.get("create_trace_node")!.execute({ title: "Missing confidence" })).isError).toBe(true);
     expect((await tools.get("create_trace_node")!.execute({
       title: "Ablation",
+      description: "Evaluate one ablation setting on a complete seed.",
+      episode: "Ablation — regularization",
       confidence: "medium",
       confidence_reason: "One complete seed.",
     })).isError).not.toBe(true);
@@ -288,11 +290,15 @@ describe("tool access control (§9)", () => {
     const agentGraph = JSON.parse((await tools.get("get_trace_graph")!.execute({})).content[0]!.text) as {
       revision: number;
       rootNodeId?: string;
-      nodes: Array<{ id: string; parents: unknown[] }>;
+      episodes?: string[];
+      nodes: Array<{ id: string; parents: unknown[]; episode?: string }>;
       dependencies?: unknown;
       artifacts?: unknown;
     };
     expect(agentGraph.nodes).toEqual([expect.objectContaining({ id: node.id, parents: [] })]);
+    expect(agentGraph.episodes).toEqual(["Ablation — regularization"]);
+    expect(agentGraph.nodes[0]?.episode).toBe("Ablation — regularization");
+    expect(agentGraph.nodes[0]).not.toHaveProperty("primaryEpisodeId");
     expect(agentGraph.rootNodeId).toBe(d.trace.getGraphV2().meta.rootNodeId);
     expect(agentGraph).not.toHaveProperty("dependencies");
     expect(agentGraph).not.toHaveProperty("artifacts");
@@ -307,6 +313,128 @@ describe("tool access control (§9)", () => {
     expect(withExplicitRoot.nodes.find((item) => item.id === node.id)?.parents).toContainEqual(
       expect.objectContaining({ nodeId: rootId, origin: "trace" }),
     );
+  });
+
+  it("normalizes Episodes and applies parent batches atomically", async () => {
+    const d = deps("trace");
+    const tools = new Map(systemToolsForRole("trace", "trace", d).map((tool) => [tool.name, tool]));
+    const create = tools.get("create_trace_node")!;
+    const update = tools.get("update_trace_node")!;
+    const validCreate = {
+      title: "Valid title",
+      description: "A complete standalone research unit.",
+      episode: "Validation Episode",
+      confidence: "medium",
+      confidence_reason: "One source record is available.",
+    };
+    for (const invalid of [
+      { ...validCreate, title: "   " },
+      { ...validCreate, description: "   " },
+      { ...validCreate, episode: "   " },
+      { ...validCreate, confidence_reason: "   " },
+      {
+        ...validCreate,
+        parent_candidates: [{
+          node_id: d.trace.getGraphV2().meta.rootNodeId,
+          reason: "   ",
+        }],
+      },
+    ]) {
+      expect((await create.execute(invalid)).isError).toBe(true);
+    }
+    expect(d.trace.getGraphV2().episodes).toEqual([]);
+
+    const parentResult = await create.execute({
+      title: "Dropout baseline setting",
+      description: "Use dropout 0.3 with the fixed evaluation protocol.",
+      episode: "  Ａｂｌａｔｉｏｎ   —  Dropout  ",
+      confidence: "high",
+      confidence_reason: "The configuration is fully specified.",
+    });
+    expect(parentResult.isError).not.toBe(true);
+    const parentId = (JSON.parse(parentResult.content[0]!.text) as { nodeId: string }).nodeId;
+
+    const childResult = await create.execute({
+      title: "Dropout baseline result",
+      description: "The baseline achieved validation accuracy 0.82.",
+      episode: "ablation — dropout",
+      confidence: "medium",
+      confidence_reason: "One complete evaluation run is available.",
+      parent_candidates: [{
+        node_id: parentId,
+        reason: "The result was produced by this exact setting.",
+      }],
+    });
+    expect(childResult.isError).not.toBe(true);
+    const childId = (JSON.parse(childResult.content[0]!.text) as { nodeId: string }).nodeId;
+    let graph = d.trace.getGraphV2();
+    expect(graph.episodes).toHaveLength(1);
+    expect(graph.episodes[0]?.title).toBe("Ablation — Dropout");
+    expect(graph.nodes.find((node) => node.id === parentId)?.primaryEpisodeId)
+      .toBe(graph.nodes.find((node) => node.id === childId)?.primaryEpisodeId);
+    expect(graph.nodes.find((node) => node.id === childId)?.parents).toEqual([
+      expect.objectContaining({ nodeId: parentId, conclusion: "candidate", origin: "trace" }),
+    ]);
+
+    const beforeNodes = graph.nodes.length;
+    const beforeEpisodes = graph.episodes.length;
+    const invalidCreate = await create.execute({
+      title: "Partially linked result",
+      description: "This node must not survive a partially invalid parent batch.",
+      episode: "Atomicity Probe",
+      confidence: "low",
+      confidence_reason: "The proposed evidence batch is incomplete.",
+      parent_candidates: [
+        { node_id: parentId, reason: "A valid parent." },
+        { node_id: "missing-parent", reason: "An invalid parent." },
+      ],
+    });
+    expect(invalidCreate.isError).toBe(true);
+    graph = d.trace.getGraphV2();
+    expect(graph.nodes).toHaveLength(beforeNodes);
+    expect(graph.episodes).toHaveLength(beforeEpisodes);
+    expect(graph.episodes.some((episode) => episode.title === "Atomicity Probe")).toBe(false);
+
+    const invalidUpdate = await update.execute({
+      node_id: childId,
+      title: "This title must not be stored",
+      episode: "Also Must Not Exist",
+      confidence: "high",
+      confidence_reason: "This update contains one invalid parent.",
+      parent_candidates: [
+        { node_id: parentId, reason: "Still the direct setting." },
+        { node_id: "missing-parent", reason: "Invalid parent." },
+      ],
+    });
+    expect(invalidUpdate.isError).toBe(true);
+    graph = d.trace.getGraphV2();
+    expect(graph.nodes.find((node) => node.id === childId)?.title).toBe("Dropout baseline result");
+    expect(graph.episodes.some((episode) => episode.title === "Also Must Not Exist")).toBe(false);
+
+    expect((await update.execute({
+      node_id: childId,
+      episode: "Environment & Reproducibility",
+      confidence: "high",
+      confidence_reason: "The result is now classified as shared reproducibility evidence.",
+    })).isError).not.toBe(true);
+    graph = d.trace.getGraphV2();
+    const moved = graph.nodes.find((node) => node.id === childId)!;
+    expect(graph.episodes.find((episode) => episode.id === moved.primaryEpisodeId)?.title)
+      .toBe("Environment & Reproducibility");
+
+    for (const invalid of [
+      { title: "   " },
+      { description: "   " },
+      { episode: "   " },
+      { parent_candidates: [{ node_id: parentId, reason: "   " }] },
+    ]) {
+      expect((await update.execute({
+        node_id: childId,
+        confidence: "high",
+        confidence_reason: "The existing node remains well supported.",
+        ...invalid,
+      })).isError).toBe(true);
+    }
   });
 });
 

--- a/packages/runtime/src/__tests__/trace-agent.test.ts
+++ b/packages/runtime/src/__tests__/trace-agent.test.ts
@@ -169,7 +169,7 @@ describe("Trace Agent — record_trace dispatches to a spawned trace agent", () 
         // Trace consumes the envelope and writes a node — exercises a real run.
         onPrompt: (text) =>
           text.includes("[Trace Event]")
-            ? { tool: "create_trace_node", args: { title: "a decision", confidence: "medium", confidence_reason: "Source record is available." } }
+            ? { tool: "create_trace_node", args: { title: "a decision", description: "The reported research decision.", episode: "Method Design — decision", confidence: "medium", confidence_reason: "Source record is available." } }
             : undefined,
       },
     });
@@ -210,7 +210,7 @@ describe("Trace Agent — record_trace dispatches to a spawned trace agent", () 
       trace: {
         onPrompt: (text) =>
           text.includes("[Trace Event]")
-            ? { tool: "create_trace_node", args: { title: "a decision", confidence: "medium", confidence_reason: "Source record is available." } }
+            ? { tool: "create_trace_node", args: { title: "a decision", description: "The reported research decision.", episode: "Method Design — decision", confidence: "medium", confidence_reason: "Source record is available." } }
             : undefined,
       },
     });
@@ -236,7 +236,7 @@ describe("Trace Agent — record_trace dispatches to a spawned trace agent", () 
       },
       trace: {
         onPrompt: (text) => text.includes("[Trace Event]")
-          ? { tool: "create_trace_node", args: { title: "Conclusion", confidence: "medium", confidence_reason: "One result file supports it." } }
+          ? { tool: "create_trace_node", args: { title: "Conclusion", description: "The reported conclusion supported by one result.", episode: "Final Synthesis", confidence: "medium", confidence_reason: "One result file supports it." } }
           : undefined,
       },
       auditor: {
@@ -262,7 +262,7 @@ describe("Trace Agent — record_trace dispatches to a spawned trace agent", () 
       },
       trace: {
         onPrompt: (text) => text.includes("[Trace Event]")
-          ? { tool: "create_trace_node", args: { title: "Ablation", confidence: "medium", confidence_reason: "One result file." } }
+          ? { tool: "create_trace_node", args: { title: "Ablation", description: "The reported ablation result.", episode: "Ablation — component", confidence: "medium", confidence_reason: "One result file." } }
           : undefined,
       },
     });
@@ -290,7 +290,7 @@ describe("Trace Agent — record_trace dispatches to a spawned trace agent", () 
       },
       trace: {
         onPrompt: (text) => text.includes("[Trace Event]")
-          ? { tool: "create_trace_node", args: { title: "Unreviewed", confidence: "medium", confidence_reason: "One source record." } }
+          ? { tool: "create_trace_node", args: { title: "Unreviewed", description: "An unreviewed research conclusion.", episode: "Final Synthesis", confidence: "medium", confidence_reason: "One source record." } }
           : undefined,
       },
       auditor: { onPrompt: () => { auditorTurns += 1; return undefined; } },
@@ -320,7 +320,7 @@ describe("Trace Agent — record_trace dispatches to a spawned trace agent", () 
       },
       trace: {
         onPrompt: (text) => text.includes("[Trace Event]")
-          ? { tool: "create_trace_node", args: { title: "Changing", confidence: "medium", confidence_reason: "Initial record." } }
+          ? { tool: "create_trace_node", args: { title: "Changing", description: "A conclusion whose evidence may change.", episode: "Final Synthesis", confidence: "medium", confidence_reason: "Initial record." } }
           : undefined,
       },
       auditor: {

--- a/packages/runtime/src/__tests__/trace-edges.test.ts
+++ b/packages/runtime/src/__tests__/trace-edges.test.ts
@@ -105,6 +105,8 @@ describe("Graph of Trace structural plumbing", () => {
             tool: "create_trace_node",
             args: {
               title: `decision ${traceTurn}`,
+              description: `Independent research decision ${traceTurn}.`,
+              episode: "Method Design — decisions",
               type: "trace",
               confidence: "medium",
               confidence_reason: "The source record is available.",
@@ -152,6 +154,8 @@ describe("Graph of Trace structural plumbing", () => {
                 tool: "create_trace_node",
                 args: {
                   title: "a decision",
+                  description: "The reported research decision.",
+                  episode: "Method Design — decision",
                   type: "trace",
                   confidence: "medium",
                   confidence_reason: "The source record is available.",

--- a/packages/runtime/src/__tests__/trace-reminder.test.ts
+++ b/packages/runtime/src/__tests__/trace-reminder.test.ts
@@ -66,16 +66,16 @@ describe("trace-reminder: event-driven trace gating", () => {
     (tool) => expect(runOnce("principal", [tool]).kinds).toEqual([]),
   );
 
-  it("substantive PI work needs trace and delegation in one reminder", () => {
-    expect(runOnce("principal", ["bash"]).kinds).toEqual(["merged"]);
+  it("substantive PI work only needs a trace reminder", () => {
+    expect(runOnce("principal", ["bash"]).kinds).toEqual(["trace"]);
   });
 
-  it("recorded substantive PI work only needs delegation", () => {
-    expect(runOnce("principal", ["write", "record_trace"]).kinds).toEqual(["delegate"]);
+  it("recorded substantive PI work needs no reminder", () => {
+    expect(runOnce("principal", ["write", "record_trace"]).kinds).toEqual([]);
   });
 
-  it("creating an agent is not itself a delegation", () => {
-    expect(runOnce("principal", ["bash", "create_agent"]).kinds).toEqual(["merged"]);
+  it("creating an agent does not suppress the trace reminder", () => {
+    expect(runOnce("principal", ["bash", "create_agent"]).kinds).toEqual(["trace"]);
   });
 
   it("sending a task counts as delegation", () => {
@@ -87,7 +87,7 @@ describe("trace-reminder: event-driven trace gating", () => {
 
   it("tool-name case does not matter", () => {
     expect(runOnce("principal", ["READ"]).kinds).toEqual([]);
-    expect(runOnce("principal", ["WRITE", "record_trace"]).kinds).toEqual(["delegate"]);
+    expect(runOnce("principal", ["WRITE", "record_trace"]).kinds).toEqual([]);
   });
 });
 

--- a/packages/runtime/src/__tests__/trace-reminder.test.ts
+++ b/packages/runtime/src/__tests__/trace-reminder.test.ts
@@ -61,7 +61,18 @@ function runOnce(
 }
 
 describe("trace-reminder: event-driven trace gating", () => {
-  it.each(["read", "grep", "glob", "ls", "find", "skill_search"])(
+  it.each([
+    "read",
+    "grep",
+    "glob",
+    "ls",
+    "find",
+    "skill_search",
+    "get_trace_graph",
+    "get_trace_node",
+    "get_trace_neighborhood",
+    "get_trace_diff",
+  ])(
     "read-only/lookup tool %s does not arm a trace reminder",
     (tool) => expect(runOnce("principal", [tool]).kinds).toEqual([]),
   );

--- a/packages/runtime/src/__tests__/trace-v2.test.ts
+++ b/packages/runtime/src/__tests__/trace-v2.test.ts
@@ -48,6 +48,9 @@ describe("TraceGraphV2 storage and audit semantics", () => {
     const conclusion = graph.createNode({ title: "Conclusion" });
     expect(graph.getNode(evidence.id)?.parentIds).toEqual([rootId]);
     expect(graph.getNode(conclusion.id)?.parentIds).toEqual([rootId]);
+    expect(graph.getNodeV2(conclusion.id)?.parents).toContainEqual(
+      expect.objectContaining({ nodeId: rootId, origin: "host_fallback" }),
+    );
     expect(graph.updateNode(rootId, { title: "Changed" })).toBeUndefined();
     expect(graph.listPendingAuditTargets().some((target) => target.nodeId === rootId)).toBe(false);
 
@@ -57,7 +60,7 @@ describe("TraceGraphV2 storage and audit semantics", () => {
       "Conclusion consumes this evidence.",
       { type: "agent", name: "trace" },
     )).toBe(true);
-    expect(graph.getNode(conclusion.id)?.parentIds).toEqual([rootId]);
+    expect(graph.getNode(conclusion.id)?.parentIds).toEqual([]);
     expect(graph.review(
       conclusion.id,
       "approve",
@@ -66,6 +69,49 @@ describe("TraceGraphV2 storage and audit semantics", () => {
       evidence.id,
     )).toBe(true);
     expect(graph.getNode(conclusion.id)?.parentIds).toEqual([evidence.id]);
+  });
+
+  it("allows Trace to replace the root fallback with an audited root candidate", () => {
+    const graph = new GraphOfTrace("s");
+    const rootId = graph.getGraphV2().meta.rootNodeId!;
+    const node = graph.createNode({ title: "Independent observation" });
+
+    expect(graph.proposeCausalParent(
+      node.id,
+      rootId,
+      "This observation depends only on the session's initial context.",
+      { type: "agent", name: "trace" },
+    )).toBe(true);
+    expect(graph.getNodeV2(node.id)?.parents).toEqual([
+      expect.objectContaining({ nodeId: rootId, conclusion: "candidate", origin: "trace" }),
+    ]);
+    expect(graph.listPendingAuditTargets([node.id])).toContainEqual(
+      expect.objectContaining({ nodeId: node.id, parentNodeId: rootId }),
+    );
+    expect(graph.review(
+      node.id,
+      "approve",
+      "No upstream research unit is required.",
+      { type: "agent", name: "auditor" },
+      rootId,
+    )).toBe(true);
+    expect(graph.getNodeV2(node.id)?.parents).toEqual([
+      expect.objectContaining({ nodeId: rootId, conclusion: "confirmed", origin: "trace" }),
+    ]);
+  });
+
+  it("does not restore the Host root fallback while any non-root parent state exists", () => {
+    const graph = new GraphOfTrace("s");
+    const rootId = graph.getGraphV2().meta.rootNodeId!;
+    const parent = graph.createNode({ title: "Evidence" });
+    const child = graph.createNode({ title: "Conclusion" });
+    graph.proposeCausalParent(child.id, parent.id, "possible evidence", { type: "agent", name: "trace" });
+    expect(graph.getNodeV2(child.id)?.parents.some((item) => item.nodeId === rootId)).toBe(false);
+
+    graph.review(child.id, "uncertain", "relationship is unresolved", { type: "agent", name: "auditor" }, parent.id);
+    expect(graph.getNodeV2(child.id)?.parents).toEqual([
+      expect.objectContaining({ nodeId: parent.id, conclusion: "uncertain" }),
+    ]);
   });
 
   it("repairs rootless and cyclic V2 data into one all-state DAG", () => {
@@ -84,9 +130,9 @@ describe("TraceGraphV2 storage and audit semantics", () => {
 
     const normalized = graph.getGraphV2();
     const rootId = normalized.meta.rootNodeId!;
-    const activeParents = new Map(normalized.nodes.map((node) => [
+    const allParents = new Map(normalized.nodes.map((node) => [
       node.id,
-      node.parents.filter((parent) => parent.conclusion === "confirmed").map((parent) => parent.nodeId),
+      node.parents.map((parent) => parent.nodeId),
     ]));
     const reachesRoot = (start: string): boolean => {
       const seen = new Set<string>();
@@ -94,17 +140,17 @@ describe("TraceGraphV2 storage and audit semantics", () => {
         if (id === rootId) return true;
         if (seen.has(id)) return false;
         seen.add(id);
-        return (activeParents.get(id) ?? []).some(visit);
+        return (allParents.get(id) ?? []).some(visit);
       };
       return visit(start);
     };
     expect(normalized.nodes.filter((node) => node.id !== rootId).every((node) => reachesRoot(node.id))).toBe(true);
-    const allParents = new Map(normalized.nodes.map((node) => [node.id, node.parents.map((parent) => parent.nodeId)]));
+    const parentMap = new Map(normalized.nodes.map((node) => [node.id, node.parents.map((parent) => parent.nodeId)]));
     const isAcyclic = (start: string, visiting = new Set<string>(), visited = new Set<string>()): boolean => {
       if (visiting.has(start)) return false;
       if (visited.has(start)) return true;
       const nextVisiting = new Set(visiting).add(start);
-      if (!(allParents.get(start) ?? []).every((parentId) => isAcyclic(parentId, nextVisiting, visited))) return false;
+      if (!(parentMap.get(start) ?? []).every((parentId) => isAcyclic(parentId, nextVisiting, visited))) return false;
       visited.add(start);
       return true;
     };

--- a/packages/runtime/src/__tests__/trace-v2.test.ts
+++ b/packages/runtime/src/__tests__/trace-v2.test.ts
@@ -100,6 +100,39 @@ describe("TraceGraphV2 storage and audit semantics", () => {
     ]);
   });
 
+  it("keeps an already confirmed explicit parent idempotent", () => {
+    const graph = new GraphOfTrace("s");
+    const parent = graph.createNode({ title: "Evidence" });
+    const child = graph.createNode({ title: "Conclusion" });
+    const reason = "Evidence directly supports the conclusion.";
+    expect(graph.proposeCausalParent(
+      child.id,
+      parent.id,
+      reason,
+      { type: "agent", name: "trace" },
+    )).toBe(true);
+    expect(graph.review(
+      child.id,
+      "approve",
+      reason,
+      { type: "agent", name: "auditor" },
+      parent.id,
+    )).toBe(true);
+
+    expect(graph.proposeCausalParent(
+      child.id,
+      parent.id,
+      reason,
+      { type: "agent", name: "trace" },
+    )).toBe(true);
+    expect(graph.getNodeV2(child.id)?.parents).toContainEqual(
+      expect.objectContaining({ nodeId: parent.id, conclusion: "confirmed", origin: "trace" }),
+    );
+    expect(graph.listPendingAuditTargets([child.id])).not.toContainEqual(
+      expect.objectContaining({ parentNodeId: parent.id }),
+    );
+  });
+
   it("does not restore the Host root fallback while any non-root parent state exists", () => {
     const graph = new GraphOfTrace("s");
     const rootId = graph.getGraphV2().meta.rootNodeId!;

--- a/packages/runtime/src/__tests__/trace-v2.test.ts
+++ b/packages/runtime/src/__tests__/trace-v2.test.ts
@@ -201,6 +201,78 @@ describe("TraceGraphV2 storage and audit semantics", () => {
     expect(graph.proposeCausalParent(a.id, b.id, "B informed A", { type: "agent", name: "trace" })).toBe(false);
   });
 
+  it("rejects an entire invalid parent batch before graph mutation", () => {
+    const graph = new GraphOfTrace("s");
+    const a = graph.createNode({ title: "A" });
+    const b = graph.createNode({ title: "B" });
+    graph.proposeCausalParent(b.id, a.id, "A produces the input for B.", { type: "agent", name: "trace" });
+    const before = graph.getGraphV2();
+
+    expect(graph.updateNode(
+      a.id,
+      { title: "Mutated", episode: "Must Not Exist" },
+      { type: "agent", name: "trace" },
+      [
+        { nodeId: b.id, reason: "This would close a cycle." },
+        { nodeId: "missing", reason: "This parent is missing." },
+      ],
+    )).toBeUndefined();
+    expect(graph.getGraphV2()).toEqual(before);
+    expect(graph.validateCausalParentCandidates(undefined, [
+      { nodeId: a.id, reason: "one" },
+      { nodeId: a.id, reason: "duplicate" },
+    ])).toMatchObject({ ok: false, reason: expect.stringContaining("duplicate") });
+    expect(graph.validateCausalParentCandidates(undefined, [
+      { nodeId: a.id, reason: "   " },
+    ])).toMatchObject({ ok: false, reason: expect.stringContaining("non-empty") });
+
+    graph.review(b.id, "reject", "A is not a valid direct parent.", { type: "agent", name: "auditor" }, a.id);
+    expect(graph.validateCausalParentCandidates(b.id, [
+      { nodeId: a.id, reason: "Try the rejected relation again." },
+    ])).toMatchObject({ ok: false, reason: expect.stringContaining("rejected") });
+
+    graph.updateNode(a.id, { revoked: true }, { type: "host" });
+    expect(graph.validateCausalParentCandidates(undefined, [
+      { nodeId: a.id, reason: "revoked evidence" },
+    ])).toMatchObject({ ok: false, reason: expect.stringContaining("revoked") });
+  });
+
+  it("normalizes, reuses, moves, and persists Episode names", async () => {
+    const root = await mkdtemp(join(tmpdir(), "bp-trace-episodes-"));
+    try {
+      const tracePath = join(root, "trace.json");
+      const graph = new GraphOfTrace("s", tracePath);
+      const first = graph.createNode({
+        title: "Baseline setting",
+        episode: "  Ａｂｌａｔｉｏｎ   —  Dropout  ",
+      });
+      const second = graph.createNode({
+        title: "Baseline result",
+        episode: "ablation — dropout",
+      });
+      let snapshot = graph.getGraphV2();
+      expect(snapshot.episodes).toHaveLength(1);
+      expect(snapshot.episodes[0]?.title).toBe("Ablation — Dropout");
+      expect(graph.getNodeV2(first.id)?.primaryEpisodeId)
+        .toBe(graph.getNodeV2(second.id)?.primaryEpisodeId);
+
+      graph.updateNode(second.id, { episode: "Environment & Reproducibility" });
+      await graph.flush();
+      const restored = new GraphOfTrace("s", tracePath);
+      restored.load(JSON.parse(await readFile(tracePath, "utf8")));
+      snapshot = restored.getGraphV2();
+      expect(snapshot.episodes.map((episode) => episode.title).sort()).toEqual([
+        "Ablation — Dropout",
+        "Environment & Reproducibility",
+      ]);
+      const restoredSecond = restored.getNodeV2(second.id)!;
+      expect(snapshot.episodes.find((episode) => episode.id === restoredSecond.primaryEpisodeId)?.title)
+        .toBe("Environment & Reproducibility");
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it("migrates V1 lazily and persists only nodes[].parents as authoritative relationships", async () => {
     const root = await mkdtemp(join(tmpdir(), "bp-trace-v2-"));
     try {

--- a/packages/runtime/src/__tests__/two-skill-paths.test.ts
+++ b/packages/runtime/src/__tests__/two-skill-paths.test.ts
@@ -103,13 +103,17 @@ describe("two-path skill loading", () => {
     expect(capturedRouterDir).toBe(root);
   });
 
-  it("trace agent does NOT receive skill_search (graph-only role)", async () => {
+  it("trace receives only its targeted GoT skill and no skill_search", async () => {
     const root = await tmp();
     await materializeSkills(root);
 
     let traceTools: string[] | undefined;
+    let traceSkillPaths: string[] | undefined;
     const wrappedFactory: AgentSessionFactory = async (params) => {
-      if (params.agentName === "trace") traceTools = params.systemTools.map((t) => t.name);
+      if (params.agentName === "trace") {
+        traceTools = params.systemTools.map((t) => t.name);
+        traceSkillPaths = params.skillPaths;
+      }
       return mockAgentFactory(params);
     };
 
@@ -123,7 +127,11 @@ describe("two-path skill loading", () => {
 
     expect(traceTools).toBeDefined();
     expect(traceTools).not.toContain("skill_search");
-    // Trace also gets no skillPaths (it is skill-less by design).
+    expect(traceSkillPaths).toEqual([
+      expect.stringMatching(/plugin-got.*curate-research-trace/),
+    ]);
+    expect(traceSkillPaths).not.toContain(join(root, "bp_template", "skills"));
+    expect(traceSkillPaths).not.toContain(join(root, "bp_template", "skills-router"));
   });
 
   it("keeps full and base sessions isolated without global mutation", async () => {

--- a/packages/runtime/src/agent-factory.ts
+++ b/packages/runtime/src/agent-factory.ts
@@ -20,6 +20,7 @@ import { resolveGatewayModel, resolveSessionModel, type PiProviderSdk } from "./
 import { makeTraceReminderExt } from "./extensions/trace-reminder.js";
 import { makeAgentStatusExt } from "./extensions/agent-status.js";
 import { makeTaskContextExt } from "./extensions/task-context.js";
+import { makeGoTContextExt } from "./extensions/got-context.js";
 import { makeRouterSkillGuardExt } from "./extensions/router-skill-guard.js";
 import { makeManagedPathGuardExt } from "./extensions/managed-path-guard.js";
 import {
@@ -132,6 +133,9 @@ export const realAgentFactory: AgentSessionFactory = async (params) => {
   }
   if (params.renderTaskContext) {
     extensionFactories.push(makeTaskContextExt({ renderTasks: params.renderTaskContext }));
+  }
+  if (params.renderGoTContext) {
+    extensionFactories.push(makeGoTContextExt({ renderContext: params.renderGoTContext }));
   }
   // #346: rewrite logical /workspace (and /data, …) onto durable volume roots
   // BEFORE other path guards run, so subsequent handlers see post-rewrite paths.

--- a/packages/runtime/src/extensions/got-context.ts
+++ b/packages/runtime/src/extensions/got-context.ts
@@ -1,0 +1,156 @@
+/** Ephemeral Graph of Trace context for Principal reasoning and bound audits. */
+import type { TraceGraphV2, TraceNodeV2 } from "@brainpilot/protocol";
+import type { TraceAuditTarget } from "../trace.js";
+
+interface PiContextMessage {
+  role: string;
+  content: Array<{ type: string; text?: string }>;
+  timestamp?: number;
+}
+
+interface PiExtensionApi {
+  on(
+    event: "context",
+    handler: (event: { messages: PiContextMessage[] }) =>
+      | { messages: PiContextMessage[] }
+      | void,
+  ): void;
+}
+
+const PRINCIPAL_TAG = "<graph_of_trace";
+const AUDIT_TAG = "<got_audit_context";
+
+export interface GoTContextDeps {
+  renderContext: () => string;
+}
+
+function isGoTContextMessage(message: PiContextMessage): boolean {
+  return message.role === "user" && message.content.some((part) => {
+    const text = part.text ?? "";
+    return part.type === "text" &&
+      (text.startsWith(PRINCIPAL_TAG) || text.startsWith(AUDIT_TAG));
+  });
+}
+
+/** Replaces the previous per-turn GoT block without writing it to Pi history. */
+export function makeGoTContextExt(deps: GoTContextDeps): (pi: PiExtensionApi) => void {
+  return (pi) => {
+    pi.on("context", (event) => {
+      const stripped = event.messages.filter((message) => !isGoTContextMessage(message));
+      const block = deps.renderContext();
+      if (!block) {
+        return stripped.length === event.messages.length ? undefined : { messages: stripped };
+      }
+      stripped.push({ role: "user", content: [{ type: "text", text: block }] });
+      return { messages: stripped };
+    });
+  };
+}
+
+function shorten(value: string | undefined, max: number): string | undefined {
+  if (!value) return undefined;
+  return value.length <= max ? value : `${value.slice(0, Math.max(0, max - 1))}…`;
+}
+
+function compactNode(node: TraceNodeV2, rootId: string | undefined): Record<string, unknown> {
+  return {
+    id: node.id,
+    title: node.title,
+    type: node.type,
+    status: node.status,
+    ...(node.description ? { description: shorten(node.description, 600) } : {}),
+    ...(node.confidence ? { confidence: node.confidence } : {}),
+    reviewConclusion: node.reviewConclusion,
+    updatedAt: node.updatedAt,
+    parents: node.parents
+      .filter((parent) => parent.nodeId !== rootId || parent.origin === "trace")
+      .map((parent) => ({
+        nodeId: parent.nodeId,
+        conclusion: parent.conclusion,
+        ...(parent.origin ? { origin: parent.origin } : {}),
+        ...(parent.reason ? { reason: shorten(parent.reason, 300) } : {}),
+      })),
+  };
+}
+
+function compactGraphLines(graph: TraceGraphV2, maxChars: number): string[] {
+  const rootId = graph.meta.rootNodeId;
+  const nodes = graph.nodes.filter((node) => !node.revoked && node.id !== rootId);
+  const lines: string[] = [];
+  let used = 0;
+  for (const node of nodes) {
+    const line = JSON.stringify(compactNode(node, rootId));
+    if (used + line.length + 1 > maxChars) break;
+    lines.push(line);
+    used += line.length + 1;
+  }
+  if (lines.length < nodes.length) {
+    lines.push(JSON.stringify({ omittedNodes: nodes.length - lines.length }));
+  }
+  return lines;
+}
+
+/** Current compact GoT plus usage guidance, injected only into Principal turns. */
+export function renderPrincipalGoTContext(
+  graph: TraceGraphV2,
+  maxChars = 24_000,
+): string {
+  const rootId = graph.meta.rootNodeId;
+  const active = graph.nodes.filter((node) => !node.revoked && node.id !== rootId);
+  if (active.length === 0) return "";
+  const header = [
+    `<graph_of_trace revision="${graph.revision}" root_node_id="${rootId ?? ""}">`,
+    "This is the current compact Graph of Trace. Use it when planning, synthesizing expert results, handling new evidence, and checking whether work already exists.",
+    "Use get_trace_graph, get_trace_node, get_trace_neighborhood, or get_trace_diff when more detail is needed. Review approval is audit history, not a substitute for your own reasoning.",
+    "<active_nodes>",
+  ];
+  const footer = ["</active_nodes>", "</graph_of_trace>"];
+  const fixed = header.join("\n").length + footer.join("\n").length + 2;
+  const lines = compactGraphLines(graph, Math.max(0, maxChars - fixed));
+  return [...header, ...lines, ...footer].join("\n");
+}
+
+function clippedJson(value: unknown, maxChars: number): string {
+  const text = JSON.stringify(value, null, 2);
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, Math.max(0, maxChars - 24))}\n... [truncated]`;
+}
+
+export interface GoTAuditContextInput {
+  graph: TraceGraphV2;
+  target: TraceAuditTarget;
+  targetNode?: unknown;
+  parentNode?: unknown;
+  neighborhood?: unknown;
+}
+
+/** Detailed bound evidence plus compact global state for one background GoT audit. */
+export function renderGoTAuditContext(
+  input: GoTAuditContextInput,
+  maxChars = 48_000,
+): string {
+  const { graph, target } = input;
+  const header = [
+    `<got_audit_context revision="${graph.revision}">`,
+    "Review exactly the bound target. Check internal consistency, conflicts with other active/approved nodes, whether evidence supports strong words such as unique/direct/proves/refutes, and whether a proposed parent is a real evidential or computational prerequisite rather than chronology or similarity.",
+    "If competing explanations cannot be excluded, return uncertain. Textual traceability alone is not scientific validation.",
+    `<bound_target>${clippedJson(target, 2_000)}</bound_target>`,
+  ];
+  const footer = "</got_audit_context>";
+  const sections: Array<[string, unknown, number]> = [
+    ["target_evidence", input.targetNode, 14_000],
+    ["parent_evidence", input.parentNode, 8_000],
+    ["local_neighborhood", input.neighborhood, 14_000],
+    ["compact_active_graph", compactGraphLines(graph, 10_000).map((line) => JSON.parse(line)), 12_000],
+  ];
+  const lines = [...header];
+  for (const [name, value, sectionLimit] of sections) {
+    if (value === undefined) continue;
+    const remaining = maxChars - lines.join("\n").length - footer.length - name.length * 2 - 16;
+    if (remaining <= 80) break;
+    const content = clippedJson(value, Math.min(sectionLimit, remaining));
+    lines.push(`<${name}>${content}</${name}>`);
+  }
+  lines.push(footer);
+  return lines.join("\n");
+}

--- a/packages/runtime/src/extensions/got-context.ts
+++ b/packages/runtime/src/extensions/got-context.ts
@@ -56,10 +56,12 @@ function compactNode(
   node: TraceNodeV2,
   rootId: string | undefined,
   activeIds: ReadonlySet<string>,
+  episodeTitle: string | undefined,
 ): Record<string, unknown> {
   return {
     id: node.id,
     title: node.title,
+    ...(episodeTitle ? { episode: episodeTitle } : {}),
     type: node.type,
     status: node.status,
     ...(node.description ? { description: shorten(node.description, 600) } : {}),
@@ -84,10 +86,16 @@ function compactGraphLines(graph: TraceGraphV2, maxChars: number): string[] {
   const rootId = graph.meta.rootNodeId;
   const nodes = graph.nodes.filter((node) => !node.revoked && node.id !== rootId);
   const activeIds = new Set(nodes.map((node) => node.id));
+  const episodeTitles = new Map(graph.episodes.map((episode) => [episode.id, episode.title]));
   const lines: string[] = [];
   let used = 0;
   for (const node of nodes) {
-    const line = JSON.stringify(compactNode(node, rootId, activeIds));
+    const line = JSON.stringify(compactNode(
+      node,
+      rootId,
+      activeIds,
+      node.primaryEpisodeId ? episodeTitles.get(node.primaryEpisodeId) : undefined,
+    ));
     if (used + line.length + 1 > maxChars) break;
     lines.push(line);
     used += line.length + 1;
@@ -139,6 +147,7 @@ export function renderGoTAuditContext(
   const header = [
     `<got_audit_context revision="${graph.revision}">`,
     "Review exactly the bound target. Check internal consistency, conflicts with other active/approved nodes, whether evidence supports strong words such as unique/direct/proves/refutes, and whether a proposed parent is a real evidential or computational prerequisite rather than chronology or similarity.",
+    "Also check whether the node is too coarse or too fine, whether independently reviewable settings/results/analyses/findings were improperly merged, whether settings in one ablation were falsely chained, and whether result-to-analysis-to-finding-to-conclusion dependencies skip necessary direct evidence. Episode membership alone never establishes dependency.",
     "If competing explanations cannot be excluded, return uncertain. Textual traceability alone is not scientific validation.",
     `<bound_target>${clippedJson(target, 2_000)}</bound_target>`,
   ];

--- a/packages/runtime/src/extensions/got-context.ts
+++ b/packages/runtime/src/extensions/got-context.ts
@@ -52,7 +52,11 @@ function shorten(value: string | undefined, max: number): string | undefined {
   return value.length <= max ? value : `${value.slice(0, Math.max(0, max - 1))}…`;
 }
 
-function compactNode(node: TraceNodeV2, rootId: string | undefined): Record<string, unknown> {
+function compactNode(
+  node: TraceNodeV2,
+  rootId: string | undefined,
+  activeIds: ReadonlySet<string>,
+): Record<string, unknown> {
   return {
     id: node.id,
     title: node.title,
@@ -63,7 +67,10 @@ function compactNode(node: TraceNodeV2, rootId: string | undefined): Record<stri
     reviewConclusion: node.reviewConclusion,
     updatedAt: node.updatedAt,
     parents: node.parents
-      .filter((parent) => parent.nodeId !== rootId || parent.origin === "trace")
+      .filter((parent) =>
+        activeIds.has(parent.nodeId) ||
+        (parent.nodeId === rootId && parent.origin === "trace"),
+      )
       .map((parent) => ({
         nodeId: parent.nodeId,
         conclusion: parent.conclusion,
@@ -76,10 +83,11 @@ function compactNode(node: TraceNodeV2, rootId: string | undefined): Record<stri
 function compactGraphLines(graph: TraceGraphV2, maxChars: number): string[] {
   const rootId = graph.meta.rootNodeId;
   const nodes = graph.nodes.filter((node) => !node.revoked && node.id !== rootId);
+  const activeIds = new Set(nodes.map((node) => node.id));
   const lines: string[] = [];
   let used = 0;
   for (const node of nodes) {
-    const line = JSON.stringify(compactNode(node, rootId));
+    const line = JSON.stringify(compactNode(node, rootId, activeIds));
     if (used + line.length + 1 > maxChars) break;
     lines.push(line);
     used += line.length + 1;
@@ -96,8 +104,6 @@ export function renderPrincipalGoTContext(
   maxChars = 24_000,
 ): string {
   const rootId = graph.meta.rootNodeId;
-  const active = graph.nodes.filter((node) => !node.revoked && node.id !== rootId);
-  if (active.length === 0) return "";
   const header = [
     `<graph_of_trace revision="${graph.revision}" root_node_id="${rootId ?? ""}">`,
     "This is the current compact Graph of Trace. Use it when planning, synthesizing expert results, handling new evidence, and checking whether work already exists.",

--- a/packages/runtime/src/extensions/trace-reminder.ts
+++ b/packages/runtime/src/extensions/trace-reminder.ts
@@ -1,4 +1,4 @@
-/** Event-driven reminders for trace capture, expert replies, and PI delegation. */
+/** Event-driven reminders for trace capture and expert task replies. */
 import type { AgentRole } from "../types.js";
 
 interface ToolStartLike {
@@ -79,21 +79,9 @@ const MERGED_REMINDER = SYS(
   "Before finishing, record the substantive milestone with record_trace and complete the pending task " +
     "with complete_task using its exact ID.",
 );
-const DELEGATE_REMINDER = SYS(
-  "delegate",
-  "As the Principal, delegate substantive execution to an expert before finishing.",
-);
-const PI_MERGED_REMINDER = SYS(
-  "merged",
-  "As the Principal, record this substantive step with record_trace and delegate the execution " +
-    "to an expert before finishing.",
-);
-
 interface RunState {
   traced: boolean;
-  delegated: boolean;
   traceWorthy: boolean;
-  didSubstantiveWork: boolean;
   dispatched: boolean;
   reminded: boolean;
 }
@@ -101,9 +89,7 @@ interface RunState {
 function freshState(): RunState {
   return {
     traced: false,
-    delegated: false,
     traceWorthy: false,
-    didSubstantiveWork: false,
     dispatched: false,
     reminded: false,
   };
@@ -111,7 +97,7 @@ function freshState(): RunState {
 
 /**
  * A reminder starts one internal follow-up agent loop. State survives that one
- * loop so a satisfied reply/trace/delegation is observed and no second reminder
+ * loop so a satisfied reply/trace is observed and no second reminder
  * is injected. The next external run starts clean.
  */
 export function makeTraceReminderExt(deps: TraceReminderDeps): (pi: PiExtensionApi) => void {
@@ -155,14 +141,12 @@ export function makeTraceReminderExt(deps: TraceReminderDeps): (pi: PiExtensionA
 
       if (tool === "dispatch_task") {
         state.dispatched = true;
-        state.delegated = true;
         state.traceWorthy = true;
         return;
       }
 
       if (!NON_TRACE_TOOLS.has(tool)) {
         state.traceWorthy = true;
-        if (deps.role === "principal") state.didSubstantiveWork = true;
       }
     });
 
@@ -178,21 +162,16 @@ export function makeTraceReminderExt(deps: TraceReminderDeps): (pi: PiExtensionA
       const needReply =
         (deps.hasPendingTasks?.() ?? false) &&
         !state.dispatched;
-      const needDelegate =
-        deps.role === "principal" && state.didSubstantiveWork && !state.delegated;
-
       const sendReminder = (reminder: string): void => {
         state.reminded = true;
         continuingFollowUp = true;
         pi.sendUserMessage(reminder, { deliverAs: "followUp" });
       };
 
-      if (!state.reminded && (needTrace || needReply || needDelegate)) {
+      if (!state.reminded && (needTrace || needReply)) {
         let reminder: string;
         if (needReply && needTrace) reminder = MERGED_REMINDER;
         else if (needReply) reminder = REPLY_REMINDER;
-        else if (needTrace && needDelegate) reminder = PI_MERGED_REMINDER;
-        else if (needDelegate) reminder = DELEGATE_REMINDER;
         else reminder = TRACE_REMINDER;
 
         if (needReply && deps.claimTaskReminder) {

--- a/packages/runtime/src/extensions/trace-reminder.ts
+++ b/packages/runtime/src/extensions/trace-reminder.ts
@@ -59,6 +59,9 @@ const NON_TRACE_TOOLS = new Set([
   "create_agent",
   "destroy_agent",
   "get_trace_graph",
+  "get_trace_node",
+  "get_trace_neighborhood",
+  "get_trace_diff",
 ]);
 
 const SYS = (kind: string, body: string): string =>

--- a/packages/runtime/src/personas.ts
+++ b/packages/runtime/src/personas.ts
@@ -197,6 +197,9 @@ appear in the graph. Call it immediately after you produce a real deliverable
 
 Each call should carry a full-sentence \`description\` (subject + action +
 outcome, not a single word) and a \`context\` explaining why the step mattered.
+Prefer one independently meaningful research unit per call. Report distinct
+settings, results, analyses, findings, or conclusions separately when each can
+be inspected or cited on its own.
 Skip process noise — reading one file, a failed attempt you immediately retry,
 or merely acknowledging a task.`;
 
@@ -890,6 +893,23 @@ graph and make zero, one, or multiple node mutations. Make no graph change when
 the record is duplicate or process noise. Create or update multiple nodes only
 when the event contains independently meaningful scientific units.
 
+## Curation procedure
+
+For every Trace Event:
+
+1. Read the active graph and identify existing Episodes and reusable nodes.
+2. Extract units that can be inspected, cited, reproduced, or revoked independently.
+3. Give every new unit one concise, human-facing \`episode\` work-package name.
+   Episode membership is presentation grouping and never creates a dependency.
+4. Create, update, or ignore each unit. Repeated seeds, folds, replicates, and
+   repeated runs of the same setting normally update the same unit.
+5. Keep units parallel when neither consumes the other. Create a dependency
+   only when the downstream unit actually consumes or relies on the upstream one.
+6. Propose only direct parents, never every transitive ancestor.
+
+The optional \`curate-research-trace\` Skill contains detailed Episode-selection,
+splitting, and end-to-end research examples. Read it whenever you judge it useful.
+
 ## What one node means
 
 A node is an independently meaningful research unit: something that can be
@@ -898,16 +918,23 @@ without revoking every sibling result. It is not one tool call or progress
 message. Multiple reports may be curated into the same node.
 
 - Each experimental condition or model variant normally gets its own node.
-- Repeated seeds, folds, and runs normally update that variant node.
-- Each distinct analysis, visualization, or scientific claim gets a node.
+- A setting, its result, a subsequent analysis, an independently meaningful
+  visualization, a finding, and a conclusion are separate nodes when each can
+  be reviewed independently.
+- Multiple metrics from one run remain one result unless they are independently
+  reusable or support independently falsifiable findings.
+- A visualization is a node only when it contains an independent analysis or
+  interpretation; otherwise keep the file as an artifact of its source node.
+- Null findings are valid results.
 - Formatting changes, immediate retries, acknowledgements, and reading one file
   are not nodes.
 - Use \`completed\` for interpretable outputs, including null findings, and
   \`failed\` only for a meaningful execution failure.
 
-Choose the correct granularity when creating a node. Update only when the new
-record belongs to the same research unit; append content and evidence rather
-than duplicating it.
+Choose the correct granularity when creating a node. Every title and description
+must make sense without the surrounding chat. Update only when the new record
+belongs to the same research unit; append content and evidence rather than
+duplicating it. Settings in one ablation are normally parallel, not a chain.
 
 Every \`create_trace_node\` and \`update_trace_node\` call must set \`confidence\`
 and a concrete \`confidence_reason\`. Confidence measures how strongly the node
@@ -918,13 +945,15 @@ probability. Re-evaluate it after every update.
 
 A parent means the current node would cease to be valid or require recomputation
 without that upstream node. Chronology, adjacency, shared authorship,
-delegation, and textual similarity are not causality. Conclusion nodes should
-propose their direct evidence nodes rather than every transitive ancestor.
+delegation, Episode membership, and textual similarity are not causality.
+Results depend on the settings and inputs actually used; analyses depend on the
+results they consume; findings depend on their direct result or analysis evidence;
+conclusions depend on direct findings rather than every transitive ancestor.
 
 Supply possible parents through \`parent_candidates\` on \`create_trace_node\` or
-\`update_trace_node\`. You only propose candidates; Auditor confirms or rejects
-them. Never recreate a rejected candidate without materially new evidence. The
-Host supplies Session Start only while a node has no parent of any conclusion.
+\`update_trace_node\`. You only propose candidates; independent review confirms
+or rejects them. Never recreate a rejected candidate without materially new
+evidence. The Host supplies Session Start only while a node has no parent of any conclusion.
 \`get_trace_graph\` exposes its ID; you may propose Session Start when the unit
 directly depends on the session's initial context rather than another research unit.
 

--- a/packages/runtime/src/personas.ts
+++ b/packages/runtime/src/personas.ts
@@ -922,9 +922,11 @@ delegation, and textual similarity are not causality. Conclusion nodes should
 propose their direct evidence nodes rather than every transitive ancestor.
 
 Supply possible parents through \`parent_candidates\` on \`create_trace_node\` or
-\`update_trace_node\`. They remain candidates until an enabled review mechanism
-concludes them. The Host supplies a hidden Session Start parent until a specific
-parent is confirmed; never propose or edit that structural root yourself.
+\`update_trace_node\`. You only propose candidates; Auditor confirms or rejects
+them. Never recreate a rejected candidate without materially new evidence. The
+Host supplies Session Start only while a node has no parent of any conclusion.
+\`get_trace_graph\` exposes its ID; you may propose Session Start when the unit
+directly depends on the session's initial context rather than another research unit.
 
 The Host binds the current source record to your create/update call. Do not pass
 record ids. Revoked nodes are hidden and must never be reused: create a new node

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -69,6 +69,7 @@ import {
 } from "./personas.js";
 import { renderAgentStatusBlock, collectAgentStatusLines } from "./extensions/agent-status.js";
 import { renderTaskListBlock } from "./extensions/task-context.js";
+import { renderGoTAuditContext, renderPrincipalGoTContext } from "./extensions/got-context.js";
 import { McpBridge, loadMcpServersConfig } from "./mcp-bridge.js";
 import { loadToolToggles, isToolEnabled, type ToolToggles } from "./tool-toggles.js";
 import { materializeSkills } from "./materialize-skills.js";
@@ -2380,6 +2381,12 @@ export class SessionManager {
       renderAgentStatus:
         name === "principal" ? () => this.renderAgentStatus(entry) : undefined,
       renderTaskContext: () => this.renderTaskContext(entry, name),
+      renderGoTContext:
+        name === "principal"
+          ? () => renderPrincipalGoTContext(entry.trace.getGraphV2())
+          : name === "auditor"
+            ? () => this.renderGoTAuditContext(entry)
+            : undefined,
     });
 
     const agent = new MasAgent({
@@ -2475,6 +2482,20 @@ export class SessionManager {
       entry.taskLedger.pendingCreatedBy(name),
       TASK_CONTEXT_MAX_CHARS,
     );
+  }
+
+  private renderGoTAuditContext(entry: SessionEntry): string {
+    const target = entry.currentTraceAuditTarget;
+    if (!target) return "";
+    return renderGoTAuditContext({
+      graph: entry.trace.getGraphV2(),
+      target,
+      targetNode: entry.trace.getNodeDetail(target.nodeId),
+      ...(target.parentNodeId
+        ? { parentNode: entry.trace.getNodeDetail(target.parentNodeId) }
+        : {}),
+      neighborhood: entry.trace.getNeighborhood(target.nodeId, 2),
+    });
   }
 
   async destroyAgent(sessionId: string, name: string): Promise<void> {

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -2321,16 +2321,18 @@ export class SessionManager {
     const mcpTools = role === "trace" ? [] : await this.ensureMcpTools();
     const rawTools = [...systemTools, ...mcpTools];
     // Built-in skills are loaded by Pi natively (not as tools). Materialize the
-    // bundled content into bp_template/skills once, then hand the dir to the
-    // factory as additionalSkillPaths. Trace agent is skill-less (graph-only).
+    // generic bundled library for non-Trace roles. System plugins may still
+    // contribute narrowly targeted skills to Trace without exposing that library.
     let skillPaths: string[] | undefined;
     if (role !== "trace" && entry.domainResources === "full") {
       await this.ensureSkillsMaterialized();
       skillPaths = [this.skillsDir];
     }
-    const pluginSkillPaths = role === "trace"
-      ? []
-      : systemPluginSkillPaths(this.bundledSystemPlugins, entry.systemPlugins, name);
+    const pluginSkillPaths = systemPluginSkillPaths(
+      this.bundledSystemPlugins,
+      entry.systemPlugins,
+      name,
+    );
     if (pluginSkillPaths.length) skillPaths = [...(skillPaths ?? []), ...pluginSkillPaths];
     // #80: guard every tool result against context-window overflow.
     const agentTools = rawTools.map((t) => this.wrapToolWithTruncation(t, sessionId, entry.bus));

--- a/packages/runtime/src/system-plugins.ts
+++ b/packages/runtime/src/system-plugins.ts
@@ -12,6 +12,7 @@ import {
 } from "@brainpilot/plugin-sdk";
 
 export const AUDITOR_PLUGIN_ID = "org.brainpilot.auditor";
+export const GOT_PLUGIN_ID = "org.brainpilot.got";
 export const SYSTEM_PLUGIN_DISABLE_ENV = "BP_EXPERIMENT_DISABLE_PLUGINS";
 
 export interface SystemPluginSnapshot {
@@ -36,6 +37,7 @@ interface SystemPluginSpec {
 
 const SPECS: readonly SystemPluginSpec[] = [
   { packageName: "@brainpilot/plugin-auditor", defaultEnabled: true },
+  { packageName: "@brainpilot/plugin-got", defaultEnabled: true },
 ];
 
 function disabledPluginIds(value: string | undefined): Set<string> {

--- a/packages/runtime/src/tools/system-tools.ts
+++ b/packages/runtime/src/tools/system-tools.ts
@@ -9,7 +9,12 @@
  */
 import type { SubagentStatus, TraceNodeRecord } from "@brainpilot/protocol";
 import type { SubagentResult, SubagentTask } from "../subagent-manager.js";
-import type { GraphOfTrace, TraceArtifactInput, TraceAuditTarget } from "../trace.js";
+import type {
+  GraphOfTrace,
+  TraceArtifactInput,
+  TraceAuditTarget,
+  TraceCausalParentCandidate,
+} from "../trace.js";
 import type { WorkspaceCheckpointStore } from "../workspace-checkpoints.js";
 import { TaskQueueFullError, type TaskRecord } from "../task-ledger.js";
 import type { AgentRole, SystemTool } from "../types.js";
@@ -100,6 +105,24 @@ function artifactInputs(value: unknown): TraceArtifactInput[] {
       ...(typeof input.blobHash === "string" ? { blobHash: input.blobHash } : {}),
     }];
   });
+}
+
+function causalParentCandidates(value: unknown):
+  | { ok: true; candidates: TraceCausalParentCandidate[] }
+  | { ok: false; error: string } {
+  if (value === undefined) return { ok: true, candidates: [] };
+  if (!Array.isArray(value)) return { ok: false, error: "parent_candidates must be an array" };
+  const candidates: TraceCausalParentCandidate[] = [];
+  for (const raw of value) {
+    if (!raw || typeof raw !== "object") return { ok: false, error: "each parent candidate must be an object" };
+    const candidate = raw as Record<string, unknown>;
+    const nodeId = typeof candidate.node_id === "string" ? candidate.node_id.trim() : "";
+    const reason = typeof candidate.reason === "string" ? candidate.reason.trim() : "";
+    if (!nodeId) return { ok: false, error: "each parent candidate requires node_id" };
+    if (!reason) return { ok: false, error: `parent ${nodeId} requires a non-empty reason` };
+    candidates.push({ nodeId, reason });
+  }
+  return { ok: true, candidates };
 }
 
 async function attachCheckpointWithGitEvidence(deps: ToolDeps, nodeId: string, checkpointId: string): Promise<void> {
@@ -384,7 +407,9 @@ export function createRecordTraceTool(deps: ToolDeps): SystemTool {
     description:
       "Notify the Trace Agent of a reasoning/trace event. The Trace Agent is a " +
       "real agent that owns the Graph of Trace; it decides whether to create a " +
-      "new node, update an existing one, or merge with a sibling.",
+      "new node, update an existing one, or ignore process noise. Prefer one " +
+      "independently meaningful research unit per call; report distinct settings, " +
+      "results, analyses, findings, or conclusions separately when they can be inspected independently.",
     parameters: {
       type: "object",
       properties: {
@@ -416,7 +441,8 @@ export function createRecordTraceTool(deps: ToolDeps): SystemTool {
       // Agents panel (otherwise it would be a permanently-dormant placeholder)
       // and lets the trace agent merge/dedupe across multiple sources, which is
       // exactly the persona we already ship for it.
-      const description = String(params.description ?? "");
+      const description = String(params.description ?? "").trim();
+      if (!description) return { ...ok("description must be non-empty"), isError: true };
       const context = String(params.context ?? "");
       const artifacts = Array.isArray(params.artifacts)
         ? params.artifacts.filter((value): value is string => typeof value === "string")
@@ -480,6 +506,7 @@ export function createTraceNodeTool(deps: ToolDeps): SystemTool {
       type: "object",
       properties: {
         title: { type: "string", description: "Concise name of the scientific result, decision, analysis, artifact, or conclusion; not an activity-log title." },
+        episode: { type: "string", description: "Human-facing research work-package name. Reuse the exact name of an existing Episode when the unit belongs there." },
         type: { type: "string", description: "Optional short presentation label; do not invent a complex ontology." },
         status: { type: "string", enum: ["completed", "failed"] },
         description: { type: "string", description: "What was scientifically decided, measured, produced, observed, or concluded." },
@@ -493,36 +520,52 @@ export function createTraceNodeTool(deps: ToolDeps): SystemTool {
         artifact_inputs: { type: "array", items: { type: "object", properties: { path: { type: "string" }, type: { type: "string" }, producer_node_id: { type: "string" } }, required: ["path"] } },
         artifact_outputs: { type: "array", items: { type: "object", properties: { path: { type: "string" }, type: { type: "string" }, blob_hash: { type: "string" } }, required: ["path"] } },
       },
-      required: ["title", "confidence", "confidence_reason"],
+      required: ["title", "episode", "description", "confidence", "confidence_reason"],
     },
     execute: async (params: Record<string, unknown>) => {
-      if ((params.confidence !== "low" && params.confidence !== "medium" && params.confidence !== "high") || !String(params.confidence_reason ?? "").trim()) {
+      const title = String(params.title ?? "").trim();
+      const episode = String(params.episode ?? "").normalize("NFKC").trim().replace(/\s+/gu, " ");
+      const description = String(params.description ?? "").trim();
+      const confidenceReason = String(params.confidence_reason ?? "").trim();
+      if (!title) return { ...ok("title must be non-empty"), isError: true };
+      if (!episode) return { ...ok("episode must be non-empty"), isError: true };
+      if (!description) return { ...ok("description must be non-empty"), isError: true };
+      if ((params.confidence !== "low" && params.confidence !== "medium" && params.confidence !== "high") || !confidenceReason) {
         return { ...ok("confidence and a non-empty confidence_reason are required"), isError: true };
       }
+      const parsedParents = causalParentCandidates(params.parent_candidates);
+      if (!parsedParents.ok) return { ...ok(parsedParents.error), isError: true };
+      const parentValidation = deps.trace.validateCausalParentCandidates(undefined, parsedParents.candidates);
+      if (!parentValidation.ok) return { ...ok(`invalid parent candidates: ${parentValidation.reason}`), isError: true };
       const record = deps.currentTraceRecord?.();
       const node = deps.trace.createNode({
-        title: String(params.title ?? ""),
-        type: params.type ? String(params.type) : undefined,
+        title,
+        episode,
+        type: params.type ? String(params.type).trim() : undefined,
         status: params.status === "failed" ? "failed" : "completed",
         executionResult: params.status === "failed" ? "failed" : "completed",
-        description: params.description ? String(params.description) : undefined,
+        description,
         confidence: params.confidence === "high" || params.confidence === "medium" ? params.confidence : "low",
-        confidenceReason: String(params.confidence_reason ?? ""),
+        confidenceReason,
         agent: record?.sourceAgent ?? deps.fromAgent,
         records: record ? [record] : [],
+        causalParents: parsedParents.candidates.map((candidate) => ({
+          nodeId: candidate.nodeId,
+          conclusion: "candidate",
+          origin: "trace",
+          reason: candidate.reason,
+        })),
         changeActor: { type: "agent", name: deps.fromAgent },
         artifactInputs: artifactInputs(params.artifact_inputs),
         artifactOutputs: artifactInputs(params.artifact_outputs),
       });
-      for (const value of Array.isArray(params.parent_candidates) ? params.parent_candidates : []) {
-        if (!value || typeof value !== "object") continue;
-        const candidate = value as Record<string, unknown>;
-        if (typeof candidate.node_id !== "string" || typeof candidate.reason !== "string") continue;
-        deps.trace.proposeCausalParent(node.id, candidate.node_id, candidate.reason, { type: "agent", name: deps.fromAgent });
-      }
       const checkpointId = record?.checkpointId;
       if (checkpointId) await attachCheckpointWithGitEvidence(deps, node.id, checkpointId);
-      return ok(`node ${node.id} created`);
+      return ok(JSON.stringify({
+        nodeId: node.id,
+        episode,
+        parentNodeIds: parsedParents.candidates.map((candidate) => candidate.nodeId),
+      }));
     },
   };
 }
@@ -538,6 +581,7 @@ export function createUpdateTraceNodeTool(deps: ToolDeps): SystemTool {
       type: "object",
       properties: {
         node_id: { type: "string", description: "Active node representing the exact same scientific unit. Inspect it with get_trace_node before updating." },
+        episode: { type: "string", description: "Optional human-facing Episode name. Supply only to move this node to another research work package." },
         title: { type: "string", description: "Supply only when the existing title is inaccurate or the same scientific unit now has a clearer stable name." },
         description: { type: "string", description: "Complete merged scientific description preserving valid prior content; this replaces the stored description." },
         status: { type: "string", enum: ["completed", "failed"] },
@@ -556,31 +600,48 @@ export function createUpdateTraceNodeTool(deps: ToolDeps): SystemTool {
     },
     execute: async (params: Record<string, unknown>) => {
       const id = String(params.node_id ?? "");
-      if (deps.trace.getNodeV2(id)?.revoked) return { ...ok(`node ${id} is revoked; create a new node instead`), isError: true };
-      if ((params.confidence !== "low" && params.confidence !== "medium" && params.confidence !== "high") || !String(params.confidence_reason ?? "").trim()) {
+      const existing = deps.trace.getNodeV2(id);
+      if (!existing) return { ...ok(`node ${id} not found`), isError: true };
+      if (existing.revoked) return { ...ok(`node ${id} is revoked; create a new node instead`), isError: true };
+      const confidenceReason = String(params.confidence_reason ?? "").trim();
+      if ((params.confidence !== "low" && params.confidence !== "medium" && params.confidence !== "high") || !confidenceReason) {
         return { ...ok("confidence and a non-empty confidence_reason are required for every node update"), isError: true };
       }
+      if (params.title !== undefined && !String(params.title).trim()) return { ...ok("title must be non-empty when supplied"), isError: true };
+      if (params.description !== undefined && !String(params.description).trim()) return { ...ok("description must be non-empty when supplied"), isError: true };
+      const episode = params.episode === undefined
+        ? undefined
+        : String(params.episode).normalize("NFKC").trim().replace(/\s+/gu, " ");
+      if (params.episode !== undefined && !episode) return { ...ok("episode must be non-empty when supplied"), isError: true };
+      const parsedParents = causalParentCandidates(params.parent_candidates);
+      if (!parsedParents.ok) return { ...ok(parsedParents.error), isError: true };
+      const parentValidation = deps.trace.validateCausalParentCandidates(id, parsedParents.candidates);
+      if (!parentValidation.ok) return { ...ok(`invalid parent candidates: ${parentValidation.reason}`), isError: true };
       const record = deps.currentTraceRecord?.();
       const updates: Record<string, unknown> = {};
       for (const k of ["status", "summary", "content", "title", "description"]) {
-        if (params[k] !== undefined) updates[k] = params[k];
+        if (params[k] !== undefined) updates[k] = typeof params[k] === "string" ? params[k].trim() : params[k];
       }
+      if (episode !== undefined) updates.episode = episode;
       if (params.status === "completed" || params.status === "failed") updates.executionResult = params.status;
       updates.confidence = params.confidence === "high" || params.confidence === "medium" ? params.confidence : "low";
-      updates.confidenceReason = String(params.confidence_reason ?? "");
+      updates.confidenceReason = confidenceReason;
       const outputs = artifactInputs(params.artifact_outputs);
       if (outputs.length) updates.artifacts = outputs.map((artifact) => ({ path: artifact.path, type: artifact.type }));
-      const node = deps.trace.updateNode(id, updates, { type: "agent", name: deps.fromAgent });
+      const node = deps.trace.updateNode(
+        id,
+        updates,
+        { type: "agent", name: deps.fromAgent },
+        parsedParents.candidates,
+      );
       if (node && record) deps.trace.appendRecord(id, record, { type: "agent", name: deps.fromAgent });
-      for (const value of Array.isArray(params.parent_candidates) ? params.parent_candidates : []) {
-        if (!value || typeof value !== "object") continue;
-        const candidate = value as Record<string, unknown>;
-        if (typeof candidate.node_id !== "string" || typeof candidate.reason !== "string") continue;
-        deps.trace.proposeCausalParent(id, candidate.node_id, candidate.reason, { type: "agent", name: deps.fromAgent });
-      }
       const checkpointId = record?.checkpointId;
       if (node && checkpointId) await attachCheckpointWithGitEvidence(deps, id, checkpointId);
-      return node ? ok(`node ${id} updated`) : { ...ok(`node ${id} not found`), isError: true };
+      return node ? ok(JSON.stringify({
+        nodeId: id,
+        ...(episode ? { episode } : {}),
+        parentNodeIds: parsedParents.candidates.map((candidate) => candidate.nodeId),
+      })) : { ...ok(`node ${id} update failed`), isError: true };
     },
   };
 }
@@ -594,6 +655,7 @@ export function createGetTraceGraphTool(deps: ToolDeps): SystemTool {
     execute: async () => {
       const graph = deps.trace.getGraphV2();
       const rootId = graph.meta.rootNodeId;
+      const episodeTitles = new Map(graph.episodes.map((episode) => [episode.id, episode.title]));
       const activeIds = new Set(
         graph.nodes
           .filter((node) => !node.revoked && node.id !== rootId)
@@ -603,11 +665,15 @@ export function createGetTraceGraphTool(deps: ToolDeps): SystemTool {
         schemaVersion: graph.schemaVersion,
         revision: graph.revision,
         rootNodeId: rootId,
+        episodes: graph.episodes.map((episode) => episode.title),
         nodes: graph.nodes
           .filter((node) => activeIds.has(node.id))
           .map((node) => ({
             id: node.id,
             title: node.title,
+            ...(node.primaryEpisodeId && episodeTitles.has(node.primaryEpisodeId)
+              ? { episode: episodeTitles.get(node.primaryEpisodeId) }
+              : {}),
             type: node.type,
             status: node.status,
             ...(node.description
@@ -765,12 +831,14 @@ export function createEditTraceReviewTool(deps: ToolDeps): SystemTool {
       if (conclusion !== "approve" && conclusion !== "reject" && conclusion !== "uncertain") {
         return { ...ok("invalid review conclusion"), isError: true };
       }
+      const reason = String(params.reason ?? "").trim();
+      if (!reason) return { ...ok("a non-empty review reason is required"), isError: true };
       const target = deps.currentTraceAuditTarget?.();
       if (!target) return { ...ok("no host-bound trace audit target for this turn"), isError: true };
       const success = deps.trace.review(
         target.nodeId,
         conclusion,
-        String(params.reason ?? ""),
+        reason,
         { type: "agent", name: deps.fromAgent },
         target.parentNodeId,
         target.fingerprint,

--- a/packages/runtime/src/tools/system-tools.ts
+++ b/packages/runtime/src/tools/system-tools.ts
@@ -474,7 +474,7 @@ export function createTraceNodeTool(deps: ToolDeps): SystemTool {
     description:
       "Create one new active Graph of Trace node only when the current host-bound record represents a distinct, durable scientific unit that is not already in the active graph. " +
       "Do not create nodes for coordination, delegation, progress, presentation, reformatting, or repetition. The Host attaches the current source record and checkpoint automatically. " +
-      "The Host also attaches the session root whenever no more specific causal parent has been confirmed; never submit the session root as a parent candidate. " +
+      "The Host attaches the session root only when no parent is present. The session root ID is exposed by get_trace_graph and may be proposed when the unit directly depends on the session's initial context. " +
       "One Trace Event may call this tool more than once only when it explicitly contains multiple independently meaningful scientific units with enough content to describe each accurately.",
     parameters: {
       type: "object",
@@ -602,6 +602,7 @@ export function createGetTraceGraphTool(deps: ToolDeps): SystemTool {
       return ok(JSON.stringify({
         schemaVersion: graph.schemaVersion,
         revision: graph.revision,
+        rootNodeId: rootId,
         nodes: graph.nodes
           .filter((node) => activeIds.has(node.id))
           .map((node) => ({
@@ -616,10 +617,15 @@ export function createGetTraceGraphTool(deps: ToolDeps): SystemTool {
             reviewConclusion: node.reviewConclusion,
             updatedAt: node.updatedAt,
             parents: node.parents
-              .filter((parent) => parent.nodeId !== rootId && activeIds.has(parent.nodeId))
+              .filter((parent) =>
+                parent.nodeId === rootId
+                  ? parent.origin === "trace"
+                  : activeIds.has(parent.nodeId)
+              )
               .map((parent) => ({
                 nodeId: parent.nodeId,
                 conclusion: parent.conclusion,
+                ...(parent.origin ? { origin: parent.origin } : {}),
                 ...(parent.reason ? { reason: parent.reason } : {}),
               })),
           })),
@@ -628,7 +634,7 @@ export function createGetTraceGraphTool(deps: ToolDeps): SystemTool {
   };
 }
 
-/** Principal-only bounded trace readers; no Principal full-graph tool exists. */
+/** Bounded trace readers shared by Principal, Trace, and Auditor as allowed below. */
 export function createGetTraceNodeTool(deps: ToolDeps): SystemTool {
   return {
     name: "get_trace_node",
@@ -880,6 +886,10 @@ export const AGENT_TOOL_CONFIG: Record<string, string[]> = {
     "create_agent",
     "destroy_agent",
     "record_trace",
+    "get_trace_graph",
+    "get_trace_node",
+    "get_trace_neighborhood",
+    "get_trace_diff",
     "ask_user",
     "skill_search",
     "get_domain_knowledge_local",

--- a/packages/runtime/src/trace.ts
+++ b/packages/runtime/src/trace.ts
@@ -412,18 +412,20 @@ export class GraphOfTrace {
   proposeCausalParent(childNodeId: string, parentNodeId: string, reason: string, actor: TraceChangeActor): boolean {
     const child = this.nodes.get(childNodeId);
     const parent = this.nodes.get(parentNodeId);
-    if (!child || !parent || child.revoked || parent.revoked || this.isSessionRoot(childNodeId) || this.isSessionRoot(parentNodeId) || childNodeId === parentNodeId) return false;
+    if (!child || !parent || child.revoked || parent.revoked || this.isSessionRoot(childNodeId) || childNodeId === parentNodeId) return false;
     const existing = child.parents.find((item) => item.nodeId === parentNodeId);
     if (existing?.conclusion === "rejected") return false;
     if (!existing && this.wouldCreateCycle(parentNodeId, childNodeId)) return false;
     const before = existing ? clone(existing) : undefined;
     if (existing) {
-      if (existing.conclusion === "confirmed" && existing.reason === reason) return true;
+      if (existing.conclusion === "candidate" && existing.reason === reason && existing.origin === "trace") return true;
       existing.conclusion = "candidate";
       existing.reason = reason;
+      existing.origin = "trace";
     } else {
-      child.parents.push({ nodeId: parentNodeId, conclusion: "candidate", ...(reason ? { reason } : {}) });
+      child.parents.push({ nodeId: parentNodeId, conclusion: "candidate", origin: "trace", ...(reason ? { reason } : {}) });
     }
+    this.normalizeCausalGraph();
     this.syncCompatibilityDependency(parentNodeId, childNodeId, "candidate", reason);
     child.updatedAt = now();
     this.commit("updated", childNodeId, {
@@ -463,7 +465,6 @@ export class GraphOfTrace {
       });
       return true;
     }
-    if (this.isSessionRoot(parentNodeId)) return false;
     const parent = this.nodes.get(parentNodeId);
     const ref = node.parents.find((item) => item.nodeId === parentNodeId);
     if (!parent || parent.revoked || !ref) return false;
@@ -1053,7 +1054,10 @@ export class GraphOfTrace {
           const conclusion = parent.conclusion === "confirmed" || parent.conclusion === "rejected" || parent.conclusion === "uncertain"
             ? parent.conclusion
             : "candidate";
-          return [{ nodeId, conclusion, ...(typeof parent.reason === "string" ? { reason: parent.reason } : {}) }];
+          const origin = parent.origin === "trace" || parent.origin === "host_fallback"
+            ? parent.origin
+            : undefined;
+          return [{ nodeId, conclusion, ...(origin ? { origin } : {}), ...(typeof parent.reason === "string" ? { reason: parent.reason } : {}) }];
         }),
         executionResult: node.executionResult === "failed" || node.status === "failed" || node.status === "error" ? "failed" : "completed",
         revoked: node.revoked === true || node.status === "rolled_back" || node.status === "inactive",
@@ -1502,28 +1506,30 @@ export class GraphOfTrace {
       node.parents = accepted;
     }
 
-    // A real confirmed parent replaces the temporary root link. Otherwise the
-    // Host supplies the root as an immediately confirmed fallback.
+    // The Host supplies a root fallback only when no parent of any conclusion
+    // exists. A root explicitly proposed by Trace is a normal reviewable edge.
     for (const node of this.nodes.values()) {
       if (node.revoked || node.id === root.id) continue;
-      const hasRealConfirmedParent = node.parents.some((parent) => {
-        const parentNode = this.nodes.get(parent.nodeId);
-        return parent.nodeId !== root.id && parent.conclusion === "confirmed" && parentNode && !parentNode.revoked;
-      });
-      if (hasRealConfirmedParent) {
-        node.parents = node.parents.filter((parent) => parent.nodeId !== root.id);
+      const hasNonRootParent = node.parents.some((parent) => parent.nodeId !== root.id);
+      if (hasNonRootParent) {
+        node.parents = node.parents.filter((parent) =>
+          parent.nodeId !== root.id || parent.origin === "trace"
+        );
+        continue;
+      }
+      const rootRef = node.parents.find((parent) => parent.nodeId === root.id);
+      if (rootRef?.origin === "trace") continue;
+      if (rootRef) {
+        rootRef.conclusion = "confirmed";
+        rootRef.origin = "host_fallback";
+        rootRef.reason = "No parent was proposed; attached to the session root by the Host.";
       } else {
-        const rootRef = node.parents.find((parent) => parent.nodeId === root.id);
-        if (rootRef) {
-          rootRef.conclusion = "confirmed";
-          rootRef.reason = "No more specific confirmed causal parent; attached to the session root by the Host.";
-        } else {
-          node.parents.unshift({
-            nodeId: root.id,
-            conclusion: "confirmed",
-            reason: "No more specific confirmed causal parent; attached to the session root by the Host.",
-          });
-        }
+        node.parents.unshift({
+          nodeId: root.id,
+          conclusion: "confirmed",
+          origin: "host_fallback",
+          reason: "No parent was proposed; attached to the session root by the Host.",
+        });
       }
     }
     this.rebuildCompatibilityDependencies();

--- a/packages/runtime/src/trace.ts
+++ b/packages/runtime/src/trace.ts
@@ -418,6 +418,11 @@ export class GraphOfTrace {
     if (!existing && this.wouldCreateCycle(parentNodeId, childNodeId)) return false;
     const before = existing ? clone(existing) : undefined;
     if (existing) {
+      if (
+        existing.conclusion === "confirmed" &&
+        existing.reason === reason &&
+        existing.origin !== "host_fallback"
+      ) return true;
       if (existing.conclusion === "candidate" && existing.reason === reason && existing.origin === "trace") return true;
       existing.conclusion = "candidate";
       existing.reason = reason;

--- a/packages/runtime/src/trace.ts
+++ b/packages/runtime/src/trace.ts
@@ -59,6 +59,14 @@ function unique(values: string[]): string[] {
   return [...new Set(values.filter(Boolean))];
 }
 
+function normalizeEpisodeTitle(value: string): string {
+  return value.normalize("NFKC").trim().replace(/\s+/gu, " ");
+}
+
+function episodeLookupKey(value: string): string {
+  return normalizeEpisodeTitle(value).toLowerCase();
+}
+
 function asRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
     ? value as Record<string, unknown>
@@ -145,6 +153,18 @@ export interface TraceAuditTarget {
   fingerprint: string;
 }
 
+export interface TraceCausalParentCandidate {
+  nodeId: string;
+  reason: string;
+}
+
+export interface TraceParentCandidateValidation {
+  ok: boolean;
+  reason?: string;
+}
+
+type TraceNodeUpdate = Partial<TraceNode> & { episode?: string };
+
 type TraceChangeDraft = Omit<TraceChange, "id" | "revision" | "createdAt">;
 
 /**
@@ -189,6 +209,8 @@ export class GraphOfTrace {
 
   createNode(input: {
     title: string;
+    /** Human-facing work-package name. Stored through the existing Episode registry. */
+    episode?: string;
     type?: string;
     status?: string;
     agent?: string;
@@ -219,6 +241,17 @@ export class GraphOfTrace {
     this.ensureSessionRoot();
     const id = input.id ?? `node_${randomUUID()}`;
     if (this.nodes.has(id)) throw new Error(`trace node already exists: ${id}`);
+    const causalParentCandidates = (input.causalParents ?? []).map((parent) => ({
+      nodeId: parent.nodeId,
+      reason: parent.reason ?? "",
+    }));
+    const parentValidation = this.validateCausalParentCandidates(undefined, causalParentCandidates);
+    if (!parentValidation.ok) {
+      throw new Error(`invalid causal parents: ${parentValidation.reason}`);
+    }
+    const episode = input.episode !== undefined
+      ? this.resolveEpisodeInternal(input.episode)
+      : undefined;
     const createdAt = now();
     const report = input.summary !== undefined || input.content !== undefined
       ? { kind: "agent_report" as const, summary: input.summary, content: input.content, author: input.agent }
@@ -237,7 +270,11 @@ export class GraphOfTrace {
       updatedAt: createdAt,
       toolCalls: [],
       artifactIds: [],
-      ...(input.primaryEpisodeId ? { primaryEpisodeId: input.primaryEpisodeId } : {}),
+      ...(episode
+        ? { primaryEpisodeId: episode.id }
+        : input.primaryEpisodeId
+          ? { primaryEpisodeId: input.primaryEpisodeId }
+          : {}),
       ...(input.episodeTags?.length ? { episodeTags: unique(input.episodeTags) } : { episodeTags: [] }),
       ...(input.metadata ? { metadata: clone(input.metadata) } : {}),
       records: clone(input.records ?? []),
@@ -283,9 +320,11 @@ export class GraphOfTrace {
       target: { nodeId: id },
       after: {
         title: node.title,
+        ...(episode ? { episode: episode.title } : {}),
         executionResult: node.executionResult,
         confidence: node.confidence,
         confidenceReason: node.confidenceReason,
+        parents: clone(node.parents),
       },
     });
     return this.getNode(id)!;
@@ -314,9 +353,16 @@ export class GraphOfTrace {
    * Legacy-shaped update. Parent/child fields are intentionally ignored: they
    * are derived from the canonical relation collections at read time.
    */
-  updateNode(id: string, updates: Partial<TraceNode>, actor: TraceChangeActor = { type: "host" }): TraceNode | undefined {
+  updateNode(
+    id: string,
+    updates: TraceNodeUpdate,
+    actor: TraceChangeActor = { type: "host" },
+    parentCandidates: TraceCausalParentCandidate[] = [],
+  ): TraceNode | undefined {
     const node = this.nodes.get(id);
     if (!node || this.isSessionRoot(id)) return undefined;
+    const parentValidation = this.validateCausalParentCandidates(id, parentCandidates);
+    if (!parentValidation.ok) return undefined;
     const patch = updates as Record<string, unknown>;
     const before = {
       confidence: node.confidence,
@@ -341,6 +387,9 @@ export class GraphOfTrace {
       node.reviewConclusion = patch.reviewConclusion;
     }
     if (typeof patch.reviewReason === "string") node.reviewReason = patch.reviewReason;
+    if (typeof patch.episode === "string") {
+      node.primaryEpisodeId = this.resolveEpisodeInternal(patch.episode).id;
+    }
     if (patch.summary !== undefined || patch.content !== undefined) {
       node.report = {
         kind: "agent_report",
@@ -377,6 +426,9 @@ export class GraphOfTrace {
       node.reviewConclusion = "unreviewed";
       delete node.reviewReason;
     }
+    for (const candidate of parentCandidates) {
+      this.applyCausalParentCandidateInternal(node, candidate.nodeId, candidate.reason);
+    }
     this.normalizeCausalGraph();
     node.updatedAt = now();
     this.commit("updated", id, {
@@ -384,7 +436,10 @@ export class GraphOfTrace {
       action: "node_updated",
       target: { nodeId: id },
       before,
-      after: clone(updates),
+      after: {
+        ...clone(updates),
+        ...(parentCandidates.length ? { parentCandidates: clone(parentCandidates) } : {}),
+      },
       ...(node.confidenceReason ? { reason: node.confidenceReason } : {}),
     });
     return this.getNode(id);
@@ -411,25 +466,14 @@ export class GraphOfTrace {
 
   proposeCausalParent(childNodeId: string, parentNodeId: string, reason: string, actor: TraceChangeActor): boolean {
     const child = this.nodes.get(childNodeId);
-    const parent = this.nodes.get(parentNodeId);
-    if (!child || !parent || child.revoked || parent.revoked || this.isSessionRoot(childNodeId) || childNodeId === parentNodeId) return false;
+    if (!child) return false;
+    const validation = this.validateCausalParentCandidates(childNodeId, [{ nodeId: parentNodeId, reason }]);
+    if (!validation.ok) return false;
     const existing = child.parents.find((item) => item.nodeId === parentNodeId);
-    if (existing?.conclusion === "rejected") return false;
-    if (!existing && this.wouldCreateCycle(parentNodeId, childNodeId)) return false;
     const before = existing ? clone(existing) : undefined;
-    if (existing) {
-      if (
-        existing.conclusion === "confirmed" &&
-        existing.reason === reason &&
-        existing.origin !== "host_fallback"
-      ) return true;
-      if (existing.conclusion === "candidate" && existing.reason === reason && existing.origin === "trace") return true;
-      existing.conclusion = "candidate";
-      existing.reason = reason;
-      existing.origin = "trace";
-    } else {
-      child.parents.push({ nodeId: parentNodeId, conclusion: "candidate", origin: "trace", ...(reason ? { reason } : {}) });
-    }
+    if (existing?.conclusion === "confirmed" && existing.reason === reason && existing.origin !== "host_fallback") return true;
+    if (existing?.conclusion === "candidate" && existing.reason === reason && existing.origin === "trace") return true;
+    this.applyCausalParentCandidateInternal(child, parentNodeId, reason);
     this.normalizeCausalGraph();
     this.syncCompatibilityDependency(parentNodeId, childNodeId, "candidate", reason);
     child.updatedAt = now();
@@ -442,6 +486,58 @@ export class GraphOfTrace {
       reason,
     });
     return true;
+  }
+
+  /** Validate a complete candidate batch before any node, Episode, or edge mutation. */
+  validateCausalParentCandidates(
+    childNodeId: string | undefined,
+    candidates: TraceCausalParentCandidate[],
+  ): TraceParentCandidateValidation {
+    const child = childNodeId ? this.nodes.get(childNodeId) : undefined;
+    if (childNodeId && (!child || child.revoked || this.isSessionRoot(childNodeId))) {
+      return { ok: false, reason: "child node is missing, revoked, or structural" };
+    }
+    const seen = new Set<string>();
+    for (const candidate of candidates) {
+      const parentNodeId = candidate.nodeId.trim();
+      const reason = candidate.reason.trim();
+      if (!parentNodeId) return { ok: false, reason: "parent node id is required" };
+      if (!reason) return { ok: false, reason: `parent ${parentNodeId} requires a non-empty reason` };
+      if (seen.has(parentNodeId)) return { ok: false, reason: `duplicate parent candidate: ${parentNodeId}` };
+      seen.add(parentNodeId);
+      const parent = this.nodes.get(parentNodeId);
+      if (!parent || parent.revoked) return { ok: false, reason: `parent ${parentNodeId} is missing or revoked` };
+      if (childNodeId === parentNodeId) return { ok: false, reason: "a node cannot depend on itself" };
+      const existing = child?.parents.find((item) => item.nodeId === parentNodeId);
+      if (existing?.conclusion === "rejected") {
+        return { ok: false, reason: `parent ${parentNodeId} was rejected` };
+      }
+      if (childNodeId && !existing && this.wouldCreateCycle(parentNodeId, childNodeId)) {
+        return { ok: false, reason: `parent ${parentNodeId} would create a cycle` };
+      }
+    }
+    return { ok: true };
+  }
+
+  private applyCausalParentCandidateInternal(
+    child: TraceNodeV2,
+    parentNodeId: string,
+    reason: string,
+  ): void {
+    const normalizedReason = reason.trim();
+    const existing = child.parents.find((item) => item.nodeId === parentNodeId);
+    if (existing) {
+      existing.conclusion = "candidate";
+      existing.reason = normalizedReason;
+      existing.origin = "trace";
+      return;
+    }
+    child.parents.push({
+      nodeId: parentNodeId,
+      conclusion: "candidate",
+      origin: "trace",
+      reason: normalizedReason,
+    });
   }
 
   review(
@@ -680,6 +776,23 @@ export class GraphOfTrace {
       }).ok;
     }
     return false;
+  }
+
+  private resolveEpisodeInternal(title: string): TraceEpisode {
+    const normalizedTitle = normalizeEpisodeTitle(title);
+    if (!normalizedTitle) throw new Error("episode must be non-empty");
+    const key = episodeLookupKey(normalizedTitle);
+    const existing = [...this.episodes.values()].find((episode) => episodeLookupKey(episode.title) === key);
+    if (existing) return existing;
+    const stamp = now();
+    const episode: TraceEpisode = {
+      id: stableId("episode", this.sessionId, key),
+      title: normalizedTitle,
+      createdAt: stamp,
+      updatedAt: stamp,
+    };
+    this.episodes.set(episode.id, episode);
+    return episode;
   }
 
   createEpisode(input: { title: string; description?: string; id?: string }): TraceEpisode {

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -223,6 +223,8 @@ export type AgentSessionFactory = (params: {
   renderAgentStatus?: () => string;
   /** Fresh flat task-list context, injected ephemerally on every turn. */
   renderTaskContext?: () => string;
+  /** Fresh role-specific GoT context, injected ephemerally on every turn. */
+  renderGoTContext?: () => string;
   /**
    * Per-session LLM provider resolved from providers.json. When omitted, the
    * factory falls back to Pi's env-based default (Docker/static compat).

--- a/packages/web/src/__tests__/traceEpisodeGrouping.test.ts
+++ b/packages/web/src/__tests__/traceEpisodeGrouping.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import type { TraceNode } from "../contracts/backend";
+import { withEpisodeGroups } from "../components/session/AgentTraceViews";
+
+function node(id: string, episode: string | undefined, parents: string[] = []): TraceNode {
+  return {
+    id,
+    title: id,
+    type: "result",
+    status: "completed",
+    parents: parents.map((parentId) => ({ id: parentId, edgeType: "confirmed" })),
+    parentIds: [...parents],
+    childIds: [],
+    artifacts: [],
+    toolCalls: [],
+    ...(episode ? { primaryEpisodeId: episode } : {}),
+  };
+}
+
+describe("Trace Episode grouping", () => {
+  it("preserves cross-Episode dependencies without mutating the source graph", () => {
+    const nodes = [
+      node("setting", "ablation"),
+      node("result", "ablation", ["setting"]),
+      node("synthesis", "final", ["result"]),
+      node("report", undefined, ["synthesis"]),
+    ];
+    const before = structuredClone(nodes);
+    const grouped = withEpisodeGroups(nodes, [
+      { id: "ablation", title: "Ablation — dropout" },
+      { id: "final", title: "Final Synthesis" },
+    ], true);
+
+    expect(nodes).toEqual(before);
+    expect(grouped.find((item) => item.id === "episode:final")?.parentIds)
+      .toEqual(["episode:ablation"]);
+    expect(grouped.find((item) => item.id === "report")?.parentIds)
+      .toEqual(["episode:final"]);
+    expect(grouped.find((item) => item.id === "episode:ablation")?.parentIds)
+      .toEqual([]);
+  });
+});

--- a/packages/web/src/__tests__/traceGraphEmptyMarkup.test.tsx
+++ b/packages/web/src/__tests__/traceGraphEmptyMarkup.test.tsx
@@ -64,4 +64,32 @@ describe("TraceGraphView empty markup (#317)", () => {
     expect(html).not.toContain("should not appear");
     expect(html).toContain("Task A");
   });
+
+  it("shows the Episode name on a node card without exposing its ID", () => {
+    const node = {
+      id: "result-a",
+      title: "No-dropout result",
+      type: "result",
+      status: "completed",
+      primaryEpisodeId: "ep-private-id",
+      parents: [] as { id: string; title?: string }[],
+      parentIds: [] as string[],
+      childIds: [] as string[],
+      artifacts: [] as { path: string }[],
+      toolCalls: [] as string[],
+    };
+    const html = renderToStaticMarkup(
+      <TraceGraphView
+        nodes={[node as never]}
+        direction="LR"
+        selectedNodeId="result-a"
+        onSelectNode={() => {}}
+        zoom={1}
+        onZoomChange={() => {}}
+        episodeTitles={new Map([["ep-private-id", "Ablation — dropout"]])}
+      />,
+    );
+    expect(html).toContain("Ablation — dropout");
+    expect(html).not.toContain("ep-private-id");
+  });
 });

--- a/packages/web/src/components/demo/DemoView.tsx
+++ b/packages/web/src/components/demo/DemoView.tsx
@@ -214,6 +214,10 @@ export function DemoView({ resetSignal }: DemoViewProps = {}) {
   }, [decoded]);
 
   const nodes = bundle?.trace.nodes ?? [];
+  const episodeTitles = useMemo(
+    () => new Map((bundle?.trace.episodes ?? []).map((episode) => [episode.id, episode.title])),
+    [bundle?.trace.episodes],
+  );
 
   // #321 — when Trace/files are empty, give conversation more width by default.
   useEffect(() => {
@@ -860,6 +864,7 @@ export function DemoView({ resetSignal }: DemoViewProps = {}) {
                 fitToken={revealedNodes.length}
                 emptyLabel={nodes.length === 0 ? t("demo.trace.empty") : undefined}
                 formatKind={formatNodeKind}
+                episodeTitles={episodeTitles}
                 zoomLabels={{
                   controls: t("trace.aria.zoomControls"),
                   zoomIn: t("trace.aria.zoomIn"),

--- a/packages/web/src/components/session/AgentTraceViews.tsx
+++ b/packages/web/src/components/session/AgentTraceViews.tsx
@@ -25,7 +25,7 @@ import {
 } from "./traceEmptyState";
 
 /** Materialize collapsible V2 episode group nodes without mutating session state. */
-function withEpisodeGroups(nodes: TraceNode[], episodes: Array<{ id: string; title: string }> | undefined, collapsed: boolean): TraceNode[] {
+export function withEpisodeGroups(nodes: TraceNode[], episodes: Array<{ id: string; title: string }> | undefined, collapsed: boolean): TraceNode[] {
   if (!collapsed || !episodes?.length) return nodes;
   const titleByEpisode = new Map(episodes.map((episode) => [episode.id, episode.title]));
   const members = new Map<string, TraceNode[]>();
@@ -157,6 +157,10 @@ export function TracePanel() {
   };
 
   const allNodes = trace?.nodes ?? [];
+  const episodeTitles = useMemo(
+    () => new Map((trace?.episodes ?? []).map((episode) => [episode.id, episode.title])),
+    [trace?.episodes],
+  );
   const playbackNodes = useMemo(() => allNodes.slice(0, playbackIndex), [allNodes, playbackIndex]);
 
   const filteredNodes = useMemo(() => {
@@ -175,12 +179,13 @@ export function TracePanel() {
         node.context,
         node.agent,
         nodeKind,
+        node.primaryEpisodeId ? episodeTitles.get(node.primaryEpisodeId) : undefined,
         ...node.toolCalls,
         ...node.artifacts.map((artifact) => artifact.path),
       ].filter(Boolean).join(" ").toLowerCase();
       return matchesStatus && matchesType && (!normalizedQuery || searchText.includes(normalizedQuery));
     });
-  }, [query, statusFilter, playbackNodes, typeFilter]);
+  }, [query, statusFilter, playbackNodes, typeFilter, episodeTitles]);
 
   const visibleNodeIds = useMemo(() => new Set(filteredNodes.map((node) => node.id)), [filteredNodes]);
   const visibleNodes = useMemo(
@@ -424,6 +429,7 @@ export function TracePanel() {
                   fitToken={fitToken}
                   emptyLabel={emptyLabel}
                   formatKind={formatNodeKind}
+                  episodeTitles={episodeTitles}
                   showProposedDependencies={showProposedDependencies}
                   zoomLabels={{
                     controls: t("trace.aria.zoomControls"),

--- a/packages/web/src/components/session/TraceGraphView.tsx
+++ b/packages/web/src/components/session/TraceGraphView.tsx
@@ -27,6 +27,8 @@ interface TraceGraphViewProps {
   /** Shown when there are no nodes to display. */
   emptyLabel?: string;
   formatKind?: (kind: string) => string;
+  /** Display labels for internal Episode IDs carried by V2 nodes. */
+  episodeTitles?: ReadonlyMap<string, string>;
   zoomLabels?: {
     controls?: string;
     zoomIn?: string;
@@ -52,6 +54,7 @@ export function TraceGraphView({
   fitToken,
   emptyLabel,
   formatKind,
+  episodeTitles,
   zoomLabels,
   showProposedDependencies = true,
 }: TraceGraphViewProps) {
@@ -290,6 +293,10 @@ export function TraceGraphView({
           {adjustedLayout.positioned.map(({ node, x, y }) => {
             const kind = getNodeKind(node);
             const kindLabel = formatKind?.(kind) ?? kind;
+            const episodeTitle = node.primaryEpisodeId
+              ? episodeTitles?.get(node.primaryEpisodeId)
+              : undefined;
+            const kindAndEpisode = episodeTitle ? `${kindLabel} · ${episodeTitle}` : kindLabel;
             return (
               <g
                 className={`trace-map-node trace-map-node--${kind} trace-map-node--${normalizeStatus(node.status)} ${node.revoked ? "is-revoked" : ""} ${selectedNodeId === node.id ? "is-selected" : ""} ${draggingNodeRef.current?.nodeId === node.id ? "is-dragging" : ""}`}
@@ -313,11 +320,12 @@ export function TraceGraphView({
                 }}
                 style={{ transform: `translate(${x}px, ${y}px)` }}
               >
+                <title>{episodeTitle ? `${node.title} — ${episodeTitle}` : node.title}</title>
                 <rect height={adjustedLayout.nodeHeight} rx="8" width={adjustedLayout.nodeWidth} />
                 <circle className={`trace-node__dot--${normalizeStatus(node.status)}`} cx="16" cy="24" r="4" />
                 <text className="trace-map-node__title" x="28" y="26">{truncateNodeTitle(node.title)}</text>
                 <text className="trace-map-node__meta" x="28" y="44">{node.revoked ? "Revoked" : `${node.agent || kindLabel} · ${node.confidence ?? "?"}`}</text>
-                <text className="trace-map-node__kind" x="28" y="58">{kindLabel}</text>
+                <text className="trace-map-node__kind" x="28" y="58">{truncateNodeTitle(kindAndEpisode)}</text>
               </g>
             );
           })}


### PR DESCRIPTION
## Summary

- require human-facing Episode names and standalone descriptions for Trace-created nodes
- normalize and reuse Episodes while atomically validating node, Episode, and parent-edge mutations
- strengthen Trace and Auditor guidance for research-unit granularity and direct causal dependencies
- add the default Trace-only `@brainpilot/plugin-got` system plugin with the `curate-research-trace` Skill and worked examples
- expose Episode names in compact GoT contexts and node cards/details without exposing Episode IDs in compact model views
- preserve Session Start fallback semantics and existing asynchronous `record_trace` behavior

## Validation

- `npm run build`
- `npm test` — 940 passed
- `npm test -w @brainpilot/web` — 485 passed
- publish-readiness test — 66 passed
- `curate-research-trace` Skill validation passed

Real-model node granularity remains a manual end-to-end acceptance scenario, as planned; CI verifies deterministic tool, prompt, plugin, storage, and UI behavior.

## Branch hygiene

Rebuilt on the latest `main` after #415 landed. The PR now contains only the required GoT context/invariant commits and the research-trace curation implementation; unrelated #409/#414 UI history has been removed.