### PR TITLE
fix(runtime): bound trace checkpoints and resolve data paths

### DIFF
--- a/packages/runtime/src/__tests__/managed-path-rewrite.test.ts
+++ b/packages/runtime/src/__tests__/managed-path-rewrite.test.ts
@@ -109,6 +109,42 @@ describe("rewriteLogicalPath", () => {
     expect(r.path).toBe(abs);
   });
 
+  it("prefers physical roots when the data root itself is mounted at /data", () => {
+    const mountedCwd = resolve("/data/workspaces/s1");
+    const mountedPersistentDir = resolve("/data/data");
+    const mountedRoots: ManagedPathRoots = {
+      cwd: mountedCwd,
+      persistentDir: mountedPersistentDir,
+    };
+
+    const workspace = rewriteLogicalPath("/data/workspaces/s1/scripts/train.py", mountedRoots);
+    expect(workspace).toMatchObject({
+      ok: true,
+      path: "/data/workspaces/s1/scripts/train.py",
+      rewritten: false,
+      root: "workspace",
+      abs: resolve(mountedCwd, "scripts/train.py"),
+    });
+
+    const physicalData = rewriteLogicalPath("/data/data/models/best.pkl", mountedRoots);
+    expect(physicalData).toMatchObject({
+      ok: true,
+      path: "/data/data/models/best.pkl",
+      rewritten: false,
+      root: "data",
+      abs: resolve(mountedPersistentDir, "models/best.pkl"),
+    });
+
+    const logicalData = rewriteLogicalPath("/data/models/best.pkl", mountedRoots);
+    expect(logicalData).toMatchObject({
+      ok: true,
+      path: resolve(mountedPersistentDir, "models/best.pkl"),
+      rewritten: true,
+      root: "data",
+      abs: resolve(mountedPersistentDir, "models/best.pkl"),
+    });
+  });
+
   it("rejects traversal out of /workspace", () => {
     const r = rewriteLogicalPath("/workspace/../../etc/passwd", roots);
     expect(r.ok).toBe(false);

--- a/packages/runtime/src/__tests__/trace-agent.test.ts
+++ b/packages/runtime/src/__tests__/trace-agent.test.ts
@@ -153,6 +153,8 @@ describe("Trace Agent — record_trace dispatches to a spawned trace agent", () 
     expect(captured!).toContain("[Trace Event]");
     expect(captured!).toContain("Description: designed an experiment");
     expect(captured!).toContain("Context: after reviewing prior art");
+    expect(captured!).toContain("Git-Evidence-Summary:");
+    expect(captured!).not.toContain("Git-Evidence: [");
     expect(captured!).toContain("- plan.md");
     expect(captured!).toContain("- diagram.png");
   });

--- a/packages/runtime/src/__tests__/workspace-checkpoints.test.ts
+++ b/packages/runtime/src/__tests__/workspace-checkpoints.test.ts
@@ -46,6 +46,49 @@ describe("WorkspaceCheckpointStore", () => {
     expect(detail?.skipped.some((item) => item.path === "ignored.txt" && item.reason === "ignored")).toBe(true);
   });
 
+  it("excludes generated environments and bounds provenance expansion", async () => {
+    const { workspace, store } = await fixture();
+    await mkdir(join(workspace, ".venv", "lib", "python", "site-packages"), { recursive: true });
+    await writeFile(join(workspace, ".venv", "pyvenv.cfg"), "home = /usr/bin\n", "utf8");
+    for (let i = 0; i < 20; i++) {
+      await writeFile(
+        join(workspace, ".venv", "lib", "python", "site-packages", `dependency_${i}.py`),
+        `VALUE = ${i}\n`,
+        "utf8",
+      );
+    }
+    for (let i = 0; i < 5; i++) {
+      await writeFile(join(workspace, `result_${i}.txt`), `${i}\n`, "utf8");
+    }
+
+    const checkpoint = await store.capture("engineer");
+    expect(checkpoint.stats?.files).toBe(5);
+    const detail = await store.detail(checkpoint.id);
+    expect(detail?.files.every((item) => !item.path.startsWith(".venv/"))).toBe(true);
+    expect(detail?.skipped.filter((item) => item.path.startsWith(".venv/"))).toEqual([
+      expect.objectContaining({ path: ".venv/", reason: "internal" }),
+    ]);
+
+    const bounded = await store.provenance(checkpoint.id, 2);
+    expect(bounded).toHaveLength(2);
+    expect(bounded?.every((item) => item.path.startsWith("result_"))).toBe(true);
+  });
+
+  it("uses an initial baseline so pre-existing inputs are not trace outputs", async () => {
+    const { workspace, store } = await fixture();
+    await writeFile(join(workspace, "input.csv"), "subject,value\n1,2\n", "utf8");
+    const baseline = await store.ensureBaseline();
+    expect(baseline?.stats).toMatchObject({ files: 1, added: 1 });
+    expect(await store.ensureBaseline()).toBeUndefined();
+
+    await writeFile(join(workspace, "result.csv"), "score\n0.8\n", "utf8");
+    const trace = await store.capture("engineer");
+    expect(trace.stats).toMatchObject({ files: 1, added: 1 });
+    expect((await store.detail(trace.id))?.files.map((item) => item.path)).toEqual([
+      "result.csv",
+    ]);
+  });
+
   it("restores managed files and makes the restored tree the next checkpoint baseline", async () => {
     const { workspace, state, store } = await fixture();
     await writeFile(join(workspace, ".gitignore"), "keep.local\n", "utf8");

--- a/packages/runtime/src/managed-path-rewrite.ts
+++ b/packages/runtime/src/managed-path-rewrite.ts
@@ -128,6 +128,27 @@ export function rewriteLogicalPath(raw: string, roots: ManagedPathRoots): Rewrit
   const attName = roots.attachmentsDirname ?? ATTACHMENTS_DEFAULT;
   const attAbs = resolve(cwdAbs, attName);
 
+  // A deployment may mount the whole BrainPilot data root at `/data`, making
+  // the real session cwd `/data/workspaces/<sid>` and the real persistent
+  // library `/data/data`. Those physical paths must win over the logical
+  // `/data` alias or an already-resolved path is rewritten a second time (for
+  // example `/data/data/x` -> `/data/data/data/x`). Relative paths and absolute
+  // paths outside known durable roots still flow through the logical-prefix
+  // handling below.
+  if (isAbsolute(p)) {
+    const abs = normalize(resolve(p));
+    const classified = classifyAbs(abs, roots);
+    if (classified !== "other") {
+      return {
+        ok: true,
+        path: p,
+        rewritten: false,
+        root: classified,
+        abs,
+      };
+    }
+  }
+
   let rootAbs: string;
   let kind: ManagedRootKind;
   let rel: string;

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -1672,6 +1672,15 @@ export class SessionManager {
     // file the user just attached. No-op when nothing was staged.
     await this.drainLocalUploads(sessionId);
 
+    // Snapshot user/Bench-provided inputs before the first agent prompt. Without
+    // this baseline the first record_trace diffs against Git's empty tree and
+    // incorrectly attributes every pre-existing workspace file to that event.
+    // A concurrent follow-up or ask_user answer must not snapshot a workspace
+    // while an agent is already mutating it.
+    if (!entry.runActive && !agent.isStreaming) {
+      await entry.checkpoints.ensureBaseline().catch(() => undefined);
+    }
+
     // Defense-in-depth for old clients/direct callers: ordinary text answers
     // the one visible FIFO head. Queued questions are never addressable.
     const visibleInput = entry.userInputs.active;

--- a/packages/runtime/src/tools/system-tools.ts
+++ b/packages/runtime/src/tools/system-tools.ts
@@ -76,6 +76,8 @@ function ok(text: string): { content: [{ type: "text"; text: string }] } {
 
 /** Detail/read tools are deliberately bounded so one graph query cannot eat a turn. */
 const TRACE_DETAIL_MAX_TOKENS = 1500;
+/** File samples sent to the Trace model; complete evidence stays in the checkpoint store. */
+const TRACE_PROMPT_PROVENANCE_FILES = 25;
 
 function cappedJson(value: unknown, maxTokens = TRACE_DETAIL_MAX_TOKENS): string {
   const text = JSON.stringify(value, null, 2);
@@ -451,7 +453,10 @@ export function createRecordTraceTool(deps: ToolDeps): SystemTool {
       const outputs = artifactInputs(params.artifact_outputs);
       const checkpoint = await deps.checkpoints?.capture(deps.fromAgent);
       const gitEvidence = checkpoint
-        ? await deps.checkpoints?.provenance(checkpoint.id).catch(() => undefined)
+        ? await deps.checkpoints?.provenance(
+            checkpoint.id,
+            TRACE_PROMPT_PROVENANCE_FILES,
+          ).catch(() => undefined)
         : undefined;
       const record: TraceNodeRecord = {
         sourceAgent: deps.fromAgent,
@@ -465,7 +470,16 @@ export function createRecordTraceTool(deps: ToolDeps): SystemTool {
       if (checkpoint) lines.push(`Checkpoint-ID: ${checkpoint.id}`);
       if (inputs.length) lines.push(`Artifact-Inputs: ${JSON.stringify(inputs)}`);
       if (outputs.length) lines.push(`Artifact-Outputs: ${JSON.stringify(outputs)}`);
-      if (gitEvidence?.length) lines.push(`Git-Evidence: ${JSON.stringify(gitEvidence)}`);
+      if (checkpoint) {
+        const totalFiles = checkpoint.stats?.files ?? gitEvidence?.length ?? 0;
+        lines.push(`Git-Evidence-Summary: ${cappedJson({
+          checkpointId: checkpoint.id,
+          stats: checkpoint.stats,
+          skippedCount: checkpoint.skippedCount,
+          sample: gitEvidence ?? [],
+          truncated: totalFiles > (gitEvidence?.length ?? 0),
+        }, 1_000)}`);
+      }
       lines.push("", "Artifacts:");
       if (artifacts.length === 0) {
         lines.push("(none)");

--- a/packages/runtime/src/workspace-checkpoints.ts
+++ b/packages/runtime/src/workspace-checkpoints.ts
@@ -6,6 +6,7 @@ import {
   lstat,
   mkdir,
   mkdtemp,
+  readdir,
   readFile,
   readlink,
   rename,
@@ -26,11 +27,23 @@ import type {
 
 const MAX_FILE_BYTES = 10 * 1024 * 1024;
 const MAX_SNAPSHOT_BYTES = 200 * 1024 * 1024;
+const MAX_SNAPSHOT_FILES = 10_000;
 const MAX_DIFF_BYTES = 1024 * 1024;
 const DEFAULT_GIT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_REPOSITORY_BYTES = 2 * 1024 * 1024 * 1024;
+const DEFAULT_MAX_PROVENANCE_FILES = 1_000;
 const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
-const HARD_EXCLUDED_ROOTS = new Set([".attachments", ".truncated"]);
+const HARD_EXCLUDED_ROOTS = new Set([
+  ".attachments",
+  ".truncated",
+  ".venv",
+  "venv",
+  "node_modules",
+  "__pycache__",
+  ".pytest_cache",
+  ".mypy_cache",
+  ".cache",
+]);
 
 type Skipped = TraceCheckpointSkippedFile;
 
@@ -263,9 +276,10 @@ export class WorkspaceCheckpointStore {
     return ((values.get("size") ?? 0) + (values.get("size-pack") ?? 0) + (values.get("size-garbage") ?? 0)) * 1024;
   }
 
-  private hardExcluded(path: string): boolean {
+  private hardExcludedPrefix(path: string): string | undefined {
     const parts = path.replace(/\/$/, "").split("/");
-    return parts.includes(".git") || HARD_EXCLUDED_ROOTS.has(parts[0] ?? "");
+    const index = parts.findIndex((part) => part === ".git" || HARD_EXCLUDED_ROOTS.has(part));
+    return index >= 0 ? `${parts.slice(0, index + 1).join("/")}/` : undefined;
   }
 
   private workspacePath(rawPath: string): string {
@@ -295,10 +309,15 @@ export class WorkspaceCheckpointStore {
     const eligible = eligibleOutput.stdout.toString("utf8").split("\0").filter(Boolean).sort();
     const ignored = ignoredOutput.stdout.toString("utf8").split("\0").filter(Boolean).sort();
     const skipped: Skipped[] = ignored.map((path) => ({ path, reason: "ignored" }));
+    const hardExcluded = new Set<string>();
     const candidates: Array<{ path: string; size: number }> = [];
     for (const path of eligible) {
-      if (this.hardExcluded(path)) {
-        skipped.push({ path, reason: "internal" });
+      const excludedPrefix = this.hardExcludedPrefix(path);
+      if (excludedPrefix) {
+        if (!hardExcluded.has(excludedPrefix)) {
+          hardExcluded.add(excludedPrefix);
+          skipped.push({ path: excludedPrefix, reason: "internal" });
+        }
         continue;
       }
       try {
@@ -333,6 +352,8 @@ export class WorkspaceCheckpointStore {
     for (const item of candidates) {
       if (item.size > MAX_FILE_BYTES) {
         skipped.push({ path: item.path, reason: "too_large", size: item.size });
+      } else if (selected.length >= MAX_SNAPSHOT_FILES) {
+        skipped.push({ path: item.path, reason: "total_limit", size: item.size });
       } else if (total + item.size > MAX_SNAPSHOT_BYTES) {
         skipped.push({ path: item.path, reason: "total_limit", size: item.size });
       } else {
@@ -414,15 +435,20 @@ export class WorkspaceCheckpointStore {
   }
 
   /** File-level Git evidence for binding one checkpoint to its GoT node. */
-  async provenance(id: string): Promise<CheckpointFileProvenance[] | undefined> {
+  async provenance(
+    id: string,
+    maxFiles = DEFAULT_MAX_PROVENANCE_FILES,
+  ): Promise<CheckpointFileProvenance[] | undefined> {
     const index = await this.index();
     const record = index.checkpoints[id];
     if (!record?.ref.commitId) return undefined;
     const base = record.ref.baseCheckpointId
       ? index.checkpoints[record.ref.baseCheckpointId]?.ref.commitId ?? EMPTY_TREE
       : EMPTY_TREE;
+    const limit = Math.max(0, Math.trunc(maxFiles));
     const changes = (await this.changesBetween(base, record.ref.commitId))
-      .filter((item) => !this.isSkipped(item.path, record.skipped));
+      .filter((item) => !this.isSkipped(item.path, record.skipped))
+      .slice(0, limit);
     return Promise.all(changes.map(async (change) => {
       const basePath = change.previousPath ?? change.path;
       const [baseBlobId, resultBlobId] = await Promise.all([
@@ -517,6 +543,30 @@ export class WorkspaceCheckpointStore {
 
   capture(sourceAgent?: string, kind: "trace" | "recovery" = "trace"): Promise<TraceCheckpointRef> {
     return this.exclusive(() => this.captureUnlocked(sourceAgent, kind));
+  }
+
+  /**
+   * Establish the initial workspace tree before an agent can mutate it. The
+   * first trace checkpoint then describes agent changes relative to this tree
+   * instead of attributing pre-existing inputs to the first trace event.
+   * Idempotent and serialized with ordinary captures.
+   */
+  ensureBaseline(sourceAgent = "system"): Promise<TraceCheckpointRef | undefined> {
+    return this.exclusive(async () => {
+      const index = await this.index();
+      if (index.headCheckpointId) return undefined;
+      // An empty workspace already has the empty Git tree as its correct
+      // implicit baseline. Avoid initializing a repository for the common
+      // chat-only case; files created later by the agent should be attributed
+      // to its first trace event.
+      try {
+        const entries = await readdir(this.workspaceDir);
+        if (!entries.some((path) => !this.hardExcludedPrefix(path))) return undefined;
+      } catch {
+        return undefined;
+      }
+      return this.captureUnlocked(sourceAgent, "baseline");
+    });
   }
 
   async refs(ids: string[]): Promise<TraceCheckpointRef[]> {


### PR DESCRIPTION
## Summary

- resolve absolute paths under known workspace/persistent roots before applying the logical `/data` alias
- add the `/data`-mounted production regression case
- establish an initial checkpoint baseline only when pre-existing workspace inputs exist
- exclude generated environments and caches from checkpoint capture
- cap checkpoint file count and provenance expansion
- replace full Trace prompt provenance with a bounded summary and sample

## Why

This fixes two failure chains observed in Bench runs:

1. Bash and structured file tools could resolve the same `/data/workspaces/...` path to different locations.
2. A workspace-local virtual environment could be serialized into Trace prompts and artifact provenance, producing extreme token and storage amplification.

## Validation

- Runtime TypeScript build/typecheck passes.
- Targeted regression suite: 102 tests passed.
- Full runtime suite: 569 tests passed.
- `git diff --check` passes.

Closes #433
Closes #434