### PR TITLE
fix(runtime): prevent repeated Auditor reviews

### DIFF
--- a/packages/runtime/src/__tests__/event-mapping.test.ts
+++ b/packages/runtime/src/__tests__/event-mapping.test.ts
@@ -17,6 +17,43 @@ import type { IAgentSession, PiAgentEvent } from "../types.js";
  * (via parseEvent) and that the expected types appear in order.
  */
 describe("event mapping (Pi -> AG-UI via parseEvent)", () => {
+  it("keeps each terminal event bound to its originating run", async () => {
+    const bus = new EventBus();
+    const captured: AgUiEvent[] = [];
+    bus.subscribe((event) => captured.push(event));
+    const pending: Array<() => void> = [];
+    const session: IAgentSession = {
+      sessionId: "overlap",
+      subscribe: () => () => {},
+      prompt: () => new Promise<void>((resolve) => pending.push(resolve)),
+      abort: async () => {},
+      dispose: () => {},
+      get isStreaming() { return pending.length > 0; },
+    };
+    const agent = new MasAgent({ sessionId: "overlap", name: "principal", role: "principal", session, bus });
+
+    const first = agent.prompt("first");
+    const second = agent.prompt("second");
+    const started = captured
+      .filter((event) => event.type === "RUN_STARTED")
+      .map((event) => (event as { run_id: string }).run_id);
+    expect(started).toHaveLength(2);
+
+    pending[0]!();
+    await first;
+    expect(agent.state().activeRunId).toBe(started[1]);
+    pending[1]!();
+    await second;
+
+    const finished = captured
+      .filter((event) => event.type === "RUN_FINISHED")
+      .map((event) => (event as { run_id: string }).run_id);
+    expect(finished).toEqual(started);
+    for (const event of captured.filter((item) => item.type.startsWith("RUN_"))) {
+      expect(() => parseEvent(event)).not.toThrow();
+    }
+  });
+
   it("maps a scripted run to valid AG-UI events", async () => {
     const bus = new EventBus({ persistPath: undefined });
     const captured: AgUiEvent[] = [];

--- a/packages/runtime/src/__tests__/tool-access.test.ts
+++ b/packages/runtime/src/__tests__/tool-access.test.ts
@@ -270,9 +270,40 @@ describe("tool access control (§9)", () => {
     expect((await tools.get("edit_trace_review")!.execute({ conclusion: "approve", reason: "The bound evidence supports this node." })).isError)
       .not.toBe(true);
     expect(d.trace.getNodeV2(node.id)?.reviewConclusion).toBe("approved");
+    const revision = d.trace.getGraphV2().revision;
+    const duplicate = await tools.get("edit_trace_review")!.execute({
+      conclusion: "reject",
+      reason: "A conflicting duplicate must not overwrite the accepted review.",
+    });
+    expect(duplicate.isError).not.toBe(true);
+    expect(duplicate.content[0]?.text).toContain("already submitted");
+    expect(d.trace.getNodeV2(node.id)?.reviewConclusion).toBe("approved");
+    expect(d.trace.getGraphV2().revision).toBe(revision);
     expect(tools.has("submit_audit_report")).toBe(false);
     expect(d.trace.getAuditReports()).toEqual([]);
     expect(tools.has("dispatch_task")).toBe(false);
+  });
+
+  it("atomically consumes a bound Auditor target across parallel calls", async () => {
+    const d = deps("auditor");
+    const node = d.trace.createNode({ title: "Parallel review" });
+    const target = d.trace.listPendingAuditTargets([node.id])[0]!;
+    d.currentTraceAuditTarget = () => target;
+    const tool = systemToolsForRole("expert", "auditor", d)
+      .find((item) => item.name === "edit_trace_review")!;
+
+    const [first, second] = await Promise.all([
+      tool.execute({ conclusion: "approve", reason: "The evidence is sufficient." }),
+      tool.execute({ conclusion: "reject", reason: "This call must be ignored." }),
+    ]);
+
+    expect(first.isError).not.toBe(true);
+    expect(second.isError).not.toBe(true);
+    expect(second.content[0]?.text).toContain("already submitted");
+    expect(d.trace.getNodeV2(node.id)).toMatchObject({
+      reviewConclusion: "approved",
+      reviewReason: "The evidence is sufficient.",
+    });
   });
 
   it("requires confidence and returns only a compact active graph to Trace", async () => {

--- a/packages/runtime/src/__tests__/trace-v2.test.ts
+++ b/packages/runtime/src/__tests__/trace-v2.test.ts
@@ -34,6 +34,35 @@ function v1Graph(): TraceGraph {
 }
 
 describe("TraceGraphV2 storage and audit semantics", () => {
+  it("records a final review once and rejects conflicting overwrites", () => {
+    const graph = new GraphOfTrace("s");
+    const parent = graph.createNode({ title: "Evidence" });
+    const child = graph.createNode({ title: "Conclusion" });
+    const actor = { type: "agent" as const, name: "auditor" };
+
+    expect(graph.review(child.id, "approve", "Supported.", actor)).toBe(true);
+    const nodeRevision = graph.getGraphV2().revision;
+    expect(graph.review(child.id, "approve", "Supported.", actor)).toBe(true);
+    expect(graph.getGraphV2().revision).toBe(nodeRevision);
+    expect(graph.review(child.id, "reject", "Conflicting.", actor)).toBe(false);
+    expect(graph.getNodeV2(child.id)).toMatchObject({
+      reviewConclusion: "approved",
+      reviewReason: "Supported.",
+    });
+
+    expect(graph.proposeCausalParent(child.id, parent.id, "Direct support.", { type: "agent", name: "trace" })).toBe(true);
+    expect(graph.review(child.id, "approve", "Direct support.", actor, parent.id)).toBe(true);
+    const edgeRevision = graph.getGraphV2().revision;
+    expect(graph.review(child.id, "approve", "Direct support.", actor, parent.id)).toBe(true);
+    expect(graph.getGraphV2().revision).toBe(edgeRevision);
+    expect(graph.review(child.id, "reject", "Conflicting.", actor, parent.id)).toBe(false);
+    expect(graph.getNodeV2(child.id)?.parents).toContainEqual(expect.objectContaining({
+      nodeId: parent.id,
+      conclusion: "confirmed",
+      reason: "Direct support.",
+    }));
+  });
+
   it("creates one protected Session Start root as the confirmed fallback", () => {
     const graph = new GraphOfTrace("s");
     const rootId = graph.getGraphV2().meta.rootNodeId!;

--- a/packages/runtime/src/mas-agent.ts
+++ b/packages/runtime/src/mas-agent.ts
@@ -458,17 +458,20 @@ export class MasAgent {
   }
 
   private async runPrompt(text: string): Promise<void> {
-    this.currentRunId = newRunId();
-    this.runStartedAt = Date.now();
+    const runId = newRunId();
+    const runStartedAt = Date.now();
+    const runStartSnapshot = cloneAgentStats(this.cumulativeStats);
+    this.currentRunId = runId;
+    this.runStartedAt = runStartedAt;
     this.abortRequested = false;
     this._lastRunOutcome = undefined;
     this.currentRetry = undefined;
     this.pendingProviderError = undefined;
     // Snapshot cumulative stats BEFORE any events flow so the eventual delta
     // (`cumulative_after - snapshot`) captures exactly this run's contribution.
-    this.runStartSnapshot = cloneAgentStats(this.cumulativeStats);
+    this.runStartSnapshot = runStartSnapshot;
     this.setStatus("running");
-    this.bus.emit(ev.runStarted({ sessionId: this.sessionId, agentName: this.name, runId: this.currentRunId }));
+    this.bus.emit(ev.runStarted({ sessionId: this.sessionId, agentName: this.name, runId }));
     let runOutcome: RunStatsStatus = "ok";
     try {
       await this.session.prompt(text);
@@ -482,7 +485,7 @@ export class MasAgent {
         this.pendingProviderError = undefined;
         runOutcome = "aborted";
         this.bus.emit(
-          ev.runFinished({ sessionId: this.sessionId, agentName: this.name, runId: this.currentRunId }),
+          ev.runFinished({ sessionId: this.sessionId, agentName: this.name, runId }),
         );
       } else if (this.pendingProviderError) {
         const raw = this.pendingProviderError;
@@ -490,13 +493,13 @@ export class MasAgent {
         const { message, details } = normalizeAgentError(raw);
         this.recordError(message, details, raw);
         this.bus.emit(
-          ev.runError({ sessionId: this.sessionId, agentName: this.name, runId: this.currentRunId }, message),
+          ev.runError({ sessionId: this.sessionId, agentName: this.name, runId }, message),
         );
         this.setStatus("error");
         runOutcome = "error";
       } else {
         this.bus.emit(
-          ev.runFinished({ sessionId: this.sessionId, agentName: this.name, runId: this.currentRunId }),
+          ev.runFinished({ sessionId: this.sessionId, agentName: this.name, runId }),
         );
       }
       // A run that reached here without an exhausted provider error completed
@@ -514,7 +517,7 @@ export class MasAgent {
         // Some session implementations reject prompt() on abort rather than
         // resolving it. Normalize both forms to the same non-error lifecycle.
         this.bus.emit(
-          ev.runFinished({ sessionId: this.sessionId, agentName: this.name, runId: this.currentRunId }),
+          ev.runFinished({ sessionId: this.sessionId, agentName: this.name, runId }),
         );
         this._lastErrorKind = undefined;
         this.setStatus("idle");
@@ -527,7 +530,7 @@ export class MasAgent {
         const { message, details } = normalizeAgentError(raw);
         this.recordError(message, details, raw);
         this.bus.emit(
-          ev.runError({ sessionId: this.sessionId, agentName: this.name, runId: this.currentRunId }, message),
+          ev.runError({ sessionId: this.sessionId, agentName: this.name, runId }, message),
         );
         this.setStatus("error");
         runOutcome = "error";
@@ -538,30 +541,36 @@ export class MasAgent {
       // consumers see a stable `runId`. Aborted-mid-run is caught by
       // `abort()`'s own cleanup path (see abort()); if we reach here with a
       // clean or error path, either way we have a well-formed snapshot.
-      this.emitRunStats(runOutcome);
-      // Pi drains accepted follow-ups before the run terminates. Anything left
-      // here was cancelled or never injected and must not leak into a later run.
-      this.pendingFollowUps = [];
-      this.currentRunId = undefined;
-      this.currentMessageId = undefined;
-      this.runStartSnapshot = undefined;
-      this.runStartedAt = undefined;
+      this.emitRunStats(runOutcome, runId, runStartedAt, runStartSnapshot);
+      if (this.currentRunId === runId) {
+        // Pi drains accepted follow-ups before the run terminates. Anything left
+        // here was cancelled or never injected and must not leak into a later run.
+        this.pendingFollowUps = [];
+        this.currentRunId = undefined;
+        this.currentMessageId = undefined;
+        this.runStartSnapshot = undefined;
+        this.runStartedAt = undefined;
+      }
     }
   }
 
   /**
    * Fire the `onRunStats` callback with the run's delta. Called from
-   * `runPrompt`'s finally block for ok/error/aborted paths. Idempotent: if no
-   * snapshot exists (e.g. abort called with no run in flight), this is a no-op.
+   * `runPrompt`'s finally block for ok/error/aborted paths. Run identity and
+   * baseline are captured locally so overlapping cleanup cannot corrupt them.
    */
-  private emitRunStats(status: RunStatsStatus): void {
-    if (!this.runStartSnapshot || !this.currentRunId || this.runStartedAt === undefined) return;
+  private emitRunStats(
+    status: RunStatsStatus,
+    runId: string,
+    startedAt: number,
+    startSnapshot: AgentStats,
+  ): void {
     const cumulative = cloneAgentStats(this.cumulativeStats);
-    const delta = subtractAgentStats(this.cumulativeStats, this.runStartSnapshot);
+    const delta = subtractAgentStats(this.cumulativeStats, startSnapshot);
     this.opts.onRunStats?.({
       name: this.name,
-      runId: this.currentRunId,
-      startedAt: this.runStartedAt,
+      runId,
+      startedAt,
       finishedAt: Date.now(),
       status,
       delta,

--- a/packages/runtime/src/tools/system-tools.ts
+++ b/packages/runtime/src/tools/system-tools.ts
@@ -815,6 +815,7 @@ export function createSearchTraceTool(deps: ToolDeps): SystemTool {
 
 /** Auditor-only mutation surface: append one bounded node/parent conclusion. */
 export function createEditTraceReviewTool(deps: ToolDeps): SystemTool {
+  const consumedTargets = new WeakSet<TraceAuditTarget>();
   return {
     name: "edit_trace_review",
     description: "Review one Trace node or one proposed causal parent. Only conclusion and reason may be changed.",
@@ -835,6 +836,10 @@ export function createEditTraceReviewTool(deps: ToolDeps): SystemTool {
       if (!reason) return { ...ok("a non-empty review reason is required"), isError: true };
       const target = deps.currentTraceAuditTarget?.();
       if (!target) return { ...ok("no host-bound trace audit target for this turn"), isError: true };
+      // Claim synchronously before mutation so sequential and parallel duplicate
+      // calls in the same Auditor turn cannot review the target twice.
+      if (consumedTargets.has(target)) return ok("trace review already submitted; end this turn");
+      consumedTargets.add(target);
       const success = deps.trace.review(
         target.nodeId,
         conclusion,

--- a/packages/runtime/src/trace.ts
+++ b/packages/runtime/src/trace.ts
@@ -550,10 +550,14 @@ export class GraphOfTrace {
   ): boolean {
     const node = this.nodes.get(nodeId);
     if (!node || node.revoked || this.isSessionRoot(nodeId)) return false;
-    if (expectedFingerprint && this.auditFingerprint(nodeId, parentNodeId) !== expectedFingerprint) return false;
     if (!parentNodeId) {
+      if (expectedFingerprint && this.auditFingerprint(nodeId) !== expectedFingerprint) return false;
+      const next = conclusion === "approve" ? "approved" : conclusion === "reject" ? "rejected" : "uncertain";
+      if (node.reviewConclusion !== "unreviewed") {
+        return node.reviewConclusion === next && node.reviewReason === reason;
+      }
       const before = node.reviewConclusion;
-      node.reviewConclusion = conclusion === "approve" ? "approved" : conclusion === "reject" ? "rejected" : "uncertain";
+      node.reviewConclusion = next;
       node.reviewReason = reason;
       node.updatedAt = now();
       this.commit("updated", nodeId, {
@@ -570,8 +574,11 @@ export class GraphOfTrace {
     const ref = node.parents.find((item) => item.nodeId === parentNodeId);
     if (!parent || parent.revoked || !ref) return false;
     if (conclusion === "approve" && parent.reviewConclusion === "rejected") return false;
+    const next = conclusion === "approve" ? "confirmed" : conclusion === "reject" ? "rejected" : "uncertain";
+    if (ref.conclusion !== "candidate") return ref.conclusion === next && ref.reason === reason;
+    if (expectedFingerprint && this.auditFingerprint(nodeId, parentNodeId) !== expectedFingerprint) return false;
     const before = ref.conclusion;
-    ref.conclusion = conclusion === "approve" ? "confirmed" : conclusion === "reject" ? "rejected" : "uncertain";
+    ref.conclusion = next;
     ref.reason = reason;
     this.normalizeCausalGraph();
     node.updatedAt = now();


### PR DESCRIPTION
## Summary

- consume each host-bound Auditor review target once, including parallel duplicate calls
- make finalized node and parent-edge reviews idempotent and prevent conflicting overwrites
- bind terminal events and run stats to the immutable run ID captured at run start

Closes #435.

This intentionally does not change audit fingerprints, durable queue formats, Auditor read tools, or normal first-review behavior.

## Verification

- `npm run typecheck --workspace packages/runtime`
- focused runtime tests: 62/62 passed
- runtime suite: 568/569 passed in parallel; the sole failure was the existing shared-`BP_DATA_DIR` isolation issue in `ask-user.test.ts`, which passed 15/15 when rerun alone in a clean directory
