### PR TITLE
fix(runtime): prohibit PI from running training

### DIFF
--- a/packages/runtime/src/__tests__/personas.test.ts
+++ b/packages/runtime/src/__tests__/personas.test.ts
@@ -217,6 +217,11 @@ Stale local routing rule.`;
     expect(pi).toContain("experimentalist` reads that contract");
     expect(pi).toContain("waits such as `sleep`");
     expect(pi).toContain("Do not write analysis");
+    expect(pi).toContain("The training prohibition is absolute");
+    expect(pi).toContain("smoke-test training");
+    expect(pi).toContain("Delegate every such run to `engineer`");
+    expect(pi).toContain("you must not");
+    expect(pi).toContain("execute the training command yourself");
   });
 
   it("requires data contracts, protocols, and independent method rechecks", () => {

--- a/packages/runtime/src/personas.ts
+++ b/packages/runtime/src/personas.ts
@@ -349,6 +349,15 @@ research data; and do not launch training, model search, statistical tests, or
 formal evaluation from \`bash\`. If an Expert fails or is unavailable, retry,
 rescope, or report the limitation instead of taking over its scientific work.
 
+The training prohibition is absolute: never start, invoke, resume, or directly
+control any process that fits or updates model parameters. This includes tiny or
+pilot training, smoke-test training, fine-tuning, cross-validation fitting,
+checkpoint resumption, hyperparameter search, and distributed training, whether
+through \`bash\`, Python, a notebook, a script, or another execution surface.
+Delegate every such run to \`engineer\`. You may inspect its saved configuration,
+logs, status, and results, and you may wait for it to finish, but you must not
+execute the training command yourself even when the user asks for a quick run.
+
 You may use \`write\`/\`edit\` for coordination plans, task briefs, synthesis,
 and user-facing documents. You may use \`bash\` for lightweight inspection,
 status checks, and waits such as \`sleep\`; retaining a tool is not permission to


### PR DESCRIPTION
## Summary
- make the PI training prohibition explicit and absolute
- forbid PI-run pilot/smoke training, fine-tuning, CV fitting, checkpoint resume, hyperparameter search, and distributed training
- require every parameter-fitting process to be delegated to Engineer
- retain PI access to configurations, logs, status inspection, and waiting

## Validation
- `npm run typecheck --workspace packages/runtime`
- persona and SessionManager tests: 75/75 passed
- `git diff --check`