### PR TITLE
Add parallel specialist audit skills

### DIFF
--- a/packages/plugin-auditor/manifest.json
+++ b/packages/plugin-auditor/manifest.json
@@ -9,13 +9,43 @@
   "protocols": { "agentInstructions": "1" },
   "environments": ["local", "cloud"],
   "contributes": {
-    "skills": [{
-      "id": "audit-feedback-loop",
-      "title": "Audit Feedback Loop",
-      "description": "Coordinate PI and Auditor review, correction, and incremental re-review.",
-      "entry": "skills/audit-feedback-loop/SKILL.md",
-      "targets": ["principal", "auditor"]
-    }],
+    "skills": [
+      {
+        "id": "audit-feedback-loop",
+        "title": "Audit Feedback Loop",
+        "description": "Coordinate PI and Auditor review, correction, and incremental re-review.",
+        "entry": "skills/audit-feedback-loop/SKILL.md",
+        "targets": ["principal", "auditor"]
+      },
+      {
+        "id": "audit-data-integrity",
+        "title": "Audit Data Integrity",
+        "description": "Audit data semantics, sample alignment, leakage, splits, and preprocessing boundaries.",
+        "entry": "skills/audit-data-integrity/SKILL.md",
+        "targets": ["auditor"]
+      },
+      {
+        "id": "audit-model-validation",
+        "title": "Audit Model Validation",
+        "description": "Audit model comparisons, validation objectives, selection evidence, and claim scope.",
+        "entry": "skills/audit-model-validation/SKILL.md",
+        "targets": ["auditor"]
+      },
+      {
+        "id": "audit-code-artifact",
+        "title": "Audit Code and Artifact",
+        "description": "Audit implementation correctness, export equivalence, packaging, and isolated inference.",
+        "entry": "skills/audit-code-artifact/SKILL.md",
+        "targets": ["auditor"]
+      },
+      {
+        "id": "audit-evidence",
+        "title": "Audit Evidence",
+        "description": "Audit numeric, artifact, log, and citation claims against inspectable evidence.",
+        "entry": "skills/audit-evidence/SKILL.md",
+        "targets": ["auditor"]
+      }
+    ],
     "agentInstructions": [
       {
         "id": "principal-audit-loop",

--- a/packages/plugin-auditor/prompts/auditor.md
+++ b/packages/plugin-auditor/prompts/auditor.md
@@ -2,25 +2,27 @@
 
 You are BrainPilot's independent reliability auditor and an adviser to the
 Principal Investigator (PI). PI may assign you its own reasoning or draft, one
-Expert result, or a synthesis across Experts. Return evidence-cited, actionable
-findings directly to PI.
+Expert result, or a synthesis across Experts. Preserve complete evidence-cited
+findings in an audit report and return only an actionable summary to PI.
 
 For every ordinary audit task, load the `audit-feedback-loop` skill and follow
 its Auditor reference and response template. Use the exact assigned task ID with
-`complete_task`; the reply itself must contain the verdict, findings, evidence,
-owners, and required corrections. Do not ask the user to relay findings, direct
-Experts, or write the user's final answer.
+`complete_task`; its reply must contain the verdict, risk, report path, open
+finding IDs, owners, and short required actions. Keep detailed evidence and
+recheck instructions in the report. Do not ask the user to relay findings,
+direct Experts, or write the user's final answer.
 
 Begin every completed audit reply with exactly one explicit verdict:
 `Verdict: PASS`, `Verdict: REVISE`, or `Verdict: BLOCK`. For `REVISE` or
 `BLOCK`, state explicitly that PI must not claim the task is complete or deliver
-the affected conclusions. List the required corrections and concrete recheck
-criteria before calling `complete_task`.
+the affected conclusions.
 
 Inspect existing evidence only. Never rerun experiments, compute missing
-results, install packages, or call external services. Use `bash` only for
-filesystem inspection. Treat plausibility as insufficient and judge evidence
-backing plus evidence-visible scientific reliability, not novelty or style.
+results, install packages, or call external services. Use `write` only to create
+a new report under `docs/audits/`; never overwrite evidence or an earlier audit.
+Use `bash` only for filesystem inspection and, if necessary, creating that
+report directory. Treat plausibility as insufficient and judge evidence backing
+plus evidence-visible scientific reliability, not novelty or style.
 
 For every modelling or statistical result, explicitly audit data/label
 alignment, split integrity, train-versus-inference transforms, exported-model

--- a/packages/plugin-auditor/prompts/principal.md
+++ b/packages/plugin-auditor/prompts/principal.md
@@ -3,8 +3,9 @@
 Do not personally perform fabrication or reliability audits. For an Expert
 result, your own reasoning or draft, or a multi-agent synthesis, load the
 `audit-feedback-loop` skill and follow its Principal reference. Raw Expert
-output is a valid intermediate audit target. Auditor findings return directly
-through task completion; never ask the user to relay them.
+output is a valid intermediate audit target. Auditor returns a compact verdict
+and report path through task completion; never ask the user to relay them or to
+paste the report into the conversation.
 
 Before approving an Expert deliverable or sending a final answer containing
 numeric results, artifact claims, external citations, datasets, benchmarks, or
@@ -13,9 +14,9 @@ for its reply. Use the skill's request template and apply its correction and
 incremental re-review procedure before delivery. Purely conversational replies
 without hard claims are exempt.
 
-After receiving an Auditor report, never immediately claim that the task is
-complete. First read and follow its explicit verdict. Only `Verdict: PASS`
+After receiving an Auditor completion summary, never immediately claim that the
+task is complete. First read and follow its explicit verdict. Only `Verdict: PASS`
 permits acceptance within the audited scope. `Verdict: REVISE` requires the
-named corrections and re-review. `Verdict: BLOCK` prohibits delivery of the
-affected claims. Positive comments, partial checks, or a complete-looking report
-must never be interpreted as `PASS`.
+named corrections from the linked report and re-review. `Verdict: BLOCK`
+prohibits delivery of the affected claims. Positive comments, partial checks,
+or a complete-looking report must never be interpreted as `PASS`.

--- a/packages/plugin-auditor/skills/audit-code-artifact/SKILL.md
+++ b/packages/plugin-auditor/skills/audit-code-artifact/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: audit-code-artifact
+description: Audit scientific implementation, exported-model equivalence, dependency completeness, manifests, packaging, and isolated inference. Use when claims depend on code, trained artifacts, evaluators, or deployable entry points.
+---
+
+# Audit Code and Artifact
+
+Inspect existing files and test outputs read-only. Do not execute the scientific
+pipeline or manufacture missing validation evidence.
+
+## Checks
+
+1. Trace critical values across data loading, preprocessing, fitting, export, and
+   inference. Check defaults, branches, feature order, transforms, and manifest
+   declarations against the scientific protocol.
+2. Require existing numeric evidence that the reference pipeline, exported model
+   or raw weights, and final entry point produce equivalent predictions on fixed
+   samples within a stated tolerance.
+3. Require an existing clean-directory or evaluator-like smoke test using only
+   collected artifacts and declared dependencies.
+4. Check for undeclared local modules, absolute workspace paths, environment
+   variables, auxiliary files, incompatible versions, and entry-point assumptions.
+5. Separate implementation correctness from scientific adequacy: a correctly
+   packaged artifact does not establish that its model or validation is suitable.
+
+For a bounded parallel review, use `code-reviewer` for concrete implementation
+defects and `repo-scout` only when imports or artifact dependencies must first be
+mapped. Ask for evidence and candidate findings, not a verdict.

--- a/packages/plugin-auditor/skills/audit-code-artifact/agents/openai.yaml
+++ b/packages/plugin-auditor/skills/audit-code-artifact/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Audit Code and Artifact"
+  short_description: "Check exports, packaging, and isolated inference"
+  default_prompt: "Use $audit-code-artifact to audit this implementation and its packaged artifact."

--- a/packages/plugin-auditor/skills/audit-data-integrity/SKILL.md
+++ b/packages/plugin-auditor/skills/audit-data-integrity/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: audit-data-integrity
+description: Audit scientific data semantics, sample and label alignment, leakage, group splits, preprocessing boundaries, and train-to-inference transforms. Use for any result based on datasets, feature matrices, tensors, repeated observations, or learned preprocessing.
+---
+
+# Audit Data Integrity
+
+Inspect existing code, contracts, manifests, and logs; do not recompute missing
+results. Report each applicable check as `pass`, `flaw`, or `unverified`, with a
+specific evidence path or exact missing evidence.
+
+## Checks
+
+1. Establish the semantic meaning and order of every source axis. Trace each
+   `transpose`, `reshape`, `ravel`, `flatten`, `stack`, concatenation, cache, and
+   reload that can change sample identity. Shape equality alone is insufficient.
+2. Verify that every feature row remains aligned with its label, subject,
+   condition, session, bin, and other grouping identifiers. Look for explicit
+   value-level assertions on representative samples.
+3. Verify train/test independence at the real sampling unit. Check subject,
+   session, site, family, temporal, repeated-measure, and augmentation leakage as
+   applicable.
+4. Verify that imputation, scaling, feature selection, dimensionality reduction,
+   resampling, threshold selection, and model selection are fitted only within
+   training folds.
+5. Establish the value domain and transform contract. Confirm that training,
+   exported artifacts, manifests, and inference use the same clipping,
+   missing-value handling, transform, and feature order.
+
+For a bounded parallel review, give a `method-reviewer` the data contract,
+pipeline files, and validation evidence. Ask for evidence and candidate findings,
+not a verdict.

--- a/packages/plugin-auditor/skills/audit-data-integrity/agents/openai.yaml
+++ b/packages/plugin-auditor/skills/audit-data-integrity/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Audit Data Integrity"
+  short_description: "Check data alignment, leakage, and transforms"
+  default_prompt: "Use $audit-data-integrity to audit this pipeline for alignment, leakage, and transform defects."

--- a/packages/plugin-auditor/skills/audit-evidence/SKILL.md
+++ b/packages/plugin-auditor/skills/audit-evidence/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: audit-evidence
+description: Audit numeric, artifact, log, citation, and cross-report claims against inspectable evidence. Use for reports, syntheses, benchmark claims, external citations, or conflicting Expert outputs.
+---
+
+# Audit Evidence
+
+Build a claim-to-evidence map from the supplied target. Plausibility is not
+evidence, and absence of evidence is `unverified`, not confirmation.
+
+## Checks
+
+1. Verify every material number, metric, sample count, configuration, artifact,
+   and completion claim against a specific file, line, log, or structured output.
+2. Verify that cited sources exist, support the exact proposition, and are not
+   overstated beyond population, method, or result scope.
+3. Reconcile conflicting Expert reports and distinguish direct evidence,
+   interpretation, assumption, and unresolved uncertainty.
+4. Check that report text matches the latest artifact revision and does not turn
+   limitations, missing checks, or qualified findings into unconditional claims.
+5. Record exact missing evidence and the likely owner; never fill gaps by
+   inference or by recomputing results.
+
+For a bounded parallel review, use `evidence-extractor` with the target report
+and its cited evidence packet. Ask for a compact claim map and candidate findings,
+not a verdict.

--- a/packages/plugin-auditor/skills/audit-evidence/agents/openai.yaml
+++ b/packages/plugin-auditor/skills/audit-evidence/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Audit Evidence"
+  short_description: "Check claims against files, logs, and citations"
+  default_prompt: "Use $audit-evidence to map these claims to inspectable evidence and flag unsupported statements."

--- a/packages/plugin-auditor/skills/audit-feedback-loop/SKILL.md
+++ b/packages/plugin-auditor/skills/audit-feedback-loop/SKILL.md
@@ -10,7 +10,7 @@ Use the durable task system for every handoff. Do not ask the user to relay audi
 ## Select the role procedure
 
 - If you are `principal`, read [references/pi-orchestration.md](references/pi-orchestration.md) and follow it. Load the request template before dispatching an audit. Load the revision-loop reference after receiving a `revise` or `block` verdict.
-- If you are `auditor`, read [references/auditor-review.md](references/auditor-review.md) and follow it. Load the response template before completing the assigned audit task.
+- If you are `auditor`, read [references/auditor-review.md](references/auditor-review.md) and follow it. Load only the specialist audit skills relevant to the assigned risks, then load the response template before completing the task.
 - If you are any other agent, provide an evidence-addressable result to PI; do not start or adjudicate the audit loop yourself.
 
 ## Load only the needed templates
@@ -19,4 +19,13 @@ Use the durable task system for every handoff. Do not ask the user to relay audi
 - Audit response: [references/audit-response-template.md](references/audit-response-template.md)
 - Correction and incremental re-review: [references/revision-loop.md](references/revision-loop.md)
 
-Keep audit content in `dispatch_task` and `complete_task`. Do not use a separate audit-report submission tool.
+Keep audit requests in `dispatch_task`, full findings in the versioned report,
+and only the compact report pointer in `complete_task`. Do not use a separate
+audit-report submission tool.
+
+## Specialist audit skills
+
+- [Data integrity](../audit-data-integrity/SKILL.md)
+- [Model validation](../audit-model-validation/SKILL.md)
+- [Code and artifact](../audit-code-artifact/SKILL.md)
+- [Evidence](../audit-evidence/SKILL.md)

--- a/packages/plugin-auditor/skills/audit-feedback-loop/references/audit-response-template.md
+++ b/packages/plugin-auditor/skills/audit-feedback-loop/references/audit-response-template.md
@@ -1,22 +1,30 @@
 # Audit response template
 
-Return this structure inside `complete_task.reply`. Use the user's language for headings and prose while preserving the machine-stable values and finding IDs.
+Use the user's language for prose while preserving machine-stable verdicts,
+statuses, finding IDs, and paths.
+
+## Complete report
+
+Create a new `docs/audits/<audit-id>.md` file. Never overwrite an existing audit;
+use the next `-rN` suffix when necessary.
 
 ```markdown
-# Audit Result
+# Audit Report
 
 Audit ID: <audit-id>
 Verdict: <PASS | REVISE | BLOCK>
 Risk: <low | medium | high>
+Target: <reviewed path or precise target>
 
-## Required scientific checks
+## Scope and review method
+- Specialist skills: <loaded skill names>
+- Parallel reviewers: <profile and assigned surface, or none>
+- Limitations: <unavailable evidence or unreviewed scope>
+
+## Required checks
 | Check | Status | Evidence |
 |---|---|---|
-| Data semantics and row/label alignment | <pass | flaw | unverified | not-applicable> | <path/line/log> |
-| Group split and fold-local preprocessing | <pass | flaw | unverified | not-applicable> | <path/line/log> |
-| Training/inference transform consistency | <pass | flaw | unverified | not-applicable> | <path/line/log> |
-| Exported-model prediction equivalence | <pass | flaw | unverified | not-applicable> | <path/line/log> |
-| Isolated artifact packaging | <pass | flaw | unverified | not-applicable> | <path/line/log> |
+| <applicable specialist check> | <pass | flaw | unverified | not-applicable> | <path/line/log or exact missing evidence> |
 
 ## Findings
 
@@ -40,4 +48,22 @@ Risk: <low | medium | high>
 - <finding IDs and changed claims that require re-review>
 ```
 
-For modelling or statistical work, include every required scientific check and justify every `not-applicable`. Use `PASS` only when no applicable check is `flaw` or `unverified` and no checked claim has an open material finding. Use `REVISE` for correctable open findings. Use `BLOCK` when a high-risk claim must not be delivered in its current form. For `REVISE` or `BLOCK`, explicitly state that PI must not claim the task is complete or deliver the affected conclusions.
+Justify every `not-applicable`. Use `PASS` only when no applicable check is
+`flaw` or `unverified` and no checked claim has an open material finding. Use
+`REVISE` for correctable open findings and `BLOCK` when a high-risk claim must
+not be delivered in its current form.
+
+## Compact completion reply
+
+Return only this summary through `complete_task.reply`; do not duplicate the
+report's evidence tables or full findings.
+
+```text
+Verdict: <PASS | REVISE | BLOCK>
+Risk: <low | medium | high>
+Report: docs/audits/<actual-report-file>.md
+Open findings: <comma-separated IDs, or none>
+Owners: <owner names, or none>
+Required actions: <one short action per open finding, or none>
+<For REVISE or BLOCK: PI must not claim the task is complete or deliver the affected conclusions.>
+```

--- a/packages/plugin-auditor/skills/audit-feedback-loop/references/auditor-review.md
+++ b/packages/plugin-auditor/skills/audit-feedback-loop/references/auditor-review.md
@@ -1,26 +1,59 @@
 # Auditor review procedure
 
-Review the exact target PI supplied: PI reasoning/draft, one Expert result, or a synthesis. Raw Expert output is a valid intermediate target. Do not rewrite it into the final user answer.
+Review the exact target PI supplied. Raw Expert output is a valid intermediate
+target. Inspect existing evidence only; do not rewrite the user's final answer,
+rerun experiments, or compute missing results.
 
-## Required review dimensions
+## Route the audit by risk
 
-1. **Evidence backing:** verify numeric claims, artifact/file claims, and external citations against concrete workspace evidence.
-2. **Data semantics and alignment:** inspect source tensor axes and every `transpose`, `reshape`, `ravel`, `flatten`, `stack`, and concatenation that can change sample identity. Require evidence that each feature row still matches its label, subject, condition, session, and bin; shape equality alone is insufficient.
-3. **Split and preprocessing integrity:** verify subject/session/group separation and that scaling, imputation, feature selection, PCA, resampling, threshold selection, and model selection are fitted only inside training folds. Distinguish overall metrics from within-subject or grouped metrics.
-4. **Transform consistency:** establish whether inputs are raw correlations, Fisher-z values, standardized values, or another representation. Verify training, manifest, exported weights, and inference apply exactly the same transform, clipping, missing-value handling, and feature/edge order.
-5. **Export equivalence:** require existing numeric evidence that the reference training pipeline, exported model or raw weights, and final inference entry point produce equivalent predictions on fixed samples within a stated tolerance.
-6. **Packaging isolation:** require an existing clean-directory or evaluator-like smoke test showing the declared entry point runs with only the collected artifact and declared dependencies. Check for undeclared local modules, workspace paths, environment variables, and auxiliary files.
-7. **General scientific reliability:** inspect invalid metrics, test-set reuse, baseline/chance confusion, circular analysis, uncorrected multiplicity, pseudoreplication, anomalously optimistic internal validation, and result–claim mismatch.
-8. **Comparison and adaptation validity:** verify that the executed comparisons are sufficient for model-selection or method-superiority claims and that resource-driven deviations preserve the evidence essential to the stated scientific objective. Reproducible execution of one candidate does not support a best-model claim when relevant alternatives were omitted. Check that shortcuts are represented accurately and that the validation objective is a credible proxy for the stated deployment or transfer objective.
+Load only the specialist skills applicable to the target:
 
-Treat plausibility as insufficient. Cite a file path, line, log, or other concrete evidence for every confirmed claim and check. For modelling or statistical work, every applicable dimension above must be reported explicitly as `pass`, `flaw`, or `unverified`. Any critical `flaw` or `unverified` dimension requires a `revise` or `block` verdict, never `pass`. Do not compute missing evidence, rerun experiments, call external services, or install packages.
+- `audit-evidence` for numeric, artifact, log, citation, or cross-report claims;
+- `audit-data-integrity` for datasets, tensors, repeated observations, splits,
+  preprocessing, or transforms;
+- `audit-model-validation` for modelling, prediction, benchmarking, selection,
+  deployment, or transfer claims;
+- `audit-code-artifact` for implementation, export, packaging, or inference.
 
-Do not prescribe a winning model or redesign the study. Report missing comparison coverage, unjustified protocol deviations, proxy-objective risks, and claims that exceed the completed evidence. A correctly qualified result may pass with explicit limitations; return `revise` when an incomplete comparison is used to claim selection or superiority, and use `block` when the validation evidence cannot support a high-risk deployment or transfer claim.
+For modelling or statistical work, report every applicable specialist check as
+`pass`, `flaw`, or `unverified`. Any critical `flaw` or `unverified` check
+requires `REVISE` or `BLOCK`, never `PASS`. Do not prescribe a winning model or
+redesign the study.
 
-Use `bash` only for filesystem inspection commands such as `grep`, `awk`, `wc`, `diff`, `jq`, `ls`, `find`, `head`, `tail`, and `cat`.
+## Use bounded parallel review
 
-## Communication boundary
+Review a small target with one risk surface directly. When two or more risk
+surfaces can be inspected independently, call `spawn_subagent` once with two to
+four tasks and its default `wait=true`; do not launch background work, poll, or
+repeatedly wake children.
 
-Do not direct or message Experts. If evidence is missing, record a precise open finding with the likely owner and required evidence. PI decides whether to ask an Expert for correction or clarification.
+Use the narrowest suitable read-only profiles:
 
-Read `audit-response-template.md`, produce a bounded actionable response, and return it with `complete_task` using the exact assigned task ID. The completion reply must contain the findings PI needs to act; do not return only a report path. End the turn after completing the task.
+- `evidence-extractor` for claim-to-evidence mapping;
+- `method-reviewer` for data, validation, and scientific-method risks;
+- `code-reviewer` for concrete implementation and export defects;
+- `repo-scout` only when code or artifact dependencies must first be mapped.
+
+Give each child only its assigned evidence paths, the relevant checklist, and
+the claims it must inspect. Avoid duplicate review of the same risk surface.
+Children return evidence and candidate findings only: they do not choose the
+verdict, contact PI, write the final report, or expand the audit scope. If a
+child fails, inspect that bounded surface yourself or mark it `unverified`;
+never treat missing child output as a pass.
+
+## Synthesize and report
+
+Independently verify material child findings, merge duplicates by root cause,
+resolve contradictions, preserve explicit limitations, and decide the final
+`PASS`, `REVISE`, or `BLOCK` verdict yourself. Cite a specific path, line, log,
+or exact missing evidence for every confirmed claim and finding.
+
+Read `audit-response-template.md`. Write the complete report to a new path under
+`docs/audits/`. Use the Audit ID as the filename; if that path already exists,
+inspect existing names and add the next `-rN` suffix. Never overwrite an earlier
+audit or any source evidence. Use `bash` only for read-only inspection and, when
+needed, `mkdir -p docs/audits`; use `write` only for the new report.
+
+Call `complete_task` with the exact assigned task ID and the compact completion
+reply from the template. The reply must carry enough information for PI to route
+open findings without embedding the full report. End the turn after completion.

--- a/packages/plugin-auditor/skills/audit-feedback-loop/references/pi-orchestration.md
+++ b/packages/plugin-auditor/skills/audit-feedback-loop/references/pi-orchestration.md
@@ -15,9 +15,19 @@ Raw Expert output is a valid intermediate target. Do not require Writer to turn 
 
 ## Process the verdict
 
-- `pass`: accept the checked scope; preserve stated limitations.
-- `revise`: assign each open finding to PI or the producing Expert, then follow `revision-loop.md`.
-- `block`: do not deliver the affected claim. Route safe correction work, ask the user only for a material decision or required authorization, then re-audit.
+- `pass`: verify that the compact reply names a report, then accept the checked
+  scope and preserve stated limitations. Read the full report only when its
+  limitations affect delivery.
+- `revise`: open the named report, read the sections for the listed finding IDs,
+  assign each finding to PI or the producing Expert, then follow
+  `revision-loop.md`.
+- `block`: open the named report and read the blocking findings; do not deliver
+  the affected claim. Route safe correction work, ask the user only for a
+  material decision or required authorization, then re-audit.
+
+The completion event is intentionally compact. Do not ask Auditor to paste the
+full report into the reply, and do not load unrelated report sections into the
+working context.
 
 PI owns all routing. Auditor advises PI and does not direct Experts. Never ask the user to carry an audit result back to PI.
 

--- a/packages/plugin-auditor/skills/audit-model-validation/SKILL.md
+++ b/packages/plugin-auditor/skills/audit-model-validation/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: audit-model-validation
+description: Audit model comparison coverage, validation design, proxy objectives, selection evidence, uncertainty, resource-driven adaptations, and the scope of scientific claims. Use for modelling, prediction, benchmarking, or method-superiority conclusions.
+---
+
+# Audit Model Validation
+
+Judge whether the completed comparisons support the stated conclusion; do not
+select a model or redesign the study.
+
+## Checks
+
+1. Identify the intended deployment or transfer objective and determine whether
+   the validation metric, grouping, cohort, condition, and time horizon are a
+   credible proxy for it.
+2. Check baselines, chance levels, negative controls, grouped metrics, uncertainty,
+   multiplicity, test-set reuse, and anomalously optimistic internal validation.
+3. Verify that evaluated candidates cover the materially different inductive
+   biases required by the protocol. One reproducible candidate cannot support a
+   best-model claim when relevant alternatives were omitted.
+4. Compare the executed study with the protocol. Confirm that resource-driven
+   reductions preserved essential comparisons and that shortcuts are not
+   represented as equivalent to the original design.
+5. Bound every conclusion to the data, candidates, metrics, and checks actually
+   completed. Treat nuisance or condition signals that can mimic the target as a
+   material proxy-objective risk.
+
+For a bounded parallel review, give a `method-reviewer` the protocol, comparison
+table, validation outputs, and stated claims. Ask for evidence and candidate
+findings, not a verdict.

--- a/packages/plugin-auditor/skills/audit-model-validation/agents/openai.yaml
+++ b/packages/plugin-auditor/skills/audit-model-validation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Audit Model Validation"
+  short_description: "Check validation design and model-selection claims"
+  default_prompt: "Use $audit-model-validation to audit whether this validation supports the stated model claims."

--- a/packages/runtime/src/__tests__/subagent-profiles.test.ts
+++ b/packages/runtime/src/__tests__/subagent-profiles.test.ts
@@ -13,6 +13,12 @@ describe("subagent profile overrides", () => {
       "api-librarian", "code-reviewer", "code-runner", "evidence-extractor",
       "literature-scout", "method-reviewer", "repo-scout",
     ]);
+    expect(builtinSubagentProfiles()
+      .filter((profile) => profile.allowedParents.includes("auditor"))
+      .map((profile) => profile.name)
+      .sort()).toEqual([
+      "code-reviewer", "evidence-extractor", "method-reviewer", "repo-scout",
+    ]);
   });
 
   it("loads prompt and validated config overrides while stripping forbidden tools", async () => {
@@ -76,4 +82,3 @@ describe("subagent profile overrides", () => {
     await expect(loadSubagentProfile(root, "../escape")).rejects.toThrow("invalid subagent profile name");
   });
 });
-

--- a/packages/runtime/src/__tests__/system-plugins.test.ts
+++ b/packages/runtime/src/__tests__/system-plugins.test.ts
@@ -17,21 +17,39 @@ describe("bundled system plugins", () => {
     const snapshot = snapshotSystemPlugins(plugins);
     expect(systemPluginEnabled(snapshot, AUDITOR_PLUGIN_ID)).toBe(true);
     expect(systemPluginEnabled(snapshot, GOT_PLUGIN_ID)).toBe(true);
-    expect(systemPluginSkillPaths(plugins, snapshot, "principal")[0]).toMatch(/plugin-auditor.*audit-feedback-loop/);
+    const principalSkills = systemPluginSkillPaths(plugins, snapshot, "principal");
+    expect(principalSkills).toHaveLength(1);
+    expect(principalSkills[0]).toMatch(/plugin-auditor.*audit-feedback-loop/);
+    const auditorSkills = systemPluginSkillPaths(plugins, snapshot, "auditor");
+    expect(auditorSkills).toHaveLength(5);
+    for (const skill of [
+      "audit-feedback-loop",
+      "audit-data-integrity",
+      "audit-model-validation",
+      "audit-code-artifact",
+      "audit-evidence",
+    ]) {
+      expect(auditorSkills).toEqual(expect.arrayContaining([expect.stringMatching(new RegExp(skill))]));
+    }
     expect(systemPluginSkillPaths(plugins, snapshot, "engineer")).toEqual([]);
     expect(systemPluginSkillPaths(plugins, snapshot, "trace")[0])
       .toMatch(/plugin-got.*curate-research-trace/);
     const principalInstructions = (await systemPluginInstructions(plugins, snapshot, "principal")).join("\n");
     expect(principalInstructions).toContain("Auditor feedback loop");
-    expect(principalInstructions).toContain("never immediately claim that the task is");
+    expect(principalInstructions).toContain("never immediately claim that the");
+    expect(principalInstructions).toContain("task is complete");
     expect(principalInstructions).toContain("Only `Verdict: PASS`");
     const auditorInstructions = (await systemPluginInstructions(plugins, snapshot, "auditor")).join("\n");
     expect(auditorInstructions).toContain("Begin every completed audit reply");
     expect(auditorInstructions).toContain("PI must not claim the task is complete");
-    const auditorSkill = systemPluginSkillPaths(plugins, snapshot, "auditor")[0]!;
+    const auditorSkill = auditorSkills.find((path) => path.endsWith("audit-feedback-loop"))!;
     const auditorReview = await readFile(join(auditorSkill, "references", "auditor-review.md"), "utf8");
-    expect(auditorReview).toContain("Comparison and adaptation validity");
-    expect(auditorReview).toContain("Do not prescribe a winning model or redesign the study");
+    expect(auditorReview).toContain("call `spawn_subagent` once with two to");
+    expect(auditorReview).toContain("Children return evidence and candidate findings only");
+    expect(auditorReview).toContain("Write the complete report to a new path under");
+    const responseTemplate = await readFile(join(auditorSkill, "references", "audit-response-template.md"), "utf8");
+    expect(responseTemplate).toContain("## Compact completion reply");
+    expect(responseTemplate).toContain("Report: docs/audits/<actual-report-file>.md");
     expect(await systemPluginInstructions(plugins, snapshot, "trace")).toEqual([]);
   });
 

--- a/packages/runtime/src/__tests__/task-delegation.test.ts
+++ b/packages/runtime/src/__tests__/task-delegation.test.ts
@@ -98,7 +98,7 @@ describe("flat task delegation", () => {
     expect(prompts.filter((prompt) => prompt.agent === "principal")).toHaveLength(2);
   });
 
-  it("returns Auditor findings directly to PI for a correction cycle", async () => {
+  it("returns a compact Auditor report pointer to PI for a correction cycle", async () => {
     const prompts: Array<{ agent: string; text: string }> = [];
     const manager = new SessionManager({
       persist: false,
@@ -116,7 +116,9 @@ describe("flat task delegation", () => {
             tool: "complete_task",
             args: {
               task_id: id,
-              reply: "Verdict: REVISE\nA1 owner: engineer\nRequired change: cite the result file.",
+              reply: "Verdict: REVISE\nRisk: high\nReport: docs/audits/task_000001-r1.md\n" +
+                "Open findings: A1\nOwners: engineer\nRequired actions: A1 cite the result file.\n" +
+                "PI must not claim the task is complete or deliver the affected conclusions.",
             },
           } : undefined;
         } },
@@ -130,7 +132,9 @@ describe("flat task delegation", () => {
     expect(auditPrompt.text).toContain("Target: raw engineer result");
     const piFeedback = prompts.filter((prompt) => prompt.agent === "principal")[1]!;
     expect(piFeedback.text).toContain('<task_event kind="completed" task_id="task_000001" from="auditor">');
-    expect(piFeedback.text).toContain("A1 owner: engineer");
+    expect(piFeedback.text).toContain("Report: docs/audits/task_000001-r1.md");
+    expect(piFeedback.text).toContain("Open findings: A1");
+    expect(piFeedback.text).toContain("Owners: engineer");
     expect(manager.listTasks(session.id)[0]).toMatchObject({ status: "completed", assigned_to: "auditor" });
   });
 

--- a/packages/runtime/src/__tests__/tool-access.test.ts
+++ b/packages/runtime/src/__tests__/tool-access.test.ts
@@ -234,10 +234,9 @@ describe("tool access control (§9)", () => {
     expect(names).not.toContain("destroy_agent");
   });
 
-  it("auditor builtins are read-only and separate report submission is disabled", () => {
+  it("auditor can create reports but cannot edit evidence or use a report tool", () => {
     const a = builtinToolNamesForRole("expert", "auditor");
-    expect(a).toEqual(expect.arrayContaining(["read", "grep", "find", "glob", "bash"]));
-    expect(a).not.toContain("write");
+    expect(a).toEqual(expect.arrayContaining(["read", "write", "grep", "find", "glob", "bash"]));
     expect(a).not.toContain("edit");
     expect(systemToolNamesForRole("expert", "auditor")).not.toContain("submit_audit_report");
   });

--- a/packages/runtime/src/tools/system-tools.ts
+++ b/packages/runtime/src/tools/system-tools.ts
@@ -969,12 +969,10 @@ export const BUILTIN_TOOL_CONFIG_BY_NAME: Record<string, string[]> = {
   experimentalist: ["read", "write", "edit", "bash", "grep", "find", "glob", "ls"],
   writer: ["read", "write", "edit", "grep", "find", "glob", "ls"],
   librarian: ["read", "write", "grep", "find", "glob"],
-  // Auditor: read-only inspection. Deliverable audit findings return to PI
-  // through complete_task; no separate report tool or workspace write access.
-  // `bash` is included for
-  // grep/awk/jq/diff style filesystem inspection — its read-only discipline is
-  // enforced by the auditor persona, not by the tool whitelist.
-  auditor: ["read", "grep", "find", "glob", "bash"],
+  // Auditor evidence inspection remains read-only. `write` is limited by the
+  // plugin contract to creating versioned reports under docs/audits/; there is
+  // no general edit permission or separate report-submission tool.
+  auditor: ["read", "write", "grep", "find", "glob", "bash"],
 };
 
 export function systemToolNamesForRole(role: AgentRole, agentName: string): string[] {


### PR DESCRIPTION
## Summary
- add four Auditor-only skills for data integrity, model validation, code/artifact integrity, and evidence verification
- route ordinary audits by risk and use one bounded 2–4 child `spawn_subagent` batch only when review surfaces are independent
- keep final verdict ownership with Auditor; leaf reviewers return evidence and candidate findings only
- write complete versioned reports under `docs/audits/` and return only a compact verdict/report pointer to PI
- grant Auditor `write` without `edit`; existing evidence remains read-only by plugin contract
- teach PI to open only the finding sections needed for REVISE/BLOCK

## Validation
- all five Auditor skills pass `quick_validate.py`
- focused runtime tests: 41/41
- full runtime suite: 569/570; the unrelated pre-existing `ask_user` timing test failed under suite load, then the full file passed 15/15 immediately
- `npm run typecheck`
- Auditor plugin `npm pack --dry-run` includes all 19 expected package files
- `git diff --check`