### PR TITLE
fix(plugins): validate MCP activation failures

### DIFF
--- a/packages/backend-core/plugins/playwright-mcp/0.0.78/.brainpilot/source.json
+++ b/packages/backend-core/plugins/playwright-mcp/0.0.78/.brainpilot/source.json
@@ -1,5 +1,9 @@
 {
   "format": "brainpilot",
   "unsupported": [],
-  "mcpConfigPath": ".mcp.json"
+  "mcpConfigPath": ".mcp.json",
+  "preflight": {
+    "command": "node",
+    "args": ["scripts/launch.mjs", "--check"]
+  }
 }

--- a/packages/backend-core/plugins/playwright-mcp/0.0.78/scripts/launch.mjs
+++ b/packages/backend-core/plugins/playwright-mcp/0.0.78/scripts/launch.mjs
@@ -21,7 +21,7 @@ async function cachedChromiumCandidates() {
 
 async function browserExecutable() {
   const configured = process.env.BRAINPILOT_PLAYWRIGHT_EXECUTABLE_PATH;
-  if (configured && await exists(configured)) return configured;
+  if (configured) return await exists(configured) ? configured : undefined;
   const cached = await cachedChromiumCandidates();
   if (cached[0]) return cached[0];
   const system = process.platform === "darwin"
@@ -38,6 +38,7 @@ if (!executable) {
   console.error("Playwright MCP requires Chrome/Chromium. Install it with `npx playwright install chromium` or set BRAINPILOT_PLAYWRIGHT_EXECUTABLE_PATH.");
   process.exit(1);
 }
+if (process.argv.includes("--check")) process.exit(0);
 
 const outputDir = process.env.BRAINPILOT_PLUGIN_DATA || path.join(os.tmpdir(), "brainpilot-playwright-mcp");
 const command = process.platform === "win32" ? "npx.cmd" : "npx";

--- a/packages/backend-core/src/plugins.ts
+++ b/packages/backend-core/src/plugins.ts
@@ -5,6 +5,7 @@
  * hosts consume enabled, compatible manifests through separate adapters.
  */
 import { promises as fs, type Stats } from "node:fs";
+import { spawn } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -609,6 +610,7 @@ interface ExternalPluginMetadata {
   mcpConfigPath?: string;
   hookConfig?: { dialect: "codex" | "claude-code"; path: string };
   extensionPaths?: string[];
+  preflight?: { command: string; args: string[] };
 }
 
 function externalSkillId(skillPath: string, used: Set<string>): string {
@@ -766,7 +768,12 @@ async function readExternalMetadata(dataDir: string, manifest: PluginManifest): 
     && raw.extensionPaths.every((entry) => typeof entry === "string" && isSafePluginPath(entry))
     ? raw.extensionPaths as string[]
     : undefined;
-  return { format: raw.format, unsupported, ...(mcpConfigPath ? { mcpConfigPath } : {}), ...(hookConfig ? { hookConfig } : {}), ...(extensionPaths?.length ? { extensionPaths } : {}) };
+  const preflight = isObject(raw.preflight)
+    && typeof raw.preflight.command === "string" && raw.preflight.command.trim()
+    && (raw.preflight.args === undefined || Array.isArray(raw.preflight.args) && raw.preflight.args.every((entry) => typeof entry === "string"))
+    ? { command: raw.preflight.command.trim(), args: (raw.preflight.args ?? []) as string[] }
+    : undefined;
+  return { format: raw.format, unsupported, ...(mcpConfigPath ? { mcpConfigPath } : {}), ...(hookConfig ? { hookConfig } : {}), ...(extensionPaths?.length ? { extensionPaths } : {}), ...(preflight ? { preflight } : {}) };
 }
 
 async function runtimeProjectionFor(dataDir: string, manifest: PluginManifest, metadata: ExternalPluginMetadata): Promise<PluginRuntimeProjection> {
@@ -879,6 +886,33 @@ async function runExternalSetup(projection: PluginRuntimeProjection): Promise<vo
   await fs.writeFile(marker, `${new Date().toISOString()}\n`, { mode: 0o600 });
 }
 
+async function runExternalPreflight(projection: PluginRuntimeProjection, preflight: NonNullable<ExternalPluginMetadata["preflight"]>): Promise<void> {
+  const env = {
+    ...process.env,
+    BRAINPILOT_PLUGIN_ROOT: projection.root,
+    BRAINPILOT_PLUGIN_DATA: projection.dataDir,
+    CLAUDE_PLUGIN_ROOT: projection.root,
+    CLAUDE_PLUGIN_DATA: projection.dataDir,
+    CLAUDE_MEM_DATA_DIR: projection.dataDir,
+    PLUGIN_ROOT: projection.root,
+  };
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(preflight.command, preflight.args, { cwd: projection.root, env, shell: false, stdio: ["ignore", "pipe", "pipe"] });
+    let output = "";
+    const append = (chunk: Buffer) => { output = `${output}${chunk.toString()}`.slice(-8_192); };
+    child.stdout.on("data", append);
+    child.stderr.on("data", append);
+    let timedOut = false;
+    const timer = setTimeout(() => { timedOut = true; child.kill("SIGKILL"); }, 15_000);
+    child.once("error", (error) => { clearTimeout(timer); reject(new Error(`Plugin preflight failed: ${error.message}`)); });
+    child.once("exit", (code, signal) => {
+      clearTimeout(timer);
+      if (code === 0) resolve();
+      else reject(new Error(`Plugin preflight failed${output.trim() ? `: ${output.trim()}` : timedOut ? ": timed out" : signal ? `: terminated by ${signal}` : ` with exit code ${code ?? "unknown"}`}`));
+    });
+  });
+}
+
 async function syncExternalRuntimeProjection(dataDir: string, manifest: PluginManifest, enabled: boolean): Promise<void> {
   const target = path.join(pluginRuntimeDir(dataDir), `${manifest.id}.json`);
   if (!enabled) { await fs.rm(target, { force: true }); return; }
@@ -886,6 +920,7 @@ async function syncExternalRuntimeProjection(dataDir: string, manifest: PluginMa
   if (!metadata) return;
   const projection = await runtimeProjectionFor(dataDir, manifest, metadata);
   await preflightExternalRuntime(dataDir, projection);
+  if (metadata.preflight) await runExternalPreflight(projection, metadata.preflight);
   await runExternalSetup(projection);
   await writeJsonAtomic(target, projection);
 }

--- a/packages/backend-core/test/plugins.test.ts
+++ b/packages/backend-core/test/plugins.test.ts
@@ -313,11 +313,29 @@ describe("plugin marketplace control plane", () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ id }),
     })).status).toBe(201);
-    expect((await app.request(`/api/plugins/${id}/enabled`, {
-      method: "PUT",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ enabled: true }),
-    })).status).toBe(200);
+    const previousExecutable = process.env.BRAINPILOT_PLAYWRIGHT_EXECUTABLE_PATH;
+    try {
+      process.env.BRAINPILOT_PLAYWRIGHT_EXECUTABLE_PATH = path.join(dataDir, "missing-chromium");
+      const failed = await app.request(`/api/plugins/${id}/enabled`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: true }),
+      });
+      expect(failed.status).toBe(400);
+      expect(await failed.json()).toEqual(expect.objectContaining({ error: expect.stringMatching(/requires Chrome\/Chromium/) }));
+      expect((await listInstalledPlugins(dataDir)).find((plugin) => plugin.manifest.id === id)?.enabled).toBe(false);
+      await expect(readFile(path.join(dataDir, "plugins", "runtime", `${id}.json`), "utf8")).rejects.toThrow();
+
+      process.env.BRAINPILOT_PLAYWRIGHT_EXECUTABLE_PATH = process.execPath;
+      expect((await app.request(`/api/plugins/${id}/enabled`, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ enabled: true }),
+      })).status).toBe(200);
+    } finally {
+      if (previousExecutable === undefined) delete process.env.BRAINPILOT_PLAYWRIGHT_EXECUTABLE_PATH;
+      else process.env.BRAINPILOT_PLAYWRIGHT_EXECUTABLE_PATH = previousExecutable;
+    }
 
     const projection = JSON.parse(await readFile(path.join(dataDir, "plugins", "runtime", `${id}.json`), "utf8")) as {
       format: string;

--- a/packages/runtime/src/__tests__/mcp-bridge.test.ts
+++ b/packages/runtime/src/__tests__/mcp-bridge.test.ts
@@ -112,11 +112,13 @@ describe("McpBridge", () => {
       return fakeClient();
     });
     const bridge = new McpBridge(connect);
-    const tools = await bridge.connectAll({
+    const result = await bridge.connectAllWithStatus({
       mcpServers: { bad: { command: "x" }, good: { command: "y" } },
     });
-    expect(tools).toHaveLength(1);
-    expect(tools[0]!.name).toBe("mcp__good__search");
+    expect(result.tools).toHaveLength(1);
+    expect(result.tools[0]!.name).toBe("mcp__good__search");
+    expect(result.connectedServers).toEqual(["good"]);
+    expect(result.failures).toEqual([{ server: "bad", error: "spawn failed" }]);
   });
 
   it("closes all clients", async () => {

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../persistent-layout.js";
 import { mockAgentFactory } from "../agent-factory.js";
 import { PERSONAS } from "../personas.js";
+import type { McpBridge } from "../mcp-bridge.js";
 
 function mgr(): SessionManager {
   // persist:false keeps tests hermetic; mock factory => no Pi SDK / API.
@@ -109,6 +110,23 @@ describe("SessionManager (mock mode)", () => {
     expect(principalTools).toContain("dispatch_task");
     expect(principalTools).toContain("complete_task");
     expect(principalTools).toContain("ask_user");
+  });
+
+  it("surfaces an error when every configured MCP server fails to start", async () => {
+    const root = await mkdtemp(join(tmpdir(), "bp-mcp-startup-failure-"));
+    await mkdir(join(root, "bp_template"), { recursive: true });
+    await writeFile(join(root, "bp_template", "mcp_servers.json"), JSON.stringify({ mcpServers: { playwright: { command: "node" } } }));
+    const mcpBridge = {
+      connectAllWithStatus: async () => ({ tools: [], connectedServers: [], failures: [{ server: "playwright", error: "Chrome/Chromium is required" }] }),
+      close: async () => {},
+    } as unknown as McpBridge;
+    const manager = new SessionManager({ dataRoot: root, persist: false, agentFactory: mockAgentFactory, mcpBridge });
+    const session = await manager.createSession();
+
+    await expect(manager.sendMessage(session.id, "browse the web")).rejects.toThrow(
+      "Configured MCP services failed to start: playwright: Chrome/Chromium is required",
+    );
+    await rm(root, { recursive: true, force: true });
   });
 
   it("injects the built-in persona (not the old placeholder) for the principal", async () => {

--- a/packages/runtime/src/__tests__/tool-truncation.test.ts
+++ b/packages/runtime/src/__tests__/tool-truncation.test.ts
@@ -19,11 +19,12 @@ import type { SystemToolResult } from "../types.js";
  * Helpers
  * ------------------------------------------------------------------ */
 
-/** Build a fake MCP bridge that returns `tools` on connectAll. */
+/** Build a fake MCP bridge that returns `tools` with a healthy server status. */
 function fakeMcpBridge(tools: SystemTool[]): McpBridge {
   return {
     tools,
     connectAll: async (_cfg: McpServersConfig) => tools,
+    connectAllWithStatus: async (_cfg: McpServersConfig) => ({ tools, connectedServers: ["test"], failures: [] }),
     close: async () => {},
   } as unknown as McpBridge;
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -53,6 +53,7 @@ export { createServer, startServer } from "./server.js";
 export type { StartServerOptions } from "./server.js";
 
 export { McpBridge, loadMcpServersConfig, defaultMcpConnect } from "./mcp-bridge.js";
+export type { McpConnectionFailure, McpConnectResult } from "./mcp-bridge.js";
 export {
   loadCompatPluginProjections,
   makeCompatHooksExt,

--- a/packages/runtime/src/mcp-bridge.ts
+++ b/packages/runtime/src/mcp-bridge.ts
@@ -8,7 +8,7 @@
  * real agent factory then wraps with Pi's `defineTool`).
  *
  * Tools are namespaced `mcp__<server>__<tool>` to avoid cross-server collisions.
- * A failing server is logged and skipped — it never aborts the others.
+ * A failing server is recorded and skipped — it never aborts the others.
  *
  * Config shape (standard MCP/Claude format). Three transports are supported,
  * selected by the optional `type` field (defaults to "stdio" for back-compat):
@@ -65,6 +65,17 @@ export interface McpServerSpec {
 
 export interface McpServersConfig {
   mcpServers: Record<string, McpServerSpec>;
+}
+
+export interface McpConnectionFailure {
+  server: string;
+  error: string;
+}
+
+export interface McpConnectResult {
+  tools: SystemTool[];
+  connectedServers: string[];
+  failures: McpConnectionFailure[];
 }
 
 function inheritedEnvironment(): Record<string, string> {
@@ -252,6 +263,13 @@ export class McpBridge {
 
   /** Connect every server in the config and collect their tools. */
   async connectAll(cfg: McpServersConfig): Promise<SystemTool[]> {
+    return (await this.connectAllWithStatus(cfg)).tools;
+  }
+
+  /** Connect every server while preserving per-server startup failures. */
+  async connectAllWithStatus(cfg: McpServersConfig): Promise<McpConnectResult> {
+    const connectedServers: string[] = [];
+    const failures: McpConnectionFailure[] = [];
     for (const [name, spec] of Object.entries(cfg.mcpServers)) {
       if (isPlaceholderSpec(spec)) {
         // A scaffolded slot whose url/command hasn't been filled in yet — skip
@@ -260,17 +278,22 @@ export class McpBridge {
         console.info(`[mcp] server '${name}' not configured yet — skipping`);
         continue;
       }
+      let client: McpClientLike | undefined;
       try {
-        const client = await this.connect(name, spec);
-        this.clients.push(client);
+        client = await this.connect(name, spec);
         const { tools } = await client.listTools();
+        this.clients.push(client);
+        connectedServers.push(name);
         for (const t of tools) this._tools.push(this.wrap(name, client, t));
       } catch (err) {
+        await client?.close().catch(() => {});
+        const error = err instanceof Error ? err.message : String(err);
+        failures.push({ server: name, error });
         // eslint-disable-next-line no-console
-        console.error(`[mcp] server '${name}' failed to connect:`, (err as Error).message);
+        console.error(`[mcp] server '${name}' failed to connect:`, error);
       }
     }
-    return this._tools;
+    return { tools: this._tools, connectedServers, failures };
   }
 
   private wrap(server: string, client: McpClientLike, t: McpToolDescriptor): SystemTool {

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -732,16 +732,28 @@ export class SessionManager {
    */
   private async ensureMcpTools(): Promise<SystemTool[]> {
     if (this.mcpLoaded) return this.mcpTools;
-    this.mcpLoaded = true;
-    if (isMockMode() && !this.mcpBridge) return this.mcpTools;
+    if (isMockMode() && !this.mcpBridge) {
+      this.mcpLoaded = true;
+      return this.mcpTools;
+    }
     try {
       const cfg = await loadMcpServersConfig(this.dataRoot);
-      if (!cfg) return this.mcpTools;
+      if (!cfg) {
+        this.mcpLoaded = true;
+        return this.mcpTools;
+      }
       if (!this.mcpBridge) this.mcpBridge = new McpBridge();
-      this.mcpTools = await this.mcpBridge.connectAll(cfg);
+      const result = await this.mcpBridge.connectAllWithStatus(cfg);
+      this.mcpTools = result.tools;
+      if (result.connectedServers.length === 0 && result.failures.length > 0) {
+        throw new Error(`Configured MCP services failed to start: ${result.failures.map(({ server, error }) => `${server}: ${error}`).join("; ")}`);
+      }
+      this.mcpLoaded = true;
     } catch (err) {
+      this.mcpLoaded = false;
       // eslint-disable-next-line no-console
       console.error("[mcp] bridge load failed:", (err as Error).message);
+      throw err;
     }
     return this.mcpTools;
   }


### PR DESCRIPTION
## Summary
- run declared plugin preflight checks before persisting the enabled state
- make the Playwright wrapper reject activation when Chrome/Chromium is unavailable
- preserve per-server MCP startup failures while keeping healthy servers available
- surface an explicit session error when every configured MCP server fails

## Tests
- `npm test -- --run` (88 files, 971 tests passed before the latest upstream rebase)
- targeted post-rebase tests (77 passed)
- `npm run typecheck`

## Note
`npm run check:playwright-mcp-upstream` reports the pre-existing 0.0.78 pin is behind 0.0.79; this PR intentionally does not mix in an upstream dependency upgrade.