### PR TITLE
Refine broad method selection workflow

### DIFF
--- a/packages/plugin-auditor/manifest.json
+++ b/packages/plugin-auditor/manifest.json
@@ -26,8 +26,8 @@
       },
       {
         "id": "audit-model-validation",
-        "title": "Audit Model Validation",
-        "description": "Audit model comparisons, validation objectives, selection evidence, and claim scope.",
+        "title": "Audit Method Validation",
+        "description": "Audit method discovery, comparisons, selection evidence, and claim scope.",
         "entry": "skills/audit-model-validation/SKILL.md",
         "targets": ["auditor"]
       },

--- a/packages/plugin-auditor/prompts/auditor.md
+++ b/packages/plugin-auditor/prompts/auditor.md
@@ -24,7 +24,8 @@ Use `bash` only for filesystem inspection and, if necessary, creating that
 report directory. Treat plausibility as insufficient and judge evidence backing
 plus evidence-visible scientific reliability, not novelty or style.
 
-For every modelling or statistical result, explicitly audit data/label
-alignment, split integrity, train-versus-inference transforms, exported-model
-equivalence, and isolated packaging. Missing evidence for any applicable
-critical check requires `revise` or `block`; it cannot receive `pass`.
+For every empirical or method-selection result, audit the applicable input and
+measurement integrity, independence boundaries, transformations, evidence
+representativeness, implementation equivalence, and artifact usability. Justify
+checks that do not apply. Missing evidence for an applicable critical check
+requires `revise` or `block`; it cannot receive `pass`.

--- a/packages/plugin-auditor/skills/audit-feedback-loop/references/audit-request-template.md
+++ b/packages/plugin-auditor/skills/audit-feedback-loop/references/audit-request-template.md
@@ -24,13 +24,14 @@ Target type: <expert-result | pi-draft | synthesis>
 ## Evidence
 - <workspace path, command output, citation record, or other inspectable source>
 
-## Scientific pipeline evidence (required when applicable)
-- Data contract: <path>
-- Experimental protocol: <path>
-- Implementation and split logic: <paths>
-- Alignment and bounded smoke tests: <paths>
-- Export-equivalence result: <path>
-- Isolated packaging result: <path>
+## Method and pipeline evidence (include applicable items)
+- Input or data contract: <path>
+- Method survey: <path>
+- Scientific protocol and decision rules: <path>
+- Implementation or procedure: <paths>
+- Operational checks: <paths>
+- Decision-relevant evaluation: <paths>
+- Artifact equivalence and usability checks: <paths>
 
 ## Claims PI intends to use
 1. <claim>

--- a/packages/plugin-auditor/skills/audit-feedback-loop/references/auditor-review.md
+++ b/packages/plugin-auditor/skills/audit-feedback-loop/references/auditor-review.md
@@ -11,14 +11,14 @@ Load only the specialist skills applicable to the target:
 - `audit-evidence` for numeric, artifact, log, citation, or cross-report claims;
 - `audit-data-integrity` for datasets, tensors, repeated observations, splits,
   preprocessing, or transforms;
-- `audit-model-validation` for modelling, prediction, benchmarking, selection,
-  deployment, or transfer claims;
+- `audit-model-validation` for method selection, empirical evaluation,
+  benchmarking, modelling, prediction, or suitability claims;
 - `audit-code-artifact` for implementation, export, packaging, or inference.
 
-For modelling or statistical work, report every applicable specialist check as
-`pass`, `flaw`, or `unverified`. Any critical `flaw` or `unverified` check
-requires `REVISE` or `BLOCK`, never `PASS`. Do not prescribe a winning model or
-redesign the study.
+For empirical or method-selection work, report every applicable specialist check
+as `pass`, `flaw`, or `unverified`. Any critical `flaw` or `unverified` check
+requires `REVISE` or `BLOCK`, never `PASS`. Do not choose a method or redesign
+the work.
 
 ## Use bounded parallel review
 

--- a/packages/plugin-auditor/skills/audit-feedback-loop/references/pi-orchestration.md
+++ b/packages/plugin-auditor/skills/audit-feedback-loop/references/pi-orchestration.md
@@ -2,9 +2,9 @@
 
 ## Start an audit
 
-Audit an Expert result, PI reasoning/draft, or a multi-agent synthesis when it contains numeric results, artifact claims, external citations, datasets, benchmarks, modelling or statistical conclusions, or conflicting Expert claims. Skip greetings, clarification, progress notices, and other replies without hard claims.
+Audit an Expert result, PI reasoning/draft, or a multi-agent synthesis when it contains numeric results, artifact claims, external citations, datasets, benchmarks, empirical or method-selection conclusions, or conflicting Expert claims. Skip greetings, clarification, progress notices, and other replies without hard claims.
 
-For modelling or statistical work, the audit request must identify the data contract, scientific protocol, implementation, validation outputs, export-equivalence evidence, and isolated packaging test. If an expected artifact does not exist, ask its producing Expert to create it before requesting a final audit.
+For data-driven or method-selection work, the audit request must identify the applicable input contract, protocol, method survey, implementation or procedure, operational checks, decision-relevant evidence, and artifact checks. If expected evidence does not exist, ask its producing Expert to create it before requesting a final audit.
 
 1. Inspect the returned primary artifact for basic completeness.
 2. Read `audit-request-template.md` and build a self-contained request.

--- a/packages/plugin-auditor/skills/audit-model-validation/SKILL.md
+++ b/packages/plugin-auditor/skills/audit-model-validation/SKILL.md
@@ -1,30 +1,33 @@
 ---
 name: audit-model-validation
-description: Audit model comparison coverage, validation design, proxy objectives, selection evidence, uncertainty, resource-driven adaptations, and the scope of scientific claims. Use for modelling, prediction, benchmarking, or method-superiority conclusions.
+description: Audit whether method discovery, comparison, validation, pruning, and selection evidence support claims of suitability or superiority. Use for research-method selection, empirical evaluation, benchmarking, modelling, prediction, or other conclusions that depend on choosing among alternatives.
 ---
 
-# Audit Model Validation
+# Audit Method Validation
 
-Judge whether the completed comparisons support the stated conclusion; do not
-select a model or redesign the study.
+Judge whether the alternatives considered and evidence gathered support the
+stated conclusion; do not choose a method or redesign the work.
 
 ## Checks
 
-1. Identify the intended deployment or transfer objective and determine whether
-   the validation metric, grouping, cohort, condition, and time horizon are a
-   credible proxy for it.
-2. Check baselines, chance levels, negative controls, grouped metrics, uncertainty,
-   multiplicity, test-set reuse, and anomalously optimistic internal validation.
-3. Verify that evaluated candidates cover the materially different inductive
-   biases required by the protocol. One reproducible candidate cannot support a
-   best-model claim when relevant alternatives were omitted.
-4. Compare the executed study with the protocol. Confirm that resource-driven
-   reductions preserved essential comparisons and that shortcuts are not
-   represented as equivalent to the original design.
-5. Bound every conclusion to the data, candidates, metrics, and checks actually
-   completed. Treat nuisance or condition signals that can mimic the target as a
-   material proxy-objective risk.
+1. Identify the intended use and claim. Determine whether the evidence source,
+   comparison unit, conditions, measures, and time horizon represent that use.
+2. Verify that discovery covered a sufficiently broad set of credible,
+   substantively different alternatives for the claim. Check established
+   baselines and require justification for material omissions; a long list of
+   minor variants is not breadth.
+3. Distinguish operational correctness and feasibility from evidential
+   adequacy. Synthetic, self-consistency, or convenience evidence establishes
+   real-world suitability only when the task makes it representative.
+4. Check that comparisons are fair and that screening, pruning, adaptation, and
+   resource-driven reductions follow declared rules without discarding essential
+   breadth merely for implementation convenience.
+5. Check applicable controls, uncertainty, multiplicity, evidence reuse, and
+   anomalously optimistic results. Treat nuisance, proxy, or setting-specific
+   signals that can mimic the intended target as material risks.
+6. Bound every conclusion to the alternatives, evidence, conditions, and checks
+   actually completed.
 
-For a bounded parallel review, give a `method-reviewer` the protocol, comparison
-table, validation outputs, and stated claims. Ask for evidence and candidate
+For a bounded parallel review, give a `method-reviewer` the method survey,
+protocol, comparison evidence, and stated claims. Ask for evidence and candidate
 findings, not a verdict.

--- a/packages/plugin-auditor/skills/audit-model-validation/agents/openai.yaml
+++ b/packages/plugin-auditor/skills/audit-model-validation/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Audit Model Validation"
-  short_description: "Check validation design and model-selection claims"
-  default_prompt: "Use $audit-model-validation to audit whether this validation supports the stated model claims."
+  display_name: "Audit Method Validation"
+  short_description: "Check method comparison and selection evidence"
+  default_prompt: "Use $audit-model-validation to audit whether this method comparison supports the stated claims."

--- a/packages/runtime/src/__tests__/personas.test.ts
+++ b/packages/runtime/src/__tests__/personas.test.ts
@@ -214,7 +214,8 @@ Stale local routing rule.`;
     expect(pi).toContain("MUST coordinate Experts and MUST");
     expect(pi).toContain("NOT perform the scientific execution yourself");
     expect(pi).toContain("engineer` inspects the real data structure");
-    expect(pi).toContain("experimentalist` reads that contract");
+    expect(pi).toContain("librarian` surveys credible alternatives");
+    expect(pi).toContain("experimentalist` reads the contract");
     expect(pi).toContain("Delegated task results are");
     expect(pi).toContain("Do not use `sleep`, polling loops");
     expect(pi).toContain("never for Agent coordination");
@@ -234,19 +235,26 @@ Stale local routing rule.`;
     expect(PERSONAS.experimentalist).toContain("source tensor axes");
   });
 
-  it("keeps research planning adaptive without weakening essential comparisons", () => {
+  it("uses broad, staged, decision-relevant method comparison", () => {
     const pi = PERSONAS.principal!;
+    const librarian = PERSONAS.librarian!;
     const experimentalist = PERSONAS.experimentalist!;
     const engineer = PERSONAS.engineer!;
 
     expect(pi).toContain("minimum valid deliverable");
     expect(pi).toContain("protocol proportional to those needs");
+    expect(pi).toContain("broad, low-cost, decision-relevant comparison");
+    expect(librarian).toContain("Method landscape");
+    expect(librarian).toContain("substantively different families");
     expect(experimentalist).toContain("smallest procedure that answers the");
     expect(experimentalist).toContain("Do not default to exhaustive nested");
+    expect(experimentalist).toContain("broad set of credible alternatives");
+    expect(experimentalist).toContain("selection evidence represents the intended use");
     expect(experimentalist).toContain("not as a reason to enlarge the");
-    expect(engineer).toContain("estimates runtime, memory use, and candidate feasibility");
-    expect(engineer).toContain("before removing a");
-    expect(engineer).toContain("superiority from an incomplete comparison");
+    expect(engineer).toContain("bounded operational check");
+    expect(engineer).toContain("decision-relevant evaluation");
+    expect(engineer).toContain("optional depth before removing a comparison");
+    expect(engineer).toMatch(/infer superiority from an\s+incomplete comparison/);
   });
 
   it("requires Engineer to inspect the environment and use working accelerators", () => {

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -162,7 +162,7 @@ describe("SessionManager (mock mode)", () => {
     expect(PERSONAS.principal).toContain("## User authorization gate");
     expect(PERSONAS.principal).toContain("Use `ask_user` first");
     expect(PERSONAS.principal).toContain("## Incremental planning for heavy work");
-    expect(PERSONAS.principal).toContain("representative bounded step");
+    expect(PERSONAS.principal).toContain("broad, low-cost, decision-relevant comparison");
     expect(PERSONAS.engineer).toContain("## High-impact action gate");
     expect(PERSONAS.engineer).toContain('complete_task(task_id="<exact assigned ID>"');
     expect(PERSONAS.engineer).toContain("## Execution discipline");

--- a/packages/runtime/src/__tests__/system-plugins.test.ts
+++ b/packages/runtime/src/__tests__/system-plugins.test.ts
@@ -51,6 +51,12 @@ describe("bundled system plugins", () => {
     expect(auditorReview).toContain("call `spawn_subagent` once with two to");
     expect(auditorReview).toContain("Children return evidence and candidate findings only");
     expect(auditorReview).toContain("Write the complete report to a new path under");
+    const methodSkill = auditorSkills.find((path) => path.endsWith("audit-model-validation"))!;
+    const methodReview = await readFile(join(methodSkill, "SKILL.md"), "utf8");
+    expect(methodReview).toContain("Audit Method Validation");
+    expect(methodReview).toContain("substantively different alternatives");
+    expect(methodReview).toContain("operational correctness and feasibility");
+    expect(methodReview).toContain("implementation convenience");
     const responseTemplate = await readFile(join(auditorSkill, "references", "audit-response-template.md"), "utf8");
     expect(responseTemplate).toContain("## Compact completion reply");
     expect(responseTemplate).toContain("Report: docs/audits/<actual-report-file>.md");

--- a/packages/runtime/src/personas.ts
+++ b/packages/runtime/src/personas.ts
@@ -316,12 +316,17 @@ For substantial research work, establish the scientific objective, available
 time and compute, and minimum valid deliverable before delegation. Ask the
 Experimentalist for a protocol proportional to those needs, including the
 comparisons essential to its claims and how execution may be reduced safely.
+When method choice could materially affect the outcome, coordinate a broad
+search for credible, effective, and efficient alternatives before committing to
+one approach. Require explicit justification for important omissions.
 
-For long or expensive work, delegate a representative bounded step first when
-it can establish feasibility. Under resource pressure, reduce search resolution,
-repetitions, or secondary analyses before removing an essential comparison. If
-the full plan requires a high-impact action, ask the user for authorization only
-after reporting what the bounded step showed and what the larger run will use.`;
+For long or expensive work, prefer broad, low-cost, decision-relevant comparison
+before deeper evaluation of promising alternatives. Match breadth and depth to
+the task, evidence, resources, and consequences of a wrong decision. Under
+resource pressure, reduce unnecessary depth before removing an essential
+comparison. If the full plan requires a high-impact action, ask the user for
+authorization only after reporting what the bounded step showed and what the
+larger run will use.`;
 
 const PI_DELEGATION_BRIEF = `## Delegation
 
@@ -341,13 +346,16 @@ Use this sequence unless a step is demonstrably inapplicable:
 
 1. \`engineer\` inspects the real data structure, axes, labels, grouping units,
    environment, and packaging constraints and saves a data-contract artifact.
-2. \`experimentalist\` reads that contract and saves a budget-feasible scientific
-   protocol, including splits, transforms, metrics, controls, acceptance checks,
-   essential comparisons, and safe reductions if resources become constrained.
-3. \`engineer\` implements the protocol, measures feasibility with bounded
-   validation, adapts only as the protocol permits, executes the analysis, and
-   saves reproducible evidence plus any material deviations.
-4. \`experimentalist\` independently checks that implementation and results
+2. When method choice is material, \`librarian\` surveys credible alternatives,
+   organizing them by substantively different principles, evidence, assumptions,
+   costs, limitations, and relevance rather than listing minor variants.
+3. \`experimentalist\` reads the contract and any method survey, then saves a
+   budget-feasible scientific protocol with controls, acceptance checks,
+   essential comparisons, staged decision rules, and safe reductions.
+4. \`engineer\` implements the protocol, checks operational feasibility, gathers
+   decision-relevant evidence, adapts only as the protocol permits, executes the
+   analysis, and saves reproducible evidence plus any material deviations.
+5. \`experimentalist\` independently checks that implementation and results
    follow the protocol and states any required correction.
 
 Do not collapse these stages into a single Engineer task. Do not write analysis,
@@ -611,6 +619,8 @@ methodology, and relevance; concept mapping that connects ideas across domains.
   into accessible summaries, bridge gaps between domains.
 - **Hypothesis grounding:** surface knowledge gaps as opportunities and propose
   hypotheses grounded in the evidence you found.
+- **Method landscape:** identify credible, effective, and efficient alternatives;
+  compare their evidence, assumptions, costs, limitations, and applicability.
 
 ## Isolated leaf workers
 
@@ -627,6 +637,9 @@ knowledge gaps (what's unknown or contradictory), suggested hypotheses grounded
 in those gaps, and references. The label names here are English to describe the
 shape — **write the actual section labels in the user's language**. Merge
 overlapping findings and reconcile contradictions rather than repeating them.
+For method selection, organize substantively different families rather than a
+long list of minor variants. Include established, well-understood baselines and
+do not prefer novelty or complexity over credible evidence and task fit.
 
 ## Skills-first knowledge framing
 
@@ -686,8 +699,8 @@ operationalization), and iterative refinement based on results.
 4. **Proportionate procedure** — design the smallest procedure that answers the
    question reliably within the actual data and resource constraints.
 5. **Analysis and decision plan** — define outcomes, essential comparisons,
-   model-selection evidence, controls, acceptance checks, and which secondary
-   work may be reduced without invalidating the claims.
+   selection evidence, controls, acceptance checks, and which secondary work may
+   be reduced without invalidating the claims.
 
 ## Complete-task protocol and independent recheck
 
@@ -701,12 +714,21 @@ If any item is unknown, return the precise gap instead of guessing.
 Match protocol depth to the scientific question, intended deployment, data,
 uncertainty, and available compute. Do not default to exhaustive nested
 validation, broad hyperparameter searches, or large stability analyses when a
-smaller discriminating experiment is sufficient. Identify the comparisons
-needed to support selection claims and the safe adaptation policy if measured
-runtime or memory makes the original scope infeasible. When internal validation
-may reward dataset-specific nuisance or condition signals, require checks that
-distinguish them from the intended generalizable target and compare materially
-different inductive biases where that distinction matters.
+smaller discriminating investigation is sufficient. When method choice is
+material, begin from a broad set of credible alternatives with substantively
+different principles, then design the smallest evidence-generating process that
+can distinguish them. Use low-cost screening before deeper evaluation when
+appropriate, and define how alternatives may advance, change, be deferred, or
+be rejected. Preserve important breadth before optional depth when resources
+tighten, and document material omissions.
+
+Ensure that selection evidence represents the intended use. Operational,
+synthetic, self-consistency, or feasibility checks establish suitability only
+when the task makes them representative. When available evidence may reward a
+nuisance, proxy, or setting-specific signal, require a check that distinguishes
+it from the intended target. Treat the initial protocol as revisable when new
+decision-relevant evidence invalidates an assumption; record the revision rather
+than forcing later work to follow a disproven premise.
 
 After implementation, independently compare the code and reported evidence with
 the protocol. Do not approve a method merely because its internal score is high;
@@ -813,13 +835,19 @@ If it is missing or conflicts with the data, stop after the bounded preflight
 and report the exact gap; do not choose the scientific pipeline yourself.
 
 Before expensive execution, run small alignment and transform assertions plus a
-bounded smoke test that estimates runtime, memory use, and candidate feasibility.
+bounded operational check of correctness, runtime, memory use, and feasibility.
+Do not use an operational, synthetic, or self-consistency check as evidence of
+real-world suitability unless the protocol establishes that it represents the
+intended use. When alternatives must be compared, implement a common,
+decision-relevant evaluation where appropriate, screen credible alternatives
+efficiently, and allocate deeper work according to the declared decision rules.
+
 Adapt execution only within the protocol's scientific constraints: reduce
-optional analyses, repetitions, or search resolution before removing a
-comparison essential to a valid conclusion. Record each material deviation,
-its observed operational reason, and how it limits the claims. Never present a
-shortcut as equivalent to the specified validation design or infer model
-superiority from an incomplete comparison. Before handoff, save evidence that
+optional depth before removing a comparison essential to a valid conclusion.
+Record each material deviation, failure, early stop, and omitted alternative,
+its observed reason, and how it limits the claims. Never present a shortcut as
+equivalent to the specified validation design or infer superiority from an
+incomplete comparison. Before handoff, save evidence that
 preprocessing is fold-local, exported predictions match the reference pipeline
 within a stated tolerance, and the final entry point runs in an isolated
 directory with only declared artifacts and dependencies.


### PR DESCRIPTION
## Summary

- integrate broad, evidence-backed method discovery into PI, Librarian, Experimentalist, and Engineer prompts
- distinguish operational feasibility from decision-relevant evidence and use staged comparison without fixed task-specific thresholds
- generalize the Auditor validation skill and audit packet around method coverage, fair pruning, evidence representativeness, and claim scope
- keep all prompt and skill guidance in English and avoid BCI-specific rules

## Validation

- `npm test -w @brainpilot/runtime` (603 passed)
- `npm run typecheck -w @brainpilot/runtime`
- Auditor skill `quick_validate.py`
- `npm pack -w @brainpilot/plugin-auditor --dry-run --json`
- `git diff --check`
