### PR TITLE
feat(runtime): guard required PI expert delegation

### DIFF
--- a/packages/client-cli/src/bin.ts
+++ b/packages/client-cli/src/bin.ts
@@ -22,6 +22,10 @@ program
   .option("-s, --session <id>", "reuse an existing session id")
   .option("-a, --agent <name>", "target agent (default principal)")
   .option(
+    "--workflow-policy <policy>",
+    "session workflow policy: direct or expert_required",
+  )
+  .option(
     "-n, --max-events <n>",
     "stop after N events (safety bound)",
     (v) => parseInt(v, 10),
@@ -29,11 +33,15 @@ program
   .option("--mock", "print events but do not require a live server", false)
   .action(async (message: string, opts) => {
     try {
+      if (opts.workflowPolicy && !["direct", "expert_required"].includes(opts.workflowPolicy)) {
+        throw new Error("--workflow-policy must be direct or expert_required");
+      }
       const result = await run({
         baseUrl: opts.baseUrl,
         message,
         agent: opts.agent,
         sessionId: opts.session,
+        workflowPolicy: opts.workflowPolicy,
         maxEvents: opts.maxEvents,
         mock: opts.mock,
       });

--- a/packages/client-cli/src/client.test.ts
+++ b/packages/client-cli/src/client.test.ts
@@ -207,6 +207,31 @@ describe("driveSession", () => {
     ).toBe(true);
   });
 
+  it("passes the workflow policy when creating a session", async () => {
+    let createBody: unknown;
+    const fetchFn = (async (url: string | URL, init?: RequestInit) => {
+      const u = String(url);
+      const method = init?.method ?? "GET";
+      if (u.endsWith("/sessions") && method === "POST") {
+        createBody = JSON.parse(String(init?.body));
+        return new Response(JSON.stringify({ id: "workflow-session" }), { status: 200 });
+      }
+      if (u.endsWith("/messages")) {
+        return new Response(JSON.stringify({ accepted: true }), { status: 200 });
+      }
+      return new Response(
+        streamFrom(['data: {"type":"RUN_FINISHED","run_id":"r1"}\n\n']),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
+    await driveSession(
+      { baseUrl: "http://h/api", message: "research", workflowPolicy: "expert_required" },
+      { fetchFn },
+    );
+    expect(createBody).toEqual({ workflowPolicy: "expert_required" });
+  });
+
   it("respects maxEvents as a safety bound", async () => {
     const fetchFn = (async (url: string | URL, init?: RequestInit) => {
       const u = String(url);

--- a/packages/client-cli/src/driver.ts
+++ b/packages/client-cli/src/driver.ts
@@ -5,7 +5,7 @@
  * (RUN_FINISHED / RUN_ERROR) or `command_complete` is seen.
  */
 import { BrainPilotClient, isTerminalEvent } from "./client.js";
-import type { AgUiEvent } from "@brainpilot/protocol";
+import type { AgUiEvent, WorkflowPolicy } from "@brainpilot/protocol";
 
 export interface DriveOptions {
   baseUrl?: string;
@@ -13,6 +13,8 @@ export interface DriveOptions {
   agent?: string;
   /** Reuse an existing session instead of creating one. */
   sessionId?: string;
+  /** Applied when this driver creates a new session. */
+  workflowPolicy?: WorkflowPolicy;
   /** Stop after this many events even without a terminal (safety bound). */
   maxEvents?: number;
 }
@@ -55,7 +57,9 @@ export async function driveSession(
   const events: AgUiEvent[] = [];
   const maxEvents = options.maxEvents ?? Infinity;
 
-  const sessionId = options.sessionId ?? (await client.createSession());
+  const sessionId = options.sessionId ?? (await client.createSession({
+    ...(options.workflowPolicy ? { workflowPolicy: options.workflowPolicy } : {}),
+  }));
 
   // Start the stream BEFORE sending so we don't miss early events. The runtime
   // replays buffered events on connect, so ordering here is best-effort.

--- a/packages/protocol/src/domain.ts
+++ b/packages/protocol/src/domain.ts
@@ -28,6 +28,10 @@ export const EXAMPLE_MODEL = "claude-sonnet-4-6";
 export const DomainResourcesSchema = z.enum(["full", "base"]);
 export type DomainResources = z.infer<typeof DomainResourcesSchema>;
 
+/** Whether Principal turns in this session require a real Expert delegation. */
+export const WorkflowPolicySchema = z.enum(["direct", "expert_required"]);
+export type WorkflowPolicy = z.infer<typeof WorkflowPolicySchema>;
+
 export const SessionSchema = z.object({
   id: z.string(),
   title: z.string(),
@@ -35,6 +39,8 @@ export const SessionSchema = z.object({
   updatedAt: z.string(),
   /** Optional for compatibility with older runtimes; new runtimes always emit it. */
   domainResources: DomainResourcesSchema.optional(),
+  /** Optional for compatibility; omitted sessions behave as direct. */
+  workflowPolicy: WorkflowPolicySchema.optional(),
 });
 export type Session = z.infer<typeof SessionSchema>;
 
@@ -281,6 +287,8 @@ export const SessionStateSnapshotSchema = z.object({
   lastActivityTs: z.string(),
   /** Frozen when the session is created and persisted across restore. */
   domainResources: DomainResourcesSchema.optional(),
+  /** Frozen Principal delegation policy for this session. */
+  workflowPolicy: WorkflowPolicySchema.optional(),
   /**
    * Cumulative real token usage for this session (total + per-agent). Optional
    * for forward/backward compat: a frame from an older runtime, or before the

--- a/packages/protocol/src/http.ts
+++ b/packages/protocol/src/http.ts
@@ -105,6 +105,8 @@ export const CreateSessionRequestSchema = z.object({
   modelId: z.string().optional(),
   /** Per-session domain resources; omitted means full for backward compatibility. */
   domainResources: z.enum(["full", "base"]).optional(),
+  /** Require Principal to delegate substantive work to an Expert in each user-work epoch. */
+  workflowPolicy: z.enum(["direct", "expert_required"]).optional(),
 });
 export type CreateSessionRequest = z.infer<typeof CreateSessionRequestSchema>;
 

--- a/packages/protocol/test/http.test.ts
+++ b/packages/protocol/test/http.test.ts
@@ -45,6 +45,9 @@ describe("Runtime HTTP contract", () => {
     expect(CreateSessionRequestSchema.parse({ title: "T" }).title).toBe("T");
     expect(CreateSessionRequestSchema.parse({ domainResources: "base" }).domainResources).toBe("base");
     expect(CreateSessionRequestSchema.safeParse({ domainResources: "disabled" }).success).toBe(false);
+    expect(CreateSessionRequestSchema.parse({ workflowPolicy: "expert_required" }).workflowPolicy)
+      .toBe("expert_required");
+    expect(CreateSessionRequestSchema.safeParse({ workflowPolicy: "unknown" }).success).toBe(false);
     expect(CreateSessionRequestSchema.parse({}).title).toBeUndefined();
     expect(CreateSessionResponseSchema.parse({ id: "s1" }).id).toBe("s1");
   });

--- a/packages/runtime/src/__tests__/principal-workflow-guard.test.ts
+++ b/packages/runtime/src/__tests__/principal-workflow-guard.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  makePrincipalWorkflowGuardExt,
+  renderPrincipalWorkflowBlock,
+  WORKFLOW_TAG_OPEN,
+} from "../extensions/principal-workflow-guard.js";
+
+type ContextHandler = (event: { messages: Message[] }) => { messages: Message[] } | void;
+type EndHandler = (event: { messages?: Array<{ role?: string; stopReason?: string }> }) => void | Promise<void>;
+type Message = { role: string; content: Array<{ type: string; text?: string }> };
+
+class FakePi {
+  context?: ContextHandler;
+  end?: EndHandler;
+  followUps: string[] = [];
+
+  on(event: string, handler: ContextHandler | EndHandler): void {
+    if (event === "context") this.context = handler as ContextHandler;
+    if (event === "agent_end") this.end = handler as EndHandler;
+  }
+
+  sendUserMessage(content: string): void {
+    this.followUps.push(content);
+  }
+}
+
+function setup(overrides: {
+  required?: boolean;
+  delegated?: boolean;
+  claim?: () => boolean | Promise<boolean>;
+} = {}) {
+  let required = overrides.required ?? true;
+  let delegated = overrides.delegated ?? false;
+  const violation = vi.fn();
+  const pi = new FakePi();
+  makePrincipalWorkflowGuardExt({
+    renderState: () => renderPrincipalWorkflowBlock(required && !delegated),
+    hasQualifyingDelegation: () => delegated,
+    claimReminder: overrides.claim ?? (() => true),
+    onViolation: violation,
+  })(pi as never);
+  return {
+    pi,
+    violation,
+    setRequired: (value: boolean) => { required = value; },
+    setDelegated: (value: boolean) => { delegated = value; },
+  };
+}
+
+describe("principal workflow guard", () => {
+  it("injects one fresh ephemeral state block and removes stale copies", () => {
+    const { pi, setDelegated } = setup();
+    const stale: Message = {
+      role: "user",
+      content: [{ type: "text", text: `${WORKFLOW_TAG_OPEN}\nstale` }],
+    };
+    const original: Message = { role: "user", content: [{ type: "text", text: "task" }] };
+    const injected = pi.context!({ messages: [original, stale] });
+    expect(injected?.messages).toHaveLength(2);
+    expect(injected?.messages[1]?.content[0]?.text).toContain("requires a qualifying Expert delegation");
+
+    setDelegated(true);
+    const stripped = pi.context!({ messages: injected!.messages });
+    expect(stripped?.messages).toEqual([original]);
+  });
+
+  it("sends one follow-up, then records a violation without looping", async () => {
+    const { pi, violation } = setup();
+    await pi.end!({ messages: [{ role: "assistant", stopReason: "stop" }] });
+    expect(pi.followUps).toHaveLength(1);
+    expect(pi.followUps[0]).toContain("Dispatch a qualifying Expert task now");
+
+    await pi.end!({ messages: [{ role: "assistant", stopReason: "stop" }] });
+    expect(pi.followUps).toHaveLength(1);
+    expect(violation).toHaveBeenCalledOnce();
+  });
+
+  it("does nothing for direct work, successful delegation, errors, or an already-claimed epoch", async () => {
+    const direct = setup({ required: false });
+    await direct.pi.end!({ messages: [{ role: "assistant", stopReason: "stop" }] });
+    expect(direct.pi.followUps).toEqual([]);
+
+    const delegated = setup({ delegated: true });
+    await delegated.pi.end!({ messages: [{ role: "assistant", stopReason: "stop" }] });
+    expect(delegated.pi.followUps).toEqual([]);
+
+    const errored = setup();
+    await errored.pi.end!({ messages: [{ role: "assistant", stopReason: "error" }] });
+    expect(errored.pi.followUps).toEqual([]);
+
+    const claimed = setup({ claim: () => false });
+    await claimed.pi.end!({ messages: [{ role: "assistant", stopReason: "stop" }] });
+    expect(claimed.pi.followUps).toEqual([]);
+  });
+});

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -186,6 +186,39 @@ describe("SessionManager (mock mode)", () => {
     expect(seen).toEqual([]);
   });
 
+  it("wires the Principal workflow guard only for expert-required sessions", async () => {
+    const seen: Parameters<typeof mockAgentFactory>[0][] = [];
+    const spyFactory: typeof mockAgentFactory = async (params) => {
+      seen.push(params);
+      return mockAgentFactory(params);
+    };
+    const manager = new SessionManager({ persist: false, agentFactory: spyFactory });
+
+    const direct = await manager.createSession({ workflowPolicy: "direct" });
+    await manager.sendMessage(direct.id, "hello");
+    await waitFor(() => seen.some((params) => params.sessionId === direct.id));
+    expect(seen.find((params) => params.sessionId === direct.id)?.principalWorkflowGuard)
+      .toBeUndefined();
+
+    const required = await manager.createSession({ workflowPolicy: "expert_required" });
+    expect(required.workflowPolicy).toBe("expert_required");
+    await manager.sendMessage(required.id, "run the research task");
+    await waitFor(() => seen.some((params) => params.sessionId === required.id));
+    const principal = seen.find(
+      (params) => params.sessionId === required.id && params.agentName === "principal",
+    )!;
+    expect(principal.principalWorkflowGuard?.renderState()).toContain(
+      "requires a qualifying Expert delegation",
+    );
+
+    const dispatch = principal.systemTools.find((tool) => tool.name === "dispatch_task")!;
+    await dispatch.execute({ to: "writer", content: "polish a document" });
+    expect(principal.principalWorkflowGuard?.hasQualifyingDelegation()).toBe(false);
+    await dispatch.execute({ to: "engineer", content: "inspect the data contract" });
+    expect(principal.principalWorkflowGuard?.hasQualifyingDelegation()).toBe(true);
+    expect(principal.principalWorkflowGuard?.renderState()).toBe("");
+  });
+
   it("keeps high-impact action authorization in PI and expert personas", () => {
     expect(PERSONAS.principal).toContain("## User authorization gate");
     expect(PERSONAS.principal).toContain("Use `ask_user` first");
@@ -255,6 +288,24 @@ describe("SessionManager (mock mode)", () => {
         reason: "experiment-override",
         version: "0.1.2",
       });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("persists and restores the session workflow policy", async () => {
+    const root = await mkdtemp(join(tmpdir(), "bp-workflow-policy-"));
+    try {
+      const manager = new SessionManager({ dataRoot: root, persist: true, agentFactory: mockAgentFactory });
+      const session = await manager.createSession({ workflowPolicy: "expert_required" });
+      const meta = JSON.parse(
+        await readFile(join(root, ".bp", session.id, "meta.json"), "utf8"),
+      ) as { workflowPolicy?: string };
+      expect(meta.workflowPolicy).toBe("expert_required");
+
+      const restored = new SessionManager({ dataRoot: root, persist: true, agentFactory: mockAgentFactory });
+      await restored.restoreFromDisk();
+      expect(restored.getSession(session.id)?.workflowPolicy).toBe("expert_required");
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/runtime/src/agent-factory.ts
+++ b/packages/runtime/src/agent-factory.ts
@@ -22,6 +22,7 @@ import { makeAgentStatusExt } from "./extensions/agent-status.js";
 import { makeTaskContextExt } from "./extensions/task-context.js";
 import { makeRouterSkillGuardExt } from "./extensions/router-skill-guard.js";
 import { makeManagedPathGuardExt } from "./extensions/managed-path-guard.js";
+import { makePrincipalWorkflowGuardExt } from "./extensions/principal-workflow-guard.js";
 import { makeCompatHooksExt } from "./compat-hooks.js";
 import {
   installBrainPilotRetryClassifier,
@@ -137,6 +138,9 @@ export const realAgentFactory: AgentSessionFactory = async (params) => {
   }
   if (params.renderTaskContext) {
     extensionFactories.push(makeTaskContextExt({ renderTasks: params.renderTaskContext }));
+  }
+  if (params.principalWorkflowGuard) {
+    extensionFactories.push(makePrincipalWorkflowGuardExt(params.principalWorkflowGuard));
   }
   // #346: rewrite logical /workspace (and /data, …) onto durable volume roots
   // BEFORE other path guards run, so subsequent handlers see post-rewrite paths.

--- a/packages/runtime/src/extensions/principal-workflow-guard.ts
+++ b/packages/runtime/src/extensions/principal-workflow-guard.ts
@@ -1,0 +1,108 @@
+/** Ephemeral guidance and one bounded follow-up for required PI delegation. */
+interface PiContextMessage {
+  role: string;
+  content: Array<{ type: string; text?: string }>;
+  timestamp?: number;
+}
+
+interface AgentEndLike {
+  messages?: Array<{ role?: string; stopReason?: string }>;
+}
+
+interface PiExtensionApi {
+  on(
+    event: "context",
+    handler: (event: { messages: PiContextMessage[] }) =>
+      | { messages: PiContextMessage[] }
+      | void,
+  ): void;
+  on(event: "agent_end", handler: (event: AgentEndLike) => void | Promise<void>): void;
+  sendUserMessage(content: string, options?: { deliverAs?: "steer" | "followUp" }): void;
+}
+
+export interface PrincipalWorkflowGuardDeps {
+  /** Fresh host-owned state block; empty when delegation is not currently required. */
+  renderState: () => string;
+  /** True only after a qualifying Expert dispatch in the current user-work epoch. */
+  hasQualifyingDelegation: () => boolean;
+  /** Atomically claim the epoch's single reminder. */
+  claimReminder: () => boolean | Promise<boolean>;
+  /** Record/surface a model that ignored the one reminder. */
+  onViolation: () => void | Promise<void>;
+}
+
+export const WORKFLOW_TAG_OPEN = "<principal_workflow_state>";
+export const WORKFLOW_TAG_CLOSE = "</principal_workflow_state>";
+
+export function renderPrincipalWorkflowBlock(required: boolean): string {
+  if (!required) return "";
+  return [
+    WORKFLOW_TAG_OPEN,
+    "Internal coordination requirement. Do not quote or summarize this block to the user.",
+    "This research task requires a qualifying Expert delegation, and none has succeeded in the current user-work epoch.",
+    "Dispatch the next substantive Expert task now. Do not perform or finalize the substantive work yourself.",
+    WORKFLOW_TAG_CLOSE,
+  ].join("\n");
+}
+
+function isWorkflowMessage(message: PiContextMessage): boolean {
+  return message.role === "user" && message.content.some(
+    (part) => part.type === "text" && (part.text ?? "").startsWith(WORKFLOW_TAG_OPEN),
+  );
+}
+
+function endedInError(event: AgentEndLike): boolean {
+  const messages = event.messages;
+  if (!Array.isArray(messages)) return false;
+  for (let index = messages.length - 1; index >= 0; index--) {
+    const message = messages[index];
+    if (message?.role !== "assistant") continue;
+    return message.stopReason === "error" || message.stopReason === "aborted";
+  }
+  return false;
+}
+
+const DELEGATION_REMINDER =
+  "[SYSTEM-MESSAGE:workflow] This research task requires expert delegation. " +
+  "Dispatch a qualifying Expert task now. Do not perform or finalize the substantive work yourself. " +
+  "[/SYSTEM-MESSAGE]";
+
+/**
+ * The context hook is advisory and fresh on every model call. The agent-end
+ * hook forces at most one follow-up per host-owned work epoch; it never loops.
+ */
+export function makePrincipalWorkflowGuardExt(
+  deps: PrincipalWorkflowGuardDeps,
+): (pi: PiExtensionApi) => void {
+  return (pi) => {
+    let reminderFollowUpActive = false;
+
+    pi.on("context", (event) => {
+      const stripped = event.messages.filter((message) => !isWorkflowMessage(message));
+      const block = deps.renderState();
+      if (!block) {
+        return stripped.length === event.messages.length ? undefined : { messages: stripped };
+      }
+      stripped.push({ role: "user", content: [{ type: "text", text: block }] });
+      return { messages: stripped };
+    });
+
+    pi.on("agent_end", async (event) => {
+      if (endedInError(event) || deps.hasQualifyingDelegation()) {
+        reminderFollowUpActive = false;
+        return;
+      }
+      if (!deps.renderState()) return;
+
+      if (reminderFollowUpActive) {
+        reminderFollowUpActive = false;
+        await deps.onViolation();
+        return;
+      }
+
+      if (!(await deps.claimReminder())) return;
+      reminderFollowUpActive = true;
+      pi.sendUserMessage(DELEGATION_REMINDER, { deliverAs: "followUp" });
+    });
+  };
+}

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -40,6 +40,7 @@ import {
   type TraceRestoreResult,
   type TraceNodeRecord,
   type UserInputCancellationReason,
+  type WorkflowPolicy,
 } from "@brainpilot/protocol";
 import { EventBus } from "./event-bus.js";
 import {
@@ -71,6 +72,7 @@ import {
 } from "./personas.js";
 import { renderAgentStatusBlock, collectAgentStatusLines } from "./extensions/agent-status.js";
 import { renderTaskListBlock } from "./extensions/task-context.js";
+import { renderPrincipalWorkflowBlock } from "./extensions/principal-workflow-guard.js";
 import { McpBridge, loadMcpServersConfig, type McpRuntimeServerStatus, type McpRuntimeStatus } from "./mcp-bridge.js";
 import { loadCompatPluginProjections } from "./compat-hooks.js";
 import { loadToolToggles, isToolEnabled, type ToolToggles } from "./tool-toggles.js";
@@ -116,6 +118,12 @@ interface Deferred<T> {
   promise: Promise<T>;
   resolve: (value: T) => void;
   reject: (reason: Error) => void;
+}
+
+function resolveWorkflowPolicy(value: unknown): WorkflowPolicy {
+  if (value === undefined || value === "direct") return "direct";
+  if (value === "expert_required") return "expert_required";
+  throw new Error(`invalid workflowPolicy: ${String(value)}`);
 }
 
 type UserInputPhase = "queued" | "activating" | "active" | "finishing";
@@ -291,6 +299,10 @@ interface SessionMeta {
   updatedAt?: string;
   lastActivityAt?: number;
   domainResources?: DomainResources;
+  workflowPolicy?: WorkflowPolicy;
+  workflowTaskSeqBaseline?: number;
+  workflowReminderClaimed?: boolean;
+  workflowViolationEmitted?: boolean;
   systemPlugins?: SystemPluginSnapshot[];
 }
 
@@ -324,6 +336,11 @@ interface SessionEntry {
   providerRef: SessionProviderRef;
   /** Frozen per-session domain-resource mode; never read from global state. */
   domainResources: DomainResources;
+  /** Frozen PI delegation policy plus the current explicit-user work epoch. */
+  workflowPolicy: WorkflowPolicy;
+  workflowTaskSeqBaseline: number;
+  workflowReminderClaimed: boolean;
+  workflowViolationEmitted: boolean;
   /** Frozen system-plugin state for reproducible experiment sessions. */
   systemPlugins: SystemPluginSnapshot[];
   monitorManager: MonitorManager;
@@ -1449,6 +1466,10 @@ export class SessionManager {
       providerId?: string;
       modelId?: string;
       domainResources?: DomainResources;
+      workflowPolicy?: WorkflowPolicy;
+      workflowTaskSeqBaseline?: number;
+      workflowReminderClaimed?: boolean;
+      workflowViolationEmitted?: boolean;
       systemPlugins?: SystemPluginSnapshot[];
     } = {},
     /**
@@ -1474,6 +1495,12 @@ export class SessionManager {
             `cannot reopen it as ${input.domainResources}`,
         );
       }
+      if (input.workflowPolicy && input.workflowPolicy !== existing.workflowPolicy) {
+        throw new Error(
+          `session ${id} already uses workflowPolicy=${existing.workflowPolicy}; ` +
+            `cannot reopen it as ${input.workflowPolicy}`,
+        );
+      }
       return this.toSession(existing);
     }
     const nowIso = _restore ? _restore.updatedAt : new Date().toISOString();
@@ -1481,6 +1508,7 @@ export class SessionManager {
     const lastActivityAt = _restore ? _restore.lastActivityAt : Date.now();
     const persistBase = this.persist ? this.bpDir(id) : undefined;
     const domainResources = resolveDomainResources(input.domainResources);
+    const workflowPolicy = resolveWorkflowPolicy(input.workflowPolicy);
     const systemPlugins = this.resolveSessionSystemPlugins(input.systemPlugins);
 
     // Provider ref: explicit input wins; otherwise reuse an existing on-disk ref
@@ -1610,6 +1638,10 @@ export class SessionManager {
       userInputs: { queue: [], operations: Promise.resolve() },
       providerRef,
       domainResources,
+      workflowPolicy,
+      workflowTaskSeqBaseline: input.workflowTaskSeqBaseline ?? 0,
+      workflowReminderClaimed: input.workflowReminderClaimed === true,
+      workflowViolationEmitted: input.workflowViolationEmitted === true,
       systemPlugins,
       monitorManager,
       monitorEvents,
@@ -1728,6 +1760,7 @@ export class SessionManager {
           createdAt: meta.createdAt ?? "",
           updatedAt: meta.updatedAt ?? "",
           domainResources: meta.domainResources === "base" ? "base" : "full",
+          workflowPolicy: resolveWorkflowPolicy(meta.workflowPolicy),
         });
       }
     }
@@ -1878,6 +1911,23 @@ export class SessionManager {
         }
       });
       return { accepted: true, runId, queued: true };
+    }
+
+    // Start a fresh host-owned delegation epoch only for a new, idle Principal
+    // user turn. Task-result deliveries and queued follow-ups remain in the
+    // existing epoch, so a completed delegation continues to satisfy the guard.
+    if (
+      agentName === "principal"
+      && entry.workflowPolicy === "expert_required"
+      && !this.deriveWorkActive(entry)
+    ) {
+      entry.workflowTaskSeqBaseline = entry.taskLedger.list().reduce(
+        (highest, task) => Math.max(highest, task.seq),
+        0,
+      );
+      entry.workflowReminderClaimed = false;
+      entry.workflowViolationEmitted = false;
+      await this.writeMeta(entry);
     }
 
     // runState tracks the Principal's user-facing turn for status/timing/Stop.
@@ -2650,6 +2700,15 @@ export class SessionManager {
       renderAgentStatus:
         name === "principal" ? () => this.renderAgentStatus(entry) : undefined,
       renderTaskContext: () => this.renderTaskContext(entry, name),
+      principalWorkflowGuard:
+        name === "principal" && entry.workflowPolicy === "expert_required"
+          ? {
+              renderState: () => this.renderPrincipalWorkflowState(entry),
+              hasQualifyingDelegation: () => this.hasQualifyingPrincipalDelegation(entry),
+              claimReminder: () => this.claimPrincipalWorkflowReminder(entry),
+              onViolation: () => this.emitPrincipalWorkflowViolation(entry),
+            }
+          : undefined,
     });
 
     const agent = new MasAgent({
@@ -2748,6 +2807,45 @@ export class SessionManager {
       entry.taskLedger.pendingCreatedBy(name),
       TASK_CONTEXT_MAX_CHARS,
     );
+  }
+
+  private hasQualifyingPrincipalDelegation(entry: SessionEntry): boolean {
+    const nonSubstantiveTargets = new Set(["principal", "trace", "auditor", "writer"]);
+    return entry.taskLedger.list().some((task) =>
+      task.created_by === "principal"
+      && task.seq > entry.workflowTaskSeqBaseline
+      && !nonSubstantiveTargets.has(task.assigned_to),
+    );
+  }
+
+  private renderPrincipalWorkflowState(entry: SessionEntry): string {
+    return renderPrincipalWorkflowBlock(
+      entry.workflowPolicy === "expert_required"
+      && !this.hasQualifyingPrincipalDelegation(entry),
+    );
+  }
+
+  private async claimPrincipalWorkflowReminder(entry: SessionEntry): Promise<boolean> {
+    if (
+      entry.workflowPolicy !== "expert_required"
+      || entry.workflowReminderClaimed
+      || this.hasQualifyingPrincipalDelegation(entry)
+    ) return false;
+    entry.workflowReminderClaimed = true;
+    await this.writeMeta(entry);
+    return true;
+  }
+
+  private async emitPrincipalWorkflowViolation(entry: SessionEntry): Promise<void> {
+    if (entry.workflowViolationEmitted || this.hasQualifyingPrincipalDelegation(entry)) return;
+    entry.workflowViolationEmitted = true;
+    entry.bus.emit(ev.systemMessage(
+      entry.id,
+      "warning",
+      "Principal ignored the required Expert-delegation reminder; the research workflow remains incomplete.",
+      { agent: "principal", recoverable: true },
+    ));
+    await this.writeMeta(entry);
   }
 
   async destroyAgent(sessionId: string, name: string): Promise<void> {
@@ -3206,6 +3304,7 @@ export class SessionManager {
         subagents: entry.subagents.list(),
         lastActivityTs: new Date(entry.lastActivityAt).toISOString(),
         domainResources: entry.domainResources,
+        workflowPolicy: entry.workflowPolicy,
         tokenUsage: entry.tokenUsage,
       }),
     );
@@ -3231,6 +3330,7 @@ export class SessionManager {
     subagents?: import("@brainpilot/protocol").SubagentStatus[];
     lastActivityTs: string;
     domainResources: DomainResources;
+    workflowPolicy: WorkflowPolicy;
     tokenUsage: SessionTokenUsage;
   } | undefined {
     const entry = this.sessions.get(sessionId);
@@ -3242,6 +3342,7 @@ export class SessionManager {
       subagents: entry.subagents.list(),
       lastActivityTs: new Date(entry.lastActivityAt).toISOString(),
       domainResources: entry.domainResources,
+      workflowPolicy: entry.workflowPolicy,
       tokenUsage: entry.tokenUsage,
     };
   }
@@ -3581,6 +3682,7 @@ export class SessionManager {
       createdAt: e.createdAt,
       updatedAt: e.updatedAt,
       domainResources: e.domainResources,
+      workflowPolicy: e.workflowPolicy,
     };
   }
 
@@ -3593,6 +3695,10 @@ export class SessionManager {
       updatedAt: entry.updatedAt,
       lastActivityAt: entry.lastActivityAt,
       domainResources: entry.domainResources,
+      workflowPolicy: entry.workflowPolicy,
+      workflowTaskSeqBaseline: entry.workflowTaskSeqBaseline,
+      workflowReminderClaimed: entry.workflowReminderClaimed,
+      workflowViolationEmitted: entry.workflowViolationEmitted,
       systemPlugins: entry.systemPlugins,
     };
     await mkdir(this.bpDir(entry.id), { recursive: true }).catch(() => {});
@@ -3762,6 +3868,7 @@ export class SessionManager {
       const raw = await readFile(join(this.dataRoot, ".bp", id, "meta.json"), "utf8");
       const meta = JSON.parse(raw) as SessionMeta;
       resolveDomainResources(meta.domainResources);
+      resolveWorkflowPolicy(meta.workflowPolicy);
       return meta;
     } catch {
       return null;
@@ -3789,6 +3896,11 @@ export class SessionManager {
           id: sid,
           title: meta.title,
           domainResources: resolveDomainResources(meta.domainResources),
+          workflowPolicy: resolveWorkflowPolicy(meta.workflowPolicy),
+          workflowTaskSeqBaseline:
+            typeof meta.workflowTaskSeqBaseline === "number" ? meta.workflowTaskSeqBaseline : 0,
+          workflowReminderClaimed: meta.workflowReminderClaimed === true,
+          workflowViolationEmitted: meta.workflowViolationEmitted === true,
           systemPlugins: meta.systemPlugins,
         },
         {

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -237,6 +237,13 @@ export type AgentSessionFactory = (params: {
   renderAgentStatus?: () => string;
   /** Fresh flat task-list context, injected ephemerally on every turn. */
   renderTaskContext?: () => string;
+  /** Principal-only, host-owned delegation guard. Omitted for direct sessions and other roles. */
+  principalWorkflowGuard?: {
+    renderState: () => string;
+    hasQualifyingDelegation: () => boolean;
+    claimReminder: () => boolean | Promise<boolean>;
+    onViolation: () => void | Promise<void>;
+  };
   /**
    * Per-session LLM provider resolved from providers.json. When omitted, the
    * factory falls back to Pi's env-based default (Docker/static compat).


### PR DESCRIPTION
## Summary
- add an independent Principal workflow guard extension for sessions marked `expert_required`
- inject fresh ephemeral delegation state and issue at most one bounded follow-up per user-work epoch
- count only successful TaskLedger dispatches to substantive Experts; Auditor, Writer, and Trace do not satisfy the guard
- persist the workflow policy and guard epoch state across restore
- expose `--workflow-policy expert_required` in the headless client

## Safety
- defaults to `direct`, preserving existing sessions and ordinary replies
- does not inspect or block `bash`, `write`, `edit`, status checks, or sleep
- stays independent from GoT/trace auditing

## Verification
- `vitest`: 70 files, 683 tests passed
- `tsc -b packages/protocol packages/runtime packages/client-cli`
