### PR TITLE
fix(runtime): harden execution harness boundaries

### DIFF
--- a/packages/runtime/src/__tests__/cancellable-bash.test.ts
+++ b/packages/runtime/src/__tests__/cancellable-bash.test.ts
@@ -1,6 +1,22 @@
 import { describe, expect, it, vi } from "vitest";
 import { wrapCancellableBash } from "../agent-factory.js";
 
+function bashDefinition(execute: (...args: any[]) => Promise<unknown>) {
+  return {
+    name: "bash",
+    description: "Run a shell command",
+    parameters: {
+      type: "object",
+      properties: {
+        command: { type: "string" },
+        timeout: { type: "number", description: "optional timeout" },
+      },
+      required: ["command"],
+    },
+    execute,
+  };
+}
+
 describe("cancellable Pi bash wrapper", () => {
   it("forwards args/update/context and aborts only the selected invocation", async () => {
     const update = vi.fn();
@@ -17,16 +33,16 @@ describe("cancellable Pi bash wrapper", () => {
       signal.addEventListener("abort", () => reject(new Error("line one\nCommand aborted")), { once: true });
     }));
     const controllers = new Map<string, AbortController>();
-    const wrapped = wrapCancellableBash({ name: "bash", execute }, controllers);
+    const wrapped = wrapCancellableBash(bashDefinition(execute), controllers);
     const runSignal = new AbortController();
-    const pending = wrapped.execute("tool-1", { command: "sleep 60" }, runSignal.signal, update, context);
+    const pending = wrapped.execute("tool-1", { command: "sleep 60", timeout: 60 }, runSignal.signal, update, context);
 
     expect(controllers.has("tool-1")).toBe(true);
     controllers.get("tool-1")!.abort();
     await expect(pending).rejects.toThrow("line one\nCommand aborted\nCommand interrupted by user");
     expect(runSignal.signal.aborted).toBe(false);
     expect(controllers.has("tool-1")).toBe(false);
-    expect(execute).toHaveBeenCalledWith("tool-1", { command: "sleep 60" }, expect.any(AbortSignal), update, context);
+    expect(execute).toHaveBeenCalledWith("tool-1", { command: "sleep 60", timeout: 60 }, expect.any(AbortSignal), update, context);
   });
 
   it("supports Pi invoking a tool without a run signal", async () => {
@@ -35,8 +51,8 @@ describe("cancellable Pi bash wrapper", () => {
       new Promise((_resolve, reject) => {
         signal?.addEventListener("abort", () => reject(new Error("partial")), { once: true });
       });
-    const wrapped = wrapCancellableBash({ name: "bash", execute }, controllers);
-    const pending = wrapped.execute("tool-no-signal", {}, undefined);
+    const wrapped = wrapCancellableBash(bashDefinition(execute), controllers);
+    const pending = wrapped.execute("tool-no-signal", { command: "sleep 60", timeout: 60 }, undefined);
     controllers.get("tool-no-signal")!.abort();
     await expect(pending).rejects.toThrow("partial\nCommand interrupted by user");
   });
@@ -46,10 +62,23 @@ describe("cancellable Pi bash wrapper", () => {
       new Promise((_resolve, reject) => {
         signal.addEventListener("abort", () => reject(new Error("Task aborted")), { once: true });
       });
-    const wrapped = wrapCancellableBash({ name: "bash", execute }, new Map());
+    const wrapped = wrapCancellableBash(bashDefinition(execute), new Map());
     const run = new AbortController();
-    const pending = wrapped.execute("tool-2", {}, run.signal);
+    const pending = wrapped.execute("tool-2", { command: "sleep 60", timeout: 60 }, run.signal);
     run.abort();
     await expect(pending).rejects.toThrow("Task aborted");
+  });
+
+  it("requires an explicit timeout of at most 300 seconds", async () => {
+    const execute = vi.fn(async () => ({ content: [] }));
+    const wrapped = wrapCancellableBash(bashDefinition(execute), new Map());
+    const parameters = wrapped.parameters as { required: string[]; properties: Record<string, Record<string, unknown>> };
+
+    expect(parameters.required).toEqual(["command", "timeout"]);
+    expect(parameters.properties.timeout).toMatchObject({ type: "number", minimum: 1, maximum: 300 });
+    await expect(wrapped.execute("missing", { command: "pwd" }, undefined)).rejects.toThrow(/timeout.*required/i);
+    await expect(wrapped.execute("zero", { command: "pwd", timeout: 0 }, undefined)).rejects.toThrow(/between 1 and 300/i);
+    await expect(wrapped.execute("long", { command: "pwd", timeout: 301 }, undefined)).rejects.toThrow(/between 1 and 300/i);
+    expect(execute).not.toHaveBeenCalled();
   });
 });

--- a/packages/runtime/src/__tests__/event-mapping.test.ts
+++ b/packages/runtime/src/__tests__/event-mapping.test.ts
@@ -491,4 +491,123 @@ describe("event mapping (Pi -> AG-UI via parseEvent)", () => {
     const runError = captured.find((e) => e.type === "RUN_ERROR") as { message?: string } | undefined;
     expect(runError?.message).toMatch(/404.*no route/i);
   });
+
+  it("continues the same run once after stopReason:length", async () => {
+    const bus = new EventBus();
+    const captured: AgUiEvent[] = [];
+    bus.subscribe((event) => captured.push(event));
+
+    let listener: ((event: unknown) => void) | undefined;
+    const prompts: string[] = [];
+    const session = {
+      subscribe(next: (event: unknown) => void) {
+        listener = next;
+        return () => {};
+      },
+      async prompt(text: string) {
+        prompts.push(text);
+        const stopReason = prompts.length === 1 ? "length" : "stop";
+        listener?.({ type: "message_start", message: { role: "assistant" } });
+        listener?.({ type: "message_end", message: { role: "assistant", stopReason } });
+      },
+      async abort() {},
+      dispose() {},
+    };
+    const agent = new MasAgent({
+      sessionId: "length-recovery",
+      name: "Engineer",
+      role: "expert",
+      session: session as never,
+      bus,
+    });
+
+    await agent.prompt("write the report");
+
+    expect(prompts).toHaveLength(2);
+    expect(prompts[1]).toMatch(/output token limit/i);
+    expect(prompts[1]).toMatch(/smaller chunks/i);
+    expect(captured.filter((event) => event.type === "RUN_STARTED")).toHaveLength(1);
+    expect(captured.filter((event) => event.type === "RUN_FINISHED")).toHaveLength(1);
+    expect(captured.some((event) => event.type === "RUN_ERROR")).toBe(false);
+  });
+
+  it("reports OUTPUT_LIMIT_EXCEEDED when the bounded recovery also reaches length", async () => {
+    const bus = new EventBus();
+    const captured: AgUiEvent[] = [];
+    bus.subscribe((event) => captured.push(event));
+
+    let listener: ((event: unknown) => void) | undefined;
+    const prompts: string[] = [];
+    const session = {
+      subscribe(next: (event: unknown) => void) {
+        listener = next;
+        return () => {};
+      },
+      async prompt(text: string) {
+        prompts.push(text);
+        listener?.({ type: "message_start", message: { role: "assistant" } });
+        listener?.({ type: "message_end", message: { role: "assistant", stopReason: "length" } });
+      },
+      async abort() {},
+      dispose() {},
+    };
+    const agent = new MasAgent({
+      sessionId: "length-exhausted",
+      name: "Engineer",
+      role: "expert",
+      session: session as never,
+      bus,
+    });
+
+    await agent.prompt("write the report");
+
+    expect(prompts).toHaveLength(2);
+    expect(captured.some((event) => event.type === "RUN_FINISHED")).toBe(false);
+    const errors = captured.filter((event) => event.type === "RUN_ERROR") as Array<{
+      code?: string;
+      message?: string;
+    }>;
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ code: "OUTPUT_LIMIT_EXCEEDED" });
+    expect(errors[0]?.message).toMatch(/maximum output token limit/i);
+  });
+
+  it("does not start output-limit recovery after the run is aborted", async () => {
+    const bus = new EventBus();
+    const captured: AgUiEvent[] = [];
+    bus.subscribe((event) => captured.push(event));
+
+    let listener: ((event: unknown) => void) | undefined;
+    let release!: () => void;
+    const prompts: string[] = [];
+    const session = {
+      subscribe(next: (event: unknown) => void) {
+        listener = next;
+        return () => {};
+      },
+      prompt(text: string) {
+        prompts.push(text);
+        listener?.({ type: "message_start", message: { role: "assistant" } });
+        listener?.({ type: "message_end", message: { role: "assistant", stopReason: "length" } });
+        return new Promise<void>((resolve) => { release = resolve; });
+      },
+      async abort() { release(); },
+      dispose() {},
+    };
+    const agent = new MasAgent({
+      sessionId: "length-aborted",
+      name: "Engineer",
+      role: "expert",
+      session: session as never,
+      bus,
+    });
+
+    const running = agent.prompt("write the report");
+    await agent.abort();
+    await running;
+
+    expect(prompts).toEqual(["write the report"]);
+    expect(captured.some((event) => event.type === "RUN_ERROR")).toBe(false);
+    expect(captured.filter((event) => event.type === "RUN_FINISHED")).toHaveLength(1);
+  });
 });

--- a/packages/runtime/src/__tests__/event-mapping.test.ts
+++ b/packages/runtime/src/__tests__/event-mapping.test.ts
@@ -17,6 +17,43 @@ import type { IAgentSession, PiAgentEvent } from "../types.js";
  * (via parseEvent) and that the expected types appear in order.
  */
 describe("event mapping (Pi -> AG-UI via parseEvent)", () => {
+  it("keeps each terminal event bound to its originating run", async () => {
+    const bus = new EventBus();
+    const captured: AgUiEvent[] = [];
+    bus.subscribe((event) => captured.push(event));
+    const pending: Array<() => void> = [];
+    const session: IAgentSession = {
+      sessionId: "overlap",
+      subscribe: () => () => {},
+      prompt: () => new Promise<void>((resolve) => pending.push(resolve)),
+      abort: async () => {},
+      dispose: () => {},
+      get isStreaming() { return pending.length > 0; },
+    };
+    const agent = new MasAgent({ sessionId: "overlap", name: "principal", role: "principal", session, bus });
+
+    const first = agent.prompt("first");
+    const second = agent.prompt("second");
+    const started = captured
+      .filter((event) => event.type === "RUN_STARTED")
+      .map((event) => (event as { run_id: string }).run_id);
+    expect(started).toHaveLength(2);
+
+    pending[0]!();
+    await first;
+    expect(agent.state().activeRunId).toBe(started[1]);
+    pending[1]!();
+    await second;
+
+    const finished = captured
+      .filter((event) => event.type === "RUN_FINISHED")
+      .map((event) => (event as { run_id: string }).run_id);
+    expect(finished).toEqual(started);
+    for (const event of captured.filter((item) => item.type.startsWith("RUN_"))) {
+      expect(() => parseEvent(event)).not.toThrow();
+    }
+  });
+
   it("maps a scripted run to valid AG-UI events", async () => {
     const bus = new EventBus({ persistPath: undefined });
     const captured: AgUiEvent[] = [];

--- a/packages/runtime/src/__tests__/execution-contract.test.ts
+++ b/packages/runtime/src/__tests__/execution-contract.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { withExecutionToolContract } from "../execution-contract.js";
+
+describe("agent execution tool contract", () => {
+  it("does not burden agents that cannot invoke Bash", () => {
+    expect(withExecutionToolContract("persona", ["read", "write"])).toBe("persona");
+  });
+
+  it("requires bounded Bash and hands long work to a background-capable agent", () => {
+    const prompt = withExecutionToolContract("persona", ["bash", "read"]);
+
+    expect(prompt).toContain("Every `bash` call must explicitly set `timeout`");
+    expect(prompt).toContain("300 seconds");
+    expect(prompt).toContain("Do not start model training");
+    expect(prompt).toContain("hand it to an agent that has `run_in_background`");
+  });
+
+  it("routes expensive workloads to Background Jobs and reserves Monitor for observation", () => {
+    const prompt = withExecutionToolContract("persona", ["bash", "run_in_background", "start_monitor"]);
+
+    expect(prompt).toContain("must use `run_in_background`");
+    expect(prompt).toContain("explicit `timeout_ms`");
+    expect(prompt).toContain("model training");
+    expect(prompt).toContain("Monitor is for streaming observation");
+  });
+});

--- a/packages/runtime/src/__tests__/managed-path-rewrite.test.ts
+++ b/packages/runtime/src/__tests__/managed-path-rewrite.test.ts
@@ -109,6 +109,42 @@ describe("rewriteLogicalPath", () => {
     expect(r.path).toBe(abs);
   });
 
+  it("prefers physical roots when the data root itself is mounted at /data", () => {
+    const mountedCwd = resolve("/data/workspaces/s1");
+    const mountedPersistentDir = resolve("/data/data");
+    const mountedRoots: ManagedPathRoots = {
+      cwd: mountedCwd,
+      persistentDir: mountedPersistentDir,
+    };
+
+    const workspace = rewriteLogicalPath("/data/workspaces/s1/scripts/train.py", mountedRoots);
+    expect(workspace).toMatchObject({
+      ok: true,
+      path: "/data/workspaces/s1/scripts/train.py",
+      rewritten: false,
+      root: "workspace",
+      abs: resolve(mountedCwd, "scripts/train.py"),
+    });
+
+    const physicalData = rewriteLogicalPath("/data/data/models/best.pkl", mountedRoots);
+    expect(physicalData).toMatchObject({
+      ok: true,
+      path: "/data/data/models/best.pkl",
+      rewritten: false,
+      root: "data",
+      abs: resolve(mountedPersistentDir, "models/best.pkl"),
+    });
+
+    const logicalData = rewriteLogicalPath("/data/models/best.pkl", mountedRoots);
+    expect(logicalData).toMatchObject({
+      ok: true,
+      path: resolve(mountedPersistentDir, "models/best.pkl"),
+      rewritten: true,
+      root: "data",
+      abs: resolve(mountedPersistentDir, "models/best.pkl"),
+    });
+  });
+
   it("rejects traversal out of /workspace", () => {
     const r = rewriteLogicalPath("/workspace/../../etc/passwd", roots);
     expect(r.ok).toBe(false);

--- a/packages/runtime/src/__tests__/tool-access.test.ts
+++ b/packages/runtime/src/__tests__/tool-access.test.ts
@@ -270,9 +270,40 @@ describe("tool access control (§9)", () => {
     expect((await tools.get("edit_trace_review")!.execute({ conclusion: "approve", reason: "The bound evidence supports this node." })).isError)
       .not.toBe(true);
     expect(d.trace.getNodeV2(node.id)?.reviewConclusion).toBe("approved");
+    const revision = d.trace.getGraphV2().revision;
+    const duplicate = await tools.get("edit_trace_review")!.execute({
+      conclusion: "reject",
+      reason: "A conflicting duplicate must not overwrite the accepted review.",
+    });
+    expect(duplicate.isError).not.toBe(true);
+    expect(duplicate.content[0]?.text).toContain("already submitted");
+    expect(d.trace.getNodeV2(node.id)?.reviewConclusion).toBe("approved");
+    expect(d.trace.getGraphV2().revision).toBe(revision);
     expect(tools.has("submit_audit_report")).toBe(false);
     expect(d.trace.getAuditReports()).toEqual([]);
     expect(tools.has("dispatch_task")).toBe(false);
+  });
+
+  it("atomically consumes a bound Auditor target across parallel calls", async () => {
+    const d = deps("auditor");
+    const node = d.trace.createNode({ title: "Parallel review" });
+    const target = d.trace.listPendingAuditTargets([node.id])[0]!;
+    d.currentTraceAuditTarget = () => target;
+    const tool = systemToolsForRole("expert", "auditor", d)
+      .find((item) => item.name === "edit_trace_review")!;
+
+    const [first, second] = await Promise.all([
+      tool.execute({ conclusion: "approve", reason: "The evidence is sufficient." }),
+      tool.execute({ conclusion: "reject", reason: "This call must be ignored." }),
+    ]);
+
+    expect(first.isError).not.toBe(true);
+    expect(second.isError).not.toBe(true);
+    expect(second.content[0]?.text).toContain("already submitted");
+    expect(d.trace.getNodeV2(node.id)).toMatchObject({
+      reviewConclusion: "approved",
+      reviewReason: "The evidence is sufficient.",
+    });
   });
 
   it("requires confidence and returns only a compact active graph to Trace", async () => {

--- a/packages/runtime/src/__tests__/trace-agent.test.ts
+++ b/packages/runtime/src/__tests__/trace-agent.test.ts
@@ -153,6 +153,8 @@ describe("Trace Agent — record_trace dispatches to a spawned trace agent", () 
     expect(captured!).toContain("[Trace Event]");
     expect(captured!).toContain("Description: designed an experiment");
     expect(captured!).toContain("Context: after reviewing prior art");
+    expect(captured!).toContain("Git-Evidence-Summary:");
+    expect(captured!).not.toContain("Git-Evidence: [");
     expect(captured!).toContain("- plan.md");
     expect(captured!).toContain("- diagram.png");
   });

--- a/packages/runtime/src/__tests__/trace-reminder.test.ts
+++ b/packages/runtime/src/__tests__/trace-reminder.test.ts
@@ -241,6 +241,19 @@ describe("trace-reminder: failures and message envelope", () => {
     expect(pi.sent).toEqual([]);
   });
 
+  it("a length-limited run leaves recovery to MasAgent", () => {
+    const pi = fakePi();
+    makeTraceReminderExt({
+      role: "expert",
+      name: "engineer",
+      hasPendingTasks: () => true,
+      onUnreplied: () => {},
+    })(pi as never);
+    pi.fire("agent_start");
+    pi.fire("agent_end", { messages: [{ role: "assistant", stopReason: "length" }] });
+    expect(pi.sent).toEqual([]);
+  });
+
   it("every reminder is wrapped in a strip-able system-message marker", () => {
     const { sent } = runOnce("expert", ["read"], { hasPendingTasks: () => true });
     expect(sent).toHaveLength(1);

--- a/packages/runtime/src/__tests__/trace-v2.test.ts
+++ b/packages/runtime/src/__tests__/trace-v2.test.ts
@@ -34,6 +34,35 @@ function v1Graph(): TraceGraph {
 }
 
 describe("TraceGraphV2 storage and audit semantics", () => {
+  it("records a final review once and rejects conflicting overwrites", () => {
+    const graph = new GraphOfTrace("s");
+    const parent = graph.createNode({ title: "Evidence" });
+    const child = graph.createNode({ title: "Conclusion" });
+    const actor = { type: "agent" as const, name: "auditor" };
+
+    expect(graph.review(child.id, "approve", "Supported.", actor)).toBe(true);
+    const nodeRevision = graph.getGraphV2().revision;
+    expect(graph.review(child.id, "approve", "Supported.", actor)).toBe(true);
+    expect(graph.getGraphV2().revision).toBe(nodeRevision);
+    expect(graph.review(child.id, "reject", "Conflicting.", actor)).toBe(false);
+    expect(graph.getNodeV2(child.id)).toMatchObject({
+      reviewConclusion: "approved",
+      reviewReason: "Supported.",
+    });
+
+    expect(graph.proposeCausalParent(child.id, parent.id, "Direct support.", { type: "agent", name: "trace" })).toBe(true);
+    expect(graph.review(child.id, "approve", "Direct support.", actor, parent.id)).toBe(true);
+    const edgeRevision = graph.getGraphV2().revision;
+    expect(graph.review(child.id, "approve", "Direct support.", actor, parent.id)).toBe(true);
+    expect(graph.getGraphV2().revision).toBe(edgeRevision);
+    expect(graph.review(child.id, "reject", "Conflicting.", actor, parent.id)).toBe(false);
+    expect(graph.getNodeV2(child.id)?.parents).toContainEqual(expect.objectContaining({
+      nodeId: parent.id,
+      conclusion: "confirmed",
+      reason: "Direct support.",
+    }));
+  });
+
   it("creates one protected Session Start root as the confirmed fallback", () => {
     const graph = new GraphOfTrace("s");
     const rootId = graph.getGraphV2().meta.rootNodeId!;

--- a/packages/runtime/src/__tests__/workspace-checkpoints.test.ts
+++ b/packages/runtime/src/__tests__/workspace-checkpoints.test.ts
@@ -46,6 +46,49 @@ describe("WorkspaceCheckpointStore", () => {
     expect(detail?.skipped.some((item) => item.path === "ignored.txt" && item.reason === "ignored")).toBe(true);
   });
 
+  it("excludes generated environments and bounds provenance expansion", async () => {
+    const { workspace, store } = await fixture();
+    await mkdir(join(workspace, ".venv", "lib", "python", "site-packages"), { recursive: true });
+    await writeFile(join(workspace, ".venv", "pyvenv.cfg"), "home = /usr/bin\n", "utf8");
+    for (let i = 0; i < 20; i++) {
+      await writeFile(
+        join(workspace, ".venv", "lib", "python", "site-packages", `dependency_${i}.py`),
+        `VALUE = ${i}\n`,
+        "utf8",
+      );
+    }
+    for (let i = 0; i < 5; i++) {
+      await writeFile(join(workspace, `result_${i}.txt`), `${i}\n`, "utf8");
+    }
+
+    const checkpoint = await store.capture("engineer");
+    expect(checkpoint.stats?.files).toBe(5);
+    const detail = await store.detail(checkpoint.id);
+    expect(detail?.files.every((item) => !item.path.startsWith(".venv/"))).toBe(true);
+    expect(detail?.skipped.filter((item) => item.path.startsWith(".venv/"))).toEqual([
+      expect.objectContaining({ path: ".venv/", reason: "internal" }),
+    ]);
+
+    const bounded = await store.provenance(checkpoint.id, 2);
+    expect(bounded).toHaveLength(2);
+    expect(bounded?.every((item) => item.path.startsWith("result_"))).toBe(true);
+  });
+
+  it("uses an initial baseline so pre-existing inputs are not trace outputs", async () => {
+    const { workspace, store } = await fixture();
+    await writeFile(join(workspace, "input.csv"), "subject,value\n1,2\n", "utf8");
+    const baseline = await store.ensureBaseline();
+    expect(baseline?.stats).toMatchObject({ files: 1, added: 1 });
+    expect(await store.ensureBaseline()).toBeUndefined();
+
+    await writeFile(join(workspace, "result.csv"), "score\n0.8\n", "utf8");
+    const trace = await store.capture("engineer");
+    expect(trace.stats).toMatchObject({ files: 1, added: 1 });
+    expect((await store.detail(trace.id))?.files.map((item) => item.path)).toEqual([
+      "result.csv",
+    ]);
+  });
+
   it("restores managed files and makes the restored tree the next checkpoint baseline", async () => {
     const { workspace, state, store } = await fixture();
     await writeFile(join(workspace, ".gitignore"), "keep.local\n", "utf8");

--- a/packages/runtime/src/agent-factory.ts
+++ b/packages/runtime/src/agent-factory.ts
@@ -204,14 +204,33 @@ export const realAgentFactory: AgentSessionFactory = async (params) => {
 };
 
 type BashDefinition = ReturnType<PiSdk["createBashToolDefinition"]>;
+const MAX_FOREGROUND_BASH_TIMEOUT_SECONDS = 300;
 
-/** Preserve Pi's official Bash behavior while adding tool-local cancellation. */
+/** Preserve Pi's official Bash behavior while requiring a bounded foreground command. */
 export function wrapCancellableBash(
   officialBash: BashDefinition,
   controllers: Map<string, AbortController>,
 ): BashDefinition {
+  const parameters = officialBash.parameters as Record<string, unknown> | undefined;
+  const properties = parameters?.properties as Record<string, unknown> | undefined;
+  const required = Array.isArray(parameters?.required)
+    ? parameters.required.filter((name): name is string => typeof name === "string")
+    : ["command"];
   return {
     ...officialBash,
+    parameters: {
+      ...(parameters ?? { type: "object" }),
+      properties: {
+        ...(properties ?? { command: { type: "string" } }),
+        timeout: {
+          type: "number",
+          minimum: 1,
+          maximum: MAX_FOREGROUND_BASH_TIMEOUT_SECONDS,
+          description: "Required foreground command deadline in seconds (maximum 300).",
+        },
+      },
+      required: [...new Set([...required, "timeout"])],
+    },
     async execute(
       toolCallId: string,
       args: Record<string, unknown>,
@@ -219,6 +238,17 @@ export function wrapCancellableBash(
       onUpdate?: (update: unknown) => void,
       context?: unknown,
     ): Promise<unknown> {
+      if (args.timeout === undefined) {
+        throw new Error("bash timeout is required; provide a deadline between 1 and 300 seconds");
+      }
+      if (
+        typeof args.timeout !== "number"
+        || !Number.isFinite(args.timeout)
+        || args.timeout < 1
+        || args.timeout > MAX_FOREGROUND_BASH_TIMEOUT_SECONDS
+      ) {
+        throw new Error("bash timeout must be between 1 and 300 seconds");
+      }
       const controller = new AbortController();
       controllers.set(toolCallId, controller);
       try {

--- a/packages/runtime/src/execution-contract.ts
+++ b/packages/runtime/src/execution-contract.ts
@@ -1,0 +1,28 @@
+const HEADER = "# Command execution contract";
+
+/** Add the runtime's shell policy only when the agent can actually invoke Bash. */
+export function withExecutionToolContract(
+  systemPrompt: string,
+  allowedToolNames: readonly string[],
+): string {
+  if (!allowedToolNames.includes("bash")) return systemPrompt;
+
+  const rules = [
+    HEADER,
+    "- Every `bash` call must explicitly set `timeout` in seconds. Use the shortest realistic deadline; the maximum is 300 seconds.",
+    "- Use foreground Bash only for bounded inspection, builds, and short tests.",
+  ];
+  if (allowedToolNames.includes("run_in_background")) {
+    rules.push(
+      "- For model training, hyperparameter search, full-data evaluation, large simulation, and any workload expected to exceed 5 minutes, you must use `run_in_background` with an explicit `timeout_ms`; never run them in foreground Bash.",
+    );
+  } else {
+    rules.push(
+      "- Do not start model training, hyperparameter search, full-data evaluation, large simulation, or work expected to exceed 5 minutes; hand it to an agent that has `run_in_background`.",
+    );
+  }
+  if (allowedToolNames.includes("start_monitor")) {
+    rules.push("- Monitor is for streaming observation and event-driven wakeups, not for running training or other one-shot compute jobs.");
+  }
+  return `${systemPrompt.trim()}\n\n${rules.join("\n")}`;
+}

--- a/packages/runtime/src/extensions/trace-reminder.ts
+++ b/packages/runtime/src/extensions/trace-reminder.ts
@@ -25,13 +25,15 @@ interface AgentEndLike {
   messages?: Array<{ role?: string; stopReason?: string }>;
 }
 
-function endedInError(e: AgentEndLike): boolean {
+function endedUnsuccessfully(e: AgentEndLike): boolean {
   const messages = e.messages;
   if (!Array.isArray(messages)) return false;
   for (let i = messages.length - 1; i >= 0; i--) {
     const message = messages[i];
     if (message?.role === "assistant") {
-      return message.stopReason === "error" || message.stopReason === "aborted";
+      return message.stopReason === "error" ||
+        message.stopReason === "aborted" ||
+        message.stopReason === "length";
     }
   }
   return false;
@@ -155,7 +157,7 @@ export function makeTraceReminderExt(deps: TraceReminderDeps): (pi: PiExtensionA
 
     pi.on("agent_end", async (e) => {
       if (deps.role === "trace") return;
-      if (endedInError(e)) {
+      if (endedUnsuccessfully(e)) {
         state = freshState();
         continuingFollowUp = false;
         return;

--- a/packages/runtime/src/managed-path-rewrite.ts
+++ b/packages/runtime/src/managed-path-rewrite.ts
@@ -128,6 +128,27 @@ export function rewriteLogicalPath(raw: string, roots: ManagedPathRoots): Rewrit
   const attName = roots.attachmentsDirname ?? ATTACHMENTS_DEFAULT;
   const attAbs = resolve(cwdAbs, attName);
 
+  // A deployment may mount the whole BrainPilot data root at `/data`, making
+  // the real session cwd `/data/workspaces/<sid>` and the real persistent
+  // library `/data/data`. Those physical paths must win over the logical
+  // `/data` alias or an already-resolved path is rewritten a second time (for
+  // example `/data/data/x` -> `/data/data/data/x`). Relative paths and absolute
+  // paths outside known durable roots still flow through the logical-prefix
+  // handling below.
+  if (isAbsolute(p)) {
+    const abs = normalize(resolve(p));
+    const classified = classifyAbs(abs, roots);
+    if (classified !== "other") {
+      return {
+        ok: true,
+        path: p,
+        rewritten: false,
+        root: classified,
+        abs,
+      };
+    }
+  }
+
   let rootAbs: string;
   let kind: ManagedRootKind;
   let rel: string;

--- a/packages/runtime/src/mas-agent.ts
+++ b/packages/runtime/src/mas-agent.ts
@@ -6,13 +6,16 @@
  *  - Translate Pi events → AG-UI events (§6) onto the session EventBus.
  *  - Per-agent error isolation (§7 L2): a thrown prompt never escapes; it is
  *    converted to RUN_ERROR + system_message and the agent goes to `error`.
+ *  - Recover one output-token-limit stop inside the same run before surfacing
+ *    a structured OUTPUT_LIMIT_EXCEEDED terminal error.
  *  - Map Pi `auto_retry_start/end` → agent_status_update + system_message;
  *    suppress internal events (turn_*, compaction_*).
  *
  * Behavioural hooks (remind/trace/reply/delegate) used to live here as per-turn
  * TurnTrackers (#79). They now live in the Pi-native `trace-reminder` extension
  * (`extensions/trace-reminder.ts`), registered per AgentSession by the real
- * factory. MasAgent is back to a pure Pi→AG-UI translator.
+ * factory. Output-limit recovery remains here because it determines whether
+ * the enclosing BrainPilot run succeeded or failed.
  */
 import {
   CUSTOM_EVENT,
@@ -52,6 +55,14 @@ export type ToolInterruptResult = {
 };
 
 const TOOL_INTERRUPT_TIMEOUT_MS = 10_000;
+const OUTPUT_LIMIT_ERROR_CODE = "OUTPUT_LIMIT_EXCEEDED";
+const OUTPUT_LIMIT_ERROR_MESSAGE =
+  "Model reached the maximum output token limit after one recovery attempt.";
+const OUTPUT_LIMIT_RECOVERY_PROMPT =
+  "[SYSTEM-MESSAGE:output_limit_recovery] The previous response hit the output token limit. " +
+  "Any final tool call truncated by that limit did not execute. Do not repeat operations that already have " +
+  "successful tool results. Continue the same task, split write/edit content into smaller chunks, and verify " +
+  "the target files. [/SYSTEM-MESSAGE]";
 
 /** Zeroed token counters — the identity element for accumulation. */
 export function emptyTokenUsage(): TokenUsage {
@@ -125,6 +136,8 @@ export class MasAgent {
   private currentRetry: AgentRetryState | undefined;
   /** Provider errors are held until Pi either retries successfully or exhausts. */
   private pendingProviderError: string | undefined;
+  /** True when the latest assistant turn stopped because it exhausted output tokens. */
+  private outputLimitReached = false;
   /** True while an explicit BrainPilot interrupt is unwinding the active run. */
   private abortRequested = false;
   private currentRunId: string | undefined;
@@ -467,6 +480,7 @@ export class MasAgent {
     this._lastRunOutcome = undefined;
     this.currentRetry = undefined;
     this.pendingProviderError = undefined;
+    this.outputLimitReached = false;
     // Snapshot cumulative stats BEFORE any events flow so the eventual delta
     // (`cumulative_after - snapshot`) captures exactly this run's contribution.
     this.runStartSnapshot = runStartSnapshot;
@@ -476,6 +490,15 @@ export class MasAgent {
     try {
       await this.session.prompt(text);
       this.finishDanglingTools(this.abortRequested ? "task_interrupted" : undefined);
+      if (!this.abortRequested && this.outputLimitReached) {
+        // A length stop is a completed provider response, so Pi intentionally
+        // does not auto-retry it. Continue the same agent history once with an
+        // explicit, side-effect-aware instruction instead of replaying the
+        // original prompt (which could duplicate already successful tools).
+        this.outputLimitReached = false;
+        await this.session.prompt(OUTPUT_LIMIT_RECOVERY_PROMPT);
+        this.finishDanglingTools(this.abortRequested ? "task_interrupted" : undefined);
+      }
       if (this.abortRequested) {
         // Pi reports an interrupted retry sleep as auto_retry_end(false,
         // "Retry cancelled"). An explicit Stop is a lifecycle outcome, not a
@@ -483,10 +506,23 @@ export class MasAgent {
         // out of the error/escalation path.
         this.currentRetry = undefined;
         this.pendingProviderError = undefined;
+        this.outputLimitReached = false;
         runOutcome = "aborted";
         this.bus.emit(
           ev.runFinished({ sessionId: this.sessionId, agentName: this.name, runId }),
         );
+      } else if (this.outputLimitReached) {
+        this.outputLimitReached = false;
+        this.recordError(OUTPUT_LIMIT_ERROR_MESSAGE, undefined, "output_limit_exceeded");
+        this.bus.emit(
+          ev.runError(
+            { sessionId: this.sessionId, agentName: this.name, runId },
+            OUTPUT_LIMIT_ERROR_MESSAGE,
+            OUTPUT_LIMIT_ERROR_CODE,
+          ),
+        );
+        this.setStatus("error");
+        runOutcome = "error";
       } else if (this.pendingProviderError) {
         const raw = this.pendingProviderError;
         this.pendingProviderError = undefined;
@@ -513,6 +549,7 @@ export class MasAgent {
       this.finishDanglingTools(this.abortRequested ? "task_interrupted" : undefined);
       this.currentRetry = undefined;
       this.pendingProviderError = undefined;
+      this.outputLimitReached = false;
       if (this.abortRequested) {
         // Some session implementations reject prompt() on abort rather than
         // resolving it. Normalize both forms to the same non-error lifecycle.
@@ -758,9 +795,14 @@ export class MasAgent {
           // error until session.prompt settles so transient attempts do not
           // produce red bubbles or briefly flip the agent out of "running".
           this.pendingProviderError = msg.errorMessage || "provider request failed";
+          this.outputLimitReached = false;
+        } else if (msg?.role === "assistant" && msg.stopReason === "length") {
+          this.pendingProviderError = undefined;
+          this.outputLimitReached = true;
         } else if (msg?.role === "assistant") {
           // A successful retry supersedes every earlier failed attempt.
           this.pendingProviderError = undefined;
+          this.outputLimitReached = false;
         }
         // Accumulate real provider token usage for this assistant turn. Pi
         // attaches `usage` to the finalized assistant message; user/tool

--- a/packages/runtime/src/mas-agent.ts
+++ b/packages/runtime/src/mas-agent.ts
@@ -458,17 +458,20 @@ export class MasAgent {
   }
 
   private async runPrompt(text: string): Promise<void> {
-    this.currentRunId = newRunId();
-    this.runStartedAt = Date.now();
+    const runId = newRunId();
+    const runStartedAt = Date.now();
+    const runStartSnapshot = cloneAgentStats(this.cumulativeStats);
+    this.currentRunId = runId;
+    this.runStartedAt = runStartedAt;
     this.abortRequested = false;
     this._lastRunOutcome = undefined;
     this.currentRetry = undefined;
     this.pendingProviderError = undefined;
     // Snapshot cumulative stats BEFORE any events flow so the eventual delta
     // (`cumulative_after - snapshot`) captures exactly this run's contribution.
-    this.runStartSnapshot = cloneAgentStats(this.cumulativeStats);
+    this.runStartSnapshot = runStartSnapshot;
     this.setStatus("running");
-    this.bus.emit(ev.runStarted({ sessionId: this.sessionId, agentName: this.name, runId: this.currentRunId }));
+    this.bus.emit(ev.runStarted({ sessionId: this.sessionId, agentName: this.name, runId }));
     let runOutcome: RunStatsStatus = "ok";
     try {
       await this.session.prompt(text);
@@ -482,7 +485,7 @@ export class MasAgent {
         this.pendingProviderError = undefined;
         runOutcome = "aborted";
         this.bus.emit(
-          ev.runFinished({ sessionId: this.sessionId, agentName: this.name, runId: this.currentRunId }),
+          ev.runFinished({ sessionId: this.sessionId, agentName: this.name, runId }),
         );
       } else if (this.pendingProviderError) {
         const raw = this.pendingProviderError;
@@ -490,13 +493,13 @@ export class MasAgent {
         const { message, details } = normalizeAgentError(raw);
         this.recordError(message, details, raw);
         this.bus.emit(
-          ev.runError({ sessionId: this.sessionId, agentName: this.name, runId: this.currentRunId }, message),
+          ev.runError({ sessionId: this.sessionId, agentName: this.name, runId }, message),
         );
         this.setStatus("error");
         runOutcome = "error";
       } else {
         this.bus.emit(
-          ev.runFinished({ sessionId: this.sessionId, agentName: this.name, runId: this.currentRunId }),
+          ev.runFinished({ sessionId: this.sessionId, agentName: this.name, runId }),
         );
       }
       // A run that reached here without an exhausted provider error completed
@@ -514,7 +517,7 @@ export class MasAgent {
         // Some session implementations reject prompt() on abort rather than
         // resolving it. Normalize both forms to the same non-error lifecycle.
         this.bus.emit(
-          ev.runFinished({ sessionId: this.sessionId, agentName: this.name, runId: this.currentRunId }),
+          ev.runFinished({ sessionId: this.sessionId, agentName: this.name, runId }),
         );
         this._lastErrorKind = undefined;
         this.setStatus("idle");
@@ -527,7 +530,7 @@ export class MasAgent {
         const { message, details } = normalizeAgentError(raw);
         this.recordError(message, details, raw);
         this.bus.emit(
-          ev.runError({ sessionId: this.sessionId, agentName: this.name, runId: this.currentRunId }, message),
+          ev.runError({ sessionId: this.sessionId, agentName: this.name, runId }, message),
         );
         this.setStatus("error");
         runOutcome = "error";
@@ -538,30 +541,36 @@ export class MasAgent {
       // consumers see a stable `runId`. Aborted-mid-run is caught by
       // `abort()`'s own cleanup path (see abort()); if we reach here with a
       // clean or error path, either way we have a well-formed snapshot.
-      this.emitRunStats(runOutcome);
-      // Pi drains accepted follow-ups before the run terminates. Anything left
-      // here was cancelled or never injected and must not leak into a later run.
-      this.pendingFollowUps = [];
-      this.currentRunId = undefined;
-      this.currentMessageId = undefined;
-      this.runStartSnapshot = undefined;
-      this.runStartedAt = undefined;
+      this.emitRunStats(runOutcome, runId, runStartedAt, runStartSnapshot);
+      if (this.currentRunId === runId) {
+        // Pi drains accepted follow-ups before the run terminates. Anything left
+        // here was cancelled or never injected and must not leak into a later run.
+        this.pendingFollowUps = [];
+        this.currentRunId = undefined;
+        this.currentMessageId = undefined;
+        this.runStartSnapshot = undefined;
+        this.runStartedAt = undefined;
+      }
     }
   }
 
   /**
    * Fire the `onRunStats` callback with the run's delta. Called from
-   * `runPrompt`'s finally block for ok/error/aborted paths. Idempotent: if no
-   * snapshot exists (e.g. abort called with no run in flight), this is a no-op.
+   * `runPrompt`'s finally block for ok/error/aborted paths. Run identity and
+   * baseline are captured locally so overlapping cleanup cannot corrupt them.
    */
-  private emitRunStats(status: RunStatsStatus): void {
-    if (!this.runStartSnapshot || !this.currentRunId || this.runStartedAt === undefined) return;
+  private emitRunStats(
+    status: RunStatsStatus,
+    runId: string,
+    startedAt: number,
+    startSnapshot: AgentStats,
+  ): void {
     const cumulative = cloneAgentStats(this.cumulativeStats);
-    const delta = subtractAgentStats(this.cumulativeStats, this.runStartSnapshot);
+    const delta = subtractAgentStats(this.cumulativeStats, startSnapshot);
     this.opts.onRunStats?.({
       name: this.name,
-      runId: this.currentRunId,
-      startedAt: this.runStartedAt,
+      runId,
+      startedAt,
       finishedAt: Date.now(),
       status,
       delta,

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -1672,6 +1672,15 @@ export class SessionManager {
     // file the user just attached. No-op when nothing was staged.
     await this.drainLocalUploads(sessionId);
 
+    // Snapshot user/Bench-provided inputs before the first agent prompt. Without
+    // this baseline the first record_trace diffs against Git's empty tree and
+    // incorrectly attributes every pre-existing workspace file to that event.
+    // A concurrent follow-up or ask_user answer must not snapshot a workspace
+    // while an agent is already mutating it.
+    if (!entry.runActive && !agent.isStreaming) {
+      await entry.checkpoints.ensureBaseline().catch(() => undefined);
+    }
+
     // Defense-in-depth for old clients/direct callers: ordinary text answers
     // the one visible FIFO head. Queued questions are never addressable.
     const visibleInput = entry.userInputs.active;

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -76,6 +76,7 @@ import { loadToolToggles, isToolEnabled, type ToolToggles } from "./tool-toggles
 import { materializeSkills } from "./materialize-skills.js";
 import { materializeKb } from "./materialize-kb.js";
 import { resolveSessionProvider, type SessionProviderRef } from "./provider-config.js";
+import { withExecutionToolContract } from "./execution-contract.js";
 import { MemWatchdog, parseMemLimitMb } from "./mem-watchdog.js";
 import { isWindows } from "./platform.js";
 import {
@@ -2275,6 +2276,7 @@ export class SessionManager {
     if (args.profile.modelId && providerConfig?.modelId !== args.profile.modelId) {
       throw new Error(`subagent profile model is not available in this provider: ${args.profile.modelId}`);
     }
+    const allowedToolNames = [...args.profile.builtinTools, ...systemTools.map((tool) => tool.name)];
     return this.agentFactory({
       sessionId: entry.id,
       agentName: args.childId,
@@ -2282,8 +2284,8 @@ export class SessionManager {
       historyPath: args.historyPath,
       cwd: args.cwd,
       systemTools,
-      allowedToolNames: [...args.profile.builtinTools, ...systemTools.map((tool) => tool.name)],
-      systemPrompt: withLanguageDirective(args.profile.prompt),
+      allowedToolNames,
+      systemPrompt: withExecutionToolContract(withLanguageDirective(args.profile.prompt), allowedToolNames),
       suppressCoordinationHooks: true,
       skillPaths,
       managedPathRoots: { cwd: args.cwd, persistentDir: join(args.cwd, ".persistent-unavailable") },
@@ -2408,12 +2410,15 @@ export class SessionManager {
       cwd: sessionCwd,
       systemTools: agentTools,
       allowedToolNames,
-      systemPrompt: await this.loadPersona(
-        name,
-        role,
-        entry.domainResources,
-        entry.systemPlugins,
-        skillSearchEnabled,
+      systemPrompt: withExecutionToolContract(
+        await this.loadPersona(
+          name,
+          role,
+          entry.domainResources,
+          entry.systemPlugins,
+          skillSearchEnabled,
+        ),
+        allowedToolNames,
       ),
       skillPaths,
       compatPluginProjections: name === "principal"

--- a/packages/runtime/src/tools/system-tools.ts
+++ b/packages/runtime/src/tools/system-tools.ts
@@ -76,6 +76,8 @@ function ok(text: string): { content: [{ type: "text"; text: string }] } {
 
 /** Detail/read tools are deliberately bounded so one graph query cannot eat a turn. */
 const TRACE_DETAIL_MAX_TOKENS = 1500;
+/** File samples sent to the Trace model; complete evidence stays in the checkpoint store. */
+const TRACE_PROMPT_PROVENANCE_FILES = 25;
 
 function cappedJson(value: unknown, maxTokens = TRACE_DETAIL_MAX_TOKENS): string {
   const text = JSON.stringify(value, null, 2);
@@ -451,7 +453,10 @@ export function createRecordTraceTool(deps: ToolDeps): SystemTool {
       const outputs = artifactInputs(params.artifact_outputs);
       const checkpoint = await deps.checkpoints?.capture(deps.fromAgent);
       const gitEvidence = checkpoint
-        ? await deps.checkpoints?.provenance(checkpoint.id).catch(() => undefined)
+        ? await deps.checkpoints?.provenance(
+            checkpoint.id,
+            TRACE_PROMPT_PROVENANCE_FILES,
+          ).catch(() => undefined)
         : undefined;
       const record: TraceNodeRecord = {
         sourceAgent: deps.fromAgent,
@@ -465,7 +470,16 @@ export function createRecordTraceTool(deps: ToolDeps): SystemTool {
       if (checkpoint) lines.push(`Checkpoint-ID: ${checkpoint.id}`);
       if (inputs.length) lines.push(`Artifact-Inputs: ${JSON.stringify(inputs)}`);
       if (outputs.length) lines.push(`Artifact-Outputs: ${JSON.stringify(outputs)}`);
-      if (gitEvidence?.length) lines.push(`Git-Evidence: ${JSON.stringify(gitEvidence)}`);
+      if (checkpoint) {
+        const totalFiles = checkpoint.stats?.files ?? gitEvidence?.length ?? 0;
+        lines.push(`Git-Evidence-Summary: ${cappedJson({
+          checkpointId: checkpoint.id,
+          stats: checkpoint.stats,
+          skippedCount: checkpoint.skippedCount,
+          sample: gitEvidence ?? [],
+          truncated: totalFiles > (gitEvidence?.length ?? 0),
+        }, 1_000)}`);
+      }
       lines.push("", "Artifacts:");
       if (artifacts.length === 0) {
         lines.push("(none)");

--- a/packages/runtime/src/tools/system-tools.ts
+++ b/packages/runtime/src/tools/system-tools.ts
@@ -829,6 +829,7 @@ export function createSearchTraceTool(deps: ToolDeps): SystemTool {
 
 /** Auditor-only mutation surface: append one bounded node/parent conclusion. */
 export function createEditTraceReviewTool(deps: ToolDeps): SystemTool {
+  const consumedTargets = new WeakSet<TraceAuditTarget>();
   return {
     name: "edit_trace_review",
     description: "Review one Trace node or one proposed causal parent. Only conclusion and reason may be changed.",
@@ -849,6 +850,10 @@ export function createEditTraceReviewTool(deps: ToolDeps): SystemTool {
       if (!reason) return { ...ok("a non-empty review reason is required"), isError: true };
       const target = deps.currentTraceAuditTarget?.();
       if (!target) return { ...ok("no host-bound trace audit target for this turn"), isError: true };
+      // Claim synchronously before mutation so sequential and parallel duplicate
+      // calls in the same Auditor turn cannot review the target twice.
+      if (consumedTargets.has(target)) return ok("trace review already submitted; end this turn");
+      consumedTargets.add(target);
       const success = deps.trace.review(
         target.nodeId,
         conclusion,

--- a/packages/runtime/src/trace.ts
+++ b/packages/runtime/src/trace.ts
@@ -550,10 +550,14 @@ export class GraphOfTrace {
   ): boolean {
     const node = this.nodes.get(nodeId);
     if (!node || node.revoked || this.isSessionRoot(nodeId)) return false;
-    if (expectedFingerprint && this.auditFingerprint(nodeId, parentNodeId) !== expectedFingerprint) return false;
     if (!parentNodeId) {
+      if (expectedFingerprint && this.auditFingerprint(nodeId) !== expectedFingerprint) return false;
+      const next = conclusion === "approve" ? "approved" : conclusion === "reject" ? "rejected" : "uncertain";
+      if (node.reviewConclusion !== "unreviewed") {
+        return node.reviewConclusion === next && node.reviewReason === reason;
+      }
       const before = node.reviewConclusion;
-      node.reviewConclusion = conclusion === "approve" ? "approved" : conclusion === "reject" ? "rejected" : "uncertain";
+      node.reviewConclusion = next;
       node.reviewReason = reason;
       node.updatedAt = now();
       this.commit("updated", nodeId, {
@@ -570,8 +574,11 @@ export class GraphOfTrace {
     const ref = node.parents.find((item) => item.nodeId === parentNodeId);
     if (!parent || parent.revoked || !ref) return false;
     if (conclusion === "approve" && parent.reviewConclusion === "rejected") return false;
+    const next = conclusion === "approve" ? "confirmed" : conclusion === "reject" ? "rejected" : "uncertain";
+    if (ref.conclusion !== "candidate") return ref.conclusion === next && ref.reason === reason;
+    if (expectedFingerprint && this.auditFingerprint(nodeId, parentNodeId) !== expectedFingerprint) return false;
     const before = ref.conclusion;
-    ref.conclusion = conclusion === "approve" ? "confirmed" : conclusion === "reject" ? "rejected" : "uncertain";
+    ref.conclusion = next;
     ref.reason = reason;
     this.normalizeCausalGraph();
     node.updatedAt = now();

--- a/packages/runtime/src/workspace-checkpoints.ts
+++ b/packages/runtime/src/workspace-checkpoints.ts
@@ -6,6 +6,7 @@ import {
   lstat,
   mkdir,
   mkdtemp,
+  readdir,
   readFile,
   readlink,
   rename,
@@ -26,11 +27,23 @@ import type {
 
 const MAX_FILE_BYTES = 10 * 1024 * 1024;
 const MAX_SNAPSHOT_BYTES = 200 * 1024 * 1024;
+const MAX_SNAPSHOT_FILES = 10_000;
 const MAX_DIFF_BYTES = 1024 * 1024;
 const DEFAULT_GIT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_REPOSITORY_BYTES = 2 * 1024 * 1024 * 1024;
+const DEFAULT_MAX_PROVENANCE_FILES = 1_000;
 const EMPTY_TREE = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
-const HARD_EXCLUDED_ROOTS = new Set([".attachments", ".truncated"]);
+const HARD_EXCLUDED_ROOTS = new Set([
+  ".attachments",
+  ".truncated",
+  ".venv",
+  "venv",
+  "node_modules",
+  "__pycache__",
+  ".pytest_cache",
+  ".mypy_cache",
+  ".cache",
+]);
 
 type Skipped = TraceCheckpointSkippedFile;
 
@@ -263,9 +276,10 @@ export class WorkspaceCheckpointStore {
     return ((values.get("size") ?? 0) + (values.get("size-pack") ?? 0) + (values.get("size-garbage") ?? 0)) * 1024;
   }
 
-  private hardExcluded(path: string): boolean {
+  private hardExcludedPrefix(path: string): string | undefined {
     const parts = path.replace(/\/$/, "").split("/");
-    return parts.includes(".git") || HARD_EXCLUDED_ROOTS.has(parts[0] ?? "");
+    const index = parts.findIndex((part) => part === ".git" || HARD_EXCLUDED_ROOTS.has(part));
+    return index >= 0 ? `${parts.slice(0, index + 1).join("/")}/` : undefined;
   }
 
   private workspacePath(rawPath: string): string {
@@ -295,10 +309,15 @@ export class WorkspaceCheckpointStore {
     const eligible = eligibleOutput.stdout.toString("utf8").split("\0").filter(Boolean).sort();
     const ignored = ignoredOutput.stdout.toString("utf8").split("\0").filter(Boolean).sort();
     const skipped: Skipped[] = ignored.map((path) => ({ path, reason: "ignored" }));
+    const hardExcluded = new Set<string>();
     const candidates: Array<{ path: string; size: number }> = [];
     for (const path of eligible) {
-      if (this.hardExcluded(path)) {
-        skipped.push({ path, reason: "internal" });
+      const excludedPrefix = this.hardExcludedPrefix(path);
+      if (excludedPrefix) {
+        if (!hardExcluded.has(excludedPrefix)) {
+          hardExcluded.add(excludedPrefix);
+          skipped.push({ path: excludedPrefix, reason: "internal" });
+        }
         continue;
       }
       try {
@@ -333,6 +352,8 @@ export class WorkspaceCheckpointStore {
     for (const item of candidates) {
       if (item.size > MAX_FILE_BYTES) {
         skipped.push({ path: item.path, reason: "too_large", size: item.size });
+      } else if (selected.length >= MAX_SNAPSHOT_FILES) {
+        skipped.push({ path: item.path, reason: "total_limit", size: item.size });
       } else if (total + item.size > MAX_SNAPSHOT_BYTES) {
         skipped.push({ path: item.path, reason: "total_limit", size: item.size });
       } else {
@@ -414,15 +435,20 @@ export class WorkspaceCheckpointStore {
   }
 
   /** File-level Git evidence for binding one checkpoint to its GoT node. */
-  async provenance(id: string): Promise<CheckpointFileProvenance[] | undefined> {
+  async provenance(
+    id: string,
+    maxFiles = DEFAULT_MAX_PROVENANCE_FILES,
+  ): Promise<CheckpointFileProvenance[] | undefined> {
     const index = await this.index();
     const record = index.checkpoints[id];
     if (!record?.ref.commitId) return undefined;
     const base = record.ref.baseCheckpointId
       ? index.checkpoints[record.ref.baseCheckpointId]?.ref.commitId ?? EMPTY_TREE
       : EMPTY_TREE;
+    const limit = Math.max(0, Math.trunc(maxFiles));
     const changes = (await this.changesBetween(base, record.ref.commitId))
-      .filter((item) => !this.isSkipped(item.path, record.skipped));
+      .filter((item) => !this.isSkipped(item.path, record.skipped))
+      .slice(0, limit);
     return Promise.all(changes.map(async (change) => {
       const basePath = change.previousPath ?? change.path;
       const [baseBlobId, resultBlobId] = await Promise.all([
@@ -517,6 +543,30 @@ export class WorkspaceCheckpointStore {
 
   capture(sourceAgent?: string, kind: "trace" | "recovery" = "trace"): Promise<TraceCheckpointRef> {
     return this.exclusive(() => this.captureUnlocked(sourceAgent, kind));
+  }
+
+  /**
+   * Establish the initial workspace tree before an agent can mutate it. The
+   * first trace checkpoint then describes agent changes relative to this tree
+   * instead of attributing pre-existing inputs to the first trace event.
+   * Idempotent and serialized with ordinary captures.
+   */
+  ensureBaseline(sourceAgent = "system"): Promise<TraceCheckpointRef | undefined> {
+    return this.exclusive(async () => {
+      const index = await this.index();
+      if (index.headCheckpointId) return undefined;
+      // An empty workspace already has the empty Git tree as its correct
+      // implicit baseline. Avoid initializing a repository for the common
+      // chat-only case; files created later by the agent should be attributed
+      // to its first trace event.
+      try {
+        const entries = await readdir(this.workspaceDir);
+        if (!entries.some((path) => !this.hardExcludedPrefix(path))) return undefined;
+      } catch {
+        return undefined;
+      }
+      return this.captureUnlocked(sourceAgent, "baseline");
+    });
   }
 
   async refs(ids: string[]): Promise<TraceCheckpointRef[]> {


### PR DESCRIPTION
## Summary

- bound trace checkpoints and managed-path restoration
- make trace audit terminal events idempotent
- recover one output-limit stop without replaying successful tool calls
- require explicit bounded timeouts for foreground Bash
- inject the shell execution contract into primary agents and subagents

## Verification

- `npm run typecheck -w @brainpilot/runtime`
- 102 targeted runtime tests covering checkpoints, trace, event mapping, output-limit recovery, cancellable Bash, and execution contracts

## Merge train

Stage 1 PR 1/4. Merge this PR first. PR 2 is stacked on this branch so its review only shows the task/subagent harness delta.