### PR TITLE
fix(web): preserve copied workspace file links

### DIFF
--- a/packages/web/src/__tests__/MarkdownMessage.test.tsx
+++ b/packages/web/src/__tests__/MarkdownMessage.test.tsx
@@ -51,6 +51,20 @@ describe("MarkdownMessage", () => {
     expect(html).not.toContain('data-workspace-file="https://example.com"');
   });
 
+  it("renders a copyable session-aware file URL when a session is known", () => {
+    const html = renderToStaticMarkup(
+      <MarkdownMessage
+        content="[report](docs/report.md)"
+        workspaceFileSessionId="session-a"
+      />,
+    );
+
+    expect(html).toContain(
+      'href="/sessions/session-a/files?path=%2Fworkspace%2Fdocs%2Freport.md"',
+    );
+    expect(html).toContain('data-workspace-file="/workspace/docs/report.md"');
+  });
+
   it("does not render unsafe URL schemes", () => {
     const html = render("[unsafe](javascript:alert(1))");
     expect(html).not.toContain("javascript:");

--- a/packages/web/src/__tests__/fileSidebarTree.test.ts
+++ b/packages/web/src/__tests__/fileSidebarTree.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyDirectoryListing,
+  createFileSidebarRoot,
+  findFileSidebarNode,
+  type FileSidebarTreeNode,
+} from "../components/files/fileSidebarTree";
+
+function folder(name: string): Omit<FileSidebarTreeNode, "path"> {
+  return { name, type: "folder", size: 0, modified: 0, permissions: "700" };
+}
+
+function file(name: string): Omit<FileSidebarTreeNode, "path"> {
+  return { name, type: "file", size: 10, modified: 0, permissions: "600" };
+}
+
+describe("linked-file directory loading", () => {
+  it("attaches each delayed directory response to the path requested for that response", () => {
+    let tree = createFileSidebarRoot();
+
+    const rootUpdate = applyDirectoryListing("/workspace", [folder("docs")]);
+    const docsUpdate = applyDirectoryListing("/workspace/docs", [folder("reports")]);
+    const reportsUpdate = applyDirectoryListing("/workspace/docs/reports", [file("data-inventory.md")]);
+
+    tree = rootUpdate(tree);
+    tree = docsUpdate(tree);
+    tree = reportsUpdate(tree);
+
+    expect(tree.children?.[0]?.children?.map((node) => node.name)).toEqual(["docs"]);
+    expect(findFileSidebarNode(tree, "/workspace/docs/reports/data-inventory.md"))
+      .toMatchObject({ name: "data-inventory.md", type: "file" });
+  });
+});

--- a/packages/web/src/__tests__/workspaceFileLink.test.ts
+++ b/packages/web/src/__tests__/workspaceFileLink.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { parseWorkspaceFileHref } from "../components/chat/workspaceFileLink";
+import {
+  buildWorkspaceFileDeepLink,
+  parseWorkspaceFileHref,
+  parseWorkspaceFileLocation,
+  resolveWorkspaceFileSession,
+} from "../components/chat/workspaceFileLink";
 
 describe("parseWorkspaceFileHref", () => {
   it("roots relative Markdown links in the active workspace", () => {
@@ -31,5 +36,81 @@ describe("parseWorkspaceFileHref", () => {
     expect(parseWorkspaceFileHref("/%2e%2e/etc/passwd")).toBeNull();
     expect(parseWorkspaceFileHref("/workspace/../data/private.txt")).toBeNull();
     expect(parseWorkspaceFileHref("/workspace")).toBeNull();
+  });
+});
+
+describe("workspace file deep links", () => {
+  it("builds and parses a session-aware URL that survives copying", () => {
+    const href = buildWorkspaceFileDeepLink("session / 中文", {
+      path: "/workspace/docs/研究 report.md",
+      line: 17,
+    });
+
+    expect(href).toBe(
+      "/sessions/session%20%2F%20%E4%B8%AD%E6%96%87/files?path=%2Fworkspace%2Fdocs%2F%E7%A0%94%E7%A9%B6%20report.md#L17",
+    );
+    expect(parseWorkspaceFileHref(href)).toEqual({
+      path: "/workspace/docs/研究 report.md",
+      line: 17,
+    });
+    expect(
+      parseWorkspaceFileLocation({
+        pathname: "/sessions/session%20%2F%20%E4%B8%AD%E6%96%87/files",
+        search: "?path=%2Fworkspace%2Fdocs%2F%E7%A0%94%E7%A9%B6%20report.md",
+        hash: "#L17",
+      }),
+    ).toEqual({
+      sessionId: "session / 中文",
+      path: "/workspace/docs/研究 report.md",
+      line: 17,
+    });
+  });
+
+  it("treats a legacy naked file URL as a workspace path", () => {
+    expect(
+      parseWorkspaceFileLocation({
+        pathname: "/docs/reports/data-inventory.md",
+        search: "",
+        hash: "#L4",
+      }),
+    ).toEqual({ path: "/workspace/docs/reports/data-inventory.md", line: 4 });
+  });
+
+  it("normalizes Windows separators into portable virtual paths", () => {
+    const target = parseWorkspaceFileHref("docs\\reports\\data inventory.md");
+    expect(target).toEqual({ path: "/workspace/docs/reports/data inventory.md" });
+    expect(buildWorkspaceFileDeepLink("session-a", target!)).toBe(
+      "/sessions/session-a/files?path=%2Fworkspace%2Fdocs%2Freports%2Fdata%20inventory.md",
+    );
+  });
+
+  it("does not mistake application routes or traversal for legacy files", () => {
+    for (const pathname of ["/api/sessions", "/assets/index.js", "/sessions/abc/files", "/../etc/passwd"]) {
+      expect(parseWorkspaceFileLocation({ pathname, search: "", hash: "" })).toBeNull();
+    }
+  });
+
+  it("honors canonical session ownership and resolves legacy URLs against the active session", () => {
+    expect(
+      resolveWorkspaceFileSession(
+        { sessionId: "session-b", path: "/workspace/docs/report.md" },
+        ["session-a", "session-b"],
+        "session-a",
+      ),
+    ).toEqual({ sessionId: "session-b", path: "/workspace/docs/report.md" });
+    expect(
+      resolveWorkspaceFileSession(
+        { path: "/workspace/docs/report.md" },
+        ["session-a", "session-b"],
+        "session-a",
+      ),
+    ).toEqual({ sessionId: "session-a", path: "/workspace/docs/report.md" });
+    expect(
+      resolveWorkspaceFileSession(
+        { sessionId: "deleted", path: "/workspace/docs/report.md" },
+        ["session-a"],
+        "session-a",
+      ),
+    ).toBeNull();
   });
 });

--- a/packages/web/src/components/chat/MarkdownMessage.tsx
+++ b/packages/web/src/components/chat/MarkdownMessage.tsx
@@ -5,14 +5,23 @@ import remarkMath from "remark-math";
 import rehypeHighlight from "rehype-highlight";
 import rehypeKatex from "rehype-katex";
 import { normalizeMarkdownForRendering } from "./normalizeMarkdown";
-import { parseWorkspaceFileHref, type WorkspaceFileTarget } from "./workspaceFileLink";
+import {
+  buildWorkspaceFileDeepLink,
+  parseWorkspaceFileHref,
+  type WorkspaceFileTarget,
+} from "./workspaceFileLink";
 
 interface MarkdownMessageProps {
   content: string;
+  workspaceFileSessionId?: string;
   onOpenWorkspaceFile?: (target: WorkspaceFileTarget) => void;
 }
 
-function MarkdownMessageImpl({ content, onOpenWorkspaceFile }: MarkdownMessageProps) {
+function MarkdownMessageImpl({
+  content,
+  workspaceFileSessionId,
+  onOpenWorkspaceFile,
+}: MarkdownMessageProps) {
   const normalizedContent = normalizeMarkdownForRendering(content);
 
   return (
@@ -20,7 +29,13 @@ function MarkdownMessageImpl({ content, onOpenWorkspaceFile }: MarkdownMessagePr
       <ReactMarkdown
         remarkPlugins={[remarkGfm, [remarkMath, { singleDollarTextMath: true }]]}
         rehypePlugins={[rehypeHighlight, rehypeKatex]}
-        urlTransform={(url) => parseWorkspaceFileHref(url) ? url : defaultUrlTransform(url)}
+        urlTransform={(url) => {
+          const target = parseWorkspaceFileHref(url);
+          if (!target) return defaultUrlTransform(url);
+          return workspaceFileSessionId
+            ? buildWorkspaceFileDeepLink(workspaceFileSessionId, target)
+            : url;
+        }}
         components={{
           a: ({ href, children, node: _node, ...props }) => {
             const target = href ? parseWorkspaceFileHref(href) : null;

--- a/packages/web/src/components/chat/MessageStream.tsx
+++ b/packages/web/src/components/chat/MessageStream.tsx
@@ -60,6 +60,7 @@ interface MessageStreamProps {
    * so demo replay keeps its flat, curated presentation.
    */
   groupExpertActivity?: boolean;
+  workspaceFileSessionId?: string;
   /** Open a workspace path referenced by an assistant Markdown link. */
   onOpenWorkspaceFile?: (target: WorkspaceFileTarget) => void;
 }
@@ -96,6 +97,7 @@ function MessageStreamImpl({
   onRetryCancel,
   runningAgents,
   groupExpertActivity = false,
+  workspaceFileSessionId,
   onOpenWorkspaceFile,
 }: MessageStreamProps) {
   const t = useT();
@@ -397,7 +399,11 @@ function MessageStreamImpl({
         {message.kind === "error" ? (
           <p className="message-card__content--plain message-row__error">{displayContent}</p>
         ) : (
-          <MarkdownMessage content={displayContent} onOpenWorkspaceFile={onOpenWorkspaceFile} />
+          <MarkdownMessage
+            content={displayContent}
+            workspaceFileSessionId={workspaceFileSessionId}
+            onOpenWorkspaceFile={onOpenWorkspaceFile}
+          />
         )}
         {message.streaming && message.kind !== "error" ? (
           <span className="message-row__streaming-cursor" aria-hidden="true" />
@@ -479,6 +485,7 @@ function MessageStreamImpl({
         {isExpert ? <span className="message-card__agent-badge">{step.agent}</span> : null}
         <MarkdownMessage
           content={step.content || (step.streaming ? t("chat.streamingPending") : "")}
+          workspaceFileSessionId={workspaceFileSessionId}
           onOpenWorkspaceFile={onOpenWorkspaceFile}
         />
       </div>

--- a/packages/web/src/components/chat/PromptComposer.tsx
+++ b/packages/web/src/components/chat/PromptComposer.tsx
@@ -671,6 +671,7 @@ export function PromptComposer({ onOpenProviderSettings, onOpenWorkspaceFile }: 
             runningAgents={runningAgents}
             groupExpertActivity
             onRetryCancel={() => void interruptCurrent()}
+            workspaceFileSessionId={currentSession?.id}
             onOpenWorkspaceFile={onOpenWorkspaceFile}
           />
         ) : null}

--- a/packages/web/src/components/chat/workspaceFileLink.ts
+++ b/packages/web/src/components/chat/workspaceFileLink.ts
@@ -3,18 +3,127 @@ export type WorkspaceFileTarget = {
   line?: number;
 };
 
+export type SessionWorkspaceFileTarget = WorkspaceFileTarget & { sessionId: string };
+
+export type WorkspaceFileLocation = Pick<Location, "pathname" | "search" | "hash">;
+
 const EXTERNAL_SCHEME = /^[a-z][a-z0-9+.-]*:/i;
 const MANAGED_ROOTS = ["/workspace", "/data"] as const;
+const APPLICATION_ROUTE_ROOTS = new Set(["api", "assets", "sessions"]);
 
-/**
- * Resolve a Markdown href into a Files-panel target. Relative links are rooted
- * in the active session workspace; explicit managed paths may address either
- * the session workspace or persistent library. Web URLs and unsafe paths are
- * deliberately left to the browser/markdown renderer.
- */
+function parseLineHash(hash: string): number | undefined {
+  const lineMatch = /^(?:#)?(?:L|line-?)(\d+)$/i.exec(hash);
+  const line = lineMatch ? Number(lineMatch[1]) : undefined;
+  return line && line > 0 ? line : undefined;
+}
+
+function normalizeManagedPath(decodedPath: string): string | null {
+  const portablePath = decodedPath.replace(/\\/g, "/");
+  if (portablePath.includes("\0")) return null;
+
+  const rooted = portablePath.startsWith("/") ? portablePath : `/workspace/${portablePath}`;
+  const parts: string[] = [];
+  for (const part of rooted.split("/")) {
+    if (!part || part === ".") continue;
+    if (part === "..") {
+      if (parts.length <= 1) return null;
+      parts.pop();
+      continue;
+    }
+    parts.push(part);
+  }
+  const normalized = `/${parts.join("/")}`;
+  if (!MANAGED_ROOTS.some((root) => normalized.startsWith(`${root}/`))) return null;
+  return normalized;
+}
+
+function parseCanonicalLocation(
+  location: WorkspaceFileLocation,
+): SessionWorkspaceFileTarget | null {
+  const match = /^\/sessions\/([^/]+)\/files\/?$/.exec(location.pathname);
+  if (!match) return null;
+
+  let sessionId: string;
+  try {
+    sessionId = decodeURIComponent(match[1]);
+  } catch {
+    return null;
+  }
+  if (!sessionId) return null;
+
+  const rawPath = new URLSearchParams(location.search).get("path");
+  if (!rawPath) return null;
+  const path = normalizeManagedPath(rawPath);
+  if (!path) return null;
+
+  const line = parseLineHash(location.hash);
+  return { sessionId, path, ...(line ? { line } : {}) };
+}
+
+export function buildWorkspaceFileDeepLink(
+  sessionId: string,
+  target: WorkspaceFileTarget,
+): string {
+  if (!sessionId) throw new TypeError("A session id is required for a workspace file link");
+  const path = normalizeManagedPath(target.path);
+  if (!path) throw new TypeError("Workspace file links must stay under /workspace or /data");
+  const hash = target.line && target.line > 0 ? `#L${Math.floor(target.line)}` : "";
+  return `/sessions/${encodeURIComponent(sessionId)}/files?path=${encodeURIComponent(path)}${hash}`;
+}
+
+export function parseWorkspaceFileLocation(
+  location: WorkspaceFileLocation,
+): SessionWorkspaceFileTarget | WorkspaceFileTarget | null {
+  const canonical = parseCanonicalLocation(location);
+  if (canonical) return canonical;
+  if (location.pathname.startsWith("/sessions/")) return null;
+
+  let decodedPathname: string;
+  try {
+    decodedPathname = decodeURIComponent(location.pathname).replace(/\\/g, "/");
+  } catch {
+    return null;
+  }
+  const firstSegment = decodedPathname.split("/").find(Boolean)?.toLowerCase();
+  if (firstSegment && APPLICATION_ROUTE_ROOTS.has(firstSegment)) return null;
+  const isExplicitManagedPath = MANAGED_ROOTS.some(
+    (root) => decodedPathname === root || decodedPathname.startsWith(`${root}/`),
+  );
+  const legacyPath = isExplicitManagedPath
+    ? location.pathname
+    : location.pathname.replace(/^\/+/, "");
+  return parseWorkspaceFileHref(`${legacyPath}${location.hash}`);
+}
+
+export function resolveWorkspaceFileSession(
+  target: SessionWorkspaceFileTarget | WorkspaceFileTarget,
+  availableSessionIds: readonly string[],
+  currentSessionId: string | null | undefined,
+): SessionWorkspaceFileTarget | null {
+  if ("sessionId" in target) {
+    return availableSessionIds.includes(target.sessionId) ? target : null;
+  }
+  const sessionId = currentSessionId && availableSessionIds.includes(currentSessionId)
+    ? currentSessionId
+    : availableSessionIds[0];
+  return sessionId ? { ...target, sessionId } : null;
+}
+
 export function parseWorkspaceFileHref(href: string): WorkspaceFileTarget | null {
   const trimmed = href.trim();
   if (!trimmed || trimmed.startsWith("#") || trimmed.startsWith("//")) return null;
+
+  if (trimmed.startsWith("/sessions/")) {
+    try {
+      const url = new URL(trimmed, "http://brainpilot.local");
+      const canonical = parseCanonicalLocation(url);
+      return canonical
+        ? { path: canonical.path, ...(canonical.line ? { line: canonical.line } : {}) }
+        : null;
+    } catch {
+      return null;
+    }
+  }
 
   let rawPath = trimmed;
   if (trimmed.toLowerCase().startsWith("brainpilot-file:")) {
@@ -41,24 +150,8 @@ export function parseWorkspaceFileHref(href: string): WorkspaceFileTarget | null
     return null;
   }
 
-  const rooted = decoded.startsWith("/") ? decoded : `/workspace/${decoded}`;
-  const parts: string[] = [];
-  for (const part of rooted.split("/")) {
-    if (!part || part === ".") continue;
-    if (part === "..") {
-      if (parts.length <= 1) return null;
-      parts.pop();
-      continue;
-    }
-    parts.push(part);
-  }
-  const normalized = `/${parts.join("/")}`;
-  if (!MANAGED_ROOTS.some((root) => normalized === root || normalized.startsWith(`${root}/`))) {
-    return null;
-  }
-  if (normalized === "/workspace" || normalized === "/data") return null;
-
-  const lineMatch = /^(?:L|line-?)(\d+)$/i.exec(hash);
-  const line = lineMatch ? Number(lineMatch[1]) : undefined;
-  return { path: normalized, ...(line && line > 0 ? { line } : {}) };
+  const normalized = normalizeManagedPath(decoded);
+  if (!normalized) return null;
+  const line = parseLineHash(hash);
+  return { path: normalized, ...(line ? { line } : {}) };
 }

--- a/packages/web/src/components/files/FileSidebar.tsx
+++ b/packages/web/src/components/files/FileSidebar.tsx
@@ -19,7 +19,7 @@ import {
   Upload,
   X,
 } from "lucide-react";
-import { FileContent, FileEntry } from "../../contracts/backend";
+import { FileContent } from "../../contracts/backend";
 import { runtimeConfig } from "../../config";
 import { useSandbox } from "../../contexts/SandboxContext";
 import { useSessions } from "../../contexts/SessionContext";
@@ -30,6 +30,13 @@ import { createZipBlob, type ZipEntry } from "../../utils/zip";
 import { IconButton } from "../primitives/IconButton";
 import { UploadProgressBar } from "../primitives/UploadProgressBar";
 import { ONE_MB, MAX_BINARY_PREVIEW, formatBytes, formatModified, getPreviewKind, isMarkdown } from "./filePreview";
+import {
+  applyDirectoryListing,
+  createFileSidebarRoot,
+  directoryListingChildren,
+  findFileSidebarNode,
+  type FileSidebarTreeNode,
+} from "./fileSidebarTree";
 import { FilePreviewView, PreviewSource } from "./FilePreviewView";
 import { PluginPreviewHost } from "./PluginPreviewHost";
 import { matchEnabledPreviewer, type EnabledPreviewer } from "./previewerRegistry";
@@ -44,11 +51,7 @@ type DataUploadState = {
   phase: UploadProgress["phase"];
 };
 
-type FileNode = FileEntry & {
-  path: string;
-  children?: FileNode[];
-  loaded?: boolean;
-};
+type FileNode = FileSidebarTreeNode;
 
 type FileSidebarProps = {
   isOpen: boolean;
@@ -81,22 +84,6 @@ export function isInlineEditable(name: string): boolean {
 function parentPath(path: string): string {
   const index = path.lastIndexOf("/");
   return index > 0 ? path.slice(0, index) : WORKSPACE_ROOT_PATH;
-}
-
-function makeRootTree(): FileNode {
-  return {
-    name: "",
-    path: "", // synthetic container — its children are the rendered roots
-    type: "folder",
-    size: 0,
-    modified: 0,
-    permissions: "",
-    loaded: true,
-    children: [
-      { name: "workspace", path: WORKSPACE_ROOT_PATH, type: "folder", size: 0, modified: 0, permissions: "" },
-      { name: "data", path: DATA_ROOT_PATH, type: "folder", size: 0, modified: 0, permissions: "" },
-    ],
-  };
 }
 
 function joinPath(parent: string, name: string) {
@@ -178,16 +165,6 @@ function sortNodes(nodes: FileNode[]): FileNode[] {
   });
 }
 
-function updateNode(root: FileNode, path: string, updater: (node: FileNode) => FileNode): FileNode {
-  if (root.path === path) {
-    return updater(root);
-  }
-  return {
-    ...root,
-    children: root.children?.map((child) => updateNode(child, path, updater)),
-  };
-}
-
 /**
  * Turn raw runtime upload errors into short, human-readable copy. The runtime
  * returns `file too large: N bytes exceeds limit of M` (#256); without this the
@@ -213,22 +190,6 @@ function formatSidebarError(message: string, t: (key: string, params?: Record<st
   return message;
 }
 
-function findNode(root: FileNode, path: string | null): FileNode | null {
-  if (!path) {
-    return null;
-  }
-  if (root.path === path) {
-    return root;
-  }
-  for (const child of root.children ?? []) {
-    const found = findNode(child, path);
-    if (found) {
-      return found;
-    }
-  }
-  return null;
-}
-
 export function FileSidebar({
   isOpen,
   openFileRequest,
@@ -250,7 +211,7 @@ export function FileSidebar({
   // mode. A full rename rides with the planned session-management cleanup.
   const sandboxId = currentSession?.id ?? null;
   const t = useT();
-  const [tree, setTree] = useState<FileNode>(makeRootTree);
+  const [tree, setTree] = useState<FileNode>(createFileSidebarRoot);
   // Both roots start expanded so the two tiers are visible at a glance.
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(
     () => new Set([WORKSPACE_ROOT_PATH, DATA_ROOT_PATH]),
@@ -362,8 +323,7 @@ export function FileSidebar({
         console.debug("[FileSidebar] listFiles", { sandboxId, path });
         const entries = await api.sandbox.listFiles(sandboxId, path);
         console.debug("[FileSidebar] listFiles ok", { sandboxId, path, count: entries.length });
-        const children = entries.map((entry) => ({ ...entry, path: joinPath(path, entry.name) }));
-        setTree((current) => updateNode(current, path, (node) => ({ ...node, children, loaded: true })));
+        setTree(applyDirectoryListing(path, entries));
       } catch (err) {
         // The runtime now returns a distinct error (instead of an empty array)
         // when readdir fails for a reason other than ENOENT (#193). Surface it
@@ -420,24 +380,24 @@ export function FileSidebar({
     };
   }, [onResize, onResizeEnd]);
 
-  const selectedNode = useMemo(() => findNode(tree, selectedPath), [selectedPath, tree]);
+  const selectedNode = useMemo(() => findFileSidebarNode(tree, selectedPath), [selectedPath, tree]);
   const selectedFile = selectedNode?.type === "file" ? selectedNode : null;
   const selectedDownloadCount = selectedDownloadPaths.size;
 
-  const getNodeForPath = useCallback((path: string) => findNode(tree, path), [tree]);
+  const getNodeForPath = useCallback((path: string) => findFileSidebarNode(tree, path), [tree]);
 
   const loadDirectoryEntries = useCallback(
     async (path: string): Promise<FileNode[]> => {
       if (!sandboxId) {
         throw new Error("No active sandbox");
       }
-      const cached = findNode(tree, path);
+      const cached = findFileSidebarNode(tree, path);
       if (cached?.loaded && cached.children) {
         return cached.children;
       }
       const entries = await api.sandbox.listFiles(sandboxId, path);
-      const children = sortNodes(entries.map((entry) => ({ ...entry, path: joinPath(path, entry.name) })));
-      setTree((current) => updateNode(current, path, (node) => ({ ...node, children, loaded: true })));
+      const children = sortNodes(directoryListingChildren(path, entries));
+      setTree(applyDirectoryListing(path, children));
       return children;
     },
     [sandboxId, tree],
@@ -762,10 +722,11 @@ export function FileSidebar({
       const expanded = new Set<string>([directory]);
       try {
         for (let index = 1; index < parts.length; index += 1) {
-          const entries = await api.sandbox.listFiles(sandboxId, directory);
+          const requestedDirectory = directory;
+          const entries = await api.sandbox.listFiles(sandboxId, requestedDirectory);
           if (cancelled) return;
-          const children = sortNodes(entries.map((entry) => ({ ...entry, path: joinPath(directory, entry.name) })));
-          setTree((current) => updateNode(current, directory, (node) => ({ ...node, children, loaded: true })));
+          const children = sortNodes(directoryListingChildren(requestedDirectory, entries));
+          setTree(applyDirectoryListing(requestedDirectory, children));
           const child = children.find((entry) => entry.name === parts[index]);
           if (!child) throw new Error(t("files.error.linkNotFound"));
           if (index === parts.length - 1) {

--- a/packages/web/src/components/files/fileSidebarTree.ts
+++ b/packages/web/src/components/files/fileSidebarTree.ts
@@ -1,0 +1,71 @@
+import type { FileEntry } from "../../contracts/backend";
+
+export type FileSidebarTreeNode = FileEntry & {
+  path: string;
+  children?: FileSidebarTreeNode[];
+  loaded?: boolean;
+};
+
+const WORKSPACE_ROOT_PATH = "/workspace";
+const DATA_ROOT_PATH = "/data";
+
+export function createFileSidebarRoot(): FileSidebarTreeNode {
+  return {
+    name: "",
+    path: "",
+    type: "folder",
+    size: 0,
+    modified: 0,
+    permissions: "",
+    loaded: true,
+    children: [
+      { name: "workspace", path: WORKSPACE_ROOT_PATH, type: "folder", size: 0, modified: 0, permissions: "" },
+      { name: "data", path: DATA_ROOT_PATH, type: "folder", size: 0, modified: 0, permissions: "" },
+    ],
+  };
+}
+
+export function directoryListingChildren(
+  path: string,
+  entries: ReadonlyArray<FileEntry>,
+): FileSidebarTreeNode[] {
+  const parent = path.replace(/\/$/, "");
+  return entries.map((entry) => ({ ...entry, path: `${parent}/${entry.name}` }));
+}
+
+function updateFileSidebarNode(
+  root: FileSidebarTreeNode,
+  path: string,
+  updater: (node: FileSidebarTreeNode) => FileSidebarTreeNode,
+): FileSidebarTreeNode {
+  if (root.path === path) return updater(root);
+  return {
+    ...root,
+    children: root.children?.map((child) => updateFileSidebarNode(child, path, updater)),
+  };
+}
+
+export function applyDirectoryListing(
+  requestedPath: string,
+  entries: ReadonlyArray<FileEntry>,
+): (root: FileSidebarTreeNode) => FileSidebarTreeNode {
+  const children = directoryListingChildren(requestedPath, entries);
+  return (root) => updateFileSidebarNode(root, requestedPath, (node) => ({
+    ...node,
+    children,
+    loaded: true,
+  }));
+}
+
+export function findFileSidebarNode(
+  root: FileSidebarTreeNode,
+  path: string | null,
+): FileSidebarTreeNode | null {
+  if (!path) return null;
+  if (root.path === path) return root;
+  for (const child of root.children ?? []) {
+    const found = findFileSidebarNode(child, path);
+    if (found) return found;
+  }
+  return null;
+}

--- a/packages/web/src/components/shell/DesktopShell.tsx
+++ b/packages/web/src/components/shell/DesktopShell.tsx
@@ -19,14 +19,30 @@ import { Sidebar } from "../sidebar/Sidebar";
 import { DiskQuotaWarningDialog } from "../quota/DiskQuotaWarningDialog";
 import { DiskQuotaCriticalDialog } from "../quota/DiskQuotaCriticalDialog";
 import { DEFAULT_SIDEBAR_WIDTH, resolveResize } from "./sidebarResize";
-import type { WorkspaceFileTarget } from "../chat/workspaceFileLink";
+import {
+  buildWorkspaceFileDeepLink,
+  parseWorkspaceFileLocation,
+  resolveWorkspaceFileSession,
+  type WorkspaceFileTarget,
+} from "../chat/workspaceFileLink";
 
 const PluginMarketplace = lazy(() => import("../plugins/PluginMarketplace").then((module) => ({ default: module.PluginMarketplace })));
 
 export function DesktopShell() {
   const { isAuthReady } = useAuth();
   const { currentSandbox, operation, error, stats } = useSandbox();
-  const { currentSession, currentView, isRefreshingMessages, refreshMessages, setCurrentView, traceUnread, hiddenErrorsUnread } = useSessions();
+  const {
+    sessions,
+    sessionsListStatus,
+    currentSession,
+    currentView,
+    isRefreshingMessages,
+    refreshMessages,
+    selectSession,
+    setCurrentView,
+    traceUnread,
+    hiddenErrorsUnread,
+  } = useSessions();
   const t = useT();
   // #131 — the sidebar collapses to an icon rail either manually (user toggle)
   // or automatically at narrow widths. Both feed the same `isCollapsed` state so
@@ -60,6 +76,10 @@ export function DesktopShell() {
   const [sandboxOverlayDismissed, setSandboxOverlayDismissed] = useState(false);
   const [isWarningOpen, setIsWarningOpen] = useState(false);
   const hasWarnedRef = useRef(false);
+  const initialWorkspaceFileTargetRef = useRef(
+    typeof window === "undefined" ? null : parseWorkspaceFileLocation(window.location),
+  );
+  const deepLinkHandledRef = useRef(false);
   const openFileRequestIdRef = useRef(0);
   const sidebarResizeRef = useRef<{ pointerX: number; width: number } | null>(null);
   const confirmFileNavigation = useCallback(
@@ -67,6 +87,7 @@ export function DesktopShell() {
     [hasUnsavedFileChanges, t],
   );
   const openWorkspaceFile = useCallback((target: WorkspaceFileTarget) => {
+    if (!currentSession?.id) return;
     setIsFilesOpen(true);
     openFileRequestIdRef.current += 1;
     setOpenFileRequest({
@@ -74,7 +95,44 @@ export function DesktopShell() {
       requestId: openFileRequestIdRef.current,
       scopeKey: fileSidebarScopeKey(currentSession?.id),
     });
+    window.history.replaceState(
+      window.history.state,
+      "",
+      buildWorkspaceFileDeepLink(currentSession.id, target),
+    );
   }, [currentSession?.id]);
+
+  useEffect(() => {
+    const initialTarget = initialWorkspaceFileTargetRef.current;
+    if (deepLinkHandledRef.current || !initialTarget || sessionsListStatus !== "ready") return;
+
+    const resolved = resolveWorkspaceFileSession(
+      initialTarget,
+      sessions.map((session) => session.id),
+      currentSession?.id,
+    );
+    if (!resolved) {
+      deepLinkHandledRef.current = true;
+      return;
+    }
+
+    if (currentSession?.id !== resolved.sessionId) {
+      selectSession(resolved.sessionId);
+      return;
+    }
+
+    deepLinkHandledRef.current = true;
+    setActivePage("workspace");
+    setCurrentView("chat");
+    openWorkspaceFile(resolved);
+  }, [
+    currentSession?.id,
+    openWorkspaceFile,
+    selectSession,
+    sessions,
+    sessionsListStatus,
+    setCurrentView,
+  ]);
 
   useEffect(() => {
     if (operation === "creating" || operation === "rebuilding") {

--- a/packages/web/src/contexts/SessionContext.tsx
+++ b/packages/web/src/contexts/SessionContext.tsx
@@ -33,6 +33,7 @@ export interface AgentMessageFilter {
 
 interface SessionContextValue {
   sessions: Session[];
+  sessionsListStatus: SessionsListStatus;
   currentSession: Session | null;
   messages: ChatMessage[];
   isLoading: boolean;
@@ -1340,6 +1341,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   const value = useMemo(
     () => ({
       sessions,
+      sessionsListStatus,
       currentSession,
       messages,
       isLoading,
@@ -1381,6 +1383,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     }),
     [
       sessions,
+      sessionsListStatus,
       currentSession,
       messages,
       isLoading,


### PR DESCRIPTION
## Summary

- render workspace Markdown links as stable, session-aware browser URLs that survive copying and refresh
- reopen canonical and legacy workspace file URLs in the owning session
- attach delayed directory responses to the directory that issued each request

## Dependency

This is intentionally stacked on #456 so the review shows only the follow-up fixes. After #456 merges, retarget this PR to `main`.

## Verification

- TDD regressions for copied deep links, legacy URLs, session ownership, and delayed directory responses
- `npm test -w @brainpilot/web` (65 files, 519 tests)
- `npm run build -w @brainpilot/web`
- `git diff --check`