### PR TITLE
fix(docs): lock Tailwind oxide for Apple Silicon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4095,6 +4095,20 @@
         "@tailwindcss/oxide-win32-x64-msvc": "4.3.2"
       }
     },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.2",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
       "version": "4.3.2",
       "cpu": [


### PR DESCRIPTION
## Summary

- add the missing Darwin arm64 Tailwind Oxide node to the committed lockfile
- keep the native package aligned with the already-resolved Tailwind 4.3.2 dependency
- avoid dependency upgrades and a full lockfile regeneration

## Root cause

The `@tailwindcss/oxide` lock entry declares `@tailwindcss/oxide-darwin-arm64` as an optional dependency, but the lockfile only contains concrete Linux x64 Oxide package nodes. npm therefore completes a clean install without the Darwin arm64 native binding, and the docs build fails when Tailwind loads it.

## Validation

Run on macOS Darwin arm64 with Node.js 22.23.2 and npm 10.9.8:

- `npm ci`
- `npm run docs:build`
- `npm run build`

Closes #406