### PR TITLE
fix(runtime): bound repeated Bash polling

### DIFF
--- a/packages/runtime/src/__tests__/bash-repetition-guard.test.ts
+++ b/packages/runtime/src/__tests__/bash-repetition-guard.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from "vitest";
+import { wrapCancellableBash } from "../agent-factory.js";
+import {
+  BASH_REPETITION_TAG_OPEN,
+  createBashRepetitionGuard,
+} from "../extensions/bash-repetition-guard.js";
+
+type ContextMessage = { role: string; content: Array<{ type: string; text?: string }> };
+type ContextHandler = (event: { messages: ContextMessage[] }) => { messages: ContextMessage[] } | void;
+type ToolEndHandler = (event: { toolName: string; isError: boolean }) => unknown;
+
+class FakePi {
+  agentStart?: () => void;
+  context?: ContextHandler;
+  toolEnd?: ToolEndHandler;
+
+  on(event: "agent_start" | "context" | "tool_execution_end", handler: unknown): void {
+    if (event === "agent_start") this.agentStart = handler as () => void;
+    if (event === "context") this.context = handler as ContextHandler;
+    if (event === "tool_execution_end") this.toolEnd = handler as ToolEndHandler;
+  }
+}
+
+function bashDefinition(execute: (...args: any[]) => Promise<unknown>) {
+  return {
+    name: "bash",
+    description: "Run a shell command",
+    parameters: {
+      type: "object",
+      properties: { command: { type: "string" }, timeout: { type: "number" } },
+      required: ["command"],
+    },
+    execute,
+  };
+}
+
+function warningText(messages: ContextMessage[]): string {
+  return messages.flatMap((message) => message.content)
+    .map((part) => part.text ?? "")
+    .find((text) => text.startsWith(BASH_REPETITION_TAG_OPEN)) ?? "";
+}
+
+describe("Bash repetition guard", () => {
+  it("warns on the third repeated command and blocks the fifth without executing it", async () => {
+    let now = 1_000;
+    const guard = createBashRepetitionGuard({ now: () => now });
+    const pi = new FakePi();
+    guard.extension(pi as never);
+    pi.agentStart!();
+
+    const execute = vi.fn(async () => ({ content: [{ type: "text", text: "ok" }], details: {} }));
+    const wrapped = wrapCancellableBash(bashDefinition(execute), new Map(), guard);
+    const args = { command: "  tail   results/full_run.log  ", timeout: 5 };
+
+    await wrapped.execute("call-1", args, undefined);
+    now += 1_000;
+    await wrapped.execute("call-2", { ...args, command: "tail results/full_run.log" }, undefined);
+    now += 1_000;
+    await wrapped.execute("call-3", args, undefined);
+
+    const injected = pi.context!({ messages: [] });
+    const warning = warningText(injected!.messages);
+    expect(warning).toContain("five executions");
+    expect(warning).toContain("the fifth execution will be blocked");
+    expect(warning).not.toContain("results/full_run.log");
+
+    const consumed = pi.context!({ messages: injected!.messages });
+    expect(consumed?.messages ?? []).toEqual([]);
+
+    now += 1_000;
+    await wrapped.execute("call-4", args, undefined);
+    now += 1_000;
+    const fifth = await wrapped.execute("call-5", args, undefined) as {
+      content: Array<{ type: string; text: string }>;
+      terminate?: boolean;
+    };
+
+    expect(fifth.terminate).toBe(true);
+    expect(fifth.content[0]?.text).toContain("was not executed");
+    expect(execute).toHaveBeenCalledTimes(4);
+  });
+
+  it("resets after write/edit, a new agent run, or expiry of the 60-second window", async () => {
+    let now = 10_000;
+    const guard = createBashRepetitionGuard({ now: () => now });
+    const pi = new FakePi();
+    guard.extension(pi as never);
+    pi.agentStart!();
+
+    const execute = vi.fn(async () => ({ content: [], details: {} }));
+    const wrapped = wrapCancellableBash(bashDefinition(execute), new Map(), guard);
+    const run = (id: string) => wrapped.execute(id, { command: "python check.py", timeout: 5 }, undefined);
+
+    await run("one");
+    await run("two");
+    pi.toolEnd!({ toolName: "write", isError: false });
+    await run("after-write");
+    expect(pi.context!({ messages: [] })).toBeUndefined();
+
+    await run("after-write-2");
+    pi.agentStart!();
+    await run("new-run");
+    expect(pi.context!({ messages: [] })).toBeUndefined();
+
+    await run("new-run-2");
+    now += 60_001;
+    await run("expired");
+    expect(pi.context!({ messages: [] })).toBeUndefined();
+    expect(execute).toHaveBeenCalledTimes(7);
+  });
+
+  it("tracks interleaved commands independently and warns only once per burst", async () => {
+    const guard = createBashRepetitionGuard({ now: () => 1_000 });
+    const pi = new FakePi();
+    guard.extension(pi as never);
+    pi.agentStart!();
+    const execute = vi.fn(async () => ({ content: [], details: {} }));
+    const wrapped = wrapCancellableBash(bashDefinition(execute), new Map(), guard);
+
+    for (const [index, command] of ["tail run.log", "date", "tail run.log", "date", "tail run.log"].entries()) {
+      await wrapped.execute(`call-${index}`, { command, timeout: 5 }, undefined);
+    }
+
+    const first = pi.context!({ messages: [] });
+    expect(warningText(first!.messages)).not.toBe("");
+    expect(pi.context!({ messages: first!.messages })?.messages ?? []).toEqual([]);
+    expect(pi.context!({ messages: [] })).toBeUndefined();
+  });
+});

--- a/packages/runtime/src/agent-factory.ts
+++ b/packages/runtime/src/agent-factory.ts
@@ -35,6 +35,10 @@ import { makeTaskContextExt } from "./extensions/task-context.js";
 import { makeRouterSkillGuardExt } from "./extensions/router-skill-guard.js";
 import { makeManagedPathGuardExt } from "./extensions/managed-path-guard.js";
 import { makePrincipalWorkflowGuardExt } from "./extensions/principal-workflow-guard.js";
+import {
+  createBashRepetitionGuard,
+  type BashRepetitionGuard,
+} from "./extensions/bash-repetition-guard.js";
 import { makeCompatHooksExt } from "./compat-hooks.js";
 import {
   installBrainPilotRetryClassifier,
@@ -122,7 +126,8 @@ export const realAgentFactory: AgentSessionFactory = async (params) => {
     commandPrefix: settingsManager.getShellCommandPrefix(),
     shellPath: settingsManager.getShellPath(),
   });
-  const cancellableBash = wrapCancellableBash(officialBash, bashControllers);
+  const bashRepetitionGuard = createBashRepetitionGuard();
+  const cancellableBash = wrapCancellableBash(officialBash, bashControllers, bashRepetitionGuard);
   const customTools = [
     ...params.systemTools.map((t) => adaptTool(defineTool, t)),
     ...(params.allowedToolNames.includes("bash") ? [cancellableBash] : []),
@@ -166,6 +171,9 @@ export const realAgentFactory: AgentSessionFactory = async (params) => {
   // hook recomputes per turn and the rewrite is ephemeral (never persisted).
   const extensionFactories: unknown[] = [];
   extensionFactories.push(...(params.extensionFactories ?? []));
+  if (params.allowedToolNames.includes("bash")) {
+    extensionFactories.push(bashRepetitionGuard.extension);
+  }
   if (params.compatPluginProjections?.length) {
     extensionFactories.push(makeCompatHooksExt(params.compatPluginProjections));
   }
@@ -259,6 +267,7 @@ const MAX_FOREGROUND_BASH_TIMEOUT_SECONDS = 300;
 export function wrapCancellableBash(
   officialBash: BashDefinition,
   controllers: Map<string, AbortController>,
+  repetitionGuard?: BashRepetitionGuard,
 ): BashDefinition {
   const parameters = officialBash.parameters as Record<string, unknown> | undefined;
   const properties = parameters?.properties as Record<string, unknown> | undefined;
@@ -297,6 +306,16 @@ export function wrapCancellableBash(
         || args.timeout > MAX_FOREGROUND_BASH_TIMEOUT_SECONDS
       ) {
         throw new Error("bash timeout must be between 1 and 300 seconds");
+      }
+      const repetition = repetitionGuard?.beforeBash(
+        typeof args.command === "string" ? args.command : "",
+      );
+      if (repetition?.terminate) {
+        return {
+          content: [{ type: "text", text: repetition.message ?? "Repeated Bash execution was blocked." }],
+          details: {},
+          terminate: true,
+        };
       }
       const controller = new AbortController();
       controllers.set(toolCallId, controller);

--- a/packages/runtime/src/extensions/bash-repetition-guard.ts
+++ b/packages/runtime/src/extensions/bash-repetition-guard.ts
@@ -1,0 +1,167 @@
+/** Bound high-frequency repeated Bash calls without persisting reminder text. */
+
+interface PiContextMessage {
+  role: string;
+  content: Array<{ type: string; text?: string }>;
+  timestamp?: number;
+}
+
+interface PiExtensionApi {
+  on(event: "agent_start", handler: () => void): void;
+  on(
+    event: "context",
+    handler: (event: { messages: PiContextMessage[] }) =>
+      | { messages: PiContextMessage[] }
+      | void,
+  ): void;
+  on(
+    event: "tool_execution_end",
+    handler: (event: { toolName: string; isError: boolean }) => void,
+  ): void;
+}
+
+export interface BashRepetitionDecision {
+  terminate: boolean;
+  message?: string;
+}
+
+export interface BashRepetitionGuard {
+  beforeBash(command: string): BashRepetitionDecision;
+  extension: (pi: PiExtensionApi) => void;
+}
+
+export interface BashRepetitionGuardOptions {
+  now?: () => number;
+}
+
+export const BASH_REPETITION_TAG_OPEN = "<bash_repetition_warning>";
+const BASH_REPETITION_TAG_CLOSE = "</bash_repetition_warning>";
+export const BASH_REPETITION_WINDOW_MS = 60_000;
+export const BASH_REPETITION_WARNING_COUNT = 3;
+export const BASH_REPETITION_TERMINATION_COUNT = 5;
+
+export const BASH_REPETITION_WARNING = [
+  BASH_REPETITION_TAG_OPEN,
+  "Repeated Bash execution was detected within the last 60 seconds.",
+  "",
+  "Do not use Bash, sleep, tail, ps, ls, or process inspection to wait for progress. " +
+    "If a managed background job is running, end this turn and wait for its completion event. " +
+    "Re-run the command only when new evidence or a concrete workflow change justifies it.",
+  "",
+  "Runtime enforcement: if the same Bash command reaches five executions within this detection " +
+    "window without an intervening state-changing action, the fifth execution will be blocked " +
+    "and the current agent turn will terminate automatically.",
+  BASH_REPETITION_TAG_CLOSE,
+].join("\n");
+
+export const BASH_REPETITION_TERMINATION_MESSAGE = [
+  "Repeated Bash execution reached the runtime safety limit.",
+  "The command was not executed, and this turn is ending automatically.",
+  "Wait for an event-driven completion notification or resume after a meaningful state change.",
+].join("\n");
+
+function normalizeCommand(command: string): string {
+  const output: string[] = [];
+  let quote: "'" | '"' | undefined;
+  let escaped = false;
+  let pendingSpace = false;
+
+  for (const character of command.trim()) {
+    if (escaped) {
+      output.push(character);
+      escaped = false;
+      continue;
+    }
+    if (character === "\\") {
+      output.push(character);
+      escaped = true;
+      continue;
+    }
+    if (quote) {
+      output.push(character);
+      if (character === quote) quote = undefined;
+      continue;
+    }
+    if (character === "'" || character === '"') {
+      if (pendingSpace && output.length > 0) output.push(" ");
+      pendingSpace = false;
+      quote = character;
+      output.push(character);
+      continue;
+    }
+    if (/\s/u.test(character)) {
+      pendingSpace = output.length > 0;
+      continue;
+    }
+    if (pendingSpace) output.push(" ");
+    pendingSpace = false;
+    output.push(character);
+  }
+  return output.join("");
+}
+
+function isWarningMessage(message: PiContextMessage): boolean {
+  return message.role === "user" && message.content.some(
+    (part) => part.type === "text" && (part.text ?? "").startsWith(BASH_REPETITION_TAG_OPEN),
+  );
+}
+
+export function createBashRepetitionGuard(
+  options: BashRepetitionGuardOptions = {},
+): BashRepetitionGuard {
+  const now = options.now ?? Date.now;
+  const attempts = new Map<string, number[]>();
+  const warned = new Set<string>();
+  let warningPending = false;
+
+  const reset = (): void => {
+    attempts.clear();
+    warned.clear();
+    warningPending = false;
+  };
+
+  const beforeBash = (command: string): BashRepetitionDecision => {
+    const fingerprint = normalizeCommand(command);
+    if (!fingerprint) return { terminate: false };
+
+    const timestamp = now();
+    const recent = (attempts.get(fingerprint) ?? [])
+      .filter((attemptedAt) => timestamp - attemptedAt <= BASH_REPETITION_WINDOW_MS);
+    if (recent.length === 0) warned.delete(fingerprint);
+    recent.push(timestamp);
+    attempts.set(fingerprint, recent);
+
+    if (recent.length >= BASH_REPETITION_TERMINATION_COUNT) {
+      return { terminate: true, message: BASH_REPETITION_TERMINATION_MESSAGE };
+    }
+    if (recent.length >= BASH_REPETITION_WARNING_COUNT && !warned.has(fingerprint)) {
+      warned.add(fingerprint);
+      warningPending = true;
+    }
+    return { terminate: false };
+  };
+
+  const extension = (pi: PiExtensionApi): void => {
+    pi.on("agent_start", reset);
+
+    pi.on("tool_execution_end", (event) => {
+      const tool = event.toolName.toLowerCase();
+      if (!event.isError && (tool === "write" || tool === "edit")) reset();
+    });
+
+    pi.on("context", (event) => {
+      const stripped = event.messages.filter((message) => !isWarningMessage(message));
+      const removedSome = stripped.length !== event.messages.length;
+      if (!warningPending) return removedSome ? { messages: stripped } : undefined;
+
+      warningPending = false;
+      stripped.push({
+        role: "user",
+        content: [{ type: "text", text: BASH_REPETITION_WARNING }],
+      });
+      return { messages: stripped };
+    });
+  };
+
+  return { beforeBash, extension };
+}


### PR DESCRIPTION
## Summary
- detect identical Bash commands repeated within a 60-second agent-run window
- inject one ephemeral English warning on the third execution, including the fifth-call cutoff
- block the fifth execution and terminate the current agent turn
- reset after successful write/edit operations or a new agent run

## Verification
- runtime typecheck passes
- targeted Bash guard and wrapper tests: 7 passed
- runtime suite: 658/659 passed; the sole temporary-directory cleanup race passed on isolated rerun