### PR TITLE
fix(runtime): preserve paused tasks and escalate nested failures

### DIFF
--- a/packages/runtime/src/__tests__/delivery-error.test.ts
+++ b/packages/runtime/src/__tests__/delivery-error.test.ts
@@ -253,8 +253,9 @@ describe("delivery error path (#97)", () => {
     await waitFor(() => observe.prompts.some((p) => p.agent === "principal" && p.text.includes("failed while task")));
   });
 
-  it("escalates to the exact task creator, not the principal, in a chain", async () => {
-    // auditor created the engineer task; a fatal error must route by task identity.
+  it("notifies the exact task creator and also escalates a nested failure to the principal", async () => {
+    // auditor created the engineer task; the direct notification must preserve
+    // task identity while the principal receives a bounded chain-level alert.
     const observe = { prompts: [] as Array<{ agent: string; text: string }> };
     const factory = factoryWith(
       { engineer: { outcome: () => "401 invalid api key" } },
@@ -281,14 +282,24 @@ describe("delivery error path (#97)", () => {
     const error = sys.find((x) => x.level === "error" && x.text.includes("已通知任务派遣者"));
     expect(error!.text).toContain("任务派遣者");
 
-    // The auditor (not the principal) received the error note.
+    // The auditor receives the task-specific error note.
     await waitFor(() => observe.prompts.some((p) => p.agent === "auditor" && p.text.includes("failed while task")));
-    expect(observe.prompts.some((p) => p.agent === "principal")).toBe(false);
+    // The principal is independently told that the nested chain is blocked.
+    await waitFor(() => observe.prompts.some(
+      (p) => p.agent === "principal" && p.text.includes("Nested task failure"),
+    ));
+    const principalEscalations = observe.prompts.filter(
+      (p) => p.agent === "principal" && p.text.includes("Nested task failure"),
+    );
+    expect(principalEscalations).toHaveLength(1);
+    expect(principalEscalations[0]!.text).toContain("task_000001");
+    expect(principalEscalations[0]!.text).toContain("engineer");
+    expect(principalEscalations[0]!.text).toContain("auditor");
   });
 
-  it("retains the task creator identity even when the creator is not live", async () => {
-    // engineer was delegated by a transient auditor that no longer exists; the
-    // escalation must fall back to the principal rather than resurrect it.
+  it("retains the task creator identity and informs the principal when the creator was not live", async () => {
+    // The durable creator identity remains the direct recipient, while the
+    // principal independently receives the bounded nested-failure alert.
     const observe = { prompts: [] as Array<{ agent: string; text: string }> };
     const factory = factoryWith(
       { engineer: { outcome: () => "401 invalid api key" } },
@@ -310,7 +321,12 @@ describe("delivery error path (#97)", () => {
 
     await waitFor(() => sys.some((x) => x.level === "error" && x.text.includes("已通知任务派遣者")));
     await waitFor(() => observe.prompts.some((p) => p.agent === "ghost" && p.text.includes("failed while task")));
-    expect(observe.prompts.some((p) => p.agent === "principal")).toBe(false);
+    await waitFor(() => observe.prompts.some(
+      (p) => p.agent === "principal" && p.text.includes("Nested task failure"),
+    ));
+    expect(observe.prompts.filter(
+      (p) => p.agent === "principal" && p.text.includes("Nested task failure"),
+    )).toHaveLength(1);
   });
 
   it("recovers and does NOT escalate when a retry succeeds", async () => {

--- a/packages/runtime/src/__tests__/tool-access.test.ts
+++ b/packages/runtime/src/__tests__/tool-access.test.ts
@@ -109,6 +109,24 @@ describe("tool access control (§9)", () => {
     expect((await complete.execute({ task_id: "task_000001", reply: "done" })).isError).toBeUndefined();
   });
 
+  it("queues work for a paused agent without claiming that delivery started", async () => {
+    const d = deps("principal");
+    let wakeCount = 0;
+    d.isTaskDeliveryPaused = (agent) => agent === "engineer";
+    d.wakeAgent = () => { wakeCount += 1; };
+
+    const result = await createDispatchTaskTool(d).execute({
+      to: "engineer",
+      content: "validate the candidate",
+    });
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]?.text).toContain('queued for paused agent "engineer"');
+    expect(result.content[0]?.text).toContain("delivery=queued_paused");
+    expect(result.content[0]?.text).toContain("delivered when the agent resumes");
+    expect(wakeCount).toBe(0);
+  });
+
   it("ask_user validates choices and defaults free text to enabled", async () => {
     const seen: Array<Record<string, unknown>> = [];
     const d = deps("principal");

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -2574,6 +2574,7 @@ export class SessionManager {
       destroyAgent: async (target) => {
         await this.destroyAgent(sessionId, target);
       },
+      isTaskDeliveryPaused: (target) => entry.taskLedger.isPaused(target),
       wakeAgent: (target) => this.wakeAgent(sessionId, target),
       requestUserInput: (req) => this.requestUserInput(
         entry,
@@ -3205,11 +3206,13 @@ export class SessionManager {
 
   private async writeErrorToTaskCreators(entry: SessionEntry, expert: string, headline: string): Promise<void> {
     const creators = new Set<string>();
-    for (const task of entry.taskLedger.pendingAssignedTo(expert)) {
+    const affectedTasks = entry.taskLedger.pendingAssignedTo(expert);
+    const compactHeadline = headline.replace(/\s+/g, " ").trim().slice(0, 500) || "unknown error";
+    for (const task of affectedTasks) {
       try {
         await entry.taskLedger.enqueueSystem(
           task.created_by,
-          `Agent "${expert}" failed while task ${task.id} remains pending. Error: ${headline}`,
+          `Agent "${expert}" failed while task ${task.id} remains pending. Error: ${compactHeadline}`,
           task.id,
         );
         creators.add(task.created_by);
@@ -3217,6 +3220,23 @@ export class SessionManager {
         // The user-facing system_message already records the terminal delivery
         // error. A full creator queue must not make the failed assignee retry
         // forever; the pending task remains visible in the creator's task list.
+      }
+    }
+    const nestedTasks = affectedTasks.filter((task) => task.created_by !== "principal");
+    if (nestedTasks.length > 0) {
+      const taskSummary = nestedTasks
+        .map((task) => `${task.id} (creator: ${task.created_by})`)
+        .join(", ");
+      try {
+        await entry.taskLedger.enqueueSystem(
+          "principal",
+          `Nested task failure: Agent "${expert}" failed; ${taskSummary} remain pending. ` +
+            `The direct task creators were notified. Error: ${compactHeadline}`,
+        );
+        creators.add("principal");
+      } catch {
+        // The user-facing system message still exposes the failure. Preserve
+        // the pending tasks so a later user turn can recover them explicitly.
       }
     }
     for (const creator of creators) this.wakeAgent(entry.id, creator);

--- a/packages/runtime/src/tools/system-tools.ts
+++ b/packages/runtime/src/tools/system-tools.ts
@@ -36,6 +36,8 @@ export interface ToolDeps {
   ensureAgent: (name: string) => Promise<void>;
   /** Destroy an agent (memory only; history kept). */
   destroyAgent: (name: string) => Promise<void>;
+  /** Whether host-owned task delivery is currently paused for this target. */
+  isTaskDeliveryPaused?: (name: string) => boolean;
   /**
    * Wake a target agent to consume task notifications. Fire-and-forget: kicks a
    * serial delivery loop on the target so a committed task actually starts
@@ -188,6 +190,12 @@ export function createDispatchTaskTool(deps: ToolDeps): SystemTool {
       try {
         await deps.ensureAgent(to);
         const task = await deps.dispatchTask(to, content);
+        if (deps.isTaskDeliveryPaused?.(to)) {
+          return ok(
+            `task ${task.id} queued for paused agent "${to}" (delivery=queued_paused); ` +
+              "it will be delivered when the agent resumes",
+          );
+        }
         deps.wakeAgent(to);
         return ok(`task ${task.id} dispatched to ${to}`);
       } catch (err) {


### PR DESCRIPTION
## Summary
- keep tasks durably queued when their target agent's delivery is paused and report  without attempting a wake
- preserve normal immediate delivery for active targets and existing resume-on-user-input behavior
- notify exact task creators on terminal delivery failure and also send one compact nested-failure escalation to Principal
- cap provider error text included in escalation notifications

## Verification
- targeted runtime regression suite: 58 passed
- runtime typecheck passed
- full runtime suite: 659/660 passed; the remaining existing temp-directory cleanup race passed in isolation
- git diff check passed