### PR TITLE
feat(runtime): add authoritative session workflow state

### DIFF
--- a/packages/backend-core/src/per-user-docker-orchestrator.ts
+++ b/packages/backend-core/src/per-user-docker-orchestrator.ts
@@ -31,6 +31,7 @@ const DEFAULT_USER = "__default__";
 /** Metrics shape we read off a per-user runtime for idle-reclaim (R-3). */
 interface RuntimeMetrics {
   runningAgents?: number;
+  reclaimable?: boolean;
   lastActivityAt?: string | null;
 }
 
@@ -47,8 +48,8 @@ export interface PerUserDockerOrchestratorOptions
   /** Highest host port to hand out (inclusive). Default 8199. */
   portMax?: number;
   /**
-   * Idle threshold (ms). A user's container with `runningAgents === 0` and no
-   * activity newer than this is stopped by the reaper. `0` disables reclaim.
+   * Idle threshold (ms). A container is considered only when Runtime reports
+   * `reclaimable=true`; the atomic reclaim probe must then also accept it.
    * Default 0 (off) — callers/compose opt in via BP_DYNAMIC_IDLE_MS.
    */
   idleMs?: number;
@@ -65,6 +66,8 @@ export interface PerUserDockerOrchestratorOptions
    * of `${baseUrl}/metrics`. Used only by the idle reaper.
    */
   metricsProbe?: (baseUrl: string) => Promise<RuntimeMetrics | null>;
+  /** Atomically fence and re-check a Runtime before its container is stopped. */
+  reclaimProbe?: (baseUrl: string) => Promise<boolean>;
   /** Injectable clock (ms). Defaults to Date.now. */
   now?: () => number;
   /** Injectable timer setter. Defaults to setInterval. */
@@ -92,6 +95,15 @@ async function defaultMetricsProbe(
   }
 }
 
+async function defaultReclaimProbe(baseUrl: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${baseUrl}/runtime/shutdown-if-reclaimable`, { method: "POST" });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
 export class PerUserDockerOrchestrator implements Orchestrator {
   private readonly base: Omit<DockerOrchestratorOptions, "hostPort" | "dataDir">;
   private readonly dataRoot?: string;
@@ -104,6 +116,7 @@ export class PerUserDockerOrchestrator implements Orchestrator {
     opts: DockerOrchestratorOptions,
   ) => Orchestrator;
   private readonly metricsProbe: (baseUrl: string) => Promise<RuntimeMetrics | null>;
+  private readonly reclaimProbe: (baseUrl: string) => Promise<boolean>;
   private readonly now: () => number;
   private readonly setIntervalFn: (
     cb: () => void,
@@ -114,6 +127,7 @@ export class PerUserDockerOrchestrator implements Orchestrator {
   private readonly users = new Map<string, UserEntry>();
   /** Single-flight per user (issue #58 pattern): concurrent first requests share one launch. */
   private readonly starting = new Map<string, Promise<RuntimeHandle>>();
+  private readonly reclaiming = new Map<string, Promise<void>>();
   private readonly usedPorts = new Set<number>();
   private reaper: ReturnType<typeof setInterval> | null = null;
 
@@ -126,6 +140,7 @@ export class PerUserDockerOrchestrator implements Orchestrator {
       reapIntervalMs,
       createOrchestrator,
       metricsProbe,
+      reclaimProbe,
       now,
       setIntervalFn,
       clearIntervalFn,
@@ -141,6 +156,7 @@ export class PerUserDockerOrchestrator implements Orchestrator {
     this.makeOrchestrator =
       createOrchestrator ?? ((opts) => new DockerOrchestrator(opts));
     this.metricsProbe = metricsProbe ?? defaultMetricsProbe;
+    this.reclaimProbe = reclaimProbe ?? defaultReclaimProbe;
     this.now = now ?? (() => Date.now());
     this.setIntervalFn =
       setIntervalFn ?? ((cb, ms) => setInterval(cb, ms));
@@ -154,6 +170,11 @@ export class PerUserDockerOrchestrator implements Orchestrator {
 
   async ensureRuntime(opts?: EnsureRuntimeOptions): Promise<RuntimeHandle> {
     const userId = opts?.userId ?? DEFAULT_USER;
+    const reclaiming = this.reclaiming.get(userId);
+    if (reclaiming) {
+      await reclaiming;
+      return this.ensureRuntime(opts);
+    }
 
     const existing = this.users.get(userId);
     if (existing) {
@@ -281,8 +302,8 @@ export class PerUserDockerOrchestrator implements Orchestrator {
   }
 
   /**
-   * Idle reclaim (#301 req 4 / R-3): stop+remove any user's container that has
-   * no running agents AND whose most recent activity is older than `idleMs`.
+   * Idle reclaim (#301 req 4 / R-3): stop+remove a user's container only after
+   * Runtime reports it reclaimable and atomically accepts the final reclaim.
    * `lastActivityAt` (from the runtime) wins; we fall back to `lastEnsuredAt`.
    */
   async reapIdle(): Promise<void> {
@@ -294,13 +315,22 @@ export class PerUserDockerOrchestrator implements Orchestrator {
       // If metrics are unreadable, don't reap — a transient probe failure must
       // not evict an in-use sandbox.
       if (!metrics) continue;
-      if ((metrics.runningAgents ?? 0) > 0) continue;
-      const lastActivity = metrics.lastActivityAt
+      if (metrics.reclaimable !== true) continue;
+      const runtimeActivity = metrics.lastActivityAt
         ? Date.parse(metrics.lastActivityAt)
         : entry.lastEnsuredAt;
-      const idleFor = now - (Number.isNaN(lastActivity) ? entry.lastEnsuredAt : lastActivity);
+      const lastActivity = Math.max(
+        entry.lastEnsuredAt,
+        Number.isNaN(runtimeActivity) ? entry.lastEnsuredAt : runtimeActivity,
+      );
+      const idleFor = now - lastActivity;
       if (idleFor >= this.idleMs) {
-        await this.disposeUser(userId);
+        const operation = (async () => {
+          if (this.users.get(userId) !== entry) return;
+          if (await this.reclaimProbe(entry.baseUrl)) await this.disposeUser(userId);
+        })().finally(() => this.reclaiming.delete(userId));
+        this.reclaiming.set(userId, operation);
+        await operation;
       }
     }
     if (this.users.size === 0) this.stopReaper();

--- a/packages/backend-core/test/per-user-docker-orchestrator.test.ts
+++ b/packages/backend-core/test/per-user-docker-orchestrator.test.ts
@@ -44,6 +44,7 @@ function makeOrch(
     portMin: 8100,
     portMax: 8102,
     createOrchestrator: (o) => new FakeOrchestrator(o),
+    reclaimProbe: async () => true,
     ...overrides,
   });
   return orch;
@@ -158,6 +159,7 @@ describe("PerUserDockerOrchestrator", () => {
       let clock = 1_000_000;
       const metricsProbe = vi.fn(async () => ({
         runningAgents: 0,
+        reclaimable: true,
         lastActivityAt: new Date(clock - 10 * 60_000).toISOString(),
       }));
       const orch = makeOrch({
@@ -168,6 +170,7 @@ describe("PerUserDockerOrchestrator", () => {
         clearIntervalFn: () => {},
       });
       await orch.ensureRuntime({ userId: "alice" });
+      clock += 10 * 60_000;
       await orch.reapIdle();
       expect(orch.activeUsers).toEqual([]);
       expect(FakeOrchestrator.instances[0]!.stopped).toBe(true);
@@ -177,7 +180,7 @@ describe("PerUserDockerOrchestrator", () => {
       let clock = 1_000_000;
       const orch = makeOrch({
         idleMs: 1,
-        metricsProbe: async () => ({ runningAgents: 2, lastActivityAt: null }),
+        metricsProbe: async () => ({ runningAgents: 2, reclaimable: false, lastActivityAt: null }),
         now: () => clock,
         setIntervalFn: () => 0 as unknown as ReturnType<typeof setInterval>,
         clearIntervalFn: () => {},
@@ -185,6 +188,64 @@ describe("PerUserDockerOrchestrator", () => {
       await orch.ensureRuntime({ userId: "alice" });
       await orch.reapIdle();
       expect(orch.activeUsers).toEqual(["alice"]);
+    });
+
+    it("does NOT infer reclaimability from legacy runningAgents", async () => {
+      const orch = makeOrch({
+        idleMs: 1,
+        metricsProbe: async () => ({ runningAgents: 0, lastActivityAt: null }),
+        setIntervalFn: () => 0 as unknown as ReturnType<typeof setInterval>,
+        clearIntervalFn: () => {},
+      });
+      await orch.ensureRuntime({ userId: "alice" });
+      await orch.reapIdle();
+      expect(orch.activeUsers).toEqual(["alice"]);
+    });
+
+    it("does NOT reap when the Runtime rejects the atomic reclaim", async () => {
+      const orch = makeOrch({
+        idleMs: 1,
+        metricsProbe: async () => ({ reclaimable: true, lastActivityAt: null }),
+        reclaimProbe: async () => false,
+        setIntervalFn: () => 0 as unknown as ReturnType<typeof setInterval>,
+        clearIntervalFn: () => {},
+      });
+      await orch.ensureRuntime({ userId: "alice" });
+      await orch.reapIdle();
+      expect(orch.activeUsers).toEqual(["alice"]);
+    });
+
+    it("makes a concurrent ensure wait for reclaim and receive a fresh container", async () => {
+      let release!: () => void;
+      let clock = 0;
+      const gate = new Promise<void>((resolve) => { release = resolve; });
+      const entered = vi.fn();
+      const orch = makeOrch({
+        idleMs: 1,
+        metricsProbe: async () => ({
+          reclaimable: true,
+          lastActivityAt: new Date(0).toISOString(),
+        }),
+        reclaimProbe: async () => {
+          entered();
+          await gate;
+          return true;
+        },
+        now: () => clock,
+        setIntervalFn: () => 0 as unknown as ReturnType<typeof setInterval>,
+        clearIntervalFn: () => {},
+      });
+      await orch.ensureRuntime({ userId: "alice" });
+      clock = 10_000;
+      const reap = orch.reapIdle();
+      await vi.waitFor(() => expect(entered).toHaveBeenCalledOnce());
+      const ensured = orch.ensureRuntime({ userId: "alice" });
+      release();
+      await reap;
+
+      expect((await ensured).baseUrl).toBe("http://127.0.0.1:8100");
+      expect(FakeOrchestrator.instances).toHaveLength(2);
+      expect(FakeOrchestrator.instances[0]!.stopped).toBe(true);
     });
 
     it("does NOT reap when metrics are unreadable (transient probe failure)", async () => {

--- a/packages/client-cli/src/bin.ts
+++ b/packages/client-cli/src/bin.ts
@@ -2,7 +2,8 @@
 /**
  * bin.ts — the `bp-client` executable. A headless verification client that
  * drives a BrainPilot session over HTTP+SSE (no web UI), printing AG-UI events
- * until RUN_FINISHED / command_complete (TS_PI_REFACTOR_DESIGN §15.4).
+ * until session_state reports idle (legacy runtimes fall back to
+ * RUN_FINISHED/RUN_ERROR) or command_complete.
  */
 import { Command } from "commander";
 import { run, DEFAULT_BASE_URL } from "./index.js";

--- a/packages/client-cli/src/client.test.ts
+++ b/packages/client-cli/src/client.test.ts
@@ -3,7 +3,10 @@ import {
   BrainPilotClient,
   parseSseStream,
   fillPath,
+  hasWorkflowStatus,
   isTerminalEvent,
+  sessionTerminalStatus,
+  sessionWorkflowState,
   DEFAULT_BASE_URL,
 } from "./client.js";
 import { driveSession } from "./driver.js";
@@ -157,6 +160,21 @@ describe("isTerminalEvent", () => {
   });
 });
 
+describe("session workflow status", () => {
+  const event = (status: unknown) => ({
+    type: "CUSTOM",
+    name: "session_state",
+    value: { workState: { active: status === "active", status, epoch: 1 } },
+  }) as unknown as AgUiEvent;
+
+  it("recognizes authoritative and terminal session states", () => {
+    expect(hasWorkflowStatus(event("active"))).toBe(true);
+    expect(sessionTerminalStatus(event("active"))).toBeNull();
+    expect(sessionTerminalStatus(event("idle"))).toBe("idle");
+    expect(sessionWorkflowState(event("active"))).toEqual({ status: "active", epoch: 1 });
+  });
+});
+
 describe("driveSession", () => {
   it("creates a session, sends a message, and stops on RUN_FINISHED", async () => {
     const calls: string[] = [];
@@ -205,6 +223,33 @@ describe("driveSession", () => {
     expect(
       calls.some((c) => c === "POST http://localhost:9001/api/sessions/sess-1/messages"),
     ).toBe(true);
+  });
+
+  it("ignores agent RUN_FINISHED when authoritative workflow state is present", async () => {
+    const fetchFn = (async (url: string | URL, init?: RequestInit) => {
+      const u = String(url);
+      const method = init?.method ?? "GET";
+      if (u.endsWith("/sessions") && method === "POST") {
+        return new Response(JSON.stringify({ id: "s-state" }), { status: 200 });
+      }
+      if (u.endsWith("/messages")) return new Response(JSON.stringify({ accepted: true }), { status: 200 });
+      return new Response(streamFrom([
+        'data: {"type":"CUSTOM","name":"session_state","value":{"workState":{"active":true,"status":"active","epoch":1}}}\n\n',
+        'data: {"type":"RUN_FINISHED","run_id":"expert-1"}\n\n',
+        'data: {"type":"CUSTOM","name":"session_state","value":{"workState":{"active":false,"status":"idle","epoch":0}}}\n\n',
+        'data: {"type":"CUSTOM","name":"session_state","value":{"workState":{"active":true,"status":"active","epoch":1}}}\n\n',
+        'data: {"type":"CUSTOM","name":"session_state","value":{"workState":{"active":false,"status":"idle","epoch":1}}}\n\n',
+      ]), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const result = await driveSession(
+      { baseUrl: "http://localhost:9001/api", message: "go" },
+      { fetchFn },
+    );
+    expect(result.reason).toBe("terminal");
+    expect(result.events.map((entry) => (entry as { type: string }).type)).toEqual([
+      "CUSTOM", "RUN_FINISHED", "CUSTOM", "CUSTOM", "CUSTOM",
+    ]);
   });
 
   it("respects maxEvents as a safety bound", async () => {

--- a/packages/client-cli/src/client.ts
+++ b/packages/client-cli/src/client.ts
@@ -182,3 +182,38 @@ export function isTerminalEvent(evt: AgUiEvent): boolean {
   const t = (evt as { type?: string }).type;
   return t === "RUN_FINISHED" || t === "RUN_ERROR";
 }
+
+/** Session-level terminal status carried by authoritative session_state frames. */
+export function sessionTerminalStatus(evt: AgUiEvent): "idle" | null {
+  const raw = evt as unknown as { type?: string; name?: string; value?: { workState?: { status?: unknown } } };
+  if (raw.type !== "CUSTOM" || raw.name !== "session_state") return null;
+  const status = raw.value?.workState?.status;
+  return status === "idle" ? status : null;
+}
+
+export function sessionWorkflowState(evt: AgUiEvent): {
+  status: "idle" | "active";
+  epoch: number;
+} | null {
+  const raw = evt as unknown as {
+    type?: string;
+    name?: string;
+    value?: { workState?: { status?: unknown; epoch?: unknown } };
+  };
+  if (!hasWorkflowStatus(evt)) return null;
+  const status = raw.value?.workState?.status;
+  if (status !== "idle" && status !== "active") {
+    return null;
+  }
+  const epoch = raw.value?.workState?.epoch;
+  return { status, epoch: typeof epoch === "number" && Number.isInteger(epoch) && epoch >= 0 ? epoch : 0 };
+}
+
+/** Whether this runtime exposes the authoritative two-state lifecycle contract. */
+export function hasWorkflowStatus(evt: AgUiEvent): boolean {
+  const raw = evt as unknown as { type?: string; name?: string; value?: { workState?: object } };
+  return raw.type === "CUSTOM"
+    && raw.name === "session_state"
+    && raw.value?.workState !== undefined
+    && Object.prototype.hasOwnProperty.call(raw.value.workState, "status");
+}

--- a/packages/client-cli/src/driver.ts
+++ b/packages/client-cli/src/driver.ts
@@ -1,10 +1,15 @@
 /**
  * driver.ts — the high-level "drive one session to completion" flow used by the
  * bin and by integration smoke tests. Creates a session, sends a message,
- * subscribes to the event stream, and resolves when a terminal event arrives
- * (RUN_FINISHED / RUN_ERROR) or `command_complete` is seen.
+ * subscribes to the event stream, and resolves on a session-level terminal
+ * status. Legacy runtimes fall back to RUN_FINISHED/RUN_ERROR.
  */
-import { BrainPilotClient, isTerminalEvent } from "./client.js";
+import {
+  BrainPilotClient,
+  hasWorkflowStatus,
+  isTerminalEvent,
+  sessionWorkflowState,
+} from "./client.js";
 import type { AgUiEvent } from "@brainpilot/protocol";
 
 export interface DriveOptions {
@@ -65,11 +70,23 @@ export async function driveSession(
   await client.sendMessage(sessionId, options.message, options.agent);
 
   let reason: DriveResult["reason"] = "stream_end";
+  let authoritativeWorkflow = false;
+  let workflowEpoch = -1;
   try {
     for await (const evt of stream) {
       events.push(evt);
       onEvent?.(evt);
-      if (isTerminalEvent(evt)) {
+      if (hasWorkflowStatus(evt)) authoritativeWorkflow = true;
+      const workflow = sessionWorkflowState(evt);
+      if (workflow && workflow.epoch >= workflowEpoch) {
+        workflowEpoch = workflow.epoch;
+        if (workflow.status === "idle" && workflow.epoch > 0) {
+          reason = "terminal";
+          break;
+        }
+      }
+      // Compatibility with runtimes predating workState.status.
+      if (!authoritativeWorkflow && isTerminalEvent(evt)) {
         reason = "terminal";
         break;
       }

--- a/packages/client-cli/src/index.ts
+++ b/packages/client-cli/src/index.ts
@@ -6,6 +6,9 @@ export {
   parseSseStream,
   fillPath,
   isTerminalEvent,
+  hasWorkflowStatus,
+  sessionTerminalStatus,
+  sessionWorkflowState,
   DEFAULT_BASE_URL,
 } from "./client.js";
 export type { BrainPilotClientOptions } from "./client.js";

--- a/packages/protocol/src/domain.ts
+++ b/packages/protocol/src/domain.ts
@@ -269,6 +269,31 @@ export const SessionStatsSchema = z.object({
 });
 export type SessionStats = z.infer<typeof SessionStatsSchema>;
 
+export const WorkStatusSchema = z.enum(["idle", "active"]);
+export type WorkStatus = z.infer<typeof WorkStatusSchema>;
+
+export const WorkStateSchema = z.object({
+  active: z.boolean(),
+  /** Absent only on legacy runtimes. */
+  status: WorkStatusSchema.optional(),
+  epoch: z.number().int().nonnegative().optional(),
+}).superRefine((value, context) => {
+  if (value.status !== undefined && value.active !== (value.status === "active")) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "workState.active must equal (status === 'active')",
+      path: ["active"],
+    });
+  }
+  if (value.status !== undefined && value.epoch === undefined) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "workState.epoch is required when status is present",
+      path: ["epoch"],
+    });
+  }
+});
+
 /**
  * Authoritative live session state. Identical shape across SSE first frame
  * (`CUSTOM:session_state`), push events, and `GET /sessions/:id/state`.
@@ -280,9 +305,7 @@ export const SessionStateSnapshotSchema = z.object({
     runId: z.string().nullable(),
   }),
   /** Aggregate lifecycle for all work owned by the session. */
-  workState: z.object({
-    active: z.boolean(),
-  }),
+  workState: WorkStateSchema,
   agents: z.array(AgentStatusSchema),
   /** Optional for compatibility with runtimes predating isolated subagents. */
   subagents: z.array(SubagentStatusSchema).optional(),

--- a/packages/protocol/src/http.ts
+++ b/packages/protocol/src/http.ts
@@ -58,6 +58,8 @@ export type HealthResponse = z.infer<typeof HealthResponseSchema>;
 export const MetricsResponseSchema = z.object({
   activeSessions: z.number(),
   runningAgents: z.number(),
+  /** Runtime-owned aggregate decision; absent only on legacy runtimes. */
+  reclaimable: z.boolean().optional(),
   /** ISO8601 of last activity across all sessions; null if never active. */
   lastActivityAt: z.string().nullable(),
   /** Resident set size in bytes. */
@@ -71,6 +73,11 @@ export const MetricsResponseSchema = z.object({
   memRatio: z.number().nullable(),
 });
 export type MetricsResponse = z.infer<typeof MetricsResponseSchema>;
+
+export const ShutdownIfReclaimableResponseSchema = z.object({
+  reclaimable: z.boolean(),
+});
+export type ShutdownIfReclaimableResponse = z.infer<typeof ShutdownIfReclaimableResponseSchema>;
 
 /* ------------------------------------------------------------------ *
  * PUT /runtime/capabilities  (backend-managed plugin capability sync)
@@ -314,6 +321,7 @@ export type EvictSessionResponse = z.infer<typeof EvictSessionResponseSchema>;
 export const RUNTIME_ROUTES = {
   health: { method: "GET", path: "/health" },
   metrics: { method: "GET", path: "/metrics" },
+  shutdownIfReclaimable: { method: "POST", path: "/runtime/shutdown-if-reclaimable" },
   setRuntimeCapabilities: { method: "PUT", path: "/runtime/capabilities" },
   mcpStatus: { method: "GET", path: "/mcp/status" },
   createSession: { method: "POST", path: "/sessions" },

--- a/packages/protocol/test/domain.test.ts
+++ b/packages/protocol/test/domain.test.ts
@@ -52,6 +52,34 @@ describe("domain schemas", () => {
     ).toBeNull();
   });
 
+  it("validates the two-state workflow lifecycle while accepting legacy workState", () => {
+    const parsed = SessionStateSnapshotSchema.parse({
+      runState: { active: false, runId: null },
+      workState: { active: false, status: "idle", epoch: 3 },
+      agents: [],
+      lastActivityTs: "",
+    });
+    expect(parsed.workState).toMatchObject({ status: "idle", epoch: 3 });
+    expect(SessionStateSnapshotSchema.safeParse({
+      runState: { active: false, runId: null },
+      workState: { active: false, status: "quiescent", epoch: 3 },
+      agents: [],
+      lastActivityTs: "",
+    }).success).toBe(false);
+    expect(SessionStateSnapshotSchema.safeParse({
+      runState: { active: false, runId: null },
+      workState: { active: false, status: "blocked", epoch: 3 },
+      agents: [],
+      lastActivityTs: "",
+    }).success).toBe(false);
+    expect(SessionStateSnapshotSchema.safeParse({
+      runState: { active: false, runId: null },
+      workState: { active: true, status: "idle", epoch: 3 },
+      agents: [],
+      lastActivityTs: "",
+    }).success).toBe(false);
+  });
+
   it("SessionStateSnapshot carries optional tokenUsage", () => {
     const parsed = SessionStateSnapshotSchema.parse({
       runState: { active: false, runId: null },

--- a/packages/protocol/test/http.test.ts
+++ b/packages/protocol/test/http.test.ts
@@ -23,6 +23,7 @@ describe("Runtime HTTP contract", () => {
       MetricsResponseSchema.parse({
         activeSessions: 2,
         runningAgents: 1,
+        reclaimable: false,
         lastActivityAt: "2026-06-12T00:00:00Z",
         memRss: 12345,
         memLimitBytes: 1048576,
@@ -101,6 +102,10 @@ describe("Runtime HTTP contract", () => {
   it("route catalog has the §15.4 endpoints with correct methods", () => {
     expect(RUNTIME_ROUTES.health).toEqual({ method: "GET", path: "/health" });
     expect(RUNTIME_ROUTES.metrics).toEqual({ method: "GET", path: "/metrics" });
+    expect(RUNTIME_ROUTES.shutdownIfReclaimable).toEqual({
+      method: "POST",
+      path: "/runtime/shutdown-if-reclaimable",
+    });
     expect(RUNTIME_ROUTES.createSession).toEqual({ method: "POST", path: "/sessions" });
     expect(RUNTIME_ROUTES.sendMessage.path).toBe("/sessions/:id/messages");
     expect(RUNTIME_ROUTES.sessionEvents).toEqual({ method: "GET", path: "/sse/:id" });

--- a/packages/runtime/src/__tests__/ask-user.test.ts
+++ b/packages/runtime/src/__tests__/ask-user.test.ts
@@ -25,6 +25,14 @@ function enqueueQuestion(
   ) as Promise<string>;
 }
 
+async function waitFor(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
+  const started = Date.now();
+  while (!predicate()) {
+    if (Date.now() - started > timeoutMs) throw new Error("waitFor timed out");
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
 describe("ask_user (SessionManager)", () => {
   let m: SessionManager;
   beforeEach(() => {
@@ -134,6 +142,10 @@ describe("ask_user (SessionManager)", () => {
     await m.sendMessage(session.id, 'decide [[tool:ask_user {"question":"Q"}]]');
     await new Promise((r) => setTimeout(r, 20));
     expect(events.find((e) => e.type === "user_input_request")).toBeTruthy();
+    expect(m.getSessionState(session.id)?.workState).toMatchObject({
+      active: true,
+      status: "active",
+    });
 
     await m.interrupt(session.id);
     await new Promise((r) => setTimeout(r, 20));
@@ -296,7 +308,7 @@ describe("ask_user (SessionManager)", () => {
     const events: AgUiEvent[] = [];
     manager.subscribe(session.id, (event) => events.push(event));
     await manager.sendMessage(session.id, 'decide [[tool:ask_user {"question":"Q"}]]');
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await waitFor(() => events.some((event) => event.type === "user_input_request"));
     const request = events.find((event) => event.type === "user_input_request") as any;
     const eventPath = join(dataRoot, ".bp", session.id, "events.jsonl");
     await rm(eventPath, { force: true });

--- a/packages/runtime/src/__tests__/background-job-integration.test.ts
+++ b/packages/runtime/src/__tests__/background-job-integration.test.ts
@@ -46,6 +46,12 @@ describe("Background Jobs runtime integration", () => {
     expect(toolNames.get("engineer")).toEqual(expect.arrayContaining(["run_in_background", "background_job"]));
     await new Promise((resolve) => setTimeout(resolve, 80));
     expect(prompts.filter((item) => item.text.includes("<background_job_events"))).toHaveLength(0);
+    expect(manager.getSessionState(session.id)?.workState).toMatchObject({
+      active: true,
+      status: "active",
+      epoch: 1,
+    });
+    expect(manager.metrics().reclaimable).toBe(false);
     await waitFor(() => prompts.some((item) => item.text.includes("<background_job_events")));
     const completion = prompts.filter((item) => item.text.includes("<background_job_events"));
     expect(completion).toHaveLength(1);
@@ -54,6 +60,8 @@ describe("Background Jobs runtime integration", () => {
     expect(completion[0]?.text).toContain("log_path=");
     expect(completion[0]?.text).toContain("Inspect the referenced log only when needed");
     expect(completion[0]?.text).toContain("untrusted=\"true\"");
+    await waitFor(() => manager.getSessionState(session.id)?.workState.status === "idle");
+    expect(manager.metrics().reclaimable).toBe(true);
     manager.shutdown();
   });
 

--- a/packages/runtime/src/__tests__/interrupt.test.ts
+++ b/packages/runtime/src/__tests__/interrupt.test.ts
@@ -133,12 +133,17 @@ describe("whole-session interrupt (#90 / #327)", () => {
 
     // The event remains durable but cannot re-wake librarian while paused.
     expect(m.taskNotificationCount(s.id, "librarian")).toBe(beforeStop);
+    expect(m.getSessionState(s.id)?.workState).toMatchObject({
+      active: false,
+      status: "idle",
+    });
     const beforeResume = observe.prompts.filter((prompt) => prompt.agent === "librarian").length;
     await new Promise((resolve) => setTimeout(resolve, 20));
     expect(observe.prompts.filter((prompt) => prompt.agent === "librarian")).toHaveLength(beforeResume);
 
     await m.sendMessage(s.id, "resume");
     await waitFor(() => observe.prompts.filter((prompt) => prompt.agent === "librarian").length > beforeResume);
+    expect(m.getSessionState(s.id)?.workState.epoch).toBe(1);
   });
 
   it("does not prompt the principal after stop; emits one system acknowledgement (#327)", async () => {

--- a/packages/runtime/src/__tests__/restore.test.ts
+++ b/packages/runtime/src/__tests__/restore.test.ts
@@ -2,8 +2,8 @@
  * Boot-time session restore. `SessionManager.restoreFromDisk` scans
  * `<dataRoot>/.bp/<id>/meta.json` for every persisted session id and rebuilds
  * the in-memory session list with the persisted timestamps intact (the
- * restore path skips `writeMeta` so the canonical file is not clobbered with
- * boot-time values).
+ * completed/legacy-idle sessions keep their canonical metadata, while
+ * in-flight execution is cancelled and restored idle.
  *
  * The `startServer` integration test in server.test.ts asserts the same
  * behavior end-to-end via `GET /sessions` after boot.
@@ -67,7 +67,7 @@ describe("SessionManager.restoreFromDisk", () => {
     expect(b.updatedAt).toBe("2026-05-21T12:30:00.000Z");
   });
 
-  it("does NOT rewrite meta.json on restore", async () => {
+  it("does NOT rewrite meta.json for a legacy idle session on restore", async () => {
     const dataRoot = await mkdtemp(join(tmpdir(), "bp-restore-"));
     const metaPath = await writeMeta(dataRoot, "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", {
       id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
@@ -116,6 +116,53 @@ describe("SessionManager.restoreFromDisk", () => {
     expect(await m.listSessions()).toHaveLength(1);
     // Timestamps still original after the second pass
     expect((await m.listSessions())[0]!.createdAt).toBe("2026-03-01T00:00:00.000Z");
+  });
+
+  it("cancels in-flight work and restores the sandbox idle", async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), "bp-restore-interrupted-"));
+    const id = "12121212-1212-1212-1212-121212121212";
+    await writeMeta(dataRoot, id, {
+      id,
+      title: "Interrupted",
+      workflowState: { epoch: 3 },
+    });
+    await writeFile(join(dataRoot, ".bp", id, "tasks.json"), JSON.stringify({
+      next_task_seq: 2,
+      next_notification_seq: 2,
+      tasks: [{
+        id: "task_000001",
+        seq: 1,
+        created_by: "principal",
+        assigned_to: "engineer",
+        content: "train model",
+        status: "pending",
+        created_at: 1,
+      }],
+      notifications: [{
+        id: "task_event_000001",
+        seq: 1,
+        kind: "assigned",
+        to_agent: "engineer",
+        from_agent: "principal",
+        task_id: "task_000001",
+        content: "train model",
+        created_at: 1,
+      }],
+      delivery_paused: false,
+      paused_agents: [],
+    }), "utf8");
+
+    const manager = new SessionManager({ dataRoot, persist: true, agentFactory: mockAgentFactory });
+    await manager.restoreFromDisk();
+    expect(manager.getSessionState(id)?.workState).toMatchObject({
+      active: false,
+      status: "idle",
+      epoch: 3,
+    });
+    expect(manager.listTasks(id)).toEqual([
+      expect.objectContaining({ id: "task_000001", status: "cancelled" }),
+    ]);
+    expect(manager.taskNotificationCount(id, "engineer")).toBe(0);
   });
 
   it("persists a cancellation for an orphaned ask_user request", async () => {

--- a/packages/runtime/src/__tests__/server.test.ts
+++ b/packages/runtime/src/__tests__/server.test.ts
@@ -29,15 +29,41 @@ describe("HTTP server (RUNTIME_ROUTES)", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
       activeSessions: number;
+      reclaimable: boolean;
       memRss: number;
       memLimitBytes: number | null;
       memRatio: number | null;
     };
     expect(body.activeSessions).toBe(0);
+    expect(body.reclaimable).toBe(true);
     expect(body.memRss).toBeGreaterThan(0);
     // Opt-in budget unset by default → null (single-user / no throttle).
     expect(body.memLimitBytes).toBeNull();
     expect(body.memRatio).toBeNull();
+  });
+
+  it("atomically rejects reclaim while a workflow is active", async () => {
+    const manager = new SessionManager({ persist: false, agentFactory: mockAgentFactory });
+    const { app } = createServer({ manager });
+    const session = await manager.createSession();
+    await manager.sendMessage(session.id, 'decide [[tool:ask_user {"question":"Q"}]]');
+    await waitFor(() => manager.getSessionState(session.id)?.workState.status === "active");
+
+    const res = await app.request("/runtime/shutdown-if-reclaimable", { method: "POST" });
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ reclaimable: false });
+    await manager.interrupt(session.id);
+  });
+
+  it("fences new work after an idle Runtime accepts reclaim", async () => {
+    const manager = new SessionManager({ persist: false, agentFactory: mockAgentFactory });
+    const { app } = createServer({ manager });
+    await manager.createSession();
+
+    const res = await app.request("/runtime/shutdown-if-reclaimable", { method: "POST" });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ reclaimable: true });
+    await expect(manager.createSession()).rejects.toThrow("runtime is shutting down");
   });
 
   it("accepts only allowlisted backend-managed runtime capabilities", async () => {

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -330,6 +330,7 @@ describe("SessionManager (mock mode)", () => {
 
   it("ignores the removed workflow policy in legacy session metadata", async () => {
     const root = await mkdtemp(join(tmpdir(), "bp-legacy-workflow-policy-"));
+    let restored: SessionManager | undefined;
     try {
       const manager = new SessionManager({ dataRoot: root, persist: true, agentFactory: mockAgentFactory });
       const session = await manager.createSession();
@@ -341,7 +342,7 @@ describe("SessionManager (mock mode)", () => {
       await writeFile(metaPath, JSON.stringify(meta));
 
       const seen: Parameters<typeof mockAgentFactory>[0][] = [];
-      const restored = new SessionManager({
+      restored = new SessionManager({
         dataRoot: root,
         persist: true,
         agentFactory: async (params) => {
@@ -356,6 +357,7 @@ describe("SessionManager (mock mode)", () => {
         .toBeDefined();
       await waitFor(() => restored.getSessionState(session.id)?.workState.active === false);
     } finally {
+      await restored?.shutdownAndSave();
       await rm(root, { recursive: true, force: true });
     }
   });

--- a/packages/runtime/src/__tests__/session-state-authority-unit.test.ts
+++ b/packages/runtime/src/__tests__/session-state-authority-unit.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from "vitest";
+import { SessionStateAuthority } from "../session-state-authority.js";
+
+describe("SessionStateAuthority", () => {
+  it("moves from idle to active and settles through a stable idle pass", () => {
+    let active = false;
+    const scheduled: Array<() => void> = [];
+    const authority = new SessionStateAuthority({
+      inspect: () => ({ active }),
+      publish: vi.fn(),
+      persist: vi.fn(),
+      schedule: (callback) => scheduled.push(callback),
+    });
+
+    expect(authority.snapshot()).toEqual({ active: false, status: "idle", epoch: 0 });
+    authority.beginEpoch();
+    expect(authority.snapshot()).toEqual({ active: true, status: "active", epoch: 1 });
+
+    authority.changed();
+    expect(authority.snapshot().status).toBe("active");
+    expect(scheduled).toHaveLength(1);
+    scheduled.shift()!();
+    expect(authority.snapshot()).toEqual({ active: false, status: "idle", epoch: 1 });
+  });
+
+  it("invalidates an idle candidate when a handoff appears", () => {
+    let active = false;
+    const scheduled: Array<() => void> = [];
+    const authority = new SessionStateAuthority({
+      inspect: () => ({ active }),
+      publish: vi.fn(),
+      persist: vi.fn(),
+      schedule: (callback) => scheduled.push(callback),
+    });
+    authority.beginEpoch();
+    authority.changed();
+
+    active = true;
+    authority.changed();
+    scheduled.shift()!();
+    expect(authority.snapshot()).toEqual({ active: true, status: "active", epoch: 1 });
+  });
+
+  it("treats dormant work as idle and a live wait as active", () => {
+    let active = false;
+    const scheduled: Array<() => void> = [];
+    const authority = new SessionStateAuthority({
+      inspect: () => ({ active }),
+      publish: vi.fn(),
+      persist: vi.fn(),
+      schedule: (callback) => scheduled.push(callback),
+    });
+    authority.beginEpoch();
+    authority.changed();
+    scheduled.shift()!();
+    expect(authority.snapshot().status).toBe("idle");
+
+    active = true;
+    authority.changed();
+    expect(authority.snapshot().status).toBe("active");
+  });
+
+  it("restores a sandbox idle without changing its epoch", async () => {
+    const persist = vi.fn();
+    const authority = new SessionStateAuthority({
+      restored: { epoch: 4 },
+      inspect: () => ({ active: false }),
+      publish: vi.fn(),
+      persist,
+    });
+    await authority.recoverAfterRestart();
+    expect(authority.snapshot()).toEqual({ active: false, status: "idle", epoch: 4 });
+    expect(persist).toHaveBeenLastCalledWith({ epoch: 4 });
+  });
+});

--- a/packages/runtime/src/__tests__/state-authority.test.ts
+++ b/packages/runtime/src/__tests__/state-authority.test.ts
@@ -16,6 +16,7 @@ describe("state authority (§10)", () => {
     const before = m.metrics();
     expect(before.activeSessions).toBe(1);
     expect(before.runningAgents).toBe(0);
+    expect(before.reclaimable).toBe(true);
 
     await m.sendMessage(s.id, "hello");
 
@@ -23,7 +24,10 @@ describe("state authority (§10)", () => {
     await waitFor(() => {
       const agents = m.listAgents(s.id);
       const state = m.getSessionState(s.id);
-      return agents.length > 0 && agents[0]!.status === "idle" && state?.runState.active === false;
+      return agents.length > 0
+        && agents[0]!.status === "idle"
+        && state?.runState.active === false
+        && state.workState.status === "idle";
     });
 
     // We observed a running->idle transition.
@@ -38,9 +42,15 @@ describe("state authority (§10)", () => {
     const state = m.getSessionState(s.id);
     expect(state).toBeDefined();
     expect(state!.runState.active).toBe(false);
+    expect(state!.workState).toMatchObject({
+      active: false,
+      status: "idle",
+      epoch: 1,
+    });
 
     const after = m.metrics();
     expect(after.runningAgents).toBe(0);
+    expect(after.reclaimable).toBe(true);
     expect(after.lastActivityAt).not.toBeNull();
     expect(after.memRss).toBeGreaterThan(0);
   });
@@ -54,7 +64,7 @@ describe("state authority (§10)", () => {
 
     type Snap = {
       runState: { active: boolean; runId: string | null };
-      workState: { active: boolean };
+      workState: { active: boolean; status: string; epoch: number };
       agents: Array<{ name: string; status: string }>;
     };
     const snapshots: Snap[] = [];
@@ -67,7 +77,9 @@ describe("state authority (§10)", () => {
     await m.sendMessage(s.id, "hello");
     await waitFor(() => {
       const agents = m.listAgents(s.id);
-      return agents.length > 0 && agents[0]!.status === "idle";
+      return agents.length > 0
+        && agents[0]!.status === "idle"
+        && m.getSessionState(s.id)?.workState.status === "idle";
     });
 
     // At least: initial frame (active) + running + idle.
@@ -78,6 +90,8 @@ describe("state authority (§10)", () => {
     const first = snapshots[0]!;
     expect(first.runState.active).toBe(true);
     expect(first.workState.active).toBe(true);
+    expect(first.workState.status).toBe("active");
+    expect(first.workState.epoch).toBe(1);
     expect(first.agents.some((a) => a.name === "principal")).toBe(true);
 
     // Somewhere we saw principal running, and the final snapshot is idle.
@@ -87,6 +101,7 @@ describe("state authority (§10)", () => {
     const last = snapshots[snapshots.length - 1]!;
     expect(last.agents.find((a) => a.name === "principal")?.status).toBe("idle");
     expect(last.workState.active).toBe(false);
+    expect(last.workState.status).toBe("idle");
 
     // Reconnect snapshot: the ring buffer replay ends on the latest
     // session_state, so a re-subscribing client recovers the idle state.
@@ -109,6 +124,7 @@ describe("state authority (§10)", () => {
     expect(m.getSession(s.id)).toBeUndefined();
     expect(m.metrics().activeSessions).toBe(0);
   });
+
 });
 
 async function waitFor(pred: () => boolean, timeoutMs = 2000): Promise<void> {

--- a/packages/runtime/src/__tests__/task-delegation.test.ts
+++ b/packages/runtime/src/__tests__/task-delegation.test.ts
@@ -79,6 +79,7 @@ describe("flat task delegation", () => {
     const prompts: Array<{ agent: string; text: string }> = [];
     const manager = new SessionManager({
       persist: false,
+      systemPluginEnv: { BP_EXPERIMENT_DISABLE_PLUGINS: "org.brainpilot.auditor" },
       agentFactory: scriptedFactory({
         principal: { onPrompt: (text) => text.includes("DELEGATE") ? { tool: "dispatch_task", args: { to: "librarian", content: "research" } } : undefined },
         librarian: { onPrompt: (text) => {
@@ -96,6 +97,10 @@ describe("flat task delegation", () => {
     await waitFor(() => manager.getSessionState(session.id)?.runState.active === false);
     expect(manager.listTasks(session.id)[0]).toMatchObject({ status: "replied" });
     expect(prompts.filter((prompt) => prompt.agent === "principal")).toHaveLength(2);
+    await waitFor(() => manager.getSessionState(session.id)?.workState.status === "idle");
+    expect(manager.getSessionState(session.id)?.workState).toMatchObject({
+      active: false, status: "idle", epoch: 1,
+    });
   });
 
   it("returns a compact Auditor report pointer to PI for a correction cycle", async () => {
@@ -164,6 +169,8 @@ describe("flat task delegation", () => {
     await manager.sendMessage(session.id, "hello", "librarian");
     await waitFor(() => prompts.length === 1);
     expect(prompts[0]?.text).toBe("hello");
+    await waitFor(() => manager.getSessionState(session.id)?.workState.status === "idle");
+    expect(manager.getSessionState(session.id)?.workState).toMatchObject({ epoch: 1, active: false });
   });
 
   it("keeps Auditor visible without holding the Principal-only foreground active", async () => {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -8,6 +8,13 @@ export const RUNTIME_NAME = "@brainpilot/runtime";
 
 export { SessionManager } from "./session-manager.js";
 export type { SessionManagerOptions } from "./session-manager.js";
+export { SessionStateAuthority } from "./session-state-authority.js";
+export type {
+  WorkState,
+  SessionWorkFacts,
+  PersistedWorkflowState,
+  SessionStateAuthorityOptions,
+} from "./session-state-authority.js";
 
 export { MasAgent } from "./mas-agent.js";
 export type { AgentStatus, MasAgentOpts } from "./mas-agent.js";

--- a/packages/runtime/src/server.ts
+++ b/packages/runtime/src/server.ts
@@ -4,7 +4,7 @@
  * streams AG-UI events for a session.
  *
  * Routes (from `@brainpilot/protocol` RUNTIME_ROUTES):
- *   GET  /health, GET /metrics
+ *   GET  /health, GET /metrics, POST /runtime/shutdown-if-reclaimable
  *   POST /sessions, GET /sessions, GET /sessions/:id, DELETE /sessions/:id
  *   GET  /sessions/:id/state, POST /sessions/:id/messages
  *   GET  /sse/:id  (+ alias GET /sessions/:id/events)
@@ -38,6 +38,11 @@ export function createServer(opts: SessionManagerOptions & { manager?: SessionMa
   app.get("/health", (c) => c.json({ status: "ok" }));
 
   app.get("/metrics", (c) => c.json(manager.metrics()));
+
+  app.post("/runtime/shutdown-if-reclaimable", async (c) => {
+    const reclaimable = await manager.shutdownIfReclaimable();
+    return c.json({ reclaimable }, reclaimable ? 200 : 409);
+  });
 
   app.put("/runtime/capabilities", async (c) => {
     const parsed = SetRuntimeCapabilitiesRequestSchema.safeParse(await safeBody(c));

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -108,6 +108,12 @@ import {
 } from "./system-plugins.js";
 import { MonitorManager, type MonitorEventBatch } from "./monitor-manager.js";
 import { BackgroundJobManager, type BackgroundJobCompletion } from "./background-job-manager.js";
+import {
+  SessionStateAuthority,
+  type PersistedWorkflowState,
+  type SessionWorkFacts,
+  type WorkState,
+} from "./session-state-authority.js";
 import { withExecutionToolContract } from "./execution-contract.js";
 import { loadRuntimePluginExtension } from "./runtime-plugins.js";
 import { makeWorkspaceLeaseGuardExt } from "./extensions/workspace-lease-guard.js";
@@ -298,6 +304,7 @@ interface SessionMeta {
   workflowTaskSeqBaseline?: number;
   workflowReminderClaimed?: boolean;
   workflowViolationEmitted?: boolean;
+  workflowState?: PersistedWorkflowState;
   systemPlugins?: SystemPluginSnapshot[];
 }
 
@@ -343,6 +350,8 @@ interface SessionEntry {
   monitorEvents: Map<string, MonitorEventBatch[]>;
   backgroundJobManager: BackgroundJobManager;
   backgroundJobEvents: Map<string, BackgroundJobCompletion[]>;
+  stateAuthority: SessionStateAuthority;
+  metaWrites: Promise<void>;
   /**
    * Cumulative real token usage for this session: whole-session `total` plus a
    * per-agent breakdown (keyed by agent name). Fed by each MasAgent's `onUsage`
@@ -1479,6 +1488,7 @@ export class SessionManager {
       workflowTaskSeqBaseline?: number;
       workflowReminderClaimed?: boolean;
       workflowViolationEmitted?: boolean;
+      workflowState?: PersistedWorkflowState;
       systemPlugins?: SystemPluginSnapshot[];
     } = {},
     /**
@@ -1489,6 +1499,7 @@ export class SessionManager {
      */
     _restore?: { createdAt: string; updatedAt: string; lastActivityAt: number },
   ): Promise<Session> {
+    if (this.shuttingDown) throw new Error("runtime is shutting down");
     if (this.memWatchdog?.isOverSoftLimit()) {
       throw new Error("memory budget exceeded: refusing new session");
     }
@@ -1564,12 +1575,16 @@ export class SessionManager {
         if (queued + batch.lines.length > MAX_MONITOR_EVENT_LINES) return false;
         queue.push(batch);
         monitorEvents.set(batch.ownerAgent, queue);
-        if (entry) this.wakeAgent(id, batch.ownerAgent);
+        if (entry) {
+          this.stateChanged(entry);
+          this.wakeAgent(id, batch.ownerAgent);
+        }
         return true;
       },
       onState: (info) => {
         if (!entry) return;
         entry.bus.emit(ev.custom({ sessionId: id, agentName: info.ownerAgent }, CUSTOM_EVENT.MONITOR_STATE, info));
+        this.stateChanged(entry);
       },
     });
     const backgroundJobEvents = new Map<string, BackgroundJobCompletion[]>();
@@ -1582,12 +1597,16 @@ export class SessionManager {
         const queue = backgroundJobEvents.get(completion.ownerAgent) ?? [];
         queue.push(completion);
         backgroundJobEvents.set(completion.ownerAgent, queue);
-        if (entry) this.wakeAgent(id, completion.ownerAgent);
+        if (entry) {
+          this.stateChanged(entry);
+          this.wakeAgent(id, completion.ownerAgent);
+        }
         return true;
       },
       onState: (info) => {
         if (!entry) return;
         entry.bus.emit(ev.custom({ sessionId: id, agentName: info.ownerAgent }, CUSTOM_EVENT.BACKGROUND_JOB_STATE, info));
+        this.stateChanged(entry);
       },
     });
     const subagents = new SubagentManager({
@@ -1620,7 +1639,18 @@ export class SessionManager {
       onChanged: () => {
         if (!entry) return;
         this.touch(entry);
-        this.emitSessionState(entry);
+        this.stateChanged(entry);
+      },
+    });
+
+    const stateAuthority = new SessionStateAuthority({
+      restored: input.workflowState,
+      inspect: () => this.inspectSessionWork(entry),
+      publish: () => {
+        if (entry) this.publishSessionState(entry);
+      },
+      persist: (state) => {
+        if (entry) return this.writeMeta(entry, state, true);
       },
     });
 
@@ -1654,6 +1684,8 @@ export class SessionManager {
       monitorEvents,
       backgroundJobManager,
       backgroundJobEvents,
+      stateAuthority,
+      metaWrites: Promise.resolve(),
       tokenUsage: { total: emptyTokenUsage(), byAgent: {} },
       stats: emptySessionStats(id),
     };
@@ -1691,6 +1723,10 @@ export class SessionManager {
         this.sessions.delete(id);
         throw err;
       }
+      if (_restore) {
+        await taskLedger.cancelAllPending("Sandbox restarted before task completion.");
+        await taskLedger.resumeDelivery();
+      }
       await this.loadTrace(entry);
       // Rehydrate cumulative token usage so the running total survives restarts.
       await this.loadUsage(entry);
@@ -1704,10 +1740,8 @@ export class SessionManager {
       if (_restore) await this.cancelRestoredOrphanInputs(entry);
     }
     await subagents.restore();
+    if (_restore) await entry.stateAuthority.recoverAfterRestart(false);
     this.emitTaskSnapshot(entry);
-    if (_restore) {
-      for (const target of taskLedger.notificationTargets()) this.wakeAgent(id, target);
-    }
     return this.toSession(entry);
   }
 
@@ -1811,6 +1845,7 @@ export class SessionManager {
     await e.backgroundJobManager.stopAll();
     for (const a of e.agents.values()) a.stop();
     await e.subagents.dispose();
+    await e.metaWrites;
     e.bus.clear();
     this.sessions.delete(id);
     this.providerSlots.delete(id);
@@ -1841,6 +1876,7 @@ export class SessionManager {
     await e.bus.flush();
     await e.taskLedger.flush();
     await e.trace.flush();
+    await e.metaWrites;
     e.bus.clear();
     this.sessions.delete(id);
     this.providerSlots.delete(id);
@@ -1914,6 +1950,7 @@ export class SessionManager {
     // exhausted principal/trace notification run. Other targets may resume
     // immediately; this target waits until its direct turn settles so prompts
     // never overlap.
+    const resumesPausedEpoch = entry.taskLedger.hasPausedDelivery();
     const resumeTargetAfterRun = await this.resumeTaskDelivery(entry, agentName);
 
     // Concurrent send: the target agent is still streaming its previous run.
@@ -1935,10 +1972,10 @@ export class SessionManager {
     // Start a fresh host-owned delegation epoch only for a new, idle Principal
     // user turn. Task-result deliveries and queued follow-ups remain in the
     // existing epoch, so a completed delegation continues to satisfy the guard.
-    if (
-      agentName === "principal"
-      && !this.deriveWorkActive(entry)
-    ) {
+    const currentWork = entry.stateAuthority.snapshot();
+    const startsEpoch = currentWork.status === "idle"
+      && (currentWork.epoch === 0 || !resumesPausedEpoch);
+    if (startsEpoch) {
       entry.workflowTaskSeqBaseline = entry.taskLedger.list().reduce(
         (highest, task) => Math.max(highest, task.seq),
         0,
@@ -1959,7 +1996,8 @@ export class SessionManager {
     // emitting, so without this the panel stays empty until the first
     // setStatus("running"). This first frame carries the appropriate PI and
     // aggregate lifecycle values plus the freshly-ensured agent.
-    this.emitSessionState(entry);
+    if (startsEpoch) entry.stateAuthority.beginEpoch();
+    else this.stateChanged(entry);
     // issue #42: persist + broadcast the user's own prompt as a role:"user"
     // CHUNK *before* the agent runs, so SSE replay reconstructs the full
     // transcript (user + assistant). The web composer's optimistic bubble uses
@@ -1984,7 +2022,7 @@ export class SessionManager {
         // correlation is cleared. For a direct reply this yields the terminal
         // active=false frame; for a delegation a pending delivery loop keeps it
         // true (the loop emits its own terminal frame when it drains).
-        this.emitSessionState(entry);
+        this.stateChanged(entry);
         if (resumeTargetAfterRun && entry.taskLedger.count(agentName) > 0) {
           this.wakeAgent(sessionId, agentName);
         }
@@ -1995,6 +2033,7 @@ export class SessionManager {
   private async resumeTaskDelivery(entry: SessionEntry, deferAgent: string): Promise<boolean> {
     if (!entry.taskLedger.hasPausedDelivery()) return false;
     await entry.taskLedger.resumeDelivery();
+    this.stateChanged(entry);
     for (const target of entry.taskLedger.notificationTargets()) {
       if (target !== deferAgent) this.wakeAgent(entry.id, target);
     }
@@ -2027,6 +2066,7 @@ export class SessionManager {
         return;
       }
       entry.userInputs.queue.push(input);
+      this.stateChanged(entry);
       await this.promoteNextUserInputLocked(entry);
     }).catch((err) => deferred.reject(err instanceof Error ? err : new Error(String(err))));
     return deferred.promise;
@@ -2071,6 +2111,7 @@ export class SessionManager {
       input.activatedAt = Date.now();
       input.deadlineAt = input.activatedAt + this.userInputTimeoutMs;
       this.armUserInputTimer(entry, input);
+      this.stateChanged(entry);
       return;
     }
   }
@@ -2122,6 +2163,7 @@ export class SessionManager {
       input.deferred.resolve(normalizedAnswer);
       this.touch(entry);
       await this.promoteNextUserInputLocked(entry);
+      this.stateChanged(entry);
       return "ok";
     });
   }
@@ -2176,6 +2218,7 @@ export class SessionManager {
     entry.userInputs.active = undefined;
     input.deferred.reject(this.userInputError(reason));
     if (promote) await this.promoteNextUserInputLocked(entry);
+    this.stateChanged(entry);
   }
 
   /** Cancel matching active/queued inputs. Queued items were never user-visible. */
@@ -2195,6 +2238,7 @@ export class SessionManager {
       const activeMatches = entry.userInputs.active && predicate(entry.userInputs.active);
       if (activeMatches) await this.cancelActiveUserInputLocked(entry, reason, false);
       if (promote && !entry.userInputs.active) await this.promoteNextUserInputLocked(entry);
+      this.stateChanged(entry);
     });
   }
 
@@ -2339,7 +2383,7 @@ export class SessionManager {
         }),
       );
       this.touch(entry);
-      this.emitSessionState(entry);
+      this.stateChanged(entry);
     }
     await entry.bus.flush();
     return targets.length > 0 || childrenCancelled > 0 || monitorsStopped > 0 || backgroundJobsStopped > 0;
@@ -2554,7 +2598,7 @@ export class SessionManager {
         const task = await entry.taskLedger.dispatch(name, target, content);
         entry.bus.emit(ev.custom({ sessionId }, CUSTOM_EVENT.TASK_STATE, { op: "created", task }));
         this.touch(entry);
-        this.emitSessionState(entry);
+        this.stateChanged(entry);
         return task;
       },
       completeTask: async (taskId, reply) => {
@@ -2563,11 +2607,14 @@ export class SessionManager {
         if (before?.status !== "replied") {
           entry.bus.emit(ev.custom({ sessionId }, CUSTOM_EVENT.TASK_STATE, { op: "replied", task }));
           this.touch(entry);
-          this.emitSessionState(entry);
+          this.stateChanged(entry);
         }
         return task;
       },
-      dispatchTrace: async (content) => entry.taskLedger.enqueueTrace(name, content),
+      dispatchTrace: async (content) => {
+        await entry.taskLedger.enqueueTrace(name, content);
+        this.stateChanged(entry);
+      },
       ensureAgent: async (target) => {
         await this.ensureAgent(sessionId, target);
       },
@@ -2676,9 +2723,15 @@ export class SessionManager {
         dataRoot: this.dataRoot, descriptor, sessionId, agentName: name, cwd: sessionCwd, checkpoints: entry.checkpoints,
         acquireLease: (owner) => {
           if (entry.workspaceLease && entry.workspaceLease.owner !== owner) return false;
-          entry.workspaceLease = { owner, agentName: name }; return true;
+          entry.workspaceLease = { owner, agentName: name };
+          this.stateChanged(entry);
+          return true;
         },
-        releaseLease: (owner) => { if (entry.workspaceLease?.owner === owner) entry.workspaceLease = undefined; },
+        releaseLease: (owner) => {
+          if (entry.workspaceLease?.owner !== owner) return;
+          entry.workspaceLease = undefined;
+          this.stateChanged(entry);
+        },
         ownsLease: (owner) => entry.workspaceLease?.owner === owner,
         emit: (eventName, value) => entry.bus.emit(ev.custom({ sessionId, agentName: name }, eventName, value)),
       }));
@@ -2754,7 +2807,7 @@ export class SessionManager {
       // setStatus early-returns on no-op transitions, so this never storms.
       onStatusChange: (_agentName, status) => {
         this.touch(entry);
-        this.emitSessionState(entry);
+        this.stateChanged(entry);
         if (status === "idle" && (entry.taskLedger.count(name) > 0 || this.hasBackgroundJobEvents(entry, name) || this.hasMonitorEvents(entry, name))) {
           this.wakeAgent(sessionId, name);
         }
@@ -2766,7 +2819,7 @@ export class SessionManager {
         entry.tokenUsage.byAgent[agentName] = cumulative;
         entry.tokenUsage.total = sumAgentUsage(entry.tokenUsage.byAgent);
         this.touch(entry);
-        this.emitSessionState(entry);
+        this.publishSessionState(entry);
         void this.writeUsage(entry);
       },
       // Per-run stats: append a RunStats entry, refresh the per-agent
@@ -2876,6 +2929,7 @@ export class SessionManager {
       { agent: "principal", recoverable: true },
     ));
     await this.writeMeta(entry);
+    this.stateChanged(entry);
   }
 
   async destroyAgent(sessionId: string, name: string): Promise<void> {
@@ -2893,6 +2947,7 @@ export class SessionManager {
       entry.bus.emit(ev.custom({ sessionId }, CUSTOM_EVENT.TASK_STATE, { op: "cancelled", task }));
       this.wakeAgent(sessionId, task.created_by);
     }
+    this.stateChanged(entry);
   }
 
   /**
@@ -2949,6 +3004,7 @@ export class SessionManager {
     const key = `${sessionId}:${name}`;
     if (this.deliveryLoops.has(key)) return;
     this.deliveryLoops.add(key);
+    this.stateChanged(current);
     void this.runDeliveryLoop(sessionId, name).finally(() => {
       this.deliveryLoops.delete(key);
       // Emit a final frame AFTER the key is gone: the agent's own running→idle
@@ -2956,7 +3012,7 @@ export class SessionManager {
       // that frame still read active via the pending-delivery check). Without
       // this trailing frame the derived run-active flag would stay stuck true.
       const entry = this.sessions.get(sessionId);
-      if (entry) this.emitSessionState(entry);
+      if (entry) this.stateChanged(entry);
       // Re-check after releasing the guard: a notification could have been written
       // between the loop's final empty read and this delete, and that writer's
       // wakeAgent would have bailed (key still present) — leaving the notification
@@ -2995,7 +3051,7 @@ export class SessionManager {
       if (agent.status === "stopped") return;
       this.touch(entry);
       // Surface the delegated run immediately (derived active flag, agent list).
-      this.emitSessionState(entry);
+      this.stateChanged(entry);
       const traceRecord = name === "trace"
         ? this.parseInternalEnvelope<TraceNodeRecord>(notifications[0]?.content, "Trace-Record")
         : undefined;
@@ -3286,21 +3342,31 @@ export class SessionManager {
     return false;
   }
 
-  /**
-   * Aggregate lifecycle for every execution owned by the session. Unlike
-   * runState this includes experts, Trace, subagents, delivery-loop handoffs,
-   * monitors, and background jobs so external harnesses can await quiescence.
-   */
-  private deriveWorkActive(entry: SessionEntry): boolean {
-    if (this.deriveRunActive(entry)) return true;
-    // Covers the acceptance→agent-running gap for a direct expert prompt.
-    if (entry.activeRunId !== null) return true;
-    if (entry.monitorManager.hasBlocking() || entry.backgroundJobManager.hasRunning()) return true;
-    if (entry.subagents.list().some((child) => child.status === "queued" || child.status === "waiting_for_capacity" || child.status === "running")) return true;
-    for (const agent of entry.agents.values()) {
-      if (agent.status === "running" || agent.isStreaming || agent.hasActiveTools()) return true;
+  private inspectSessionWork(entry: SessionEntry): SessionWorkFacts {
+    if (entry.workspaceOperationActive || entry.workspaceLease) return { active: true };
+    if (entry.activeRunId !== null || entry.userInputs.active || entry.userInputs.queue.length > 0) {
+      return { active: true };
     }
-    return [...this.deliveryLoops].some((key) => key.startsWith(`${entry.id}:`));
+    if (entry.monitorManager.hasBlocking() || entry.backgroundJobManager.hasRunning()) {
+      return { active: true };
+    }
+    if (entry.subagents.list().some((child) =>
+      child.status === "queued" || child.status === "waiting_for_capacity" || child.status === "running"
+    )) return { active: true };
+
+    for (const agent of entry.agents.values()) {
+      if (agent.status === "running" || agent.isStreaming || agent.hasActiveTools()) return { active: true };
+    }
+
+    if ([...this.deliveryLoops].some((key) => key.startsWith(`${entry.id}:`))) return { active: true };
+
+    const runnableTarget = new Set<string>([
+      ...entry.taskLedger.notificationTargets(),
+      ...entry.backgroundJobEvents.keys(),
+      ...entry.monitorEvents.keys(),
+    ]);
+    if ([...runnableTarget].some((target) => !entry.taskLedger.isPaused(target))) return { active: true };
+    return { active: false };
   }
 
   /** Restore gate blocks live execution; durable queued work is cancelled after restore. */
@@ -3325,10 +3391,12 @@ export class SessionManager {
       (error as Error & { code?: string }).code = "SESSION_ACTIVE";
       throw error;
     }
+    this.stateChanged(entry);
   }
 
   private endWorkspaceOperation(entry: SessionEntry): void {
     entry.workspaceOperationActive = false;
+    this.stateChanged(entry);
     for (const agent of entry.taskLedger.notificationTargets()) this.wakeAgent(entry.id, agent);
   }
 
@@ -3337,16 +3405,20 @@ export class SessionManager {
    * event. This is the wholesale source the web Agents panel replaces its
    * agents list from; it is pushed on every agent status transition
    * (`onStatusChange`), an initial frame in `sendMessage`, and on delivery-loop
-   * entry/exit. `runState.active` is PI-only; `workState.active` is the
+   * entry/exit. `runState.active` is PI-only; the two-state `workState` is the
    * aggregate completion authority for the whole session. The
    * ring buffer replays the last frame on reconnect, so a re-subscribing client
    * recovers the current snapshot. Shape matches `SessionStateSnapshotSchema`.
    */
-  private emitSessionState(entry: SessionEntry): void {
+  private stateChanged(entry: SessionEntry): void {
+    entry.stateAuthority.changed();
+  }
+
+  private publishSessionState(entry: SessionEntry): void {
     entry.bus.emit(
       ev.custom({ sessionId: entry.id }, "session_state", {
         runState: { active: this.deriveRunActive(entry), runId: entry.activeRunId },
-        workState: { active: this.deriveWorkActive(entry) },
+        workState: entry.stateAuthority.snapshot(),
         agents: this.listAgents(entry.id),
         subagents: entry.subagents.list(),
         lastActivityTs: new Date(entry.lastActivityAt).toISOString(),
@@ -3371,7 +3443,7 @@ export class SessionManager {
 
   getSessionState(sessionId: string): {
     runState: { active: boolean; runId: string | null };
-    workState: { active: boolean };
+    workState: WorkState;
     agents: AgentStatus[];
     subagents?: import("@brainpilot/protocol").SubagentStatus[];
     lastActivityTs: string;
@@ -3382,7 +3454,7 @@ export class SessionManager {
     if (!entry) return undefined;
     return {
       runState: { active: this.deriveRunActive(entry), runId: entry.activeRunId },
-      workState: { active: this.deriveWorkActive(entry) },
+      workState: entry.stateAuthority.snapshot(),
       agents: this.listAgents(sessionId),
       subagents: entry.subagents.list(),
       lastActivityTs: new Date(entry.lastActivityAt).toISOString(),
@@ -3581,6 +3653,7 @@ export class SessionManager {
   metrics(): {
     activeSessions: number;
     runningAgents: number;
+    reclaimable: boolean;
     lastActivityAt: string | null;
     memRss: number;
     memLimitBytes: number | null;
@@ -3594,12 +3667,35 @@ export class SessionManager {
     return {
       activeSessions: this.sessions.size,
       runningAgents,
+      reclaimable: this.isReclaimable(),
       lastActivityAt: this.lastActivityAt ? new Date(this.lastActivityAt).toISOString() : null,
       memRss: process.memoryUsage().rss,
       // null when the opt-in budget is unset (single-user) — keeps the metric meaningful.
       memLimitBytes: snap ? snap.limitBytes : null,
       memRatio: snap ? snap.ratio : null,
     };
+  }
+
+  isReclaimable(): boolean {
+    for (const entry of this.sessions.values()) {
+      if (entry.stateAuthority.snapshot().status !== "idle") return false;
+      if (this.inspectSessionWork(entry).active) return false;
+    }
+    return true;
+  }
+
+  async shutdownIfReclaimable(): Promise<boolean> {
+    if (this.shuttingDown || !this.isReclaimable()) return false;
+    // Admission is fenced synchronously before any await; a concurrent message
+    // or session creation cannot enter between the decision and final save.
+    this.shuttingDown = true;
+    if (!this.isReclaimable()) {
+      this.shuttingDown = false;
+      return false;
+    }
+    this.memWatchdog?.stop();
+    await this.emergencySaveAll();
+    return true;
   }
 
   /**
@@ -3732,7 +3828,21 @@ export class SessionManager {
     };
   }
 
-  private async writeMeta(entry: SessionEntry): Promise<void> {
+  private writeMeta(
+    entry: SessionEntry,
+    workflowState = entry.stateAuthority.persisted(),
+    strict = false,
+  ): Promise<void> {
+    const operation = entry.metaWrites.then(() => this.writeMetaNow(entry, workflowState, strict));
+    entry.metaWrites = operation.catch(() => undefined);
+    return operation;
+  }
+
+  private async writeMetaNow(
+    entry: SessionEntry,
+    workflowState: PersistedWorkflowState,
+    strict: boolean,
+  ): Promise<void> {
     if (!this.persist) return;
     const meta = {
       id: entry.id,
@@ -3745,10 +3855,23 @@ export class SessionManager {
       workflowTaskSeqBaseline: entry.workflowTaskSeqBaseline,
       workflowReminderClaimed: entry.workflowReminderClaimed,
       workflowViolationEmitted: entry.workflowViolationEmitted,
+      workflowState,
       systemPlugins: entry.systemPlugins,
     };
-    await mkdir(this.bpDir(entry.id), { recursive: true }).catch(() => {});
-    await writeFile(join(this.bpDir(entry.id), "meta.json"), JSON.stringify(meta, null, 2), "utf8").catch(() => {});
+    const directory = this.bpDir(entry.id);
+    const target = join(directory, "meta.json");
+    const temporary = `${target}.${process.pid}.${randomUUID()}.tmp`;
+    const persist = async () => {
+      await mkdir(directory, { recursive: true });
+      await writeFile(temporary, JSON.stringify(meta, null, 2), "utf8");
+      await rename(temporary, target);
+    };
+    try {
+      await persist();
+    } catch (error) {
+      await rm(temporary, { force: true }).catch(() => undefined);
+      if (strict) throw error;
+    }
   }
 
   private providerRefPath(sid: string): string {
@@ -3946,6 +4069,7 @@ export class SessionManager {
             typeof meta.workflowTaskSeqBaseline === "number" ? meta.workflowTaskSeqBaseline : 0,
           workflowReminderClaimed: meta.workflowReminderClaimed === true,
           workflowViolationEmitted: meta.workflowViolationEmitted === true,
+          workflowState: meta.workflowState,
           systemPlugins: meta.systemPlugins,
         },
         {

--- a/packages/runtime/src/session-state-authority.ts
+++ b/packages/runtime/src/session-state-authority.ts
@@ -1,0 +1,115 @@
+import type { WorkStatus } from "@brainpilot/protocol";
+
+export interface WorkState {
+  active: boolean;
+  status: WorkStatus;
+  epoch: number;
+}
+
+export interface SessionWorkFacts {
+  active: boolean;
+}
+
+export interface PersistedWorkflowState {
+  epoch: number;
+}
+
+export interface SessionStateAuthorityOptions {
+  restored?: PersistedWorkflowState;
+  inspect: () => SessionWorkFacts;
+  publish: () => void;
+  persist: (state: PersistedWorkflowState) => void | Promise<void>;
+  schedule?: (callback: () => void) => void;
+}
+
+/** Owns the session's two-state liveness projection. */
+export class SessionStateAuthority {
+  private epoch: number;
+  private state: WorkState;
+  private revision = 0;
+  private idleRevision?: number;
+  private persistOperations: Promise<void> = Promise.resolve();
+
+  constructor(private readonly options: SessionStateAuthorityOptions) {
+    this.epoch = Math.max(0, Math.trunc(options.restored?.epoch ?? 0));
+    this.state = this.makeState("idle");
+  }
+
+  snapshot(): WorkState {
+    return { ...this.state };
+  }
+
+  persisted(): PersistedWorkflowState {
+    return { epoch: this.epoch };
+  }
+
+  beginEpoch(): void {
+    this.epoch += 1;
+    this.revision += 1;
+    this.idleRevision = undefined;
+    this.state = this.makeState("active");
+    void this.enqueuePersist(this.persisted()).catch(() => undefined);
+    this.options.publish();
+  }
+
+  /** A restarted sandbox never revives its pre-crash execution. */
+  async recoverAfterRestart(publish = true): Promise<void> {
+    this.revision += 1;
+    this.idleRevision = undefined;
+    this.state = this.makeState("idle");
+    if (this.epoch === 0) {
+      if (publish) this.options.publish();
+      return;
+    }
+    await this.enqueuePersist(this.persisted()).catch(() => undefined);
+    if (publish) this.options.publish();
+  }
+
+  changed(publish = true): void {
+    this.revision += 1;
+    if (this.options.inspect().active) {
+      this.idleRevision = undefined;
+      this.update(this.makeState("active"), publish);
+      return;
+    }
+    if (this.state.status === "idle") {
+      this.idleRevision = undefined;
+      if (publish) this.options.publish();
+      return;
+    }
+    this.scheduleIdle(publish);
+  }
+
+  private scheduleIdle(publish: boolean): void {
+    const candidate = this.revision;
+    if (this.idleRevision === candidate) return;
+    this.idleRevision = candidate;
+    const schedule = this.options.schedule ?? queueMicrotask;
+    schedule(() => {
+      if (this.idleRevision !== candidate || this.revision !== candidate) return;
+      if (this.options.inspect().active) {
+        this.idleRevision = undefined;
+        this.changed(publish);
+        return;
+      }
+      this.idleRevision = undefined;
+      this.update(this.makeState("idle"), publish);
+    });
+  }
+
+  private makeState(status: WorkStatus): WorkState {
+    return { active: status === "active", status, epoch: this.epoch };
+  }
+
+  private update(next: WorkState, publish: boolean): void {
+    this.state = next;
+    if (publish) this.options.publish();
+  }
+
+  private enqueuePersist(state: PersistedWorkflowState): Promise<void> {
+    const snapshot = structuredClone(state);
+    const operation = this.persistOperations.then(() => this.options.persist(snapshot));
+    this.persistOperations = operation.catch(() => undefined);
+    return operation;
+  }
+}

--- a/packages/runtime/src/task-ledger.ts
+++ b/packages/runtime/src/task-ledger.ts
@@ -402,6 +402,10 @@ export class TaskLedger {
     return this.deliveryPaused || this.pausedAgents.size > 0;
   }
 
+  isDeliveryPausedGlobally(): boolean {
+    return this.deliveryPaused;
+  }
+
   isPaused(agent: string): boolean {
     return this.deliveryPaused || this.pausedAgents.has(agent);
   }

--- a/packages/web/src/__tests__/subagentState.test.ts
+++ b/packages/web/src/__tests__/subagentState.test.ts
@@ -45,4 +45,18 @@ describe("subagent session state", () => {
     expect(state.runState.active).toBe(false);
     expect(state.workState.active).toBe(true);
   });
+
+  it("normalizes the two-state workflow status and epoch", () => {
+    const state = normalizeSessionState({
+      run_state: { active: false, run_id: null },
+      work_state: { active: false, status: "idle", epoch: 2 },
+      agents: [],
+      last_activity_ts: "2026-08-19T00:00:00.000Z",
+    });
+    expect(state.workState).toEqual({
+      active: false,
+      status: "idle",
+      epoch: 2,
+    });
+  });
 });

--- a/packages/web/src/components/chat/PromptComposer.tsx
+++ b/packages/web/src/components/chat/PromptComposer.tsx
@@ -481,8 +481,8 @@ export function PromptComposer({ onOpenProviderSettings, onOpenWorkspaceFile }: 
       : current));
   }, [runActive, sessionId]);
 
-  // #99: whole-turn timer — spans user input → every agent finished (workState
-  // settles false), debounced against hook/system re-wakes.
+  // #99: whole-turn timer — spans user input through blocked handoffs until the
+  // workflow returns to idle; legacy runtimes fall back to active.
   const turnTiming = useTurnTimer({ runActive: workActive, resetKey: currentSession?.id ?? null });
 
   const handleSubmit = async (event: FormEvent) => {

--- a/packages/web/src/contexts/SessionContext.tsx
+++ b/packages/web/src/contexts/SessionContext.tsx
@@ -1,6 +1,6 @@
 import { createContext, ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 // TODO(dead-code): SessionEventEntry removed with pre-AG-UI polling protocol.
-import { AgentStatus, SubagentStatus, ChatMessage, DomainResources, MessageFilterConfig, MessageFilterRule, Session, SessionTokenUsage, ThinkingLevel, TraceGraph, normalizeSessionState, normalizeWebSocketEvent, /* SessionEventEntry, */ SessionMessageEntry } from "../contracts/backend";
+import { AgentStatus, SubagentStatus, ChatMessage, DomainResources, MessageFilterConfig, MessageFilterRule, Session, SessionTokenUsage, ThinkingLevel, TraceGraph, WorkStatus, normalizeSessionState, normalizeWebSocketEvent, /* SessionEventEntry, */ SessionMessageEntry } from "../contracts/backend";
 import { api } from "../utils/api";
 import { tg } from "../i18n/translate";
 import { useAuth } from "./AuthContext";
@@ -53,7 +53,7 @@ interface SessionContextValue {
   /** PI/Principal foreground lifecycle from session_state.runState. */
   runActive: { active: boolean; atMs: number } | null;
   /** Aggregate session-work signal; use this for completion and workspace safety. */
-  workActive: { active: boolean; atMs: number } | null;
+  workActive: { active: boolean; status?: WorkStatus; epoch?: number; atMs: number } | null;
   /**
    * Cumulative real token usage for the current session (total + per-agent),
    * fed live from `session_state` frames. null until the first frame carrying
@@ -386,7 +386,12 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   // runState is PI-only. workState is the authoritative whole-session signal
   // used for completion/timing and includes delegated/background execution.
   const [runActive, setRunActive] = useState<{ active: boolean; atMs: number } | null>(null);
-  const [workActive, setWorkActive] = useState<{ active: boolean; atMs: number } | null>(null);
+  const [workActive, setWorkActive] = useState<{
+    active: boolean;
+    status?: WorkStatus;
+    epoch?: number;
+    atMs: number;
+  } | null>(null);
   // Cumulative real token usage for the current session, fed from session_state.
   const [tokenUsage, setTokenUsage] = useState<SessionTokenUsage | null>(null);
   const [agentFilters, setAgentFilters] = useState<Record<string, AgentMessageFilter>>({});
@@ -1092,9 +1097,17 @@ export function SessionProvider({ children }: { children: ReactNode }) {
           active: stateSnapshot.runState.active,
           atMs,
         });
-        setWorkActive({
-          active: stateSnapshot.workState.active,
-          atMs,
+        setWorkActive((current) => {
+          const incomingEpoch = stateSnapshot.workState.epoch;
+          if (incomingEpoch !== undefined && current?.epoch !== undefined && incomingEpoch < current.epoch) {
+            return current;
+          }
+          return {
+            active: stateSnapshot.workState.active,
+            status: stateSnapshot.workState.status,
+            epoch: incomingEpoch,
+            atMs,
+          };
         });
         // Cumulative real token usage rides on the same frame (optional).
         const usage = parseTokenUsageValue(value.tokenUsage);

--- a/packages/web/src/contexts/turnTimer.ts
+++ b/packages/web/src/contexts/turnTimer.ts
@@ -3,8 +3,7 @@
  * ("本轮对话用时"), issue #99.
  *
  * A turn is NOT a single assistant message. It spans from the user's input
- * until all session work has finished — i.e. authoritative `workState.active`
- * goes false and STAYS false.
+ * until the authoritative workflow status becomes `idle`.
  *
  * The subtlety (#99): `workState.active` can briefly flip true→false→true when a
  * turn ends and a hook / system message / queued task event immediately
@@ -14,7 +13,7 @@
  * inside the window, the candidate end is discarded and the same turn continues.
  *
  * This reducer is pure and driven entirely by authoritative backend signals
- * (`workState.active` + the event's ISO timestamp). The host attaches the settle
+ * (`workState.status` with a legacy `active` fallback + the event timestamp). The host attaches the settle
  * timer and a live "ticking" clock for the running display.
  */
 

--- a/packages/web/src/contexts/useTurnTimer.ts
+++ b/packages/web/src/contexts/useTurnTimer.ts
@@ -2,7 +2,7 @@
  * useTurnTimer — React host for the whole-turn timer reducer (#99).
  *
  * Consumes the authoritative whole-session activity signal from SessionContext
- * (session_state.workState.active + backend timestamp) and produces:
+ * (session_state.workState.status + backend timestamp, with legacy active fallback) and produces:
  *   - `running`: a turn is in progress (active, or within the settle window);
  *   - `elapsedMs`: live elapsed while running (ticks ~every second), or the
  *     last settled whole-turn duration once finished;
@@ -31,7 +31,11 @@ export interface TurnTiming {
 
 interface UseTurnTimerOptions {
   /** Backend run-active snapshot; null until the first session_state arrives. */
-  runActive: { active: boolean; atMs: number } | null;
+  runActive: {
+    active: boolean;
+    status?: "idle" | "active";
+    atMs: number;
+  } | null;
   /** Key that resets the timer when it changes (e.g. session id). */
   resetKey?: string | null;
   settleMs?: number;
@@ -53,7 +57,10 @@ export function useTurnTimer(options: UseTurnTimerOptions): TurnTiming {
   // Feed authoritative active transitions into the reducer.
   useEffect(() => {
     if (!runActive) return;
-    dispatch({ type: "active", value: runActive.active, atMs: runActive.atMs });
+    const value = runActive.status === undefined
+      ? runActive.active
+      : runActive.status === "active";
+    dispatch({ type: "active", value, atMs: runActive.atMs });
   }, [runActive]);
 
   // Arm/disarm the settle timer based on a pending candidate end.

--- a/packages/web/src/contracts/backend.ts
+++ b/packages/web/src/contracts/backend.ts
@@ -51,6 +51,7 @@ import type {
   TraceNodeRecord,
   TraceCausalParent,
   AuditReport,
+  WorkStatus,
 } from "@brainpilot/protocol";
 
 // Re-export the canonical protocol domain types under their existing names so
@@ -96,6 +97,7 @@ export type {
   TraceNodeRecord,
   TraceCausalParent,
   AuditReport,
+  WorkStatus,
 };
 
 /**
@@ -1053,6 +1055,10 @@ export function normalizeSessionState(rawValue: unknown): SessionStateSnapshot {
     workState: {
       // Compatibility fallback for runtimes where runState was aggregate.
       active: typeof ws.active === "boolean" ? ws.active : rs.active === true,
+      ...(ws.status === "idle" || ws.status === "active"
+        ? { status: ws.status as WorkStatus }
+        : {}),
+      ...(typeof ws.epoch === "number" ? { epoch: ws.epoch } : {}),
     },
     agents,
     subagents,


### PR DESCRIPTION
## Summary
- add an authoritative two-state session lifecycle: active / idle
- keep workflow compliance in hooks and task records instead of overloading liveness state
- reconcile sandbox restarts to idle while cancelling stale pending deliveries
- expose Runtime-owned reclaimability plus an atomic shutdown guard for Docker idle reaping
- migrate CLI and Web consumers with epoch-aware compatibility handling

## Validation
- npm run typecheck
- npm test (1093 passed)
- npm test -w @brainpilot/web (529 passed)
- npm run build -w @brainpilot/web
- git diff --check