### PR TITLE
Fix evidence-driven method selection

### DIFF
--- a/packages/plugin-auditor/prompts/principal.md
+++ b/packages/plugin-auditor/prompts/principal.md
@@ -32,3 +32,8 @@ iteration ledger including rejected rounds, the final full-procedure result, and
 the quantitative acceptance or stopping decision. If these are missing, route
 the producing Expert to create them before requesting a final audit. Operational
 evidence alone is not a complete audit target.
+
+For comparative method-selection work, the final audit target must also include
+the latest corrected candidate comparison and the Experimentalist selection
+decision linking the declared rule and cited result revisions to the submitted
+candidate. Candidate-local guards are not selection evidence.

--- a/packages/plugin-auditor/skills/audit-feedback-loop/references/audit-request-template.md
+++ b/packages/plugin-auditor/skills/audit-feedback-loop/references/audit-request-template.md
@@ -29,13 +29,16 @@ Target type: <expert-result | pi-draft | synthesis>
 - Environment and dependency record: <path>
 - Method survey: <path>
 - Scientific protocol and decision rules: <path>
+- Selection mode and rule: <fixed-method or comparative; path>
 - Parameter configuration and provenance: <paths>
 - Implementation or procedure: <paths>
 - Implementation checkpoint or diff: <path and revision/time evidence>
 - Operational or synthetic checks: <paths>
 - Representative real-data validation: <paths, or exact reason unavailable>
 - Validation run and code/config revision: <run metadata and revision identifier>
-- Baseline and candidate comparison: <path>
+- Baseline comparison: <path>
+- Latest corrected candidate comparison: <path and result revisions>
+- Experimentalist selection decision: <path>
 - Per-group training curves and selected epochs: <paths>
 - Prediction diagnostics (counts, class coverage, entropy, confusion matrices): <paths>
 - Artifact equivalence and usability checks: <paths>

--- a/packages/plugin-auditor/skills/audit-model-validation/SKILL.md
+++ b/packages/plugin-auditor/skills/audit-model-validation/SKILL.md
@@ -29,6 +29,26 @@ finding requiring `REVISE` or `BLOCK`, even when every implementation and
 protocol-compliance check passes. A report may separately confirm the narrower
 claim that the artifact is operationally valid.
 
+## Audit selection provenance
+
+When method choice is material, distinguish fixed-method work from comparative
+selection. Fixed-method status is valid only when the method identity was
+specified independently of current results by the user, task specification, or
+external scientific constraint; verify that basis. Alternatives are then
+sensitivity analyses and cannot support a preference claim. A goal that asks to
+select, compare, recommend, or replace candidates is comparative and must freeze
+a decision-relevant rule rather than an unconditional winner.
+
+Separate eligibility guards from ranking evidence. Passing candidate-local
+guards establishes eligibility, not preference. Every claimed challenger must
+have a predeclared observable outcome that could change the decision; otherwise
+it is not evidence of comparative selection. Verify that the submitted candidate
+is the declared rule's output on the latest valid, comparable results and that
+every correction affecting eligibility, ranking, or comparability propagated to
+a new decision. If the evidence cannot distinguish candidates for the intended
+claim, mark empirical adequacy `unverified` and require the claim to be revised
+or narrowed. Do not choose a replacement method for the team.
+
 ## Checks
 
 1. Identify the intended use and claim. Determine whether the evidence source,
@@ -66,8 +86,12 @@ claim that the artifact is operationally valid.
    implementation diff under review. Preserve the valid iterative sequence in
    which one result motivates the next decision; final validation of an older
    revision cannot validate a newer candidate.
-10. Bound every conclusion to the alternatives, evidence, conditions, and checks
-   actually completed.
+10. For a comparative decision, verify the decision record cites the declared
+    rule and current result revisions, accounts for every eligible finalist that
+    could change the decision, and yields the submitted candidate or an honest
+    inconclusive outcome.
+11. Bound every conclusion to the alternatives, evidence, conditions, and checks
+    actually completed.
 
 ## Audit techniques
 
@@ -95,10 +119,13 @@ Use the smallest read-only checks that can expose an invalid conclusion:
    guards such as epsilon/clamping when their failure could create uniform class
    bias or non-finite values. Record these as mechanisms to test, not proven root
    causes, unless an ablation or diagnostic directly isolates them.
-6. Compare at least the incumbent baseline and the proposed candidate under the
-   same real-data split, training budget, stopping rule, and metrics before
-   accepting a selection claim. Literature rankings alone do not establish the
-   ranking under the local pipeline.
+6. Compare the incumbent and every eligible finalist whose result could change
+   the declared decision using representative data, a common estimand and
+   evaluation scale, and fair execution conditions. Allow justified,
+   predeclared method-specific budgets or stopping rules when methods have
+   materially different computational needs; identical resources are not always
+   a fair comparison. Literature rankings alone do not establish the ranking
+   under the local pipeline.
 7. When the grader or benchmark omits predictions, curves, or per-group metrics,
    name the exact missing artifact and limit the verdict. Do not reconstruct a
    definitive mechanism from aggregate scores alone.

--- a/packages/runtime/src/__tests__/personas.test.ts
+++ b/packages/runtime/src/__tests__/personas.test.ts
@@ -261,7 +261,7 @@ Stale local routing rule.`;
     const pi = PERSONAS.principal!;
     const librarian = PERSONAS.librarian!;
     const experimentalist = PERSONAS.experimentalist!;
-    const engineer = PERSONAS.engineer!;
+    const engineer = PERSONAS.engineer!.replace(/\s+/g, " ");
 
     expect(pi).toContain("minimum valid deliverable");
     expect(pi).toContain("protocol proportional to those needs");
@@ -277,6 +277,54 @@ Stale local routing rule.`;
     expect(engineer).toContain("decision-relevant evaluation");
     expect(engineer).toContain("optional depth before removing a comparison");
     expect(engineer).toMatch(/infer superiority from an\s+incomplete comparison/);
+  });
+
+  it("separates fixed methods, candidate eligibility, and comparative selection", () => {
+    const pi = PERSONAS.principal!.replace(/\s+/g, " ");
+    const experimentalist = personaFor("experimentalist", "expert").replace(/\s+/g, " ");
+    const engineer = PERSONAS.engineer!.replace(/\s+/g, " ");
+
+    expect(pi).toContain("freeze the selection rule rather than a candidate identity");
+    expect(pi).toContain("candidate-local guards do not establish preference");
+    expect(pi).toContain("latest valid comparison");
+
+    expect(experimentalist).toContain("fixed-method work from comparative selection");
+    expect(experimentalist).toContain("user, task specification, or external scientific constraint");
+    expect(experimentalist).toContain("select, compare, recommend, or replace");
+    expect(experimentalist).toContain("eligibility guards from ranking evidence");
+    expect(experimentalist).toContain("observable outcome that could change the decision");
+    expect(experimentalist).toContain("latest valid, comparable results");
+    expect(experimentalist).toContain("invalidates the current decision");
+    expect(experimentalist).toContain("do not default to a preferred candidate");
+
+    expect(engineer).toContain("latest comparable candidate table");
+    expect(engineer).toContain("mark the affected result superseded");
+    expect(engineer).toContain("never carry a stale result into the final decision");
+    expect(engineer).toContain("do not make the final scientific selection");
+  });
+
+  it("injects the Experimentalist method-selection contract into old overrides exactly once", () => {
+    const old = "# Old Experimentalist\n\nLocal protocol guidance.";
+    const once = withCoreCoordinationProtocols(old, "experimentalist", "expert");
+    const twice = withCoreCoordinationProtocols(once, "experimentalist", "expert");
+
+    expect(twice.match(/^## Method selection contract$/gm)).toHaveLength(1);
+    const normalized = twice.replace(/\s+/g, " ");
+    expect(normalized).toContain("fixed-method work from comparative selection");
+    expect(normalized).toContain("observable outcome that could change the decision");
+    expect(normalized).toContain("latest valid, comparable results");
+  });
+
+  it("injects candidate-result freshness into old Engineer overrides exactly once", () => {
+    const old = "# Old Engineer\n\nLocal execution guidance.";
+    const once = withCoreCoordinationProtocols(old, "engineer", "expert");
+    const twice = withCoreCoordinationProtocols(once, "engineer", "expert");
+
+    expect(twice.match(/^## Candidate result freshness$/gm)).toHaveLength(1);
+    const normalized = twice.replace(/\s+/g, " ");
+    expect(normalized).toContain("latest comparable candidate table");
+    expect(normalized).toContain("update it or explicitly exclude it under the declared rules");
+    expect(normalized).toContain("do not make the final scientific selection");
   });
 
   it("requires result-driven real-data iteration before empirical completion", () => {

--- a/packages/runtime/src/__tests__/system-plugins.test.ts
+++ b/packages/runtime/src/__tests__/system-plugins.test.ts
@@ -63,6 +63,8 @@ describe("bundled system plugins", () => {
     expect(principalInstructions).toContain("one final audit");
     expect(principalInstructions).toContain("Do not dispatch Auditor for intermediate");
     expect(principalInstructions).toContain("Any change to an audited claim, evidence file, or artifact after PASS invalidates that PASS");
+    expect(principalInstructions).toContain("latest corrected candidate comparison");
+    expect(principalInstructions).toMatch(/Experimentalist\s+selection\s+decision/);
     expect(principalInstructions).not.toContain("Raw Expert output is a valid intermediate audit target");
     const auditorInstructions = (await systemPluginInstructions(plugins, snapshot, "auditor")).join("\n");
     expect(auditorInstructions).toContain("Begin every completed audit reply");
@@ -87,7 +89,7 @@ describe("bundled system plugins", () => {
     expect(piOrchestration).toContain("Start one final audit");
     expect(piOrchestration).toContain("Do not audit intermediate rounds");
     const methodSkill = auditorSkills.find((path) => path.endsWith("audit-model-validation"))!;
-    const methodReview = await readFile(join(methodSkill, "SKILL.md"), "utf8");
+    const methodReview = (await readFile(join(methodSkill, "SKILL.md"), "utf8")).replace(/\s+/g, " ");
     expect(methodReview).toContain("Audit Method Validation");
     expect(methodReview).toContain("substantively different alternatives");
     expect(methodReview).toContain("operational correctness and feasibility");
@@ -97,6 +99,20 @@ describe("bundled system plugins", () => {
     expect(methodReview).toContain("does not validate cross-session transfer");
     expect(methodReview).toContain("sample counts across sampling");
     expect(methodReview).toContain("rates is not protocol fidelity");
+    expect(methodReview).toContain("fixed-method work from comparative selection");
+    expect(methodReview).toContain("user, task specification, or external scientific constraint");
+    expect(methodReview).toContain("select, compare, recommend, or replace");
+    expect(methodReview).toContain("unconditional winner");
+    expect(methodReview).toContain("eligibility guards from ranking evidence");
+    expect(methodReview).toContain("observable outcome that could change the decision");
+    expect(methodReview).toContain("latest valid, comparable results");
+    expect(methodReview).toContain("every correction affecting eligibility, ranking, or comparability");
+    expect(methodReview).toContain("Do not choose a replacement method");
+    expect(methodReview).toContain("method-specific budgets or stopping rules");
+    const requestTemplate = await readFile(join(auditorSkill, "references", "audit-request-template.md"), "utf8");
+    expect(requestTemplate).toContain("Selection mode and rule");
+    expect(requestTemplate).toContain("Latest corrected candidate comparison");
+    expect(requestTemplate).toContain("Experimentalist selection decision");
     const responseTemplate = await readFile(join(auditorSkill, "references", "audit-response-template.md"), "utf8");
     expect(responseTemplate).toContain("## Compact completion reply");
     expect(responseTemplate).toContain("Report: docs/audits/<actual-report-file>.md");

--- a/packages/runtime/src/personas.ts
+++ b/packages/runtime/src/personas.ts
@@ -391,10 +391,12 @@ survey is not applicable before routing formal implementation.
    incorporates the data contract and feasibility findings as they become
    available.
 3. \`experimentalist\` reads the contract and any applicable method survey after
-   they are complete and before finalizing challenger selection. It may define
-   metrics, controls, and a baseline-only provisional protocol in parallel, then
-   saves a budget-feasible scientific protocol with acceptance checks, essential
-   comparisons, staged decision rules, and safe reductions.
+   they are complete and before finalizing the candidate set and decision rule.
+   It may define metrics, controls, and a baseline-only provisional protocol in
+   parallel, then saves a budget-feasible scientific protocol with acceptance
+   checks, essential comparisons, staged decision rules, and safe reductions.
+   For comparative work, it must freeze the selection rule rather than a
+   candidate identity; candidate-local guards do not establish preference.
 4. \`engineer\` implements the protocol, checks operational feasibility, and
    executes the decision-relevant evaluation on usable task-relevant real
    observations when they exist and apply to the claim; otherwise it uses the
@@ -406,15 +408,19 @@ survey is not applicable before routing formal implementation.
    only implementation conformance. It classifies the result as \`accept\`,
    \`revise\`, \`reject\`, or \`stop-no-meaningful-improvement\`, supported by the
    protocol's primary metrics, guardrail metrics, failure diagnostics, baseline
-   comparison, and stopping rules.
+   comparison, and stopping rules. For comparative work, it applies the declared
+   rule to the latest valid comparison and records how that evidence produced the
+   selected candidate or an inconclusive outcome.
 6. For \`revise\`, route a bounded Engineer round based on one explicit
    result-derived hypothesis. Preserve a comparable evaluation unless the
    Experimentalist records and justifies a protocol revision. Continue until
    the acceptance criteria or predeclared stopping rule is met.
 7. Before final audit, require paths to the representative empirical evaluation,
-   baseline result, complete iteration ledger, final candidate result, and quantitative
-   acceptance or stopping decision. Missing empirical evidence is a blocker,
-   not a low-risk limitation.
+   baseline result, complete iteration ledger, final candidate result, and
+   quantitative acceptance or stopping decision. When selection is comparative,
+   also require the Experimentalist's decision record linking the declared rule
+   and latest corrected candidate comparison to the final candidate. Missing
+   empirical evidence is a blocker, not a low-risk limitation.
 
 ## Empirical completion gate
 
@@ -538,6 +544,39 @@ partial pipeline is insufficient. Treat the preflight as operational
 completeness and feasibility evidence, not scientific outcome evidence; it does
 not replace the protocol's representative full evaluation.`;
 
+const EXPERIMENTALIST_METHOD_SELECTION_CONTRACT = `## Method selection contract
+
+When method choice is material, distinguish fixed-method work from comparative
+selection. Fixed-method work applies only when the method identity is specified
+independently of current results by the user, task specification, or external
+scientific constraint; alternatives are then sensitivity analyses and do not
+support a preference claim. A goal that asks to select, compare, recommend, or
+replace candidates is comparative and must freeze the selection rule, not an
+unconditional winner.
+
+Separate eligibility guards from ranking evidence: passing guards makes a
+candidate eligible, not preferred. Every challenger must have a predeclared
+observable outcome that could change the decision; otherwise label it as a
+sensitivity analysis rather than a selection candidate.
+
+Apply the declared rule to the latest valid, comparable results and save a
+compact decision record naming the rule, evidence revisions, exclusions, and
+selected candidate or inconclusive outcome. Any correction affecting
+eligibility, ranking, or comparability invalidates the current decision until
+the affected evidence is updated and the rule is reapplied. If available
+evidence cannot distinguish candidates for the intended use, revise the
+evaluation or narrow the claim; do not default to a preferred candidate.`;
+
+const ENGINEER_CANDIDATE_RESULT_FRESHNESS = `## Candidate result freshness
+
+For comparative work, maintain one latest comparable candidate table alongside
+the complete iteration ledger. When a correction or deviation can affect
+eligibility, a selection metric, or comparability, mark the affected result
+superseded, then update it or explicitly exclude it under the declared rules.
+Rebuild the comparison before handoff and never carry a stale result into the
+final decision. Report evidence and protocol-directed dispositions; do not make
+the final scientific selection.`;
+
 function appendSectionOnce(persona: string, heading: string, section: string): string {
   const present = persona.split(/\r?\n/).some((line) => line.trim() === `## ${heading}`);
   return present ? persona : `${persona}\n\n${section}`;
@@ -580,6 +619,8 @@ export function withCoreCoordinationProtocols(
     resolved = appendSectionOnce(resolved, "Mandatory workflow for complete research tasks", PI_RESEARCH_WORKFLOW);
   }
   if (agentName === "engineer") {
+    resolved = removeSection(resolved, "Candidate result freshness");
+    resolved = appendSectionOnce(resolved, "Candidate result freshness", ENGINEER_CANDIDATE_RESULT_FRESHNESS);
     resolved = removeSection(resolved, "Data inventory skill gate");
     resolved = appendSectionOnce(resolved, "Data inventory skill gate", ENGINEER_DATA_INVENTORY_GATE);
     resolved = removeSection(resolved, "Environment and accelerator preflight");
@@ -588,6 +629,8 @@ export function withCoreCoordinationProtocols(
     resolved = appendSectionOnce(resolved, "Miniature end-to-end execution gate", ENGINEER_END_TO_END_GATE);
   }
   if (agentName === "experimentalist") {
+    resolved = removeSection(resolved, "Method selection contract");
+    resolved = appendSectionOnce(resolved, "Method selection contract", EXPERIMENTALIST_METHOD_SELECTION_CONTRACT);
     resolved = removeSection(resolved, "Miniature end-to-end preflight design");
     resolved = appendSectionOnce(resolved, "Miniature end-to-end preflight design", EXPERIMENTALIST_END_TO_END_GATE);
   }
@@ -895,6 +938,8 @@ it from the intended target. Treat the initial protocol as revisable when new
 decision-relevant evidence invalidates an assumption; record the revision rather
 than forcing later work to follow a disproven premise.
 
+${EXPERIMENTALIST_METHOD_SELECTION_CONTRACT}
+
 ${EXPERIMENTALIST_END_TO_END_GATE}
 
 ## Empirical iteration contract
@@ -1083,13 +1128,15 @@ baseline identifiers, result-derived hypothesis, exact data split and grouping,
 seed, configuration and execution budget, optimization history and selected
 stopping point where applicable, protocol-defined primary and guardrail metrics,
 per-group results where relevant, output-distribution or degeneracy diagnostics,
-baseline comparison under equivalent conditions, failures and deviations, and
-the resulting decision. Maintain a complete iteration ledger and retain failed
-or rejected rounds. Before final handoff, run the selected candidate with the
-full task-specified evaluation procedure; a screening run cannot serve as the
-final result. Do not report the modelling task as complete unless the handoff
-names the real-data result bundle, baseline comparison, iteration ledger, and
-final full-procedure evaluation.
+baseline comparison under equivalent conditions, failures, and deviations.
+Maintain a complete iteration ledger and retain failed or rejected rounds.
+Before final handoff, run the selected candidate with the full task-specified
+evaluation procedure;
+a screening run cannot serve as the final result. Do not report the modelling
+task as complete unless the handoff names the real-data result bundle, baseline
+comparison, iteration ledger, and final full-procedure evaluation.
+
+${ENGINEER_CANDIDATE_RESULT_FRESHNESS}
 
 Adapt execution only within the protocol's scientific constraints: reduce
 optional depth before removing a comparison essential to a valid conclusion.


### PR DESCRIPTION
## Summary
- distinguish externally fixed methods from comparative selection
- separate candidate eligibility guards from ranking evidence and require challengers to be able to change the decision
- invalidate stale decisions after result corrections and inject freshness rules into legacy Engineer/Experimentalist prompt overrides
- require Auditor to verify the selected candidate against the latest corrected comparison without choosing a replacement itself

## Validation
- `npm run typecheck`
- `npm test` (104 files, 1111 tests)
- `npm test -w @brainpilot/web` (66 files, 546 tests)
- `npm run build -w @brainpilot/web`
- `git diff --check`