### PR TITLE
fix(research): stop on contradicted evidence

### DIFF
--- a/docker/sandbox/Dockerfile
+++ b/docker/sandbox/Dockerfile
@@ -76,12 +76,13 @@ CMD ["node", "packages/runtime/dist/server.js"]
 #   ⚠️ base tag 写死（经典构建器不支持 FROM ${ARG}）；升级须同步三处（见文件头）。
 FROM ghcr.io/neuroaihub/brainpilot-gpu-base:cu124-torch2.6.0 AS gpu
 # Older published GPU base tags may predate workspace checkpoints and the
-# agent's code/file inspection tools, so the thin image guarantees all three.
+# agent's code/file inspection tools, so the thin image guarantees them here.
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends git ripgrep file \
+    && apt-get install -y --no-install-recommends git ripgrep fd-find file \
     && rm -rf /var/lib/apt/lists/* \
     && git --version >/dev/null \
     && rg --version >/dev/null \
+    && fdfind --version >/dev/null \
     && file --version >/dev/null
 WORKDIR /app
 COPY --from=builder /app/node_modules ./node_modules

--- a/docker/sandbox/_python-base.sh
+++ b/docker/sandbox/_python-base.sh
@@ -2,7 +2,7 @@
 # _python-base.sh — cpu/gpu sandbox 共享的 Python、网络与文件工具安装段。
 # 由 Dockerfile 的 python-baseline stage 直接 RUN（gpu-base 继承该 stage，无需重跑）。
 # curl/ca-certificates 供 HEALTHCHECK 探活；Git 供 GoT workspace checkpoint；
-# ripgrep/file 供 agent 搜索代码与识别上传文件。它们都是 cpu/gpu 运行时依赖。
+# ripgrep/fd/file 供 agent 搜索代码、发现文件与识别上传文件。它们都是 cpu/gpu 运行时依赖。
 # 镜像源来自 ENV（Dockerfile 经 build-arg 透传），为空则用镜像自带官方源
 # （pypi.org / deb.debian.org）。
 set -euo pipefail
@@ -11,13 +11,14 @@ set -euo pipefail
 [ -n "${APT_MIRROR:-}" ] && sed -i "s|http://deb.debian.org|$APT_MIRROR|g" \
   /etc/apt/sources.list.d/*.sources /etc/apt/sources.list 2>/dev/null || true
 apt-get update && apt-get install -y --no-install-recommends \
-  python3 python3-pip python3-venv curl ca-certificates git ripgrep file
+  python3 python3-pip python3-venv curl ca-certificates git ripgrep fd-find file
 rm -rf /var/lib/apt/lists/*
 
 # Fail the image build rather than shipping a runtime whose checkpoint feature
 # can only report unavailable.
 git --version >/dev/null
 rg --version >/dev/null
+fdfind --version >/dev/null
 file --version >/dev/null
 
 # pip 源：PIP_INDEX_URL 注入则固化 /etc/pip.conf，否则用 pip 官方默认

--- a/packages/plugin-auditor/skills/audit-model-validation/SKILL.md
+++ b/packages/plugin-auditor/skills/audit-model-validation/SKILL.md
@@ -49,6 +49,11 @@ a new decision. If the evidence cannot distinguish candidates for the intended
 claim, mark empirical adequacy `unverified` and require the claim to be revised
 or narrowed. Do not choose a replacement method for the team.
 
+Verify that every material challenge and contradictory result propagated into
+the latest protocol, evidence, and decision. Protocol conformance cannot pass
+when the protocol still depends on a premise that current evidence has
+invalidated or left unresolved.
+
 ## Checks
 
 1. Identify the intended use and claim. Determine whether the evidence source,

--- a/packages/runtime/src/__tests__/managed-tool-permissions.test.ts
+++ b/packages/runtime/src/__tests__/managed-tool-permissions.test.ts
@@ -1,0 +1,33 @@
+import { chmod, mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+import { repairPiManagedToolPermissions } from "../managed-tool-permissions.js";
+
+describe("Pi managed tool permissions", () => {
+  const temporaryRoots: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+  });
+
+  it.runIf(process.platform !== "win32")("repairs a persisted non-executable fd before Pi uses it", async () => {
+    const agentDir = await mkdtemp(join(tmpdir(), "brainpilot-agent-tools-"));
+    temporaryRoots.push(agentDir);
+    const binDir = join(agentDir, "bin");
+    const fd = join(binDir, "fd");
+    await mkdir(binDir);
+    await writeFile(fd, "#!/bin/sh\nprintf 'fd test version\\n'\n", { mode: 0o644 });
+    await chmod(fd, 0o644);
+
+    expect(spawnSync(fd, ["--version"]).error).toMatchObject({ code: "EACCES" });
+
+    await repairPiManagedToolPermissions(agentDir);
+
+    const result = spawnSync(fd, ["--version"], { encoding: "utf8" });
+    expect(result.error).toBeUndefined();
+    expect(result.status).toBe(0);
+    expect(result.stdout).toBe("fd test version\n");
+  });
+});

--- a/packages/runtime/src/__tests__/personas.test.ts
+++ b/packages/runtime/src/__tests__/personas.test.ts
@@ -279,6 +279,34 @@ Stale local routing rule.`;
     expect(engineer).toMatch(/infer superiority from an\s+incomplete comparison/);
   });
 
+  it("stops affected work on unsupported or contradicted evidence before commitment", () => {
+    for (const name of ["principal", "librarian", "experimentalist", "engineer", "writer"]) {
+      const persona = PERSONAS[name]!.replace(/\s+/g, " ");
+      expect(persona, name).toContain("Every decision-relevant claim must point to inspectable evidence");
+      expect(persona, name).toContain("address material counterevidence");
+      expect(persona, name).toContain("access failure is not evidence of absence");
+      expect(persona, name).toContain("stop the affected path");
+      expect(persona, name).toContain("mark dependent work stale");
+      expect(persona, name).toContain("Independent unaffected work may continue");
+    }
+
+    const pi = PERSONAS.principal!.replace(/\s+/g, " ");
+    expect(pi).toContain("synthesize their canonical artifacts before commissioning a binding protocol");
+    expect(pi).toContain("route bounded follow-up research");
+    expect(pi).toContain("complete-looking first report is not a commitment point");
+
+    const experimentalist = PERSONAS.experimentalist!.replace(/\s+/g, " ");
+    expect(experimentalist).toContain("Every decision-relevant diagnostic must have an outcome");
+    expect(experimentalist).toContain("cannot be reduced to a warning-only flag");
+
+    const oldLibrarian = withCoreCoordinationProtocols("# Old Librarian", "librarian", "expert").replace(/\s+/g, " ");
+    expect(oldLibrarian).toContain("address material counterevidence");
+    const oldPi = withCoreCoordinationProtocols("# Old PI", "principal", "principal").replace(/\s+/g, " ");
+    expect(oldPi).toContain("synthesize their canonical artifacts before commissioning a binding protocol");
+    const oldExperimentalist = withCoreCoordinationProtocols("# Old Experimentalist", "experimentalist", "expert").replace(/\s+/g, " ");
+    expect(oldExperimentalist).toContain("cannot be reduced to a warning-only flag");
+  });
+
   it("separates fixed methods, candidate eligibility, and comparative selection", () => {
     const pi = PERSONAS.principal!.replace(/\s+/g, " ");
     const experimentalist = personaFor("experimentalist", "expert").replace(/\s+/g, " ");

--- a/packages/runtime/src/__tests__/system-plugins.test.ts
+++ b/packages/runtime/src/__tests__/system-plugins.test.ts
@@ -107,6 +107,8 @@ describe("bundled system plugins", () => {
     expect(methodReview).toContain("observable outcome that could change the decision");
     expect(methodReview).toContain("latest valid, comparable results");
     expect(methodReview).toContain("every correction affecting eligibility, ranking, or comparability");
+    expect(methodReview).toContain("every material challenge and contradictory result propagated");
+    expect(methodReview).toContain("current evidence has invalidated or left unresolved");
     expect(methodReview).toContain("Do not choose a replacement method");
     expect(methodReview).toContain("method-specific budgets or stopping rules");
     const requestTemplate = await readFile(join(auditorSkill, "references", "audit-request-template.md"), "utf8");

--- a/packages/runtime/src/agent-factory.ts
+++ b/packages/runtime/src/agent-factory.ts
@@ -46,6 +46,7 @@ import {
   PROVIDER_MAX_RETRIES,
   PROVIDER_RETRY_BASE_DELAY_MS,
 } from "./pi-retry.js";
+import { repairPiManagedToolPermissions } from "./managed-tool-permissions.js";
 
 export function isMockMode(env: Record<string, string | undefined> = process.env): boolean {
   return env.BP_MOCK === "1" || env.BP_MOCK === "true";
@@ -103,6 +104,7 @@ export const realAgentFactory: AgentSessionFactory = async (params) => {
   } = sdk;
 
   const agentDir = getAgentDir();
+  await repairPiManagedToolPermissions(agentDir);
   const settingsManager = SettingsManager.create(params.cwd, agentDir, {
     projectTrusted: true,
   });

--- a/packages/runtime/src/managed-tool-permissions.ts
+++ b/packages/runtime/src/managed-tool-permissions.ts
@@ -1,0 +1,24 @@
+import { chmod, stat } from "node:fs/promises";
+import { join } from "node:path";
+
+const PI_MANAGED_TOOLS = ["fd", "rg"] as const;
+
+/** Restore executable bits that persisted Pi-managed binaries may have lost. */
+export async function repairPiManagedToolPermissions(
+  agentDir: string,
+  platform: NodeJS.Platform = process.platform,
+): Promise<void> {
+  if (platform === "win32") return;
+
+  await Promise.all(PI_MANAGED_TOOLS.map(async (name) => {
+    const file = join(agentDir, "bin", name);
+    try {
+      const info = await stat(file);
+      if (!info.isFile() || (info.mode & 0o111) !== 0) return;
+      await chmod(file, (info.mode & 0o777) | 0o111);
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT" && code !== "EACCES" && code !== "EPERM") throw error;
+    }
+  }));
+}

--- a/packages/runtime/src/personas.ts
+++ b/packages/runtime/src/personas.ts
@@ -201,15 +201,16 @@ which the recipient reads before starting. The Principal or other task creator
 must emphasize the canonical artifact and the relevant sections in each
 dependent delegation; an orienting summary does not replace the artifact.
 
-If a recipient finds any suspected error, ambiguity, missing support, or question
-in an upstream artifact, it must raise a bounded, evidence-addressed challenge
-with the artifact's author, directly when possible or through the task creator,
-before relying on the disputed point. Cite the path and exact claim or section.
-The author responds by updating the canonical artifact, adding a linked
-clarification, or marking the issue unresolved with its impact. Hold only the
-affected downstream decision while independent work continues. Report missing
-or conflicting context instead of guessing. Mark work as complete, partial, or
-blocked.`;
+Every decision-relevant claim must point to inspectable evidence, address
+material counterevidence, or be marked provisional or unresolved. Unavailable
+evidence stays unknown; access failure is not evidence of absence. When new
+evidence materially contradicts an upstream premise, protocol, method, or
+result, stop the affected path: report the exact conflict and impact, mark
+dependent work stale, and obtain a resolution from the author or task creator
+before continuing it. Resolve the challenge by updating the canonical artifact,
+adding a linked clarification, or preserving the open issue and its impact.
+Independent unaffected work may continue. Report completion as complete,
+partial, or blocked with any remaining issue and impact.`;
 
 /** Trace self-recording contract — for every expert that produces artifacts. */
 const TRACE_EXPERT = `## Recording your own work
@@ -368,6 +369,12 @@ Preserve the evidence dependencies below while scheduling independent work
 flexibly. Experts may proceed in parallel when their current work does not
 consume an unfinished artifact; they should share material constraints and
 revise provisional work when later evidence changes its assumptions.
+
+After exploratory tasks return, synthesize their canonical artifacts before
+commissioning a binding protocol or final implementation. Identify conflicts,
+unsupported assumptions, and missing decision evidence, then route bounded
+follow-up research until they are resolved or explicitly bounded. A
+complete-looking first report is not a commitment point.
 
 Engineer preflight may begin before the method survey. Limit that preflight to
 the data contract, environment report, real-input inspection, and
@@ -558,6 +565,11 @@ Separate eligibility guards from ranking evidence: passing guards makes a
 candidate eligible, not preferred. Every challenger must have a predeclared
 observable outcome that could change the decision; otherwise label it as a
 sensitivity analysis rather than a selection candidate.
+
+Every decision-relevant diagnostic must have an outcome that can change,
+invalidate, or narrow the decision. Evidence that materially falsifies a method
+assumption or estimand cannot be reduced to a warning-only flag; revise the
+protocol, reject the method, or narrow the claim.
 
 Apply the declared rule to the latest valid, comparable results and save a
 compact decision record naming the rule, evidence revisions, exclusions, and


### PR DESCRIPTION
## Summary
- require evidence-addressable claims, material counterevidence, and stop-the-line handling for invalidated work
- make PI synthesize exploratory artifacts before binding protocols and keep Experimentalist diagnostics decision-capable
- make Auditor reject protocol conformance built on invalidated premises
- repair persisted Pi fd/rg executable bits and preinstall fd-find in CPU/GPU sandboxes

## Verification
- npm run build
- npm run typecheck
- npm test (105 files, 1113 tests)
- bash -n docker/sandbox/_python-base.sh
- git diff --check

Docker daemon access is unavailable in this environment, so the image itself was not built locally.