### PR TITLE
fix(research): diagnose decision-critical assumptions

### DIFF
--- a/packages/plugin-research/skills/create-data-inventory/SKILL.md
+++ b/packages/plugin-research/skills/create-data-inventory/SKILL.md
@@ -24,6 +24,9 @@ Include:
 - loaded structure where relevant: shapes, axes, dtypes, value domains, feature
   ordering, labels and label mappings;
 - documented or observed split relationships and grouping boundaries;
+- bounded, structure-aware summaries of decision-relevant variation across
+  natural groups or axes, including localized concentration, extreme patterns,
+  and quality or covariate coverage that could invalidate downstream assumptions;
 - reconciled totals and the checks used to obtain them;
 - missing metadata, ambiguous mappings, unreadable inputs, discrepancies, and
   any parts of the assigned scope that could not be inspected;
@@ -31,8 +34,9 @@ Include:
   must preserve when designing or reviewing later work.
 
 Keep the inventory descriptive. Do not train models, choose methods, freeze
-hyperparameters, or treat inventory inspection as empirical validation. Link
-supporting metadata or inspection outputs when they are useful, but keep the
+hyperparameters, or treat inventory inspection as empirical validation. Report
+observed patterns without selecting a method or assigning a scientific cause.
+Link supporting metadata or inspection outputs when they are useful, but keep the
 inventory self-contained enough that another agent can use it without repeating
 the discovery work.
 

--- a/packages/runtime/src/__tests__/personas.test.ts
+++ b/packages/runtime/src/__tests__/personas.test.ts
@@ -324,6 +324,9 @@ Stale local routing rule.`;
     expect(experimentalist).toContain("latest valid, comparable results");
     expect(experimentalist).toContain("invalidates the current decision");
     expect(experimentalist).toContain("do not default to a preferred candidate");
+    expect(experimentalist).toContain("map each decision-critical assumption to existing evidence");
+    expect(experimentalist).toContain("Route a bounded diagnostic for any unresolved assumption");
+    expect(experimentalist).toContain("do not exclude or commit to a method while such evidence is missing");
 
     expect(engineer).toContain("latest comparable candidate table");
     expect(engineer).toContain("mark the affected result superseded");
@@ -341,6 +344,8 @@ Stale local routing rule.`;
     expect(normalized).toContain("fixed-method work from comparative selection");
     expect(normalized).toContain("observable outcome that could change the decision");
     expect(normalized).toContain("latest valid, comparable results");
+    expect(normalized).toContain("map each decision-critical assumption to existing evidence");
+    expect(normalized).toContain("Route a bounded diagnostic for any unresolved assumption");
   });
 
   it("injects candidate-result freshness into old Engineer overrides exactly once", () => {

--- a/packages/runtime/src/__tests__/system-plugins.test.ts
+++ b/packages/runtime/src/__tests__/system-plugins.test.ts
@@ -40,10 +40,13 @@ describe("bundled system plugins", () => {
     const engineerSkills = systemPluginSkillPaths(plugins, snapshot, "engineer");
     expect(engineerSkills).toHaveLength(1);
     expect(engineerSkills[0]).toMatch(/plugin-research.*create-data-inventory/);
-    const inventorySkill = await readFile(join(engineerSkills[0]!, "SKILL.md"), "utf8");
+    const inventorySkill = (await readFile(join(engineerSkills[0]!, "SKILL.md"), "utf8")).replace(/\s+/g, " ");
     expect(inventorySkill).toContain("before creating or updating any data inventory");
     expect(inventorySkill).toContain("docs/specs/data-inventory.md");
     expect(inventorySkill).toContain("one canonical Markdown document");
+    expect(inventorySkill).toContain("bounded, structure-aware summaries");
+    expect(inventorySkill).toContain("localized concentration, extreme patterns");
+    expect(inventorySkill).toContain("Report observed patterns without selecting a method");
     expect(inventorySkill).not.toContain("forbidden/private");
     const librarianSkills = systemPluginSkillPaths(plugins, snapshot, "librarian");
     expect(librarianSkills).toHaveLength(1);

--- a/packages/runtime/src/personas.ts
+++ b/packages/runtime/src/personas.ts
@@ -566,6 +566,11 @@ candidate eligible, not preferred. Every challenger must have a predeclared
 observable outcome that could change the decision; otherwise label it as a
 sensitivity analysis rather than a selection candidate.
 
+Before freezing finalists or a decision rule, map each decision-critical
+assumption to existing evidence. Route a bounded diagnostic for any unresolved
+assumption that available task data can discriminate; do not exclude or commit
+to a method while such evidence is missing.
+
 Every decision-relevant diagnostic must have an outcome that can change,
 invalidate, or narrow the decision. Evidence that materially falsifies a method
 assumption or estimand cannot be reduced to a warning-only flag; revise the


### PR DESCRIPTION
## Summary
- make canonical data inventories include bounded structure-aware variation without selecting methods or causal explanations
- require Experimentalist to map decision-critical assumptions to evidence and route bounded diagnostics before freezing methods
- preserve the updated method-selection contract in legacy persona overrides

## Verification
- npm run build
- npm run typecheck
- npm test (105 files, 1113 tests)
- git diff --check