### PR TITLE
fix(research): preserve viable method families

### DIFF
--- a/packages/plugin-auditor/skills/audit-model-validation/SKILL.md
+++ b/packages/plugin-auditor/skills/audit-model-validation/SKILL.md
@@ -56,6 +56,12 @@ the latest protocol, evidence, and decision. Protocol conformance cannot pass
 when the protocol still depends on a premise that current evidence has
 invalidated or left unresolved.
 
+For material inclusions and exclusions, distinguish the scientific principle,
+method family, and concrete implementation. An implementation-specific
+limitation cannot exclude a method family without evidence against the family's
+assumptions or estimand. Verify that a minimal, adapted, or alternative
+implementation was considered when the full tool or pipeline was unsuitable.
+
 ## Checks
 
 1. Identify the intended use and claim. Determine whether the evidence source,

--- a/packages/runtime/src/__tests__/personas.test.ts
+++ b/packages/runtime/src/__tests__/personas.test.ts
@@ -340,6 +340,19 @@ Stale local routing rule.`;
     expect(engineer).toContain("do not make the final scientific selection");
   });
 
+  it("separates method families from concrete implementations", () => {
+    const librarian = PERSONAS.librarian!.replace(/\s+/g, " ");
+    const experimentalist = personaFor("experimentalist", "expert").replace(/\s+/g, " ");
+
+    expect(librarian).toContain("scientific principle, method family, and concrete implementation");
+    expect(librarian).toContain("does not by itself exclude the underlying family");
+    expect(librarian).toContain("minimal, adapted, or alternative implementation remains viable");
+
+    expect(experimentalist).toContain("feasible representative of each credible, materially distinct method family");
+    expect(experimentalist).toContain("family-level assumptions or estimand");
+    expect(experimentalist).toContain("implementation cost, dependency, interface, or default configuration");
+  });
+
   it("injects the Experimentalist method-selection contract into old overrides exactly once", () => {
     const old = "# Old Experimentalist\n\nLocal protocol guidance.";
     const once = withCoreCoordinationProtocols(old, "experimentalist", "expert");

--- a/packages/runtime/src/__tests__/system-plugins.test.ts
+++ b/packages/runtime/src/__tests__/system-plugins.test.ts
@@ -115,6 +115,9 @@ describe("bundled system plugins", () => {
     expect(methodReview).toContain("current evidence has invalidated or left unresolved");
     expect(methodReview).toContain("Do not choose a replacement method");
     expect(methodReview).toContain("method-specific budgets or stopping rules");
+    expect(methodReview).toContain("scientific principle, method family, and concrete implementation");
+    expect(methodReview).toContain("implementation-specific limitation cannot exclude a method family");
+    expect(methodReview).toContain("minimal, adapted, or alternative implementation");
     const requestTemplate = await readFile(join(auditorSkill, "references", "audit-request-template.md"), "utf8");
     expect(requestTemplate).toContain("Decision provenance");
     expect(requestTemplate).toContain("Material alternatives or unresolved challenges");

--- a/packages/runtime/src/personas.ts
+++ b/packages/runtime/src/personas.ts
@@ -584,6 +584,11 @@ invalidate, or narrow the decision. Evidence that materially falsifies a method
 assumption or estimand cannot be reduced to a warning-only flag; revise the
 protocol, reject the method, or narrow the claim.
 
+Preserve a feasible representative of each credible, materially distinct method
+family. Exclude the family only when evidence challenges its family-level
+assumptions or estimand; implementation cost, dependency, interface, or default
+configuration may determine the representative, not erase the family.
+
 Apply the declared rule to the latest valid, comparable results and save a
 compact decision record naming the decision, basis, evidence revisions,
 exclusions, and selected candidate or inconclusive outcome. Any correction
@@ -870,6 +875,12 @@ candidate set with \`high\`, \`medium\`, or \`low\` applicability confidence,
 reasons, protocol mismatches, implementation assumptions, and unknowns. The
 survey may prioritize empirical comparison but does not bind the team to one
 architecture or exclude a credible baseline solely from literature rankings.
+For every material inclusion or exclusion, distinguish the scientific
+principle, method family, and concrete implementation. A package, default
+configuration, interface, scale, or full-pipeline limitation does not by itself
+exclude the underlying family. State whether a minimal, adapted, or alternative
+implementation remains viable; exclude the family only with evidence about its
+assumptions or estimand.
 
 ## Skills-first knowledge framing
 


### PR DESCRIPTION
## Summary
- distinguish scientific principles, method families, and concrete implementations in Librarian surveys
- require Experimentalist protocols to retain a feasible representative of each credible method family
- make Auditor reject family-level exclusions supported only by implementation-specific limitations

## Validation
- npm run build
- npm run typecheck
- npm test (106 files, 1118 tests)