### PR TITLE
fix(research): defer final candidate selection

### DIFF
--- a/packages/plugin-auditor/skills/audit-feedback-loop/references/audit-request-template.md
+++ b/packages/plugin-auditor/skills/audit-feedback-loop/references/audit-request-template.md
@@ -38,8 +38,10 @@ Target type: <expert-result | pi-draft | synthesis>
 - Representative real-data validation: <paths, or exact reason unavailable>
 - Validation run and code/config revision: <run metadata and revision identifier>
 - Baseline comparison: <path>
-- Latest corrected candidate comparison: <path and result revisions>
-- Experimentalist selection decision: <path>
+- Validated fallback: <path or none; confirm it carried no preference>
+- Frozen comparison snapshot: <path, revision, included candidates, and exclusions>
+- Final decision record: <path and referenced snapshot revision>
+- Pre-freeze exclusions and resource allocations: <evidence paths>
 - Per-group training curves and selected epochs: <paths>
 - Prediction diagnostics (counts, class coverage, entropy, confusion matrices): <paths>
 - Artifact equivalence and usability checks: <paths>

--- a/packages/plugin-auditor/skills/audit-model-validation/SKILL.md
+++ b/packages/plugin-auditor/skills/audit-model-validation/SKILL.md
@@ -42,12 +42,20 @@ protocol's own declaration cannot prescribe the winner.
 Separate eligibility guards from ranking evidence. Passing candidate-local
 guards establishes eligibility, not preference. Every claimed challenger must
 have a predeclared observable outcome that could change the decision; otherwise
-it is not evidence of comparative selection. Verify that the submitted candidate
-is the declared rule's output on the latest valid, comparable results and that
-every correction affecting eligibility, ranking, or comparability propagated to
-a new decision. If the evidence cannot distinguish candidates for the intended
-claim, mark empirical adequacy `unverified` and require the claim to be revised
-or narrowed. Do not choose a replacement method for the team.
+it is not evidence of comparative selection. Verify that the final method was
+first designated after the final comparable evidence snapshot was frozen and is
+the declared rule's output on that frozen final comparable evidence snapshot. A
+validated fallback protects delivery continuity but carries no scientific
+preference. Determine whether any earlier preference changed candidate coverage,
+evaluation effort, pruning, or interpretation. Verify that every correction
+affecting eligibility, ranking, or comparability invalidated the snapshot and
+decision before a new revision was frozen. If the evidence cannot distinguish
+candidates for the intended claim, mark empirical adequacy `unverified` and
+require the claim to be revised or narrowed. Do not choose a replacement method
+for the team.
+
+An early designation that altered coverage, effort, pruning, or interpretation
+is invalid decision provenance and requires `REVISE`.
 
 Missing, invalid, or stale decision provenance requires `REVISE`.
 
@@ -100,9 +108,9 @@ implementation was considered when the full tool or pipeline was unsuitable.
    which one result motivates the next decision; final validation of an older
    revision cannot validate a newer candidate.
 10. For a comparative decision, verify the decision record cites the declared
-    rule and current result revisions, accounts for every eligible finalist that
-    could change the decision, and yields the submitted candidate or an honest
-    inconclusive outcome.
+    rule and frozen snapshot revision, accounts for every eligible finalist and
+    valid exclusion, and yields the submitted candidate or an honest inconclusive
+    outcome.
 11. Bound every conclusion to the alternatives, evidence, conditions, and checks
     actually completed.
 

--- a/packages/runtime/src/__tests__/personas.test.ts
+++ b/packages/runtime/src/__tests__/personas.test.ts
@@ -320,15 +320,15 @@ Stale local routing rule.`;
 
     expect(pi).toContain("freeze the selection rule rather than a candidate identity");
     expect(pi).toContain("candidate-local guards do not establish preference");
-    expect(pi).toContain("latest valid comparison");
+    expect(pi).toContain("final comparable evidence snapshot");
 
     expect(experimentalist).toContain("independent prescribing constraint or a decision rule");
     expect(experimentalist).toContain("user, task, or external scientific requirement independently determines");
     expect(experimentalist).toContain("Literature recommendations, candidate-local guards, convenience");
     expect(experimentalist).toContain("eligibility guards from ranking evidence");
     expect(experimentalist).toContain("observable outcome that could change the decision");
-    expect(experimentalist).toContain("latest valid, comparable results");
-    expect(experimentalist).toContain("invalidates the current decision");
+    expect(experimentalist).toContain("frozen final comparable evidence snapshot");
+    expect(experimentalist).toContain("invalidates both the snapshot and decision");
     expect(experimentalist).toContain("do not default to a preferred candidate");
     expect(experimentalist).toContain("map each decision-critical assumption to existing evidence");
     expect(experimentalist).toContain("Route a bounded diagnostic for any unresolved assumption");
@@ -338,6 +338,26 @@ Stale local routing rule.`;
     expect(engineer).toContain("mark the affected result superseded");
     expect(engineer).toContain("never carry a stale result into the final decision");
     expect(engineer).toContain("do not make the final scientific selection");
+  });
+
+  it("defers comparative selection until final evidence is frozen", () => {
+    const pi = PERSONAS.principal!.replace(/\s+/g, " ");
+    const experimentalist = personaFor("experimentalist", "expert").replace(/\s+/g, " ");
+    const engineer = PERSONAS.engineer!.replace(/\s+/g, " ");
+
+    expect(pi).toContain("baseline or validated fallback carries no scientific preference");
+    expect(pi).toContain("Before the final decision checkpoint");
+    expect(pi).toContain("do not designate, endorse, or freeze a preferred candidate");
+    expect(pi).toContain("Freeze one final comparable evidence snapshot before selection");
+
+    expect(experimentalist).toContain("During exploration, maintain candidate eligibility and evidence needs without naming a winner");
+    expect(experimentalist).toContain("A current lead alone is insufficient justification");
+    expect(experimentalist).toContain("protocol-defined minimum comparable evidence");
+    expect(experimentalist).toContain("Apply the predeclared decision rule once");
+
+    expect(engineer).toContain("without recommendation, preference labels, or a selected-candidate field");
+    expect(engineer).toContain("emit a frozen comparison snapshot with its revision");
+    expect(engineer).toContain("do not apply the scientific decision rule");
   });
 
   it("separates method families from concrete implementations", () => {
@@ -362,7 +382,7 @@ Stale local routing rule.`;
     const normalized = twice.replace(/\s+/g, " ");
     expect(normalized).toContain("independent prescribing constraint or a decision rule");
     expect(normalized).toContain("observable outcome that could change the decision");
-    expect(normalized).toContain("latest valid, comparable results");
+    expect(normalized).toContain("frozen final comparable evidence snapshot");
     expect(normalized).toContain("map each decision-critical assumption to existing evidence");
     expect(normalized).toContain("Route a bounded diagnostic for any unresolved assumption");
   });

--- a/packages/runtime/src/__tests__/system-plugins.test.ts
+++ b/packages/runtime/src/__tests__/system-plugins.test.ts
@@ -109,7 +109,7 @@ describe("bundled system plugins", () => {
     expect(methodReview).toContain("Missing, invalid, or stale decision provenance requires `REVISE`");
     expect(methodReview).toContain("eligibility guards from ranking evidence");
     expect(methodReview).toContain("observable outcome that could change the decision");
-    expect(methodReview).toContain("latest valid, comparable results");
+    expect(methodReview).toContain("frozen final comparable evidence snapshot");
     expect(methodReview).toContain("every correction affecting eligibility, ranking, or comparability");
     expect(methodReview).toContain("every material challenge and contradictory result propagated");
     expect(methodReview).toContain("current evidence has invalidated or left unresolved");
@@ -118,12 +118,17 @@ describe("bundled system plugins", () => {
     expect(methodReview).toContain("scientific principle, method family, and concrete implementation");
     expect(methodReview).toContain("implementation-specific limitation cannot exclude a method family");
     expect(methodReview).toContain("minimal, adapted, or alternative implementation");
+    expect(methodReview).toContain("first designated after the final comparable evidence snapshot was frozen");
+    expect(methodReview).toContain("earlier preference changed candidate coverage, evaluation effort, pruning, or interpretation");
+    expect(methodReview).toContain("fallback protects delivery continuity but carries no scientific preference");
     const requestTemplate = await readFile(join(auditorSkill, "references", "audit-request-template.md"), "utf8");
     expect(requestTemplate).toContain("Decision provenance");
     expect(requestTemplate).toContain("Material alternatives or unresolved challenges");
     expect(requestTemplate).not.toContain("Selection mode and rule");
-    expect(requestTemplate).toContain("Latest corrected candidate comparison");
-    expect(requestTemplate).toContain("Experimentalist selection decision");
+    expect(requestTemplate).toContain("Final decision record");
+    expect(requestTemplate).toContain("Validated fallback");
+    expect(requestTemplate).toContain("Frozen comparison snapshot");
+    expect(requestTemplate).toContain("Pre-freeze exclusions and resource allocations");
     const responseTemplate = await readFile(join(auditorSkill, "references", "audit-response-template.md"), "utf8");
     expect(responseTemplate).toContain("## Compact completion reply");
     expect(responseTemplate).toContain("Report: docs/audits/<actual-report-file>.md");

--- a/packages/runtime/src/personas.ts
+++ b/packages/runtime/src/personas.ts
@@ -398,9 +398,10 @@ survey is not applicable before routing formal implementation.
    task-relevant inputs in scope, and saves the canonical inventory as the
    data-contract artifact that subsequent agents read directly.
    It may repair the environment, load the real inputs, prepare reusable data
-   and evaluation plumbing, and establish an incumbent baseline when its
-   evaluation is already task-specified or covered by an Experimentalist-authored
-   baseline-only provisional protocol.
+   and evaluation plumbing, and establish a baseline or validated fallback when
+   its evaluation is already task-specified or covered by an
+   Experimentalist-authored baseline-only provisional protocol. A baseline or
+   validated fallback carries no scientific preference.
 2. When method choice is material, \`librarian\` surveys credible alternatives,
    organizing them by substantively different principles, evidence, assumptions,
    costs, limitations, and relevance rather than listing minor variants. It
@@ -413,6 +414,8 @@ survey is not applicable before routing formal implementation.
    checks, essential comparisons, staged decision rules, and safe reductions.
    For comparative work, it must freeze the selection rule rather than a
    candidate identity; candidate-local guards do not establish preference.
+   Before the final decision checkpoint, do not designate, endorse, or freeze a
+   preferred candidate.
 4. \`engineer\` implements the protocol, checks operational feasibility, and
    executes the decision-relevant evaluation on usable task-relevant real
    observations when they exist and apply to the claim; otherwise it uses the
@@ -421,22 +424,26 @@ survey is not applicable before routing formal implementation.
    Synthetic data, shortened runs, subset runs, loss-only checks, and smoke tests
    may establish feasibility but do not complete empirical evaluation.
 5. \`experimentalist\` independently reviews the saved empirical results, not
-   only implementation conformance. It classifies the result as \`accept\`,
+   only implementation conformance. It classifies each round as \`accept\`,
    \`revise\`, \`reject\`, or \`stop-no-meaningful-improvement\`, supported by the
    protocol's primary metrics, guardrail metrics, failure diagnostics, baseline
-   comparison, and stopping rules. For comparative work, it applies the declared
-   rule to the latest valid comparison and records how that evidence produced the
-   selected candidate or an inconclusive outcome.
+   comparison, and stopping rules. Intermediate comparative reviews decide
+   validity, eligibility, missing evidence, and next work—not the winner. Route
+   more work from the declared evidence-acquisition or futility rules, not a
+   candidate's current lead alone.
 6. For \`revise\`, route a bounded Engineer round based on one explicit
    result-derived hypothesis. Preserve a comparable evaluation unless the
    Experimentalist records and justifies a protocol revision. Continue until
    the acceptance criteria or predeclared stopping rule is met.
-7. Before final audit, require paths to the representative empirical evaluation,
-   baseline result, complete iteration ledger, final candidate result, and
-   quantitative acceptance or stopping decision. When selection is comparative,
-   also require the Experimentalist's decision record linking the declared rule
-   and latest corrected candidate comparison to the final candidate. Missing
-   empirical evidence is a blocker, not a low-risk limitation.
+7. Freeze one final comparable evidence snapshot before selection, once
+   comparative evidence is complete or validly excluded. The Experimentalist then
+   applies the predeclared rule once and records the selected candidate or an
+   inconclusive outcome. Before final audit, require paths to the representative
+   empirical evaluation, baseline result, complete iteration ledger, final
+   candidate result, and quantitative acceptance or stopping decision. When
+   selection is comparative, also require the Experimentalist's decision record
+   linking the declared rule and frozen snapshot revision to the final candidate.
+   Missing empirical evidence is a blocker, not a low-risk limitation.
 
 ## Empirical completion gate
 
@@ -569,6 +576,14 @@ requirement independently determines the method identity. Literature
 recommendations, candidate-local guards, convenience, and the protocol's own
 declaration are selection evidence at most; they cannot prescribe the winner.
 
+During exploration, maintain candidate eligibility and evidence needs without
+naming a winner. Use \`untested\`, \`eligible\`, \`invalid\`, \`incomplete\`, or
+\`superseded\` status; a baseline or validated fallback is a control and
+continuity artifact, not a preferred candidate. Allocate further evaluation by
+the predeclared evidence-acquisition rule, unresolved decision-relevant
+uncertainty, or expected information value. A current lead alone is insufficient
+justification.
+
 Separate eligibility guards from ranking evidence: passing guards makes a
 candidate eligible, not preferred. Every challenger must have a predeclared
 observable outcome that could change the decision; otherwise label it as a
@@ -585,27 +600,35 @@ assumption or estimand cannot be reduced to a warning-only flag; revise the
 protocol, reject the method, or narrow the claim.
 
 Preserve a feasible representative of each credible, materially distinct method
-family. Exclude the family only when evidence challenges its family-level
-assumptions or estimand; implementation cost, dependency, interface, or default
-configuration may determine the representative, not erase the family.
+family. Before evidence-based pruning, each receives the protocol-defined
+minimum comparable evidence unless a hard constraint applies, evidence
+challenges its family-level assumptions or estimand, invalidity is demonstrated,
+a conservative futility bound is met, or cost is infeasible with no viable
+adaptation; implementation cost, dependency, interface, or default configuration
+may determine the representative, not erase the family.
 
-Apply the declared rule to the latest valid, comparable results and save a
-compact decision record naming the decision, basis, evidence revisions,
-exclusions, and selected candidate or inconclusive outcome. Any correction
-affecting eligibility, ranking, or comparability invalidates the current decision
-until the affected evidence is updated and the rule is reapplied. If available
-evidence cannot distinguish candidates for the intended use, revise the
-evaluation or narrow the claim; do not default to a preferred candidate.`;
+After required evidence is complete or validly excluded, freeze the final
+comparable evidence snapshot with a revision identifier. Apply the predeclared
+decision rule once and save a compact decision record naming the decision,
+basis, exclusions, and the frozen final comparable evidence snapshot. Any
+correction affecting eligibility, ranking, or comparability invalidates both the
+snapshot and decision; update the evidence, freeze a new revision, and reapply
+the rule. If available evidence cannot distinguish candidates for the intended
+use, revise the evaluation or narrow the claim; do not default to a preferred
+candidate.`;
 
 const ENGINEER_CANDIDATE_RESULT_FRESHNESS = `## Candidate result freshness
 
-For comparative work, maintain one latest comparable candidate table alongside
-the complete iteration ledger. When a correction or deviation can affect
+For comparative work, maintain one latest comparable candidate table without
+recommendation, preference labels, or a selected-candidate field, alongside the
+complete iteration ledger. When a correction or deviation can affect
 eligibility, a selection metric, or comparability, mark the affected result
 superseded, then update it or explicitly exclude it under the declared rules.
 Rebuild the comparison before handoff and never carry a stale result into the
-final decision. Report evidence and protocol-directed dispositions; do not make
-the final scientific selection.`;
+final decision. When the protocol declares evidence collection complete, emit a
+frozen comparison snapshot with its revision. Report evidence and
+protocol-directed dispositions; do not apply the scientific decision rule and
+do not make the final scientific selection.`;
 
 function appendSectionOnce(persona: string, heading: string, section: string): string {
   const present = persona.split(/\r?\n/).some((line) => line.trim() === `## ${heading}`);
@@ -998,16 +1021,19 @@ routinely rerun the implementation or recompute reported metrics. Perform a
 targeted independent calculation only when the protocol explicitly requires it
 or when a concrete discrepancy, alignment risk, aggregation error, or missing
 evidence could change the decision. The final pre-delivery independent
-verification belongs to the final audit gate. Issue exactly one decision:
+verification belongs to the final audit gate. Issue exactly one workflow
+decision for the round:
 \`accept\`; \`revise\` with one result-derived hypothesis and the evidence that
 would support or reject it; \`reject\`; or
 \`stop-no-meaningful-improvement\` after the declared threshold and patience are
-exhausted. Do not approve a method merely because it trains, its loss decreases,
-or it faithfully implements the protocol. Do not request another round without
-a concrete hypothesis grounded in the previous round's observed result. Flag
-unexplained discrepancies, missing alignment assertions, transform drift, or
-absent export/packaging evidence and return required corrections to the task
-creator.
+exhausted. In comparative work, an intermediate \`accept\` validates the current
+evidence or closes evidence collection; it does not select a method before the
+final decision checkpoint. Do not approve a method merely because it trains,
+its loss decreases, or it faithfully implements the protocol. Do not request
+another round without a concrete hypothesis grounded in the previous round's
+observed result. Flag unexplained discrepancies, missing alignment assertions,
+transform drift, or absent export/packaging evidence and return required
+corrections to the task creator.
 
 ## Output format
 


### PR DESCRIPTION
## Summary
- treat baselines and validated fallbacks as non-preferred continuity artifacts
- keep exploration focused on eligibility and evidence acquisition, then select once from a frozen final comparison snapshot
- keep Engineer evidence tables recommendation-free and require snapshot revisions
- make Auditor reject early preferences that changed candidate coverage, effort, pruning, or interpretation
- update the audit request packet with fallback, frozen snapshot, decision record, and pre-freeze allocation evidence

## Validation
- npm run build
- npm run typecheck
- npm test (106 files, 1119 tests)