### PR TITLE
fix(research): validate empirical ranking evidence

### DIFF
--- a/packages/plugin-auditor/skills/audit-feedback-loop/references/audit-request-template.md
+++ b/packages/plugin-auditor/skills/audit-feedback-loop/references/audit-request-template.md
@@ -30,6 +30,7 @@ Target type: <expert-result | pi-draft | synthesis>
 - Method survey: <path>
 - Scientific protocol and decision rules: <path>
 - Decision provenance: <decision; independent constraint or selection rule; evidence paths and revisions>
+- Evaluation validity: <decision claim; target and evidence conditions; criterion; material mismatches and checks>
 - Material alternatives or unresolved challenges: <paths or concise summary>
 - Parameter configuration and provenance: <paths>
 - Implementation or procedure: <paths>

--- a/packages/plugin-auditor/skills/audit-model-validation/SKILL.md
+++ b/packages/plugin-auditor/skills/audit-model-validation/SKILL.md
@@ -57,6 +57,13 @@ for the team.
 An early designation that altered coverage, effort, pruning, or interpretation
 is invalid decision provenance and requires `REVISE`.
 
+When a material choice among alternatives depends on empirical evidence, verify
+the decision claim, target conditions, evidence conditions, decision criterion,
+and every evidence-backed mismatch that could plausibly reverse the choice. Only
+evidence adequately linked to the claim may rank alternatives. An unresolved
+material gap must separate any required delivery choice from a scientific
+superiority claim and use the predeclared risk rule.
+
 Missing, invalid, or stale decision provenance requires `REVISE`.
 
 Verify that every material challenge and contradictory result propagated into

--- a/packages/runtime/src/__tests__/personas.test.ts
+++ b/packages/runtime/src/__tests__/personas.test.ts
@@ -271,7 +271,7 @@ Stale local routing rule.`;
     expect(experimentalist).toContain("smallest procedure that answers the");
     expect(experimentalist).toContain("Do not default to exhaustive nested");
     expect(experimentalist).toContain("broad set of credible alternatives");
-    expect(experimentalist).toContain("selection evidence represents the intended use");
+    expect(experimentalist).toContain("evidence with an adequate link to the claim may rank alternatives");
     expect(experimentalist).toContain("not as a reason to enlarge the");
     expect(engineer).toContain("bounded operational check");
     expect(engineer).toContain("decision-relevant evaluation");
@@ -358,6 +358,24 @@ Stale local routing rule.`;
     expect(engineer).toContain("without recommendation, preference labels, or a selected-candidate field");
     expect(engineer).toContain("emit a frozen comparison snapshot with its revision");
     expect(engineer).toContain("do not apply the scientific decision rule");
+  });
+
+  it("admits ranking evidence only when it supports the intended claim", () => {
+    const pi = PERSONAS.principal!.replace(/\s+/g, " ");
+    const experimentalist = personaFor("experimentalist", "expert").replace(/\s+/g, " ");
+    const engineer = PERSONAS.engineer!.replace(/\s+/g, " ");
+
+    expect(pi).toContain("material choice among alternatives depends on empirical evidence");
+    expect(pi).toContain("evaluation-validity record");
+
+    expect(experimentalist).toContain("decision claim, target conditions, evidence conditions, decision criterion");
+    expect(experimentalist).toContain("evidence-backed mismatch that could plausibly reverse the choice");
+    expect(experimentalist).toContain("adequate link to the claim may rank alternatives");
+    expect(experimentalist).toContain("required delivery choice under a predeclared risk rule");
+    expect(experimentalist).toContain("separate that delivery choice from a scientific superiority claim");
+
+    expect(engineer).toContain("evidence conditions and protocol-assigned role of every ranking field");
+    expect(engineer).toContain("screening, diagnostic, and guardrail evidence outside ranking fields");
   });
 
   it("separates method families from concrete implementations", () => {

--- a/packages/runtime/src/__tests__/system-plugins.test.ts
+++ b/packages/runtime/src/__tests__/system-plugins.test.ts
@@ -121,6 +121,10 @@ describe("bundled system plugins", () => {
     expect(methodReview).toContain("first designated after the final comparable evidence snapshot was frozen");
     expect(methodReview).toContain("earlier preference changed candidate coverage, evaluation effort, pruning, or interpretation");
     expect(methodReview).toContain("fallback protects delivery continuity but carries no scientific preference");
+    expect(methodReview).toContain("material choice among alternatives depends on empirical evidence");
+    expect(methodReview).toContain("decision claim, target conditions, evidence conditions, decision criterion");
+    expect(methodReview).toContain("could plausibly reverse the choice");
+    expect(methodReview).toContain("required delivery choice from a scientific superiority claim");
     const requestTemplate = await readFile(join(auditorSkill, "references", "audit-request-template.md"), "utf8");
     expect(requestTemplate).toContain("Decision provenance");
     expect(requestTemplate).toContain("Material alternatives or unresolved challenges");
@@ -129,6 +133,7 @@ describe("bundled system plugins", () => {
     expect(requestTemplate).toContain("Validated fallback");
     expect(requestTemplate).toContain("Frozen comparison snapshot");
     expect(requestTemplate).toContain("Pre-freeze exclusions and resource allocations");
+    expect(requestTemplate).toContain("Evaluation validity");
     const responseTemplate = await readFile(join(auditorSkill, "references", "audit-response-template.md"), "utf8");
     expect(responseTemplate).toContain("## Compact completion reply");
     expect(responseTemplate).toContain("Report: docs/audits/<actual-report-file>.md");

--- a/packages/runtime/src/personas.ts
+++ b/packages/runtime/src/personas.ts
@@ -416,6 +416,8 @@ survey is not applicable before routing formal implementation.
    candidate identity; candidate-local guards do not establish preference.
    Before the final decision checkpoint, do not designate, endorse, or freeze a
    preferred candidate.
+   When a material choice among alternatives depends on empirical evidence,
+   require its evaluation-validity record before comparison or selection.
 4. \`engineer\` implements the protocol, checks operational feasibility, and
    executes the decision-relevant evaluation on usable task-relevant real
    observations when they exist and apply to the claim; otherwise it uses the
@@ -626,7 +628,9 @@ eligibility, a selection metric, or comparability, mark the affected result
 superseded, then update it or explicitly exclude it under the declared rules.
 Rebuild the comparison before handoff and never carry a stale result into the
 final decision. When the protocol declares evidence collection complete, emit a
-frozen comparison snapshot with its revision. Report evidence and
+frozen comparison snapshot with its revision. Preserve the evidence conditions
+and protocol-assigned role of every ranking field; keep screening, diagnostic,
+and guardrail evidence outside ranking fields. Report evidence and
 protocol-directed dispositions; do not apply the scientific decision rule and
 do not make the final scientific selection.`;
 
@@ -989,13 +993,18 @@ deeper evaluation when appropriate, and define how alternatives may advance,
 change, be deferred, or be rejected. Preserve important breadth before optional
 depth when resources tighten, and document material omissions.
 
-Ensure that selection evidence represents the intended use. Operational,
-synthetic, self-consistency, or feasibility checks establish suitability only
-when the task makes them representative. When available evidence may reward a
-nuisance, proxy, or setting-specific signal, require a check that distinguishes
-it from the intended target. Treat the initial protocol as revisable when new
-decision-relevant evidence invalidates an assumption; record the revision rather
-than forcing later work to follow a disproven premise.
+When a material choice among alternatives depends on empirical evidence, record
+the decision claim, target conditions, evidence conditions, decision criterion,
+and any evidence-backed mismatch that could plausibly reverse the choice. Only
+evidence with an adequate link to the claim may rank alternatives; other
+evidence may screen or diagnose. Investigate only evidence-backed or
+task-plausible mismatches that could materially reverse the decision, and give
+each one a discriminating check capable of invalidating the affected ranking
+evidence. If a material gap cannot be resolved, make any required delivery
+choice under a predeclared risk rule and separate that delivery choice from a
+scientific superiority claim. Treat the protocol as revisable when new evidence
+invalidates an assumption; record the revision rather than forcing later work to
+follow a disproven premise.
 
 ${EXPERIMENTALIST_METHOD_SELECTION_CONTRACT}
 


### PR DESCRIPTION
## Summary
- trigger evaluation-validity records only for material empirical choices
- admit ranking evidence only when it is adequately linked to the intended claim
- require decision-reversing mismatches to receive discriminating checks
- preserve required delivery while separating it from unsupported superiority claims
- keep screening, diagnostic, and guardrail evidence outside Engineer ranking fields
- make Auditor verify the compact final evidence-to-claim chain

## Validation
- npm run build
- npm run typecheck
- npm test (106 files, 1120 tests)