### PR TITLE
chore(release): prepare v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 This file records notable changes to the public BrainPilot release. For the complete commit
 history, follow the comparison links for each version.
 
+## [0.2.2] - 2026-08-22
+
+This patch makes the hosted plugin experience accurately reflect Cloud availability. Hosted
+deployments previously opened the local plugin marketplace even when its Cloud control plane was
+not enabled, which exposed raw 404 responses and could make the marketplace look broken.
+
+### Cloud plugin experience
+
+- Shows a compact, localized “not yet available in Cloud” state when hosted users open Plugins.
+- Does not mount the local marketplace in hosted mode, avoiding unsupported marketplace,
+  installation, update, and MCP-status requests from that page.
+- Keeps the existing plugin marketplace unchanged for local and self-hosted installations.
+
+### Upgrade
+
+```bash
+npm install -g @brainpilot/app@0.2.2
+brainpilot --version
+```
+
+Docker and hosted deployments should use the matching `0.2.2` CPU or GPU sandbox image. No manual
+user-data migration is required.
+
 ## [0.2.1] - 2026-08-22
 
 This patch release makes **Stop** a hard boundary for model, tool, and Trace work. In v0.2.0, an
@@ -220,6 +243,7 @@ First public open-source release of BrainPilot, including the PI-led multi-agent
 workflow, Graph of Trace, the built-in scientific skills library, provider configuration, MCP
 integration, local CLI, web interface, and Docker sandbox support.
 
+[0.2.2]: https://github.com/NeuroAIHub/BrainPilot/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/NeuroAIHub/BrainPilot/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/NeuroAIHub/BrainPilot/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/NeuroAIHub/BrainPilot/compare/v0.1.1...v0.1.2

--- a/README-zh.md
+++ b/README-zh.md
@@ -43,6 +43,7 @@ BrainPilot 是一个开源、人在回路的脑科学智能体研究系统。它
 
 ## 📰 最新动态
 
+- **2026-08-22** — [BrainPilot v0.2.2](https://github.com/NeuroAIHub/BrainPilot/releases/tag/v0.2.2) 在云端插件功能尚未开放时显示简洁、明确的提示，不再暴露不受支持的插件市场请求；本地和自托管版本的完整插件市场保持不变。详见[更新日志](CHANGELOG.md#022---2026-08-22)。
 - **2026-08-22** — [BrainPilot v0.2.1](https://github.com/NeuroAIHub/BrainPilot/releases/tag/v0.2.1) 将“停止”变成严格边界，已取消的模型、工具、文件和轨迹任务不会在用户提出新需求后继续执行。详见[更新日志](CHANGELOG.md#021---2026-08-22)。
 - **2026-08-22** — [BrainPilot v0.2.0](https://github.com/NeuroAIHub/BrainPilot/releases/tag/v0.2.0) 新增公共插件平台、可持久追踪的专家任务与后台任务、支持工作区恢复的科研轨迹、公共脑科学数据集，并重新设计服务商、模型和思考强度的选择流程；同时系统性改进文件与附件、停止与恢复、移动端布局和错误处理。详见[更新日志](CHANGELOG.md#020---2026-08-22)。
 - **2026-07-28** — [BrainPilot v0.1.2](https://github.com/NeuroAIHub/BrainPilot/releases/tag/v0.1.2) 完善工具生命周期、托管 MCP BYOK、npm 知识库脚本、数学公式渲染和新手引导，并通过 GHCR 与中国大陆 ACR 正式发布 CPU/GPU 沙箱镜像。详见[更新日志](CHANGELOG.md#012---2026-07-28)。
@@ -122,7 +123,7 @@ BrainPilot 通过 **`@brainpilot/app`** 以本地进程方式运行 —— 无�
 ### 1. 安装并启动
 
 ```bash
-npm install -g @brainpilot/app@0.2.1
+npm install -g @brainpilot/app@0.2.2
 brainpilot up
 ```
 
@@ -431,8 +432,8 @@ NVIDIA GPU、驱动和 NVIDIA Container Toolkit。
 
 | 版本 | 全球 | 中国大陆 |
 | --- | --- | --- |
-| CPU | `ghcr.io/neuroaihub/brainpilot-sandbox:0.2.1` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.1` |
-| GPU | `ghcr.io/neuroaihub/brainpilot-sandbox-gpu:0.2.1` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.1` |
+| CPU | `ghcr.io/neuroaihub/brainpilot-sandbox:0.2.2` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2` |
+| GPU | `ghcr.io/neuroaihub/brainpilot-sandbox-gpu:0.2.2` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2` |
 
 这些是 runtime 沙箱镜像，不是独立的 Web 应用，需要配合 BrainPilot main 进程或云端托管层使用。
 预构建镜像的 Compose 命令、GPU 验证、动态/云端配置、升级方式和 Docker 安全边界，详见双语

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ BrainPilot is an open-source, human-in-the-loop agentic system for brain science
 
 ## 📰 News
 
+- **2026-08-22** — [BrainPilot v0.2.2](https://github.com/NeuroAIHub/BrainPilot/releases/tag/v0.2.2) replaces unsupported plugin-marketplace requests in hosted Cloud with a concise availability message, while preserving the full local and self-hosted marketplace. See the [changelog](CHANGELOG.md#022---2026-08-22).
 - **2026-08-22** — [BrainPilot v0.2.1](https://github.com/NeuroAIHub/BrainPilot/releases/tag/v0.2.1) makes Stop a hard boundary so cancelled model, tool, file, and Trace work cannot resume after the user's next message. See the [changelog](CHANGELOG.md#021---2026-08-22).
 - **2026-08-22** — [BrainPilot v0.2.0](https://github.com/NeuroAIHub/BrainPilot/releases/tag/v0.2.0) adds a public plugin platform, durable expert tasks and background jobs, richer research traces with workspace recovery, public neuroscience datasets, and a redesigned provider/model/reasoning workflow, with broad improvements to files, Stop/recovery, mobile layouts, and error handling. See the [changelog](CHANGELOG.md#020---2026-08-22).
 - **2026-07-28** — [BrainPilot v0.1.2](https://github.com/NeuroAIHub/BrainPilot/releases/tag/v0.1.2) improves tool lifecycle, managed MCP BYOK, npm knowledge-base setup, math rendering, and onboarding, and adds official CPU/GPU sandbox distribution through GHCR and mainland China ACR. See the [changelog](CHANGELOG.md#012---2026-07-28).
@@ -122,7 +123,7 @@ This is the recommended way to get started.
 ### 1. Install and launch
 
 ```bash
-npm install -g @brainpilot/app@0.2.1
+npm install -g @brainpilot/app@0.2.2
 brainpilot up
 ```
 
@@ -461,8 +462,8 @@ production; `latest` follows the newest release.
 
 | Variant | Global | Mainland China |
 | --- | --- | --- |
-| CPU | `ghcr.io/neuroaihub/brainpilot-sandbox:0.2.1` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.1` |
-| GPU | `ghcr.io/neuroaihub/brainpilot-sandbox-gpu:0.2.1` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.1` |
+| CPU | `ghcr.io/neuroaihub/brainpilot-sandbox:0.2.2` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2` |
+| GPU | `ghcr.io/neuroaihub/brainpilot-sandbox-gpu:0.2.2` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2` |
 
 These are runtime sandbox images, not standalone web applications. Use them with the BrainPilot
 main process or hosted cloud layer. See the bilingual [Docker deployment guide](packages/docs/content/docs/docker.mdx)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brainpilot",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "brainpilot",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "workspaces": [
@@ -11337,12 +11337,12 @@
     },
     "packages/backend-core": {
       "name": "@brainpilot/backend-core",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@brainpilot/plugin-sdk": "^0.2.1",
-        "@brainpilot/protocol": "^0.2.1",
-        "@brainpilot/runtime": "^0.2.1",
+        "@brainpilot/plugin-sdk": "^0.2.2",
+        "@brainpilot/protocol": "^0.2.2",
+        "@brainpilot/runtime": "^0.2.2",
         "@hono/node-server": "^2.1.0",
         "hono": "^4.13.0"
       },
@@ -11358,14 +11358,14 @@
     },
     "packages/cli": {
       "name": "@brainpilot/app",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@brainpilot/backend-core": "^0.2.1",
-        "@brainpilot/plugin-sdk": "^0.2.1",
-        "@brainpilot/protocol": "^0.2.1",
-        "@brainpilot/runtime": "^0.2.1",
-        "@brainpilot/web": "^0.2.1",
+        "@brainpilot/backend-core": "^0.2.2",
+        "@brainpilot/plugin-sdk": "^0.2.2",
+        "@brainpilot/protocol": "^0.2.2",
+        "@brainpilot/runtime": "^0.2.2",
+        "@brainpilot/web": "^0.2.2",
         "commander": "^12.1.0",
         "picocolors": "^1.1.0"
       },
@@ -11379,7 +11379,7 @@
     },
     "packages/client-cli": {
       "name": "@brainpilot/client-cli",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@brainpilot/protocol": "*",
         "commander": "^12.1.0"
@@ -11390,7 +11390,7 @@
     },
     "packages/docs": {
       "name": "@brainpilot/docs",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "hasInstallScript": true,
       "dependencies": {
         "fumadocs-core": "16.15.0",
@@ -12196,7 +12196,7 @@
     },
     "packages/kb-scripts": {
       "name": "@brainpilot/kb-scripts",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "AGPL-3.0-only",
       "engines": {
         "node": ">=22"
@@ -12204,7 +12204,7 @@
     },
     "packages/plugin-auditor": {
       "name": "@brainpilot/plugin-auditor",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "AGPL-3.0-only",
       "engines": {
         "node": ">=22"
@@ -12212,7 +12212,7 @@
     },
     "packages/plugin-got": {
       "name": "@brainpilot/plugin-got",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "AGPL-3.0-only",
       "engines": {
         "node": ">=22"
@@ -12220,7 +12220,7 @@
     },
     "packages/plugin-monitor": {
       "name": "@brainpilot/plugin-monitor",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "AGPL-3.0-only",
       "engines": {
         "node": ">=22"
@@ -12228,7 +12228,7 @@
     },
     "packages/plugin-research": {
       "name": "@brainpilot/plugin-research",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "AGPL-3.0-only",
       "engines": {
         "node": ">=22"
@@ -12236,7 +12236,7 @@
     },
     "packages/plugin-sdk": {
       "name": "@brainpilot/plugin-sdk",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "semver": "^7.7.3"
@@ -12262,7 +12262,7 @@
     },
     "packages/protocol": {
       "name": "@brainpilot/protocol",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "zod": "^3.24.0"
@@ -12273,17 +12273,17 @@
     },
     "packages/runtime": {
       "name": "@brainpilot/runtime",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@brainpilot/kb-scripts": "^0.2.1",
-        "@brainpilot/plugin-auditor": "^0.2.1",
-        "@brainpilot/plugin-got": "^0.2.1",
-        "@brainpilot/plugin-monitor": "^0.2.1",
-        "@brainpilot/plugin-research": "^0.2.1",
-        "@brainpilot/plugin-sdk": "^0.2.1",
-        "@brainpilot/protocol": "^0.2.1",
-        "@brainpilot/skills": "^0.2.1",
+        "@brainpilot/kb-scripts": "^0.2.2",
+        "@brainpilot/plugin-auditor": "^0.2.2",
+        "@brainpilot/plugin-got": "^0.2.2",
+        "@brainpilot/plugin-monitor": "^0.2.2",
+        "@brainpilot/plugin-research": "^0.2.2",
+        "@brainpilot/plugin-sdk": "^0.2.2",
+        "@brainpilot/protocol": "^0.2.2",
+        "@brainpilot/skills": "^0.2.2",
         "@earendil-works/pi-coding-agent": "0.84.2",
         "@hono/node-server": "^2.1.0",
         "@modelcontextprotocol/sdk": "^1.30.0",
@@ -12297,7 +12297,7 @@
     },
     "packages/skills": {
       "name": "@brainpilot/skills",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "AGPL-3.0-only",
       "engines": {
         "node": ">=22"
@@ -12305,11 +12305,11 @@
     },
     "packages/web": {
       "name": "@brainpilot/web",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "AGPL-3.0-only",
       "devDependencies": {
-        "@brainpilot/plugin-sdk": "^0.2.1",
-        "@brainpilot/protocol": "^0.2.1",
+        "@brainpilot/plugin-sdk": "^0.2.2",
+        "@brainpilot/protocol": "^0.2.2",
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource-variable/geist-mono": "^5.2.8",
         "@types/react": "^18.3.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainpilot",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "description": "BrainPilot — multi-agent research collaboration platform (TS + Pi SDK)",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/backend-core",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "engines": {
     "node": ">=22"
   },
@@ -39,9 +39,9 @@
     "start": "node ./dist/server.js"
   },
   "dependencies": {
-    "@brainpilot/plugin-sdk": "^0.2.1",
-    "@brainpilot/protocol": "^0.2.1",
-    "@brainpilot/runtime": "^0.2.1",
+    "@brainpilot/plugin-sdk": "^0.2.2",
+    "@brainpilot/protocol": "^0.2.2",
+    "@brainpilot/runtime": "^0.2.2",
     "@hono/node-server": "^2.1.0",
     "hono": "^4.13.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/app",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "engines": {
     "node": ">=22"
   },
@@ -32,11 +32,11 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@brainpilot/backend-core": "^0.2.1",
-    "@brainpilot/plugin-sdk": "^0.2.1",
-    "@brainpilot/protocol": "^0.2.1",
-    "@brainpilot/runtime": "^0.2.1",
-    "@brainpilot/web": "^0.2.1",
+    "@brainpilot/backend-core": "^0.2.2",
+    "@brainpilot/plugin-sdk": "^0.2.2",
+    "@brainpilot/protocol": "^0.2.2",
+    "@brainpilot/runtime": "^0.2.2",
+    "@brainpilot/web": "^0.2.2",
     "commander": "^12.1.0",
     "picocolors": "^1.1.0"
   }

--- a/packages/client-cli/package.json
+++ b/packages/client-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/client-cli",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "description": "BrainPilot headless verification client (dev/CI) — drive a session without the web UI",

--- a/packages/docs/content/docs/docker.mdx
+++ b/packages/docs/content/docs/docker.mdx
@@ -25,20 +25,20 @@ testing, but it can change on the next publication. The current images target `l
 
 | Variant | Global (GHCR) | Mainland China (Alibaba Cloud ACR) |
 | --- | --- | --- |
-| CPU | `ghcr.io/neuroaihub/brainpilot-sandbox:0.2.1` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.1` |
-| GPU | `ghcr.io/neuroaihub/brainpilot-sandbox-gpu:0.2.1` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.1` |
+| CPU | `ghcr.io/neuroaihub/brainpilot-sandbox:0.2.2` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2` |
+| GPU | `ghcr.io/neuroaihub/brainpilot-sandbox-gpu:0.2.2` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2` |
 
 Both endpoints allow anonymous pulls. Mainland China users should prefer ACR; other users should
 prefer GHCR.
 
 ```bash title="Global"
-docker pull ghcr.io/neuroaihub/brainpilot-sandbox:0.2.1
-docker pull ghcr.io/neuroaihub/brainpilot-sandbox-gpu:0.2.1
+docker pull ghcr.io/neuroaihub/brainpilot-sandbox:0.2.2
+docker pull ghcr.io/neuroaihub/brainpilot-sandbox-gpu:0.2.2
 ```
 
 ```bash title="Mainland China"
-docker pull brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.1
-docker pull brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.1
+docker pull brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2
+docker pull brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2
 ```
 
 The CPU image includes Node.js, Python, pip, curl, and the BrainPilot runtime. The GPU image adds
@@ -72,7 +72,7 @@ To avoid rebuilding the CPU sandbox, set its full registry path and pull it firs
 main image, then start Compose without rebuilding the sandbox:
 
 ```bash
-export BP_SANDBOX_IMAGE=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.1
+export BP_SANDBOX_IMAGE=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2
 docker compose pull sandbox
 docker compose build main
 docker compose up -d --no-build
@@ -103,7 +103,7 @@ docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d --build
 To use the official prebuilt GPU sandbox instead:
 
 ```bash
-export BP_SANDBOX_IMAGE_GPU=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.1
+export BP_SANDBOX_IMAGE_GPU=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2
 docker compose -f docker-compose.yml -f docker-compose.gpu.yml pull sandbox
 docker compose build main
 docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d --no-build
@@ -113,7 +113,7 @@ Verify PyTorch can see the GPU:
 
 ```bash
 docker run --rm --gpus all --entrypoint python \
-  brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.1 \
+  brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2 \
   -c 'import torch; print(torch.cuda.is_available(), torch.cuda.get_device_name(0))'
 ```
 
@@ -123,7 +123,7 @@ Dynamic mode runs one sandbox per user through the host Docker daemon. Build the
 service and point it at a versioned sandbox image:
 
 ```bash
-export BP_SANDBOX_IMAGE=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.1
+export BP_SANDBOX_IMAGE=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2
 docker pull "$BP_SANDBOX_IMAGE"
 docker compose -f docker-compose.dynamic.yml up -d --build
 ```
@@ -131,8 +131,8 @@ docker compose -f docker-compose.dynamic.yml up -d --build
 The hosted BrainPilot cloud layer supports separate CPU and GPU images:
 
 ```dotenv
-BP_SANDBOX_IMAGE_CPU=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.1
-BP_SANDBOX_IMAGE_GPU=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.1
+BP_SANDBOX_IMAGE_CPU=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2
+BP_SANDBOX_IMAGE_GPU=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2
 ```
 
 After changing either value, pull the new image and use the cloud deployment procedure to roll
@@ -158,7 +158,7 @@ Pull a new fixed tag, update the corresponding environment variable, and recreat
 containers:
 
 ```bash
-docker pull brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.1
+docker pull brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2
 docker compose up -d --no-build --force-recreate sandbox
 ```
 
@@ -175,4 +175,3 @@ volumes.
 - **Main cannot reach sandbox** — check `docker compose ps`, then inspect `docker compose logs
   sandbox` and confirm the runtime health check reaches port 8081.
 - **Pulls are slow in mainland China** — use the ACR endpoint instead of GHCR.
-

--- a/packages/docs/content/docs/docker.zh-cn.mdx
+++ b/packages/docs/content/docs/docker.zh-cn.mdx
@@ -24,19 +24,19 @@ npm 安装是最简单的单用户方案。如果你需要可复现的运行环�
 
 | 版本 | 全球（GHCR） | 中国大陆（阿里云 ACR） |
 | --- | --- | --- |
-| CPU | `ghcr.io/neuroaihub/brainpilot-sandbox:0.2.1` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.1` |
-| GPU | `ghcr.io/neuroaihub/brainpilot-sandbox-gpu:0.2.1` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.1` |
+| CPU | `ghcr.io/neuroaihub/brainpilot-sandbox:0.2.2` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2` |
+| GPU | `ghcr.io/neuroaihub/brainpilot-sandbox-gpu:0.2.2` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2` |
 
 两组地址都支持匿名拉取。中国大陆用户优先使用 ACR，其他地区优先使用 GHCR。
 
 ```bash title="全球"
-docker pull ghcr.io/neuroaihub/brainpilot-sandbox:0.2.1
-docker pull ghcr.io/neuroaihub/brainpilot-sandbox-gpu:0.2.1
+docker pull ghcr.io/neuroaihub/brainpilot-sandbox:0.2.2
+docker pull ghcr.io/neuroaihub/brainpilot-sandbox-gpu:0.2.2
 ```
 
 ```bash title="中国大陆"
-docker pull brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.1
-docker pull brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.1
+docker pull brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2
+docker pull brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2
 ```
 
 CPU 镜像包含 Node.js、Python、pip、curl 和 BrainPilot runtime。GPU 镜像额外包含 CUDA 12.4、
@@ -69,7 +69,7 @@ docker compose ps
 沙箱的情况下启动 Compose：
 
 ```bash
-export BP_SANDBOX_IMAGE=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.1
+export BP_SANDBOX_IMAGE=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2
 docker compose pull sandbox
 docker compose build main
 docker compose up -d --no-build
@@ -100,7 +100,7 @@ docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d --build
 如果使用官方预构建 GPU 沙箱：
 
 ```bash
-export BP_SANDBOX_IMAGE_GPU=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.1
+export BP_SANDBOX_IMAGE_GPU=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2
 docker compose -f docker-compose.yml -f docker-compose.gpu.yml pull sandbox
 docker compose build main
 docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d --no-build
@@ -110,7 +110,7 @@ docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d --no-build
 
 ```bash
 docker run --rm --gpus all --entrypoint python \
-  brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.1 \
+  brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2 \
   -c 'import torch; print(torch.cuda.is_available(), torch.cuda.get_device_name(0))'
 ```
 
@@ -120,7 +120,7 @@ docker run --rm --gpus all --entrypoint python \
 沙箱镜像：
 
 ```bash
-export BP_SANDBOX_IMAGE=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.1
+export BP_SANDBOX_IMAGE=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2
 docker pull "$BP_SANDBOX_IMAGE"
 docker compose -f docker-compose.dynamic.yml up -d --build
 ```
@@ -128,8 +128,8 @@ docker compose -f docker-compose.dynamic.yml up -d --build
 BrainPilot 云端托管层可以分别指定 CPU 和 GPU 镜像：
 
 ```dotenv
-BP_SANDBOX_IMAGE_CPU=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.1
-BP_SANDBOX_IMAGE_GPU=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.1
+BP_SANDBOX_IMAGE_CPU=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2
+BP_SANDBOX_IMAGE_GPU=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2
 ```
 
 修改后先拉取新镜像，再按云端部署流程滚动更新。根据编排器策略，已经存在的用户容器可能会继续使用
@@ -151,7 +151,7 @@ Docker 能提供实用的进程和文件系统隔离，但默认 Docker 容器�
 拉取新的固定版本标签，更新对应环境变量，再重建受影响的容器：
 
 ```bash
-docker pull brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.1
+docker pull brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2
 docker compose up -d --no-build --force-recreate sandbox
 ```
 
@@ -167,4 +167,3 @@ docker compose up -d --no-build --force-recreate sandbox
 - **main 无法连接 sandbox**：检查 `docker compose ps` 和 `docker compose logs sandbox`，确认
   runtime 的 8081 端口健康检查正常。
 - **中国大陆拉取缓慢**：用 ACR 地址替换 GHCR 地址。
-

--- a/packages/docs/content/docs/installation.mdx
+++ b/packages/docs/content/docs/installation.mdx
@@ -8,7 +8,7 @@ description: Install, update, run, and uninstall BrainPilot without surprising y
 Use the published npm package for the simplest single-user setup:
 
 ```bash
-npm install -g @brainpilot/app@0.2.1
+npm install -g @brainpilot/app@0.2.2
 brainpilot up
 ```
 

--- a/packages/docs/content/docs/installation.zh-cn.mdx
+++ b/packages/docs/content/docs/installation.zh-cn.mdx
@@ -8,7 +8,7 @@ description: 安装、更新、运行和卸载 BrainPilot，同时避免影响�
 单用户本地使用时，推荐直接安装已发布的 npm 包：
 
 ```bash
-npm install -g @brainpilot/app@0.2.1
+npm install -g @brainpilot/app@0.2.2
 brainpilot up
 ```
 

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/docs",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/kb-scripts/package.json
+++ b/packages/kb-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/kb-scripts",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "engines": {
     "node": ">=22"
   },

--- a/packages/plugin-auditor/manifest.json
+++ b/packages/plugin-auditor/manifest.json
@@ -1,6 +1,6 @@
 {
   "id": "org.brainpilot.auditor",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "apiVersion": "1",
   "displayName": "BrainPilot Auditor",
   "description": "Independent evidence and scientific-reliability audit feedback loop for PI and Expert results.",
@@ -10,7 +10,7 @@
     "skills"
   ],
   "engines": {
-    "brainpilot": ">=0.2.1 <0.3.0"
+    "brainpilot": ">=0.2.2 <0.3.0"
   },
   "protocols": {
     "agentInstructions": "1"

--- a/packages/plugin-auditor/package.json
+++ b/packages/plugin-auditor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/plugin-auditor",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "engines": {
     "node": ">=22"
   },

--- a/packages/plugin-got/manifest.json
+++ b/packages/plugin-got/manifest.json
@@ -1,6 +1,6 @@
 {
   "id": "org.brainpilot.got",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "apiVersion": "1",
   "displayName": "BrainPilot Graph of Trace",
   "description": "Research-event curation guidance for readable Graph of Trace Episodes and direct dependencies.",
@@ -10,7 +10,7 @@
     "skills"
   ],
   "engines": {
-    "brainpilot": ">=0.2.1 <0.3.0"
+    "brainpilot": ">=0.2.2 <0.3.0"
   },
   "environments": [
     "local",

--- a/packages/plugin-got/package.json
+++ b/packages/plugin-got/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/plugin-got",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "engines": {
     "node": ">=22"
   },

--- a/packages/plugin-monitor/manifest.json
+++ b/packages/plugin-monitor/manifest.json
@@ -1,6 +1,6 @@
 {
   "id": "org.brainpilot.monitor",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "apiVersion": "1",
   "displayName": "Monitor",
   "description": "Start session-scoped background commands and wake the owning agent when stdout emits lines.",
@@ -8,7 +8,7 @@
     "workflow"
   ],
   "engines": {
-    "brainpilot": ">=0.2.1 <0.3.0"
+    "brainpilot": ">=0.2.2 <0.3.0"
   },
   "environments": [
     "local"

--- a/packages/plugin-monitor/package.json
+++ b/packages/plugin-monitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/plugin-monitor",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "engines": {
     "node": ">=22"
   },

--- a/packages/plugin-research/manifest.json
+++ b/packages/plugin-research/manifest.json
@@ -1,6 +1,6 @@
 {
   "id": "org.brainpilot.research",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "apiVersion": "1",
   "displayName": "BrainPilot Research",
   "description": "Canonical research evidence and data-inventory workflows for BrainPilot experts.",
@@ -10,7 +10,7 @@
     "skills"
   ],
   "engines": {
-    "brainpilot": ">=0.2.1 <0.3.0"
+    "brainpilot": ">=0.2.2 <0.3.0"
   },
   "environments": [
     "local",

--- a/packages/plugin-research/package.json
+++ b/packages/plugin-research/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/plugin-research",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "engines": {
     "node": ">=22"
   },

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/plugin-sdk",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "engines": {
     "node": ">=22"
   },

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/protocol",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "engines": {
     "node": ">=22"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/runtime",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "engines": {
     "node": ">=22"
   },
@@ -37,14 +37,14 @@
     "start": "node ./dist/server.js"
   },
   "dependencies": {
-    "@brainpilot/kb-scripts": "^0.2.1",
-    "@brainpilot/plugin-auditor": "^0.2.1",
-    "@brainpilot/plugin-got": "^0.2.1",
-    "@brainpilot/plugin-research": "^0.2.1",
-    "@brainpilot/plugin-monitor": "^0.2.1",
-    "@brainpilot/plugin-sdk": "^0.2.1",
-    "@brainpilot/protocol": "^0.2.1",
-    "@brainpilot/skills": "^0.2.1",
+    "@brainpilot/kb-scripts": "^0.2.2",
+    "@brainpilot/plugin-auditor": "^0.2.2",
+    "@brainpilot/plugin-got": "^0.2.2",
+    "@brainpilot/plugin-research": "^0.2.2",
+    "@brainpilot/plugin-monitor": "^0.2.2",
+    "@brainpilot/plugin-sdk": "^0.2.2",
+    "@brainpilot/protocol": "^0.2.2",
+    "@brainpilot/skills": "^0.2.2",
     "@earendil-works/pi-coding-agent": "0.84.2",
     "@hono/node-server": "^2.1.0",
     "@modelcontextprotocol/sdk": "^1.30.0",

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -409,7 +409,7 @@ describe("SessionManager (mock mode)", () => {
         id: "org.brainpilot.auditor",
         enabled: false,
         reason: "experiment-override",
-        version: "0.2.1",
+        version: "0.2.2",
       });
     } finally {
       await rm(root, { recursive: true, force: true });

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/skills",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "engines": {
     "node": ">=22"
   },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/web",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "engines": {
     "node": ">=22"
   },
@@ -31,8 +31,8 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@brainpilot/plugin-sdk": "^0.2.1",
-    "@brainpilot/protocol": "^0.2.1",
+    "@brainpilot/plugin-sdk": "^0.2.2",
+    "@brainpilot/protocol": "^0.2.2",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.8",
     "@types/react": "^18.3.12",

--- a/release-notes/v0.2.2.md
+++ b/release-notes/v0.2.2.md
@@ -1,0 +1,28 @@
+BrainPilot v0.2.2 is a focused Cloud user-experience patch.
+
+Hosted deployments previously opened the local plugin marketplace even when the Cloud plugin
+control plane was not enabled. Users could see raw 404 responses, which made the marketplace look
+broken or incorrectly suggested that its catalogue was empty.
+
+This release now:
+
+- shows a concise, localized “not yet available in Cloud” state for hosted users;
+- avoids unsupported marketplace, installation, update, and MCP-status requests from that page;
+- leaves the plugin marketplace unchanged for local and self-hosted installations.
+
+The patch passed the complete Web suite (80 files, 653 tests), the monorepo release gates, and
+separate local and hosted Web production builds. No user-data migration is required.
+
+## Install or upgrade
+
+```bash
+npm install -g @brainpilot/app@0.2.2
+brainpilot --version
+```
+
+Official `linux/amd64` sandbox images:
+
+- CPU: `ghcr.io/neuroaihub/brainpilot-sandbox:0.2.2`
+- GPU: `ghcr.io/neuroaihub/brainpilot-sandbox-gpu:0.2.2`
+- CPU, mainland China: `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2`
+- GPU, mainland China: `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2`


### PR DESCRIPTION
## Summary

- bump all BrainPilot workspaces and internal dependency ranges to 0.2.2
- document the hosted plugin-availability UX fix in the changelog, release notes, and bilingual README/docs
- update npm installation and official CPU/GPU image references to 0.2.2

## Release scope

This is a focused Cloud UX patch. Hosted builds show that plugins are not yet available instead of issuing unsupported marketplace requests. Local and self-hosted plugin marketplaces are unchanged.

## Validation

- npm ci
- npm run version:check
- npm run typecheck
- npm test: 99 files, 1,112 tests
- npm run build
- VITE_LOCAL_MODE=0 npm run build -w @brainpilot/web
- npm run docs:check
- npm audit --omit=dev: 0 vulnerabilities
- npm run release:dry
- git diff --check

Depends on merged fix #537.