### PR TITLE
Make Monitor opt-in by default

### DIFF
--- a/packages/backend-core/src/plugins.ts
+++ b/packages/backend-core/src/plugins.ts
@@ -188,9 +188,9 @@ const BUILTIN_PLUGIN_RELEASES: readonly BuiltinPluginRelease[] = [
   },
 ];
 const TEST_PLUGIN_SOURCES = new Set<string>();
-const DEFAULT_RUNTIME_TOOL_PLUGINS = [
-  { id: "org.brainpilot.monitor", capability: "builtin.monitor" },
-  { id: "org.brainpilot.background-jobs", capability: "builtin.backgroundJobs" },
+const BUNDLED_RUNTIME_TOOL_PLUGINS = [
+  { id: "org.brainpilot.monitor", capability: "builtin.monitor", defaultEnabled: false },
+  { id: "org.brainpilot.background-jobs", capability: "builtin.backgroundJobs", defaultEnabled: true },
 ] as const;
 
 export function pluginsDir(dataDir: string): string {
@@ -564,10 +564,12 @@ export async function listInstalledPlugins(dataDir: string): Promise<InstalledPl
 export async function listEnabledRuntimeTools(dataDir: string): Promise<string[]> {
   const installed = await listInstalledPlugins(dataDir);
   const capabilities = new Set<string>();
-  for (const defaultPlugin of DEFAULT_RUNTIME_TOOL_PLUGINS) {
-    const override = installed.find((plugin) => plugin.manifest.id === defaultPlugin.id);
-    if (!override || (override.enabled && override.compatibility?.compatible !== false)) {
-      capabilities.add(defaultPlugin.capability);
+  for (const bundledPlugin of BUNDLED_RUNTIME_TOOL_PLUGINS) {
+    const override = installed.find((plugin) => plugin.manifest.id === bundledPlugin.id);
+    if (override
+      ? override.enabled && override.compatibility?.compatible !== false
+      : bundledPlugin.defaultEnabled) {
+      capabilities.add(bundledPlugin.capability);
     }
   }
   for (const plugin of installed) {
@@ -1087,7 +1089,7 @@ export async function installPlugin(dataDir: string, id: string, requestedVersio
       manifest: release.manifest,
       publisher: entry.publisher,
       verified: entry.verified === true,
-      enabled: DEFAULT_RUNTIME_TOOL_PLUGINS.some((plugin) => plugin.id === release.manifest.id),
+      enabled: BUNDLED_RUNTIME_TOOL_PLUGINS.find((plugin) => plugin.id === release.manifest.id)?.defaultEnabled ?? false,
       installedAt: new Date().toISOString(),
       activeVersion: release.version,
       sourceFormat: entry.sourceFormat ?? "brainpilot",

--- a/packages/backend-core/test/plugins.test.ts
+++ b/packages/backend-core/test/plugins.test.ts
@@ -365,7 +365,7 @@ describe("plugin marketplace control plane", () => {
   it("publishes the official Monitor capability only while its plugin is enabled", async () => {
     const dataDir = await mkdtemp(path.join(tmpdir(), "bp-plugin-monitor-"));
     const id = "org.brainpilot.monitor";
-    expect(await listEnabledRuntimeTools(dataDir)).toEqual(["builtin.monitor", "builtin.backgroundJobs"]);
+    expect(await listEnabledRuntimeTools(dataDir)).toEqual(["builtin.backgroundJobs"]);
     expect((await installPlugin(dataDir, id))?.verified).toBe(true);
     await setPluginEnabled(dataDir, id, true);
     expect(await listEnabledRuntimeTools(dataDir)).toEqual(["builtin.monitor", "builtin.backgroundJobs"]);
@@ -378,9 +378,9 @@ describe("plugin marketplace control plane", () => {
     const id = "org.brainpilot.background-jobs";
     expect((await installPlugin(dataDir, id))?.verified).toBe(true);
     await setPluginEnabled(dataDir, id, true);
-    expect(await listEnabledRuntimeTools(dataDir)).toEqual(["builtin.monitor", "builtin.backgroundJobs"]);
+    expect(await listEnabledRuntimeTools(dataDir)).toEqual(["builtin.backgroundJobs"]);
     await setPluginEnabled(dataDir, id, false);
-    expect(await listEnabledRuntimeTools(dataDir)).toEqual(["builtin.monitor"]);
+    expect(await listEnabledRuntimeTools(dataDir)).toEqual([]);
   });
   it("requires per-version trust before enabling executable Autoresearch", async () => {
     const dataDir = await mkdtemp(path.join(tmpdir(), "bp-plugin-autoresearch-"));
@@ -415,7 +415,7 @@ describe("plugin marketplace control plane", () => {
       body: "{}",
     });
     expect(calls.find((call) => call.url.endsWith("/runtime/capabilities"))?.body)
-      .toBe('{"capabilities":["builtin.monitor","builtin.backgroundJobs"]}');
+      .toBe('{"capabilities":["builtin.backgroundJobs"]}');
 
     const id = "org.brainpilot.monitor";
     await app.request("/api/plugins/install", {

--- a/packages/runtime/src/__tests__/monitor-integration.test.ts
+++ b/packages/runtime/src/__tests__/monitor-integration.test.ts
@@ -46,13 +46,13 @@ describe("Monitor runtime integration", () => {
     manager.shutdown();
   });
 
-  it("omits Monitor tools when the marketplace capability is disabled", async () => {
+  it("omits Monitor tools by default and exposes them after explicit enablement", async () => {
     const toolNames: string[][] = [];
     const factory: AgentSessionFactory = async (params) => {
       toolNames.push(params.systemTools.map((tool) => tool.name));
       return mockAgentFactory(params);
     };
-    const manager = new SessionManager({ persist: false, agentFactory: factory, runtimeCapabilities: [] });
+    const manager = new SessionManager({ persist: false, agentFactory: factory });
     const session = await manager.createSession();
     await manager.sendMessage(session.id, "hello");
     await waitFor(() => toolNames.length > 0);

--- a/packages/runtime/src/__tests__/system-plugins.test.ts
+++ b/packages/runtime/src/__tests__/system-plugins.test.ts
@@ -15,12 +15,12 @@ import {
 } from "../system-plugins.js";
 
 describe("bundled system plugins", () => {
-  it("loads all official workflow plugins by default from their npm packages", async () => {
+  it("loads official workflow plugins while leaving Monitor opt-in", async () => {
     const plugins = loadBundledSystemPlugins({});
     const snapshot = snapshotSystemPlugins(plugins);
     expect(systemPluginEnabled(snapshot, AUDITOR_PLUGIN_ID)).toBe(true);
     expect(systemPluginEnabled(snapshot, GOT_PLUGIN_ID)).toBe(true);
-    expect(systemPluginEnabled(snapshot, MONITOR_PLUGIN_ID)).toBe(true);
+    expect(systemPluginEnabled(snapshot, MONITOR_PLUGIN_ID)).toBe(false);
     expect(systemPluginEnabled(snapshot, BACKGROUND_JOBS_PLUGIN_ID)).toBe(true);
     expect(systemPluginEnabled(snapshot, RESEARCH_PLUGIN_ID)).toBe(true);
     const principalSkills = systemPluginSkillPaths(plugins, snapshot, "principal");

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -637,7 +637,7 @@ export class SessionManager {
       opts.routerSkillsDir ?? join(this.dataRoot, "bp_template", "skills-router");
     this.bundledSystemPlugins = loadBundledSystemPlugins(opts.systemPluginEnv ?? process.env);
     this.defaultSystemPlugins = snapshotSystemPlugins(this.bundledSystemPlugins);
-    for (const capability of opts.runtimeCapabilities ?? ["builtin.monitor", "builtin.backgroundJobs"]) {
+    for (const capability of opts.runtimeCapabilities ?? ["builtin.backgroundJobs"]) {
       this.runtimeCapabilities.add(capability);
     }
     this.runtimeExtensions = [...(opts.runtimeExtensions ?? [])];

--- a/packages/runtime/src/system-plugins.ts
+++ b/packages/runtime/src/system-plugins.ts
@@ -41,7 +41,7 @@ interface SystemPluginSpec {
 const SPECS: readonly SystemPluginSpec[] = [
   { packageName: "@brainpilot/plugin-auditor", defaultEnabled: true },
   { packageName: "@brainpilot/plugin-got", defaultEnabled: true },
-  { packageName: "@brainpilot/plugin-monitor", defaultEnabled: true },
+  { packageName: "@brainpilot/plugin-monitor", defaultEnabled: false },
   { packageName: "@brainpilot/plugin-background-jobs", defaultEnabled: true },
   { packageName: "@brainpilot/plugin-research", defaultEnabled: true },
 ];


### PR DESCRIPTION
## Summary
- disable the bundled Monitor plugin in default Runtime snapshots
- stop advertising the Monitor capability until explicitly enabled
- keep explicit marketplace enablement and live capability updates working

## Verification
- npm run typecheck
- npm test (107 files, 1133 tests)