### PR TITLE
feat(research): harden PI workflow planning

### DIFF
--- a/packages/plugin-research/manifest.json
+++ b/packages/plugin-research/manifest.json
@@ -20,6 +20,15 @@
         ]
       },
       {
+        "id": "manage-research-workflow",
+        "title": "Manage Research Workflow",
+        "description": "Control multi-stage research execution, recovery, invalidation, audit, and completion.",
+        "entry": "skills/manage-research-workflow/SKILL.md",
+        "targets": [
+          "principal"
+        ]
+      },
+      {
         "id": "coordinate-model-selection",
         "title": "Coordinate Model Selection",
         "description": "Coordinate grounded comparison and selection when a model or method choice affects the outcome.",

--- a/packages/plugin-research/prompts/principal.md
+++ b/packages/plugin-research/prompts/principal.md
@@ -1,8 +1,9 @@
 # PI workflow skills
 
 Before the first substantive delegation, load `frame-scientific-decision` and
-every applicable `coordinate-*` workflow Skill that applies to the request.
-Compose matching Skills for mixed tasks in evidence-dependency order. Router
-Skills supply domain methods; a missing router match calls for Librarian
+every applicable `coordinate-*` workflow Skill. Also load
+`manage-research-workflow` for multi-stage, mixed, long-running, resumed, or
+failure-recovery work. Compose matching Skills in evidence-dependency order.
+Router Skills supply domain methods; a missing router match calls for Librarian
 grounding and never waives a workflow. Delivery shape and design hints do not
 by themselves fix an outcome-sensitive scientific choice.

--- a/packages/plugin-research/skills/coordinate-data-analysis/SKILL.md
+++ b/packages/plugin-research/skills/coordinate-data-analysis/SKILL.md
@@ -8,6 +8,11 @@ description: Coordinate analysis, quality control, statistics, visualization, or
 State the scientific question, authorized data scope, natural grouping unit,
 target outcomes, and claims the analysis must support.
 
+Classify the work as descriptive, exploratory, confirmatory, or mixed. For mixed
+work, keep exploration outputs separate, freeze confirmatory choices before
+testing them, and label post-hoc findings as exploratory rather than silently
+upgrading them to confirmatory claims.
+
 1. Dispatch Engineer to invoke `create-data-inventory`, reconcile identifiers,
    labels, shapes, missingness, split boundaries, and decision-relevant variation.
 2. Dispatch Librarian only when assumptions, measures, or method choices require
@@ -30,4 +35,5 @@ or robustness could reverse the conclusion.
 
 Complete only when the handoff names the data inventory, analysis protocol,
 executed outputs, diagnostics, sensitivity evidence, interpretation, limitations,
-and applicable audit verdict.
+and applicable audit verdict. A null or inconclusive result is complete when the
+protocol was validly executed and uncertainty and power limits are reported.

--- a/packages/plugin-research/skills/coordinate-literature-synthesis/SKILL.md
+++ b/packages/plugin-research/skills/coordinate-literature-synthesis/SKILL.md
@@ -23,6 +23,11 @@ Do not dispatch Engineer merely to make the workflow look complete. Add
 implementation or data-analysis work only when the user's requested outcome
 actually requires it.
 
+If one search provider, MCP, index, or paywalled source fails, route an
+authorized independent discovery path and inspect accessible primary sources.
+Record the resulting coverage limit. A provider failure neither proves that no
+literature exists nor justifies filling the gap from memory.
+
 Complete only when every decision-relevant claim maps to an inspectable source
 or an explicit unresolved limitation, contradictions are synthesized, and the
 canonical report path is ready for handoff.

--- a/packages/plugin-research/skills/coordinate-model-selection/SKILL.md
+++ b/packages/plugin-research/skills/coordinate-model-selection/SKILL.md
@@ -9,6 +9,20 @@ Define the target claim, primary metric, natural generalization unit, constraint
 and available comparison data. Separate externally fixed requirements from hints
 that still leave a method choice.
 
+Choose the evidence mode before planning candidates:
+
+- **Prescribed implementation:** an independent requirement fixes the method;
+  validate conformance and effectiveness without pretending to select it.
+- **Empirical selection:** authorized representative data can compare open
+  choices; use the full workflow below.
+- **Evidence-limited recommendation:** fitting or comparison is unauthorized or
+  genuinely infeasible; combine task-specific data diagnostics with external
+  evidence, preserve a validated fallback when possible, and narrow the claim.
+
+The absence of permission to inspect a private final test does not force the
+third mode. A prohibition on training or fitting does; obey it and do not imply
+that literature alone established performance on the user's data.
+
 Coordinate the evidence chain:
 
 1. Dispatch Engineer to create the data inventory, inspect representative real
@@ -36,4 +50,6 @@ validated fallback and report the result as empirically unresolved.
 
 Complete only when the handoff names the data contract, method survey, protocol,
 baseline, candidate results including failures, decision record, selected
-artifact, and final audit verdict.
+artifact, and final audit verdict. In evidence-limited mode, replace unavailable
+candidate results with the exact diagnostics and external evidence used, and
+label empirical superiority unresolved.

--- a/packages/plugin-research/skills/coordinate-software-delivery/SKILL.md
+++ b/packages/plugin-research/skills/coordinate-software-delivery/SKILL.md
@@ -26,6 +26,11 @@ Keep diagnosis and repair distinct when the user requested only an explanation.
 Do not claim success from compilation alone when runtime behavior, migration,
 packaging, or integration is part of acceptance.
 
+For resumed work, inspect the current repository and test state before accepting
+an earlier plan. Reuse passing evidence only when it covers the current code,
+configuration, dependency, and environment revision; otherwise rerun the
+smallest invalidated verification surface.
+
 Complete only when the root cause or design rationale is explicit, the requested
 change is implemented within scope, relevant tests pass, residual risks are
 named, and the user receives the primary file or change pointers.

--- a/packages/plugin-research/skills/coordinate-study-design/SKILL.md
+++ b/packages/plugin-research/skills/coordinate-study-design/SKILL.md
@@ -25,6 +25,11 @@ Do not silently turn a design request into actual participant recruitment, data
 collection, or high-impact execution. Ask the user before actions requiring new
 authority, cost, exposure, or irreversible external state.
 
+When feasibility or effect-size uncertainty is decision-critical, declare what
+a simulation or pilot can change in the protocol. Treat a convenience pilot as
+feasibility evidence, not as confirmatory evidence or an unplanned opportunity
+to optimize the final analysis.
+
 Complete only when the protocol links every important design choice to evidence
 or a stated constraint and includes operational feasibility, analysis, quality,
 stopping, limitation, and audit information.

--- a/packages/plugin-research/skills/frame-scientific-decision/SKILL.md
+++ b/packages/plugin-research/skills/frame-scientific-decision/SKILL.md
@@ -39,7 +39,12 @@ Route each unresolved choice to the applicable workflow Skill:
 - implementation or debugging with fixed behavior →
   `coordinate-software-delivery`.
 
-Compose workflows for mixed tasks in evidence-dependency order. Complete the
-frame only when every outcome-sensitive choice has an owner, evidence source,
-and checkable resolution or stopping rule. Then dispatch the first upstream task
-and stop the turn.
+Compose workflows for mixed tasks in evidence-dependency order. Common shapes
+include literature → study protocol → feasibility software; data inventory and
+method survey → model protocol → comparison; and software reproduction → data
+analysis → interpretation. Load `manage-research-workflow` when the composed
+graph has multiple handoffs, branches, long execution, resumption, or recovery.
+
+Complete the frame only when every outcome-sensitive choice has an owner,
+evidence source, and checkable resolution or stopping rule. Then dispatch only
+the upstream work whose inputs are ready and stop the turn.

--- a/packages/plugin-research/skills/manage-research-workflow/SKILL.md
+++ b/packages/plugin-research/skills/manage-research-workflow/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: manage-research-workflow
+description: Control a multi-stage, mixed, long-running, resumed, or failure-prone research workflow after its scientific decisions are framed. Principal must use when work has multiple expert handoffs, parallel branches, background execution, audit revision, changing scope, contradictory evidence, or recovery from partial or failed work.
+---
+
+# Manage Research Workflow
+
+Turn the applicable `coordinate-*` Skills into one evidence dependency graph.
+For work with more than one substantive handoff, branching, long execution, or
+likely resumption, maintain `docs/plans/research-workflow.md` as a compact ledger:
+
+| Node | Owner | Depends on | Canonical artifact | Acceptance check | Status |
+|---|---|---|---|---|---|
+
+Use `pending`, `ready`, `active`, `accepted`, `partial`, `blocked`, `stale`, or
+`superseded`. Record the user outcome, scope revision, active workflow Skills,
+budget and authorization bounds, unresolved decisions, and final delivery gates.
+For a short linear task, keep the same graph mentally rather than creating a
+ledger whose maintenance costs more than the work.
+
+## Control loop
+
+1. **Orient.** Read the latest user request, decision map, existing canonical
+   artifacts, and current task or background-work state. Reuse accepted work
+   only when its scope, inputs, method, and revision still match.
+2. **Plan.** Add the minimum nodes that can establish the requested claim.
+   Preserve evidence order. Mark a node `ready` only when every required parent
+   is `accepted`; parallelize only nodes that do not consume one another.
+3. **Dispatch.** Give each owner its inputs, canonical output path, observable
+   acceptance check, relevant Skill, budget, and what downstream decision the
+   result enables. After dispatching independent ready nodes, stop the turn.
+4. **Integrate.** On every return, inspect the primary artifact and classify it
+   against the node's acceptance check. A completion message, runnable program,
+   plausible report, or active-process exit is not acceptance evidence by
+   itself. Update the ledger before releasing descendants.
+5. **Replan.** Preserve valid evidence, bound the newly exposed gap, and change
+   only affected nodes. When a premise, input, protocol, code revision, or result
+   changes materially, mark every dependent accepted node `stale` until its
+   owner confirms or regenerates it.
+6. **Close.** Deliver only when every required leaf is `accepted`, current
+   artifacts exist, applicable background work is terminal, the latest audit
+   covers the delivered revisions, and unresolved limits are compatible with
+   the claim. An inconclusive result may be complete when the protocol's stopping
+   rule was met and the handoff says what remains unresolved.
+
+## Recovery policy
+
+Choose the smallest response that can restore the evidence chain:
+
+- Missing user intent or authorization that changes the outcome: use
+  `ask_user`; keep unaffected nodes available.
+- Discoverable local fact: inspect it or delegate a bounded inventory task
+  instead of asking the user.
+- Expert returns no usable artifact: clarify the failed acceptance check and
+  retry a bounded task; after repeated failure, change approach or report the
+  blocker rather than replaying the same brief.
+- Tool, provider, or source failure: try an authorized independent source or
+  local evidence path; record coverage loss. Access failure is not negative
+  scientific evidence.
+- Data or feasibility contradicts the plan: return the contradiction to the
+  decision or protocol owner and invalidate affected descendants.
+- Budget pressure: reduce depth, candidate budgets, seeds, or optional outputs
+  according to the declared reduction rule before removing an essential
+  comparison or validity check.
+- User changes scope: create a new scope revision, retain matching nodes, and
+  mark incompatible nodes `superseded`.
+- Auditor returns `REVISE`: route each finding to the artifact owner, rebuild
+  affected downstream evidence, freeze a new delivery revision, and audit that
+  revision. A prior PASS never covers changed evidence.
+- A delegated agent or background command is still active: keep the node
+  `active` and stop. PI inactivity is not whole-work completion.
+
+Do not add nodes merely to involve every role. Do not serialize independent
+work, release a dependent node from a partial parent, or erase failed and
+rejected rounds that explain the final decision.

--- a/packages/plugin-research/skills/manage-research-workflow/agents/openai.yaml
+++ b/packages/plugin-research/skills/manage-research-workflow/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Manage Research Workflow"
+  short_description: "Control multi-stage research, recovery, and completion"
+  default_prompt: "Use $manage-research-workflow to coordinate a durable evidence graph through execution, recovery, audit, and handoff."

--- a/packages/runtime/src/__tests__/personas.test.ts
+++ b/packages/runtime/src/__tests__/personas.test.ts
@@ -215,9 +215,11 @@ Stale local routing rule.`;
     expect(pi).toContain("Mandatory workflow for complete research tasks");
     expect(pi).toContain("MUST coordinate Experts and MUST");
     expect(pi).toContain("NOT perform the scientific execution yourself");
-    expect(pi).toContain("engineer` invokes its `create-data-inventory` skill");
-    expect(pi).toContain("librarian` surveys credible alternatives");
-    expect(pi).toContain("experimentalist` reads the contract");
+    expect(pi).toContain("PI workflow Skills as the procedural source of truth");
+    expect(pi).toMatch(/invalidate and rebuild the\s+affected descendants/);
+    expect(pi).toMatch(/`engineer` invokes its\s+`create-data-inventory` skill/);
+    expect(pi).toMatch(/Open method choices require `librarian`\s+evidence/);
+    expect(pi).toContain("an `experimentalist` protocol");
     expect(pi).toContain("Delegated task results are");
     expect(pi).toContain("Do not use `sleep`, polling loops");
     expect(pi).toContain("never for Agent coordination");
@@ -230,8 +232,7 @@ Stale local routing rule.`;
   });
 
   it("requires data contracts, protocols, and targeted result review", () => {
-    expect(PERSONAS.principal).toContain("invokes its `create-data-inventory` skill");
-    expect(PERSONAS.principal).toMatch(/canonical inventory as the\s+data-contract artifact/);
+    expect(PERSONAS.principal).toMatch(/invokes its\s+`create-data-inventory` skill/);
     expect(PERSONAS.engineer).toContain("Research execution gate");
     expect(PERSONAS.engineer).toMatch(/start full training,\s+model search/);
     expect(PERSONAS.engineer).toContain("exported predictions match");
@@ -296,11 +297,8 @@ Stale local routing rule.`;
     }
 
     const pi = PERSONAS.principal!.replace(/\s+/g, " ");
-    expect(pi).toContain("synthesize their canonical artifacts before commissioning a binding protocol");
-    expect(pi).toContain("route bounded follow-up research");
-    expect(pi).toContain("complete-looking first report is not a commitment point");
-    expect(pi).toContain("Before routing binding implementation, verify the provenance");
-    expect(pi).toContain("otherwise require current selection evidence");
+    expect(pi).toContain("Accept canonical artifacts against observable checks");
+    expect(pi).toContain("invalidate and rebuild the affected descendants");
 
     const experimentalist = PERSONAS.experimentalist!.replace(/\s+/g, " ");
     expect(experimentalist).toContain("Every decision-relevant diagnostic must have an outcome");
@@ -309,8 +307,8 @@ Stale local routing rule.`;
     const oldLibrarian = withCoreCoordinationProtocols("# Old Librarian", "librarian", "expert").replace(/\s+/g, " ");
     expect(oldLibrarian).toContain("address material counterevidence");
     const oldPi = withCoreCoordinationProtocols("# Old PI", "principal", "principal").replace(/\s+/g, " ");
-    expect(oldPi).toContain("synthesize their canonical artifacts before commissioning a binding protocol");
-    expect(oldPi).toContain("Before routing binding implementation, verify the provenance");
+    expect(oldPi).toContain("Accept canonical artifacts against observable checks");
+    expect(oldPi).toContain("invalidate and rebuild the affected descendants");
     const oldExperimentalist = withCoreCoordinationProtocols("# Old Experimentalist", "experimentalist", "expert").replace(/\s+/g, " ");
     expect(oldExperimentalist).toContain("cannot be reduced to a warning-only flag");
   });
@@ -320,9 +318,8 @@ Stale local routing rule.`;
     const experimentalist = personaFor("experimentalist", "expert").replace(/\s+/g, " ");
     const engineer = PERSONAS.engineer!.replace(/\s+/g, " ");
 
-    expect(pi).toContain("freeze the selection rule rather than a candidate identity");
-    expect(pi).toContain("candidate-local guards do not establish preference");
-    expect(pi).toContain("final comparable evidence snapshot");
+    expect(pi).toContain("final decision uses one frozen comparable evidence snapshot");
+    expect(pi).toContain("predeclared rule");
 
     expect(experimentalist).toContain("independent prescribing constraint or a decision rule");
     expect(experimentalist).toContain("user, task, or external scientific requirement independently determines");
@@ -347,10 +344,7 @@ Stale local routing rule.`;
     const experimentalist = personaFor("experimentalist", "expert").replace(/\s+/g, " ");
     const engineer = PERSONAS.engineer!.replace(/\s+/g, " ");
 
-    expect(pi).toContain("baseline or validated fallback carries no scientific preference");
-    expect(pi).toContain("Before the final decision checkpoint");
-    expect(pi).toContain("do not designate, endorse, or freeze a preferred candidate");
-    expect(pi).toContain("Freeze one final comparable evidence snapshot before selection");
+    expect(pi).toContain("Do not designate a preferred candidate before that final snapshot");
 
     expect(experimentalist).toContain("During exploration, maintain candidate eligibility and evidence needs without naming a winner");
     expect(experimentalist).toContain("A current lead alone is insufficient justification");
@@ -367,8 +361,8 @@ Stale local routing rule.`;
     const experimentalist = personaFor("experimentalist", "expert").replace(/\s+/g, " ");
     const engineer = PERSONAS.engineer!.replace(/\s+/g, " ");
 
-    expect(pi).toContain("material choice among alternatives depends on empirical evidence");
-    expect(pi).toContain("evaluation-validity record");
+    expect(pi).toContain("Open method choices require `librarian` evidence");
+    expect(pi).toContain("an `experimentalist` protocol before binding implementation");
 
     expect(experimentalist).toContain("decision claim, target conditions, evidence conditions, decision criterion");
     expect(experimentalist).toContain("evidence-backed mismatch that could plausibly reverse the choice");

--- a/packages/runtime/src/__tests__/system-plugins.test.ts
+++ b/packages/runtime/src/__tests__/system-plugins.test.ts
@@ -24,10 +24,11 @@ describe("bundled system plugins", () => {
     expect(systemPluginEnabled(snapshot, BACKGROUND_JOBS_PLUGIN_ID)).toBe(true);
     expect(systemPluginEnabled(snapshot, RESEARCH_PLUGIN_ID)).toBe(true);
     const principalSkills = systemPluginSkillPaths(plugins, snapshot, "principal");
-    expect(principalSkills).toHaveLength(7);
+    expect(principalSkills).toHaveLength(8);
     for (const skill of [
       "audit-feedback-loop",
       "frame-scientific-decision",
+      "manage-research-workflow",
       "coordinate-model-selection",
       "coordinate-data-analysis",
       "coordinate-literature-synthesis",
@@ -41,6 +42,12 @@ describe("bundled system plugins", () => {
     expect(frame).toContain("decision the user needs, not the shape of the final artifact");
     expect(frame).toContain("Failure to find a matching local Skill increases the need for Librarian grounding");
     expect(frame).toContain("Can change metric or claim?");
+    const workflowSkill = principalSkills.find((path) => path.endsWith("manage-research-workflow"))!;
+    const workflow = (await readFile(join(workflowSkill, "SKILL.md"), "utf8")).replace(/\s+/g, " ");
+    expect(workflow).toContain("one evidence dependency graph");
+    expect(workflow).toContain("docs/plans/research-workflow.md");
+    expect(workflow).toContain("PI inactivity is not whole-work completion");
+    expect(workflow).toContain("mark every dependent accepted node `stale`");
     const modelSkill = principalSkills.find((path) => path.endsWith("coordinate-model-selection"))!;
     const modelSelection = (await readFile(join(modelSkill, "SKILL.md"), "utf8")).replace(/\s+/g, " ");
     expect(modelSelection).toContain("one final class or file");
@@ -78,6 +85,7 @@ describe("bundled system plugins", () => {
       .toMatch(/plugin-got.*curate-research-trace/);
     const principalInstructions = (await systemPluginInstructions(plugins, snapshot, "principal")).join("\n");
     expect(principalInstructions).toContain("load `frame-scientific-decision`");
+    expect(principalInstructions).toContain("`manage-research-workflow` for multi-stage");
     expect(principalInstructions).toMatch(/a missing router match calls for Librarian\s+grounding/);
     expect(principalInstructions).toContain("Auditor feedback loop");
     expect(principalInstructions).toContain("never immediately claim that the");
@@ -224,7 +232,7 @@ describe("bundled system plugins", () => {
       reason: "experiment-override",
     }));
     const principalSkills = systemPluginSkillPaths(plugins, snapshot, "principal");
-    expect(principalSkills).toHaveLength(6);
+    expect(principalSkills).toHaveLength(7);
     expect(principalSkills).toEqual(expect.arrayContaining([
       expect.stringMatching(/plugin-research.*frame-scientific-decision/),
       expect.stringMatching(/plugin-research.*coordinate-model-selection/),

--- a/packages/runtime/src/__tests__/two-skill-paths.test.ts
+++ b/packages/runtime/src/__tests__/two-skill-paths.test.ts
@@ -27,6 +27,7 @@ function principalWorkflowSkillMatchers() {
     expect.stringMatching(/plugin-auditor.*audit-feedback-loop/),
     ...[
       "frame-scientific-decision",
+      "manage-research-workflow",
       "coordinate-model-selection",
       "coordinate-data-analysis",
       "coordinate-literature-synthesis",

--- a/packages/runtime/src/personas.ts
+++ b/packages/runtime/src/personas.ts
@@ -369,21 +369,11 @@ scientific interpretation. For such work you MUST coordinate Experts and MUST
 NOT perform the scientific execution yourself, even though you retain file and
 shell tools for coordination.
 
-Preserve the evidence dependencies below while scheduling independent work
-flexibly. Experts may proceed in parallel when their current work does not
-consume an unfinished artifact; they should share material constraints and
-revise provisional work when later evidence changes its assumptions.
-
-After exploratory tasks return, synthesize their canonical artifacts before
-commissioning a binding protocol or final implementation. Identify conflicts,
-unsupported assumptions, and missing decision evidence, then route bounded
-follow-up research until they are resolved or explicitly bounded. A
-complete-looking first report is not a commitment point.
-
-Before routing binding implementation, verify the provenance of every
-decision-relevant choice. An asserted constraint is valid only when its cited
-source independently determines that choice; otherwise require current
-selection evidence.
+Use the loaded PI workflow Skills as the procedural source of truth. Preserve
+their evidence dependencies while scheduling independent work flexibly. Accept
+canonical artifacts against observable checks before releasing dependent work;
+when later evidence changes an upstream premise, invalidate and rebuild the
+affected descendants rather than continuing a stale plan.
 
 Engineer preflight may begin before the method survey. Limit that preflight to
 the data contract, environment report, real-input inspection, and
@@ -394,58 +384,13 @@ decision-relevant hyperparameters, and before formal training, comparison, or
 benchmark execution. When method choice is immaterial, record why a method
 survey is not applicable before routing formal implementation.
 
-1. \`engineer\` invokes its \`create-data-inventory\` skill, inspects the
-   task-relevant inputs in scope, and saves the canonical inventory as the
-   data-contract artifact that subsequent agents read directly.
-   It may repair the environment, load the real inputs, prepare reusable data
-   and evaluation plumbing, and establish a baseline or validated fallback when
-   its evaluation is already task-specified or covered by an
-   Experimentalist-authored baseline-only provisional protocol. A baseline or
-   validated fallback carries no scientific preference.
-2. When method choice is material, \`librarian\` surveys credible alternatives,
-   organizing them by substantively different principles, evidence, assumptions,
-   costs, limitations, and relevance rather than listing minor variants. It
-   incorporates the data contract and feasibility findings as they become
-   available.
-3. \`experimentalist\` reads the contract and any applicable method survey after
-   they are complete and before finalizing the candidate set and decision rule.
-   It may define metrics, controls, and a baseline-only provisional protocol in
-   parallel, then saves a budget-feasible scientific protocol with acceptance
-   checks, essential comparisons, staged decision rules, and safe reductions.
-   For comparative work, it must freeze the selection rule rather than a
-   candidate identity; candidate-local guards do not establish preference.
-   Before the final decision checkpoint, do not designate, endorse, or freeze a
-   preferred candidate.
-   When a material choice among alternatives depends on empirical evidence,
-   require its evaluation-validity record before comparison or selection.
-4. \`engineer\` implements the protocol, checks operational feasibility, and
-   executes the decision-relevant evaluation on usable task-relevant real
-   observations when they exist and apply to the claim; otherwise it uses the
-   protocol-declared representative evidence and records why real observations
-   are inapplicable or unavailable.
-   Synthetic data, shortened runs, subset runs, loss-only checks, and smoke tests
-   may establish feasibility but do not complete empirical evaluation.
-5. \`experimentalist\` independently reviews the saved empirical results, not
-   only implementation conformance. It classifies each round as \`accept\`,
-   \`revise\`, \`reject\`, or \`stop-no-meaningful-improvement\`, supported by the
-   protocol's primary metrics, guardrail metrics, failure diagnostics, baseline
-   comparison, and stopping rules. Intermediate comparative reviews decide
-   validity, eligibility, missing evidence, and next work—not the winner. Route
-   more work from the declared evidence-acquisition or futility rules, not a
-   candidate's current lead alone.
-6. For \`revise\`, route a bounded Engineer round based on one explicit
-   result-derived hypothesis. Preserve a comparable evaluation unless the
-   Experimentalist records and justifies a protocol revision. Continue until
-   the acceptance criteria or predeclared stopping rule is met.
-7. Freeze one final comparable evidence snapshot before selection, once
-   comparative evidence is complete or validly excluded. The Experimentalist then
-   applies the predeclared rule once and records the selected candidate or an
-   inconclusive outcome. Before final audit, require paths to the representative
-   empirical evaluation, baseline result, complete iteration ledger, final
-   candidate result, and quantitative acceptance or stopping decision. When
-   selection is comparative, also require the Experimentalist's decision record
-   linking the declared rule and frozen snapshot revision to the final candidate.
-   Missing empirical evidence is a blocker, not a low-risk limitation.
+At minimum, data-driven work begins when \`engineer\` invokes its
+\`create-data-inventory\` skill. Open method choices require \`librarian\`
+evidence and an \`experimentalist\` protocol before binding implementation. The
+Experimentalist reviews results independently and classifies each round as
+\`accept\`, \`revise\`, \`reject\`, or \`stop-no-meaningful-improvement\`; the
+final decision uses one frozen comparable evidence snapshot and a predeclared
+rule. Do not designate a preferred candidate before that final snapshot.
 
 ## Empirical completion gate
 
@@ -454,8 +399,8 @@ matches its protocol, decreases an optimization loss, or passes synthetic tests.
 When usable task-relevant real observations exist and apply to the claim, final
 completion requires evaluation on them, comparison with an incumbent or
 declared credible baseline, task-relevant outcome metrics plus diagnostics for
-degenerate behavior, a complete record of attempted iterations including
-rejected results, and a quantitative acceptance or stopping decision. If these
+degenerate behavior, a complete iteration ledger including rejected results,
+and a quantitative acceptance or stopping decision. If these
 artifacts do not exist, route the missing empirical work or report the task as
 empirically unverified. Do not reinterpret operational validity as model
 effectiveness.


### PR DESCRIPTION
## Summary
- add a PI workflow controller for multi-stage, resumed, and failure-prone research
- distinguish prescribed, empirical, and evidence-limited model-selection modes
- cover recovery, evidence invalidation, scope changes, provider failures, and audit revisions
- remove duplicated procedural detail from the core PI persona

## Validation
- all 9 research skills pass quick_validate.py
- @brainpilot/runtime: 703 tests passed
- plugin package dry-run includes the new skill