### PR TITLE
fix(web): render single-line $$....$$ as display math

### DIFF
--- a/packages/web/src/__tests__/MarkdownMessage.test.tsx
+++ b/packages/web/src/__tests__/MarkdownMessage.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { MarkdownMessage } from "../components/chat/MarkdownMessage";
 import {
   normalizeMarkdownTables,
+  promoteSingleLineDisplayMath,
   protectCurrencyDollars,
 } from "../components/chat/normalizeMarkdown";
 
@@ -22,6 +23,15 @@ describe("MarkdownMessage", () => {
 
     expect(html).not.toContain('class="katex"');
     expect(html).toContain("$E = mc^2$");
+  });
+
+  it("renders single-line $$..$$ math as a display equation", () => {
+    const html = render(
+      "$$y_t \\sim \\text{Poisson}(\\Delta t \\lambda_t), \\qquad \\lambda_t = \\text{softplus}(C z_t + d_t) \\tag{1}$$",
+    );
+
+    expect(html).toContain('class="katex-display"');
+    expect(html).not.toContain("katex-error");
   });
 
   it("renders a collapsed model-generated table", () => {
@@ -95,6 +105,26 @@ describe("normalizeMarkdownTables", () => {
   it("leaves ambiguous pipe-delimited prose untouched", () => {
     const prose = "Compare A | B ||---|---| without treating this as a table.";
     expect(normalizeMarkdownTables(prose)).toBe(prose);
+  });
+});
+
+describe("promoteSingleLineDisplayMath", () => {
+  it("promotes a single-line $$..$$ equation to flow math", () => {
+    expect(promoteSingleLineDisplayMath("$$x \\tag{1}$$")).toBe("$$\nx \\tag{1}\n$$");
+  });
+
+  it("leaves delimiters on separate lines unchanged", () => {
+    const markdown = "$$\nx \\tag{1}\n$$";
+    expect(promoteSingleLineDisplayMath(markdown)).toBe(markdown);
+  });
+
+  it("leaves mid-paragraph math, inline code, and fenced code untouched", () => {
+    const markdown = "成本 $$5\\text{元}$$ 左右\n\n`$$not math$$`\n\n```tex\n$$not math$$\n```";
+    expect(promoteSingleLineDisplayMath(markdown)).toBe(markdown);
+  });
+
+  it("leaves multiple math pairs on one line untouched", () => {
+    expect(promoteSingleLineDisplayMath("$$a$$ and $$b$$")).toBe("$$a$$ and $$b$$");
   });
 });
 

--- a/packages/web/src/components/chat/normalizeMarkdown.ts
+++ b/packages/web/src/components/chat/normalizeMarkdown.ts
@@ -82,8 +82,58 @@ export function protectCurrencyDollars(markdown: string): string {
     .join("\n");
 }
 
+/**
+ * GFM math treats `$$...$$` on a single line as a display equation, but
+ * remark-math only recognizes display math when the `$$` delimiters sit on
+ * their own lines, so a single-line `$$...$$` is parsed as *text* math.
+ * KaTeX then rejects display-only commands such as `\tag{1}` and renders the
+ * raw TeX in red (`.katex-error`). Promote lines that are exactly `$$...$$`
+ * (outside code fences, with up to three spaces of indentation) to
+ * newline-delimited display math so the two parsers agree with GFM.
+ */
+export function promoteSingleLineDisplayMath(markdown: string): string {
+  let fence: FenceState | null = null;
+
+  return markdown
+    .split("\n")
+    .map((line) => {
+      const fenceMatch = line.match(fencePattern);
+      if (fenceMatch) {
+        const markers = fenceMatch[2]!;
+        const marker = markers[0] as "`" | "~";
+
+        if (!fence) {
+          fence = { marker, length: markers.length };
+        } else if (
+          fence.marker === marker &&
+          markers.length >= fence.length &&
+          line.slice(fenceMatch[0].length).trim() === ""
+        ) {
+          fence = null;
+        }
+        return line;
+      }
+
+      if (fence) return line;
+
+      const indentation = line.match(/^ */)?.[0] ?? "";
+      if (indentation.length > 3) return line;
+
+      const trimmed = line.trim();
+      if (!trimmed.startsWith("$$") || !trimmed.endsWith("$$") || trimmed.length <= 4) {
+        return line;
+      }
+
+      const inner = trimmed.slice(2, -2);
+      if (inner.includes("$$")) return line;
+
+      return `${indentation}$$\n${indentation}${inner}\n${indentation}$$`;
+    })
+    .join("\n");
+}
+
 export function normalizeMarkdownForRendering(markdown: string): string {
-  return protectCurrencyDollars(normalizeMarkdownTables(markdown));
+  return protectCurrencyDollars(normalizeMarkdownTables(promoteSingleLineDisplayMath(markdown)));
 }
 
 function repairCollapsedTableLine(line: string): string {


### PR DESCRIPTION
## Summary

- remark-math only recognizes `$$...$$` blocks delimited by newlines as display math; a single-line `$$ formula $$` is parsed as inline math, where KaTeX rejects display-only commands such as `\tag{}` and renders raw TeX with red `katex-error` styling
- add `promoteSingleLineDisplayMath` to `normalizeMarkdown.ts`, promoted before rendering: a double-dollar formula that occupies a whole line is rewritten into newline-delimited display math (code fences and indentation are respected)
- add regression tests for the MarkdownMessage rendering and the normalization function

## Related Issues

- (none — no existing issue found for this rendering bug)

## Changes

- `packages/web/src/components/chat/normalizeMarkdown.ts`: add `promoteSingleLineDisplayMath`
- `packages/web/src/__tests__/MarkdownMessage.test.tsx`: regression tests

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that changes existing behavior)
- [ ] New skill (added under `packages/skills-mcp/skills/`)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI/CD or build changes

## Verification

### How to test

1. Send a chat message containing a single-line `$$ E = mc^2 \tag{1.1} $$` formula
2. Observe it rendered as centered display math with the tag, instead of red raw TeX
3. Send the same formula wrapped in newlines and in a code fence — both should be untouched

### What you personally verified

- `npm test -w @brainpilot/web` — 80 files, 658 tests passed (includes the new regression tests)
- `npm run build -w @brainpilot/web` — passed
- `npm run typecheck` — passed
- `BP_MOCK=1 npx vitest run` — 99 files, 1112 tests passed
- cherry-picked verbatim from a local branch (`git range-diff` verified identical); behavior not re-tested manually in a browser

### Checks

- [x] `npm run typecheck` passes
- [x] `BP_MOCK=1 npx vitest run` passes
- [x] Web build passes (`cd packages/web && npm test && npm run build`) — if web changed
- [ ] Manually tested locally
- [ ] Screenshots / recordings attached (if UI changes)

## Checklist

- [x] This PR is AI-assisted, and I have self-reviewed the generated code (see CONTRIBUTING.md) <!-- delete if not AI-assisted -->
- [x] My code follows the project's style
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes do not introduce new warnings