### PR TITLE
fix(runtime): use system role for custom completion gateways

### DIFF
--- a/packages/runtime/src/__tests__/provider-system-role.test.ts
+++ b/packages/runtime/src/__tests__/provider-system-role.test.ts
@@ -1,0 +1,80 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { ModelRuntime } from "@earendil-works/pi-coding-agent";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveSessionModel } from "../pi-provider.js";
+
+// pi-coding-agent may nest its pinned pi-ai dependency instead of hoisting it.
+function completionsPath(): string {
+  let dir = dirname(fileURLToPath(import.meta.url));
+  while (dirname(dir) !== dir) {
+    for (const prefix of ["@earendil-works/pi-coding-agent/node_modules", ""]) {
+      const path = join(dir, "node_modules", prefix,
+        "@earendil-works/pi-ai/dist/api/openai-completions.js");
+      if (existsSync(path)) return path;
+    }
+    dir = dirname(dir);
+  }
+  throw new Error("Could not locate the installed pi-ai Chat Completions transport");
+}
+
+const { stream } = await import(pathToFileURL(completionsPath()).href);
+
+describe("custom provider system role (#549)", () => {
+  let agentDir: string;
+  beforeEach(() => {
+    agentDir = mkdtempSync(join(tmpdir(), "bp-system-role-"));
+    // Request inspection must never contact a real provider.
+    vi.stubGlobal("fetch", vi.fn(() => { throw new Error("Unexpected network request"); }));
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    rmSync(agentDir, { recursive: true, force: true });
+  });
+
+  it.each([
+    ["https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1", "openai-completions", "system"],
+    ["https://unknown-gateway.example/v1", "openai-completions", "system"],
+    ["https://unknown-gateway.example/v1", undefined, "system"],
+    ["https://api.openai.com/v1", "openai-completions", "developer"],
+    ["https://api.openai.com.proxy.example/v1", "openai-completions", "system"],
+  ])("sends the correct role for %s (api=%s), retaining reasoning", async (baseUrl, api, role) => {
+    const { model } = await resolveSessionModel({ ModelRuntime }, agentDir, {
+      providerId: "custom",
+      modelId: "deepseek-v4-flash-0731",
+      baseUrl,
+      api,
+      adapter: "openai",
+      apiKey: "fake-test-key",
+      reasoningEnabled: true,
+    });
+    expect(model).toMatchObject({ reasoning: true });
+    const onPayload = vi.fn((_payload: unknown) => { throw new Error("STOP_BEFORE_NETWORK"); });
+    await stream(model, {
+      systemPrompt: "You are a helpful research assistant.",
+      messages: [{ role: "user", content: "Hello", timestamp: 0 }],
+    }, { apiKey: "fake-test-key", reasoningEffort: "medium", onPayload }).result();
+    expect(onPayload).toHaveBeenCalledOnce();
+    expect(onPayload.mock.calls[0]?.[0]).toMatchObject({
+      messages: [
+        { role, content: "You are a helpful research assistant." },
+        { role: "user", content: "Hello" },
+      ],
+      reasoning_effort: "medium",
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it.each(["anthropic-messages", "openai-responses", "azure-openai-responses"])(
+    "does not add Chat Completions compatibility overrides to %s", async (api) => {
+      await resolveSessionModel({ ModelRuntime }, agentDir, {
+        providerId: "custom", modelId: "test-model", api,
+        baseUrl: "https://gateway.example/v1", apiKey: "fake-test-key",
+      });
+      const cfg = JSON.parse(readFileSync(join(agentDir, "bp-session-custom-models.json"), "utf8"));
+      expect(cfg.providers.custom.models[0].compat).toBeUndefined();
+    },
+  );
+});

--- a/packages/runtime/src/pi-provider.ts
+++ b/packages/runtime/src/pi-provider.ts
@@ -269,6 +269,13 @@ export async function resolveSessionModel(
             {
               id: cfg.modelId,
               reasoning: cfg.reasoningEnabled ?? true,
+              // #549: reasoning support does not imply developer-role support.
+              // Custom Chat Completions gateways default to system messages;
+              // leave the native OpenAI endpoint and other APIs to the SDK.
+              ...(api === "openai-completions" &&
+                new URL(cfg.baseUrl).origin !== "https://api.openai.com"
+                ? { compat: { supportsDeveloperRole: false } }
+                : {}),
               input: ["text"],
               contextWindow:
                 cfg.contextWindow ?? intEnv("ANTHROPIC_CONTEXT_WINDOW") ?? DEFAULT_CONTEXT_WINDOW,


### PR DESCRIPTION
## Summary

Custom OpenAI-compatible Chat Completions gateways can reject the first message when a reasoning model sends the system prompt with the `developer` role. Session models now default to `compat.supportsDeveloperRole: false` outside the native `https://api.openai.com` origin, sending `system` while retaining reasoning.

## Related Issues

Fixes #549

## Changes

- Add the compatibility default in `resolveSessionModel`; preserve native OpenAI and other API families.
- Inspect real Pi ModelRuntime/Chat Completions request payloads in regression tests, stopping before network access. Cover the reported Aliyun URL, unknown gateways, adapter-derived API selection, native OpenAI, a lookalike hostname and other protocols.

## Type of Change

- [x] Bug fix

## Verification

### How to test

1. Run `npx vitest run packages/runtime/src/__tests__/provider-system-role.test.ts packages/runtime/src/__tests__/pi-provider.test.ts packages/runtime/src/__tests__/provider-config.test.ts`.
2. Run the full typecheck, root/Web tests and workspace/docs builds.
3. During integrated acceptance, send a message through a custom gateway with reasoning enabled and confirm the prompt is accepted.

### What you personally verified

- Focused request-construction coverage passes; removing the fix makes four new cases fail. Prompt text and `reasoning_effort: medium` are preserved; request-inspection tests never contact a provider.
- Full local verification on `df50bc22`: typecheck, 1,120 non-Web tests, 658 Web tests, docs checks and all workspace builds passed.
- The later base update only incorporates the merged dependency fixes. Required CI and both CodeQL analyses passed on current head `c4f542121b4dc53e1d8bf27f674b7d798ad92846`.
- Live Aliyun-specific validation has not been performed. Real-provider and integrated release acceptance remain a separate 0.2.3 gate.

### Checks

- [x] Full local typecheck
- [x] Full local root/Web tests
- [x] Docs checks/build and all-workspace build
- [x] Current-head required CI and CodeQL

## Checklist

- [x] AI-assisted; generated code has been self-reviewed
- [x] Request-level regression coverage added
- [x] No settings schema, UI or other protocol behavior changed
