### PR TITLE
fix(docker): make docs builds and GPU checks reproducible

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,10 @@ node_modules
 **/dist
 *.tsbuildinfo
 **/*.tsbuildinfo
+# Fumadocs/Next caches contain host-specific paths; regenerate them in the image.
+packages/docs/.source
+packages/docs/.next
+packages/docs/out
 .git
 .gitignore
 .worktrees

--- a/packages/docs/content/docs/docker.mdx
+++ b/packages/docs/content/docs/docker.mdx
@@ -112,7 +112,7 @@ docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d --no-build
 Verify PyTorch can see the GPU:
 
 ```bash
-docker run --rm --gpus all --entrypoint python \
+docker run --rm --gpus all --entrypoint python3 \
   brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2 \
   -c 'import torch; print(torch.cuda.is_available(), torch.cuda.get_device_name(0))'
 ```

--- a/packages/docs/content/docs/docker.zh-cn.mdx
+++ b/packages/docs/content/docs/docker.zh-cn.mdx
@@ -109,7 +109,7 @@ docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d --no-build
 验证 PyTorch 是否能识别 GPU：
 
 ```bash
-docker run --rm --gpus all --entrypoint python \
+docker run --rm --gpus all --entrypoint python3 \
   brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2 \
   -c 'import torch; print(torch.cuda.is_available(), torch.cuda.get_device_name(0))'
 ```


### PR DESCRIPTION
Building `docker/main/Dockerfile` after a host documentation build copies generated Fumadocs/Next caches into the image. Those caches contain the host's absolute `.source/source.config.mjs` path, causing the container build to fail resolving MDX files outside its filesystem root.

Exclude only the docs workspace's `.source`, `.next` and `out` directories from the Docker context. Documentation source remains included and is regenerated inside the builder. The paired GPU documentation checks also use `python3`, the executable verified in the published-base-derived GPU image. No runtime code, dependency, version or published tag changes.

Validation: reproduced on the Linux release checkout after a full host build; the same main builder now passes with all English/Chinese docs exports present. A real NVIDIA A10 tensor check passed with `python3`. The full Linux/amd64 main image now builds successfully from current head c69474a6 with the standard release proxy arguments; DataLad 1.6.0, DANDI 0.76.7 and wget checks pass. Actual dataset/container restart smoke follows before release acceptance.
