### PR TITLE
chore(release): BrainPilot v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file records notable changes to the public BrainPilot release. For the complete commit
 history, follow the comparison links for each version.
 
-## Unreleased
+## [0.2.3] - 2026-09-08
 
 - Expand dataset discovery to 48 entries across 15 overlapping research topics, including smaller selections where available and bilingual research questions/access metadata.
 - Add durable, bounded download jobs, cancellation/resume, tool checks and safe checksum recovery that preserves invalid files before a fresh explicit retry.
@@ -11,6 +11,12 @@ history, follow the comparison links for each version.
 - Connect the knowledge-resource market to guided PDF upload/indexing and improve build-log inspection.
 - Correct custom Chat Completions gateway system-role compatibility and DataLad cache identity in clean environments; update compatible dependencies.
 - Add bilingual dataset/workspace guides and refresh installation, KB, Docker, troubleshooting and maintainer documentation.
+
+### Packaging and upgrade
+
+- Exclude generated documentation caches from Docker builds and use the verified Python 3 GPU check.
+- Upgrade with `npm install -g @brainpilot/app@0.2.3`, then restart with the same data and knowledge-base roots. Use matching 0.2.3 sandbox images.
+- Cloud is released separately; local dataset/KB management remains disabled in hosted mode. Download completion is not scientific validation.
 
 ## [0.2.2] - 2026-08-22
 
@@ -252,6 +258,7 @@ First public open-source release of BrainPilot, including the PI-led multi-agent
 workflow, Graph of Trace, the built-in scientific skills library, provider configuration, MCP
 integration, local CLI, web interface, and Docker sandbox support.
 
+[0.2.3]: https://github.com/NeuroAIHub/BrainPilot/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/NeuroAIHub/BrainPilot/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/NeuroAIHub/BrainPilot/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/NeuroAIHub/BrainPilot/compare/v0.1.2...v0.2.0

--- a/README-zh.md
+++ b/README-zh.md
@@ -43,6 +43,8 @@ BrainPilot 是一个开源、人在回路的脑科学智能体研究系统。它
 
 ## 📰 最新动态
 
+- **2026-09-08** — [BrainPilot v0.2.3](https://github.com/NeuroAIHub/BrainPilot/releases/tag/v0.2.3) 扩展研究数据集，打通桌面端数据与证据工作流，并更新中英文指南。详见[更新日志](CHANGELOG.md#023---2026-09-08)。
+
 - **2026-08-22** — [BrainPilot v0.2.2](https://github.com/NeuroAIHub/BrainPilot/releases/tag/v0.2.2) 让托管界面与当前已开放的 Cloud 能力保持一致，并移除不受支持的控制面请求。详见[更新日志](CHANGELOG.md#022---2026-08-22)。
 - **2026-08-22** — [BrainPilot v0.2.1](https://github.com/NeuroAIHub/BrainPilot/releases/tag/v0.2.1) 将“停止”变成严格边界，已取消的模型、工具、文件和轨迹任务不会在用户提出新需求后继续执行。详见[更新日志](CHANGELOG.md#021---2026-08-22)。
 - **2026-08-22** — [BrainPilot v0.2.0](https://github.com/NeuroAIHub/BrainPilot/releases/tag/v0.2.0) 新增可持久追踪的专家任务与后台任务、支持工作区恢复的科研轨迹、公共脑科学数据集和最高 1M token 的可配置模型上下文，并重新设计服务商、模型和思考强度的选择流程；同时系统性改进文件与附件、停止与恢复、移动端布局和错误处理。详见[更新日志](CHANGELOG.md#020---2026-08-22)。
@@ -123,7 +125,7 @@ BrainPilot 通过 **`@brainpilot/app`** 以本地进程方式运行 —— 无�
 ### 1. 安装并启动
 
 ```bash
-npm install -g @brainpilot/app@0.2.2
+npm install -g @brainpilot/app@0.2.3
 brainpilot up
 ```
 
@@ -446,8 +448,8 @@ NVIDIA GPU、驱动和 NVIDIA Container Toolkit。
 
 | 版本 | 全球 | 中国大陆 |
 | --- | --- | --- |
-| CPU | `ghcr.io/neuroaihub/brainpilot-sandbox:0.2.2` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2` |
-| GPU | `ghcr.io/neuroaihub/brainpilot-sandbox-gpu:0.2.2` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2` |
+| CPU | `ghcr.io/neuroaihub/brainpilot-sandbox:0.2.3` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.3` |
+| GPU | `ghcr.io/neuroaihub/brainpilot-sandbox-gpu:0.2.3` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.3` |
 
 这些是 runtime 沙箱镜像，不是独立的 Web 应用，需要配合 BrainPilot main 进程或云端托管层使用。
 预构建镜像的 Compose 命令、GPU 验证、动态/云端配置、升级方式和 Docker 安全边界，详见双语

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ BrainPilot is an open-source, human-in-the-loop agentic system for brain science
 
 ## 📰 News
 
+- **2026-09-08** — [BrainPilot v0.2.3](https://github.com/NeuroAIHub/BrainPilot/releases/tag/v0.2.3) expands research datasets, connects desktop data and evidence workflows, and updates bilingual guides. See the [changelog](CHANGELOG.md#023---2026-09-08).
+
 - **2026-08-22** — [BrainPilot v0.2.2](https://github.com/NeuroAIHub/BrainPilot/releases/tag/v0.2.2) aligns the hosted interface with currently available Cloud capabilities and removes unsupported control-plane requests. See the [changelog](CHANGELOG.md#022---2026-08-22).
 - **2026-08-22** — [BrainPilot v0.2.1](https://github.com/NeuroAIHub/BrainPilot/releases/tag/v0.2.1) makes Stop a hard boundary so cancelled model, tool, file, and Trace work cannot resume after the user's next message. See the [changelog](CHANGELOG.md#021---2026-08-22).
 - **2026-08-22** — [BrainPilot v0.2.0](https://github.com/NeuroAIHub/BrainPilot/releases/tag/v0.2.0) adds durable expert tasks and background jobs, richer research traces with workspace recovery, public neuroscience datasets, configurable model contexts up to 1M tokens, and a redesigned provider/model/reasoning workflow, with broad improvements to files, Stop/recovery, mobile layouts, and error handling. See the [changelog](CHANGELOG.md#020---2026-08-22).
@@ -123,7 +125,7 @@ This is the recommended way to get started.
 ### 1. Install and launch
 
 ```bash
-npm install -g @brainpilot/app@0.2.2
+npm install -g @brainpilot/app@0.2.3
 brainpilot up
 ```
 
@@ -480,8 +482,8 @@ production; `latest` follows the newest release.
 
 | Variant | Global | Mainland China |
 | --- | --- | --- |
-| CPU | `ghcr.io/neuroaihub/brainpilot-sandbox:0.2.2` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2` |
-| GPU | `ghcr.io/neuroaihub/brainpilot-sandbox-gpu:0.2.2` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2` |
+| CPU | `ghcr.io/neuroaihub/brainpilot-sandbox:0.2.3` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.3` |
+| GPU | `ghcr.io/neuroaihub/brainpilot-sandbox-gpu:0.2.3` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.3` |
 
 These are runtime sandbox images, not standalone web applications. Use them with the BrainPilot
 main process or hosted cloud layer. See the bilingual [Docker deployment guide](packages/docs/content/docs/docker.mdx)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "brainpilot",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "brainpilot",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "hasInstallScript": true,
       "license": "AGPL-3.0-only",
       "workspaces": [
@@ -10957,12 +10957,12 @@
     },
     "packages/backend-core": {
       "name": "@brainpilot/backend-core",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@brainpilot/plugin-sdk": "^0.2.2",
-        "@brainpilot/protocol": "^0.2.2",
-        "@brainpilot/runtime": "^0.2.2",
+        "@brainpilot/plugin-sdk": "^0.2.3",
+        "@brainpilot/protocol": "^0.2.3",
+        "@brainpilot/runtime": "^0.2.3",
         "@hono/node-server": "^2.1.0",
         "hono": "^4.13.0"
       },
@@ -10978,14 +10978,14 @@
     },
     "packages/cli": {
       "name": "@brainpilot/app",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@brainpilot/backend-core": "^0.2.2",
-        "@brainpilot/plugin-sdk": "^0.2.2",
-        "@brainpilot/protocol": "^0.2.2",
-        "@brainpilot/runtime": "^0.2.2",
-        "@brainpilot/web": "^0.2.2",
+        "@brainpilot/backend-core": "^0.2.3",
+        "@brainpilot/plugin-sdk": "^0.2.3",
+        "@brainpilot/protocol": "^0.2.3",
+        "@brainpilot/runtime": "^0.2.3",
+        "@brainpilot/web": "^0.2.3",
         "commander": "^12.1.0",
         "picocolors": "^1.1.0"
       },
@@ -10999,7 +10999,7 @@
     },
     "packages/client-cli": {
       "name": "@brainpilot/client-cli",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "dependencies": {
         "@brainpilot/protocol": "*",
         "commander": "^12.1.0"
@@ -11010,7 +11010,7 @@
     },
     "packages/docs": {
       "name": "@brainpilot/docs",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "hasInstallScript": true,
       "dependencies": {
         "fumadocs-core": "16.15.0",
@@ -11811,7 +11811,7 @@
     },
     "packages/kb-scripts": {
       "name": "@brainpilot/kb-scripts",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "AGPL-3.0-only",
       "engines": {
         "node": ">=22"
@@ -11819,7 +11819,7 @@
     },
     "packages/plugin-auditor": {
       "name": "@brainpilot/plugin-auditor",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "AGPL-3.0-only",
       "engines": {
         "node": ">=22"
@@ -11827,7 +11827,7 @@
     },
     "packages/plugin-got": {
       "name": "@brainpilot/plugin-got",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "AGPL-3.0-only",
       "engines": {
         "node": ">=22"
@@ -11835,7 +11835,7 @@
     },
     "packages/plugin-monitor": {
       "name": "@brainpilot/plugin-monitor",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "AGPL-3.0-only",
       "engines": {
         "node": ">=22"
@@ -11843,7 +11843,7 @@
     },
     "packages/plugin-research": {
       "name": "@brainpilot/plugin-research",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "AGPL-3.0-only",
       "engines": {
         "node": ">=22"
@@ -11851,7 +11851,7 @@
     },
     "packages/plugin-sdk": {
       "name": "@brainpilot/plugin-sdk",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "semver": "^7.7.3"
@@ -11877,7 +11877,7 @@
     },
     "packages/protocol": {
       "name": "@brainpilot/protocol",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "zod": "^3.24.0"
@@ -11888,17 +11888,17 @@
     },
     "packages/runtime": {
       "name": "@brainpilot/runtime",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@brainpilot/kb-scripts": "^0.2.2",
-        "@brainpilot/plugin-auditor": "^0.2.2",
-        "@brainpilot/plugin-got": "^0.2.2",
-        "@brainpilot/plugin-monitor": "^0.2.2",
-        "@brainpilot/plugin-research": "^0.2.2",
-        "@brainpilot/plugin-sdk": "^0.2.2",
-        "@brainpilot/protocol": "^0.2.2",
-        "@brainpilot/skills": "^0.2.2",
+        "@brainpilot/kb-scripts": "^0.2.3",
+        "@brainpilot/plugin-auditor": "^0.2.3",
+        "@brainpilot/plugin-got": "^0.2.3",
+        "@brainpilot/plugin-monitor": "^0.2.3",
+        "@brainpilot/plugin-research": "^0.2.3",
+        "@brainpilot/plugin-sdk": "^0.2.3",
+        "@brainpilot/protocol": "^0.2.3",
+        "@brainpilot/skills": "^0.2.3",
         "@earendil-works/pi-coding-agent": "0.84.2",
         "@hono/node-server": "^2.1.0",
         "@modelcontextprotocol/sdk": "^1.30.0",
@@ -11912,7 +11912,7 @@
     },
     "packages/skills": {
       "name": "@brainpilot/skills",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "AGPL-3.0-only",
       "engines": {
         "node": ">=22"
@@ -11920,11 +11920,11 @@
     },
     "packages/web": {
       "name": "@brainpilot/web",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "AGPL-3.0-only",
       "devDependencies": {
-        "@brainpilot/plugin-sdk": "^0.2.2",
-        "@brainpilot/protocol": "^0.2.2",
+        "@brainpilot/plugin-sdk": "^0.2.3",
+        "@brainpilot/protocol": "^0.2.3",
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource-variable/geist-mono": "^5.2.8",
         "@types/react": "^18.3.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainpilot",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "type": "module",
   "description": "BrainPilot — multi-agent research collaboration platform (TS + Pi SDK)",

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/backend-core",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "engines": {
     "node": ">=22"
   },
@@ -39,9 +39,9 @@
     "start": "node ./dist/server.js"
   },
   "dependencies": {
-    "@brainpilot/plugin-sdk": "^0.2.2",
-    "@brainpilot/protocol": "^0.2.2",
-    "@brainpilot/runtime": "^0.2.2",
+    "@brainpilot/plugin-sdk": "^0.2.3",
+    "@brainpilot/protocol": "^0.2.3",
+    "@brainpilot/runtime": "^0.2.3",
     "@hono/node-server": "^2.1.0",
     "hono": "^4.13.0"
   },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/app",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "engines": {
     "node": ">=22"
   },
@@ -32,11 +32,11 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@brainpilot/backend-core": "^0.2.2",
-    "@brainpilot/plugin-sdk": "^0.2.2",
-    "@brainpilot/protocol": "^0.2.2",
-    "@brainpilot/runtime": "^0.2.2",
-    "@brainpilot/web": "^0.2.2",
+    "@brainpilot/backend-core": "^0.2.3",
+    "@brainpilot/plugin-sdk": "^0.2.3",
+    "@brainpilot/protocol": "^0.2.3",
+    "@brainpilot/runtime": "^0.2.3",
+    "@brainpilot/web": "^0.2.3",
     "commander": "^12.1.0",
     "picocolors": "^1.1.0"
   }

--- a/packages/client-cli/package.json
+++ b/packages/client-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/client-cli",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "type": "module",
   "description": "BrainPilot headless verification client (dev/CI) — drive a session without the web UI",

--- a/packages/docs/content/docs/docker.mdx
+++ b/packages/docs/content/docs/docker.mdx
@@ -25,20 +25,20 @@ testing, but it can change on the next publication. The current images target `l
 
 | Variant | Global (GHCR) | Mainland China (Alibaba Cloud ACR) |
 | --- | --- | --- |
-| CPU | `ghcr.io/neuroaihub/brainpilot-sandbox:0.2.2` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2` |
-| GPU | `ghcr.io/neuroaihub/brainpilot-sandbox-gpu:0.2.2` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2` |
+| CPU | `ghcr.io/neuroaihub/brainpilot-sandbox:0.2.3` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.3` |
+| GPU | `ghcr.io/neuroaihub/brainpilot-sandbox-gpu:0.2.3` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.3` |
 
 Both endpoints allow anonymous pulls. Mainland China users should prefer ACR; other users should
 prefer GHCR.
 
 ```bash title="Global"
-docker pull ghcr.io/neuroaihub/brainpilot-sandbox:0.2.2
-docker pull ghcr.io/neuroaihub/brainpilot-sandbox-gpu:0.2.2
+docker pull ghcr.io/neuroaihub/brainpilot-sandbox:0.2.3
+docker pull ghcr.io/neuroaihub/brainpilot-sandbox-gpu:0.2.3
 ```
 
 ```bash title="Mainland China"
-docker pull brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2
-docker pull brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2
+docker pull brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.3
+docker pull brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.3
 ```
 
 The CPU image includes Node.js, Python, pip, curl, and the BrainPilot runtime. The GPU image adds
@@ -72,7 +72,7 @@ To avoid rebuilding the CPU sandbox, set its full registry path and pull it firs
 main image, then start Compose without rebuilding the sandbox:
 
 ```bash
-export BP_SANDBOX_IMAGE=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2
+export BP_SANDBOX_IMAGE=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.3
 docker compose pull sandbox
 docker compose build main
 docker compose up -d --no-build
@@ -103,7 +103,7 @@ docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d --build
 To use the official prebuilt GPU sandbox instead:
 
 ```bash
-export BP_SANDBOX_IMAGE_GPU=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2
+export BP_SANDBOX_IMAGE_GPU=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.3
 docker compose -f docker-compose.yml -f docker-compose.gpu.yml pull sandbox
 docker compose build main
 docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d --no-build
@@ -113,7 +113,7 @@ Verify PyTorch can see the GPU:
 
 ```bash
 docker run --rm --gpus all --entrypoint python3 \
-  brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2 \
+  brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.3 \
   -c 'import torch; print(torch.cuda.is_available(), torch.cuda.get_device_name(0))'
 ```
 
@@ -123,7 +123,7 @@ Dynamic mode runs one sandbox per user through the host Docker daemon. Build the
 service and point it at a versioned sandbox image:
 
 ```bash
-export BP_SANDBOX_IMAGE=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2
+export BP_SANDBOX_IMAGE=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.3
 docker pull "$BP_SANDBOX_IMAGE"
 docker compose -f docker-compose.dynamic.yml up -d --build
 ```
@@ -131,8 +131,8 @@ docker compose -f docker-compose.dynamic.yml up -d --build
 The hosted BrainPilot cloud layer supports separate CPU and GPU images:
 
 ```dotenv
-BP_SANDBOX_IMAGE_CPU=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2
-BP_SANDBOX_IMAGE_GPU=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2
+BP_SANDBOX_IMAGE_CPU=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.3
+BP_SANDBOX_IMAGE_GPU=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.3
 ```
 
 After changing either value, pull the new image and use the cloud deployment procedure to roll
@@ -158,7 +158,7 @@ Pull a new fixed tag, update the corresponding environment variable, and recreat
 containers:
 
 ```bash
-docker pull brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2
+docker pull brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.3
 docker compose up -d --no-build --force-recreate sandbox
 ```
 

--- a/packages/docs/content/docs/docker.zh-cn.mdx
+++ b/packages/docs/content/docs/docker.zh-cn.mdx
@@ -24,19 +24,19 @@ npm 安装是最简单的单用户方案。如果你需要可复现的运行环�
 
 | 版本 | 全球（GHCR） | 中国大陆（阿里云 ACR） |
 | --- | --- | --- |
-| CPU | `ghcr.io/neuroaihub/brainpilot-sandbox:0.2.2` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2` |
-| GPU | `ghcr.io/neuroaihub/brainpilot-sandbox-gpu:0.2.2` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2` |
+| CPU | `ghcr.io/neuroaihub/brainpilot-sandbox:0.2.3` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.3` |
+| GPU | `ghcr.io/neuroaihub/brainpilot-sandbox-gpu:0.2.3` | `brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.3` |
 
 两组地址都支持匿名拉取。中国大陆用户优先使用 ACR，其他地区优先使用 GHCR。
 
 ```bash title="全球"
-docker pull ghcr.io/neuroaihub/brainpilot-sandbox:0.2.2
-docker pull ghcr.io/neuroaihub/brainpilot-sandbox-gpu:0.2.2
+docker pull ghcr.io/neuroaihub/brainpilot-sandbox:0.2.3
+docker pull ghcr.io/neuroaihub/brainpilot-sandbox-gpu:0.2.3
 ```
 
 ```bash title="中国大陆"
-docker pull brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2
-docker pull brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2
+docker pull brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.3
+docker pull brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.3
 ```
 
 CPU 镜像包含 Node.js、Python、pip、curl 和 BrainPilot runtime。GPU 镜像额外包含 CUDA 12.4、
@@ -69,7 +69,7 @@ docker compose ps
 沙箱的情况下启动 Compose：
 
 ```bash
-export BP_SANDBOX_IMAGE=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2
+export BP_SANDBOX_IMAGE=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.3
 docker compose pull sandbox
 docker compose build main
 docker compose up -d --no-build
@@ -100,7 +100,7 @@ docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d --build
 如果使用官方预构建 GPU 沙箱：
 
 ```bash
-export BP_SANDBOX_IMAGE_GPU=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2
+export BP_SANDBOX_IMAGE_GPU=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.3
 docker compose -f docker-compose.yml -f docker-compose.gpu.yml pull sandbox
 docker compose build main
 docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d --no-build
@@ -110,7 +110,7 @@ docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d --no-build
 
 ```bash
 docker run --rm --gpus all --entrypoint python3 \
-  brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2 \
+  brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.3 \
   -c 'import torch; print(torch.cuda.is_available(), torch.cuda.get_device_name(0))'
 ```
 
@@ -120,7 +120,7 @@ docker run --rm --gpus all --entrypoint python3 \
 沙箱镜像：
 
 ```bash
-export BP_SANDBOX_IMAGE=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2
+export BP_SANDBOX_IMAGE=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.3
 docker pull "$BP_SANDBOX_IMAGE"
 docker compose -f docker-compose.dynamic.yml up -d --build
 ```
@@ -128,8 +128,8 @@ docker compose -f docker-compose.dynamic.yml up -d --build
 BrainPilot 云端托管层可以分别指定 CPU 和 GPU 镜像：
 
 ```dotenv
-BP_SANDBOX_IMAGE_CPU=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2
-BP_SANDBOX_IMAGE_GPU=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.2
+BP_SANDBOX_IMAGE_CPU=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.3
+BP_SANDBOX_IMAGE_GPU=brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox-gpu:0.2.3
 ```
 
 修改后先拉取新镜像，再按云端部署流程滚动更新。根据编排器策略，已经存在的用户容器可能会继续使用
@@ -151,7 +151,7 @@ Docker 能提供实用的进程和文件系统隔离，但默认 Docker 容器�
 拉取新的固定版本标签，更新对应环境变量，再重建受影响的容器：
 
 ```bash
-docker pull brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.2
+docker pull brainpilot-registry.cn-wulanchabu.cr.aliyuncs.com/brainpilot/sandbox:0.2.3
 docker compose up -d --no-build --force-recreate sandbox
 ```
 

--- a/packages/docs/content/docs/getting-started.mdx
+++ b/packages/docs/content/docs/getting-started.mdx
@@ -30,7 +30,7 @@ If the result is below `v22`, install a newer Node.js release before continuing.
 Install the published package globally and start it:
 
 ```bash
-npm install -g @brainpilot/app@0.2.0
+npm install -g @brainpilot/app@0.2.3
 brainpilot up
 ```
 

--- a/packages/docs/content/docs/getting-started.zh-cn.mdx
+++ b/packages/docs/content/docs/getting-started.zh-cn.mdx
@@ -30,7 +30,7 @@ node -v
 全局安装已经发布的 npm 包，然后启动：
 
 ```bash
-npm install -g @brainpilot/app@0.2.0
+npm install -g @brainpilot/app@0.2.3
 brainpilot up
 ```
 

--- a/packages/docs/content/docs/installation.mdx
+++ b/packages/docs/content/docs/installation.mdx
@@ -8,7 +8,7 @@ description: Install, update, run, and uninstall BrainPilot without surprising y
 Use the published npm package for the simplest single-user setup:
 
 ```bash
-npm install -g @brainpilot/app@0.2.2
+npm install -g @brainpilot/app@0.2.3
 brainpilot up
 ```
 

--- a/packages/docs/content/docs/installation.zh-cn.mdx
+++ b/packages/docs/content/docs/installation.zh-cn.mdx
@@ -8,7 +8,7 @@ description: 安装、更新、运行和卸载 BrainPilot，同时避免影响�
 单用户本地使用时，推荐直接安装已发布的 npm 包：
 
 ```bash
-npm install -g @brainpilot/app@0.2.2
+npm install -g @brainpilot/app@0.2.3
 brainpilot up
 ```
 

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/docs",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/kb-scripts/package.json
+++ b/packages/kb-scripts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/kb-scripts",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "engines": {
     "node": ">=22"
   },

--- a/packages/plugin-auditor/manifest.json
+++ b/packages/plugin-auditor/manifest.json
@@ -1,6 +1,6 @@
 {
   "id": "org.brainpilot.auditor",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "apiVersion": "1",
   "displayName": "BrainPilot Auditor",
   "description": "Independent evidence and scientific-reliability audit feedback loop for PI and Expert results.",
@@ -10,7 +10,7 @@
     "skills"
   ],
   "engines": {
-    "brainpilot": ">=0.2.2 <0.3.0"
+    "brainpilot": ">=0.2.3 <0.3.0"
   },
   "protocols": {
     "agentInstructions": "1"

--- a/packages/plugin-auditor/package.json
+++ b/packages/plugin-auditor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/plugin-auditor",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "engines": {
     "node": ">=22"
   },

--- a/packages/plugin-got/manifest.json
+++ b/packages/plugin-got/manifest.json
@@ -1,6 +1,6 @@
 {
   "id": "org.brainpilot.got",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "apiVersion": "1",
   "displayName": "BrainPilot Graph of Trace",
   "description": "Research-event curation guidance for readable Graph of Trace Episodes and direct dependencies.",
@@ -10,7 +10,7 @@
     "skills"
   ],
   "engines": {
-    "brainpilot": ">=0.2.2 <0.3.0"
+    "brainpilot": ">=0.2.3 <0.3.0"
   },
   "environments": [
     "local",

--- a/packages/plugin-got/package.json
+++ b/packages/plugin-got/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/plugin-got",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "engines": {
     "node": ">=22"
   },

--- a/packages/plugin-monitor/manifest.json
+++ b/packages/plugin-monitor/manifest.json
@@ -1,6 +1,6 @@
 {
   "id": "org.brainpilot.monitor",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "apiVersion": "1",
   "displayName": "Monitor",
   "description": "Start session-scoped background commands and wake the owning agent when stdout emits lines.",
@@ -8,7 +8,7 @@
     "workflow"
   ],
   "engines": {
-    "brainpilot": ">=0.2.2 <0.3.0"
+    "brainpilot": ">=0.2.3 <0.3.0"
   },
   "environments": [
     "local"

--- a/packages/plugin-monitor/package.json
+++ b/packages/plugin-monitor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/plugin-monitor",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "engines": {
     "node": ">=22"
   },

--- a/packages/plugin-research/manifest.json
+++ b/packages/plugin-research/manifest.json
@@ -1,6 +1,6 @@
 {
   "id": "org.brainpilot.research",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "apiVersion": "1",
   "displayName": "BrainPilot Research",
   "description": "Canonical research evidence and data-inventory workflows for BrainPilot experts.",
@@ -10,7 +10,7 @@
     "skills"
   ],
   "engines": {
-    "brainpilot": ">=0.2.2 <0.3.0"
+    "brainpilot": ">=0.2.3 <0.3.0"
   },
   "environments": [
     "local",

--- a/packages/plugin-research/package.json
+++ b/packages/plugin-research/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/plugin-research",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "engines": {
     "node": ">=22"
   },

--- a/packages/plugin-sdk/package.json
+++ b/packages/plugin-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/plugin-sdk",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "engines": {
     "node": ">=22"
   },

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/protocol",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "engines": {
     "node": ">=22"
   },

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/runtime",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "engines": {
     "node": ">=22"
   },
@@ -37,14 +37,14 @@
     "start": "node ./dist/server.js"
   },
   "dependencies": {
-    "@brainpilot/kb-scripts": "^0.2.2",
-    "@brainpilot/plugin-auditor": "^0.2.2",
-    "@brainpilot/plugin-got": "^0.2.2",
-    "@brainpilot/plugin-research": "^0.2.2",
-    "@brainpilot/plugin-monitor": "^0.2.2",
-    "@brainpilot/plugin-sdk": "^0.2.2",
-    "@brainpilot/protocol": "^0.2.2",
-    "@brainpilot/skills": "^0.2.2",
+    "@brainpilot/kb-scripts": "^0.2.3",
+    "@brainpilot/plugin-auditor": "^0.2.3",
+    "@brainpilot/plugin-got": "^0.2.3",
+    "@brainpilot/plugin-research": "^0.2.3",
+    "@brainpilot/plugin-monitor": "^0.2.3",
+    "@brainpilot/plugin-sdk": "^0.2.3",
+    "@brainpilot/protocol": "^0.2.3",
+    "@brainpilot/skills": "^0.2.3",
     "@earendil-works/pi-coding-agent": "0.84.2",
     "@hono/node-server": "^2.1.0",
     "@modelcontextprotocol/sdk": "^1.30.0",

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -393,6 +393,9 @@ describe("SessionManager (mock mode)", () => {
   it("persists the frozen plugin assignment and resolved installed version", async () => {
     const root = await mkdtemp(join(tmpdir(), "bp-system-plugin-meta-"));
     try {
+      const bundledAuditor = JSON.parse(await readFile(
+        new URL("../../../plugin-auditor/manifest.json", import.meta.url), "utf8",
+      )) as { version: string };
       const manager = new SessionManager({
         dataRoot: root,
         persist: true,
@@ -409,7 +412,7 @@ describe("SessionManager (mock mode)", () => {
         id: "org.brainpilot.auditor",
         enabled: false,
         reason: "experiment-override",
-        version: "0.2.2",
+        version: bundledAuditor.version,
       });
     } finally {
       await rm(root, { recursive: true, force: true });

--- a/packages/skills/package.json
+++ b/packages/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/skills",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "engines": {
     "node": ">=22"
   },

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brainpilot/web",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "engines": {
     "node": ">=22"
   },
@@ -31,8 +31,8 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "@brainpilot/plugin-sdk": "^0.2.2",
-    "@brainpilot/protocol": "^0.2.2",
+    "@brainpilot/plugin-sdk": "^0.2.3",
+    "@brainpilot/protocol": "^0.2.3",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.8",
     "@types/react": "^18.3.12",

--- a/release-notes/v0.2.3.md
+++ b/release-notes/v0.2.3.md
@@ -1,0 +1,21 @@
+# BrainPilot v0.2.3
+
+
+- Expand dataset discovery to 48 entries across 15 overlapping research topics, including smaller selections where available and bilingual research questions/access metadata.
+- Add durable, bounded download jobs, cancellation/resume, tool checks and safe checksum recovery that preserves invalid files before a fresh explicit retry.
+- Connect downloaded data to persistent files and new research drafts; retain market navigation and open saved outputs from live Trace.
+- Connect the knowledge-resource market to guided PDF upload/indexing and improve build-log inspection.
+- Correct custom Chat Completions gateway system-role compatibility and DataLad cache identity in clean environments; update compatible dependencies.
+- Add bilingual dataset/workspace guides and refresh installation, KB, Docker, troubleshooting and maintainer documentation.
+
+### Packaging and upgrade
+
+- Exclude generated documentation caches from Docker builds and use the verified Python 3 GPU check.
+- Upgrade with `npm install -g @brainpilot/app@0.2.3`, then restart with the same data and knowledge-base roots. Use matching 0.2.3 sandbox images.
+- Cloud is released separately; local dataset/KB management remains disabled in hosted mode. Download completion is not scientific validation.
+
+## Release scope
+
+48 datasets across 15 overlapping topics; 37 downloadable datasets and 13 sample/participant selections. Provider access, licensing and supplied provenance still apply. The desktop workflow connects downloads, persistent files, research drafts, live Trace and local PDF indexing. See the updated English and Chinese guides.
+
+The GPU base is unchanged. Preserve user data when replacing application images. Release verification and final immutable artifact identities are recorded in the GitHub Release; deployment acceptance is tracked separately.


### PR DESCRIPTION
Prepare the approved OSS v0.2.3 release from functional baseline e81fa813: align all workspace/plugin versions and internal ranges, update lockfile metadata, publishable release notes, both README news entries and current installation/image examples. Historical release notes remain intact.

The frozen-plugin assignment test now compares against the shipped manifest instead of hardcoding 0.2.2. This keeps the same assertion meaningful across releases.

Validation: version alignment, full workspace/docs build, Web tests and docs checks passed. Final 0.2.3 tarballs passed isolated fresh install and published-0.2.2 upgrade with retained history/configuration/files. Backend/runtime tests passed on rerun after one external-process startup timing failure; no source change was made for that timing failure. Functional main previously passed real CPU/GPU, dataset checksum/retry, user isolation, container recovery and paired backup/restore acceptance. Publication and staged deployment are explicitly authorized by the user, with registry checks and exact merged-main CI gating dependent operations.
